### PR TITLE
fix(imports): make provider icons the same visual size

### DIFF
--- a/apps/desktop/public/assets/google-meet.svg
+++ b/apps/desktop/public/assets/google-meet.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 176 176">
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-22 0 220 176">
   <g transform="translate(0 19)">
     <path
       fill="url(#meetLens)"

--- a/apps/desktop/public/assets/zoom-icon.svg
+++ b/apps/desktop/public/assets/zoom-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-32 -32 320 320">
   <defs>
     <linearGradient id="zoomIconBg" x1="23.666%" x2="76.334%" y1="95.612%" y2="4.388%">
       <stop offset="0%" stop-color="#0845bf" />

--- a/apps/desktop/src/imports/icons.test.ts
+++ b/apps/desktop/src/imports/icons.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { PROVIDER_BRAND_ICONS, providerIconSrc } from "./icons";
+import {
+  PROVIDER_BRAND_ICONS,
+  providerIconOpticalClass,
+  providerIconSrc,
+} from "./icons";
 
 describe("providerIconSrc", () => {
   it("uses the official Meet camera instead of a letter fallback", () => {
@@ -47,5 +51,38 @@ describe("providerIconSrc", () => {
 
   it("leaves unknown apps without an icon source", () => {
     expect(providerIconSrc({ id: "circleback" })).toBeUndefined();
+  });
+});
+
+describe("providerIconOpticalClass", () => {
+  it("enlarges line-art brand marks so they match filled app icons", () => {
+    expect(providerIconOpticalClass({ id: "chatgpt-record" })).toBe(
+      "scale-[1.22]",
+    );
+    expect(providerIconOpticalClass({ id: "slack-huddles" })).toBe(
+      "scale-[1.12]",
+    );
+  });
+
+  it("leaves filled brand marks and native app icons unscaled", () => {
+    expect(providerIconOpticalClass({ id: "google-meet" })).toBeUndefined();
+    expect(
+      providerIconOpticalClass({
+        id: "zoom",
+        iconUrl: "data:image/png;base64,zoom-wordmark",
+      }),
+    ).toBeUndefined();
+    expect(
+      providerIconOpticalClass({
+        id: "granola",
+        iconUrl: "data:image/png;base64,granola",
+      }),
+    ).toBeUndefined();
+    expect(
+      providerIconOpticalClass({
+        id: "chatgpt-record",
+        iconUrl: "data:image/png;base64,chatgpt",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/apps/desktop/src/imports/icons.ts
+++ b/apps/desktop/src/imports/icons.ts
@@ -9,6 +9,12 @@ export const PROVIDER_BRAND_ICONS: Record<string, string> = {
 // Meet has no desktop app icon. Zoom's native icon is the wordmark, not the camera.
 const BRAND_ICON_OVERRIDES = new Set(["google-meet", "zoom"]);
 
+// Line-art marks read smaller than filled app icons in the same 32px slot.
+const BRAND_ICON_OPTICAL_CLASS: Record<string, string> = {
+  "chatgpt-record": "scale-[1.22]",
+  "slack-huddles": "scale-[1.12]",
+};
+
 export function providerIconSrc(provider: {
   id: string;
   iconUrl?: string;
@@ -21,4 +27,13 @@ export function providerIconSrc(provider: {
     return brandIcon;
   }
   return provider.iconUrl ?? brandIcon;
+}
+
+export function providerIconOpticalClass(provider: {
+  id: string;
+  iconUrl?: string;
+}): string | undefined {
+  const src = providerIconSrc(provider);
+  if (src !== PROVIDER_BRAND_ICONS[provider.id]) return undefined;
+  return BRAND_ICON_OPTICAL_CLASS[provider.id];
 }

--- a/apps/desktop/src/imports/screen.test.tsx
+++ b/apps/desktop/src/imports/screen.test.tsx
@@ -241,6 +241,18 @@ describe("MeetingImportScreen", () => {
         installedAppId: "com.granola.app",
         iconUrl: "data:image/png;base64,granola",
       },
+      {
+        ...MEETING_IMPORT_PROVIDERS.find(
+          (provider) => provider.id === "chatgpt-record",
+        )!,
+        installedAppId: "chatgpt-record",
+      },
+      {
+        ...MEETING_IMPORT_PROVIDERS.find(
+          (provider) => provider.id === "slack-huddles",
+        )!,
+        installedAppId: "slack-huddles",
+      },
     ]);
 
     const { container } = renderImports();
@@ -253,8 +265,16 @@ describe("MeetingImportScreen", () => {
       container.querySelector('img[src="/assets/zoom-icon.svg"]'),
     ).toBeTruthy();
     expect(
-      container.querySelector('img[src="data:image/png;base64,granola"]'),
-    ).toBeTruthy();
+      container.querySelector('img[src="data:image/png;base64,granola"]')
+        ?.className,
+    ).not.toContain("scale-");
+    expect(
+      container.querySelector('img[src="/assets/model-icons/openai-logo.svg"]')
+        ?.className,
+    ).toContain("scale-[1.22]");
+    expect(
+      container.querySelector('img[src="/assets/slack-icon.svg"]')?.className,
+    ).toContain("scale-[1.12]");
     expect(container.querySelector("iconify-icon")).toBeNull();
   });
 

--- a/apps/desktop/src/imports/screen.tsx
+++ b/apps/desktop/src/imports/screen.tsx
@@ -44,7 +44,7 @@ import {
   nangoImportSyncQueryOptions,
 } from "./connected-import";
 import { detectImportSources } from "./detection";
-import { providerIconSrc } from "./icons";
+import { providerIconOpticalClass, providerIconSrc } from "./icons";
 import type {
   DetectedMeetingImportProvider,
   MeetingImportProvider,
@@ -77,7 +77,16 @@ function ProviderIcon({
 }) {
   const src = providerIconSrc(provider);
   if (src) {
-    return <img src={src} alt="" className="size-8 object-contain" />;
+    return (
+      <img
+        src={src}
+        alt=""
+        className={cn([
+          "size-8 object-contain object-center",
+          providerIconOpticalClass(provider),
+        ])}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Imports list used a shared 32px slot, but the brand marks themselves did not read at the same size: Meet and Zoom filled the box, while ChatGPT and Slack are thin logos with a lot of negative space.

This evens them optically:

- Add canvas padding to the Meet and Zoom SVGs so those filled marks match native app-icon padding (Granola and similar).
- Scale the ChatGPT and Slack line-art marks up in the list. Native app icons are left alone.

## Test plan

- [x] `pnpm exec dprint fmt` / scoped `dprint check` on the changed files
- [x] `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- [x] `pnpm -F desktop typecheck`
- [x] `pnpm -F desktop test`
- Open Settings → Imports and confirm Meet, Granola, Zoom, ChatGPT Record, and Slack Huddles look like the same visual size.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7904d84b-1f36-4d2e-9ad2-0f351358a433?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7904d84b-1f36-4d2e-9ad2-0f351358a433&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

