### PR TITLE
fix(desktop): persist window size and position

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -338,7 +338,8 @@ pub async fn main() {
         .plugin(tauri_plugin_js::init())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                .skip_initial_state("main")
+                .with_state_flags(tauri_plugin_windows::persisted_window_state_flags())
+                .with_denylist(&["composer"])
                 .build(),
         )
         .plugin(tauri_plugin_transcription::init())

--- a/apps/desktop/src/shared/main/chat-panels.test.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.test.tsx
@@ -515,6 +515,64 @@ describe("MainChatPanels", () => {
     expect(mocks.windowRestoreWidth).toHaveBeenCalledTimes(1);
   });
 
+  it("does not restore window width when leaving a meeting for settings with chat still open", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 700,
+      leftSidebarWidth: 200,
+      rightPanelWidth: 120,
+    });
+
+    const renderPanels = () => (
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>
+    );
+    const { rerender } = render(renderPanels());
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalled();
+    mocks.windowRestoreWidth.mockClear();
+
+    mocks.currentTab = { type: "settings" };
+    rerender(renderPanels());
+
+    expect(mocks.windowRestoreWidth).not.toHaveBeenCalled();
+  });
+
+  it("restores window width when docked chat closes while the sidebar stays open", () => {
+    mocks.chatMode = "RightPanelOpen";
+    mocks.currentTab = { type: "sessions" };
+    mocks.leftSidebarExpanded = true;
+    mockPanelWidths({
+      bodyPanelWidth: 700,
+      leftSidebarWidth: 200,
+      rightPanelWidth: 120,
+    });
+
+    const renderPanels = () => (
+      <MainChatPanels>
+        <div data-left-sidebar-chrome />
+        <div data-chat-floating-anchor>
+          <div data-session-surface />
+        </div>
+      </MainChatPanels>
+    );
+    const { rerender } = render(renderPanels());
+
+    expect(mocks.windowExpandWidth).toHaveBeenCalled();
+    mocks.windowRestoreWidth.mockClear();
+
+    mocks.chatMode = "FloatingClosed";
+    rerender(renderPanels());
+
+    expect(mocks.windowRestoreWidth).toHaveBeenCalledTimes(1);
+  });
+
   it("collapses the left sidebar when a window resize would make the note surface narrower than 500px", () => {
     mocks.currentTab = { type: "sessions" };
     mocks.leftSidebarExpanded = true;

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -177,10 +177,18 @@ function useNoteSurfaceWindowWidthGuard({
   useLayoutEffect(() => {
     const previousState = previousStateRef.current;
     const hasOpenPanel = enabled && (leftPanelOpen || rightPanelOpen);
+    const rightPanelJustClosed =
+      previousState.rightPanelOpen && !rightPanelOpen;
+
+    if (
+      rightPanelJustClosed ||
+      (enabled && !leftPanelOpen && !rightPanelOpen)
+    ) {
+      restoreWidthExpansions();
+    }
 
     if (!hasOpenPanel) {
       previousStateRef.current = { enabled, leftPanelOpen, rightPanelOpen };
-      restoreWidthExpansions();
       return;
     }
 

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -359,12 +359,6 @@ impl AppWindow {
         }
 
         if let Some(window) = self.get(app) {
-            if matches!(self, Self::Main) {
-                use tauri_plugin_window_state::{StateFlags, WindowExt};
-
-                let _ = window.restore_state(StateFlags::SIZE | StateFlags::POSITION);
-            }
-
             self.ensure_visible(app, &window);
             window.show()?;
             window.set_focus()?;
@@ -385,7 +379,7 @@ impl AppWindow {
         use tauri_plugin_window_state::{StateFlags, WindowExt};
 
         let state_flags = if matches!(self, Self::Main) {
-            StateFlags::SIZE | StateFlags::POSITION
+            crate::persisted_window_state_flags()
         } else {
             StateFlags::SIZE
         };

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -11,14 +11,19 @@ pub use ext::{Windows, WindowsPluginExt};
 pub use tab::*;
 pub use window::*;
 
-const PLUGIN_NAME: &str = "windows";
-
 use std::collections::HashMap;
 use std::sync::{
     Mutex,
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use std::time::{Duration, Instant};
+
+const PLUGIN_NAME: &str = "windows";
+
+pub fn persisted_window_state_flags() -> tauri_plugin_window_state::StateFlags {
+    use tauri_plugin_window_state::StateFlags;
+    StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED
+}
 
 const WEBVIEW_RECOVERY_GRACE_PERIOD: Duration = Duration::from_secs(10);
 
@@ -307,8 +312,8 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
         })
         .on_event(move |app, event| {
             if let tauri::RunEvent::ExitRequested { .. } = event {
-                use tauri_plugin_window_state::{AppHandleExt, StateFlags};
-                let _ = app.save_window_state(StateFlags::SIZE);
+                use tauri_plugin_window_state::AppHandleExt;
+                let _ = app.save_window_state(persisted_window_state_flags());
             }
         })
         .build()
@@ -392,6 +397,19 @@ mod test {
 
         assert_eq!(expansions.pop("note-1"), Some((100.0, 120.0, false)));
         assert!(expansions.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn persisted_window_state_includes_size_and_position() {
+        use tauri_plugin_window_state::StateFlags;
+
+        let flags = persisted_window_state_flags();
+        assert!(flags.contains(StateFlags::SIZE));
+        assert!(flags.contains(StateFlags::POSITION));
+        assert!(flags.contains(StateFlags::MAXIMIZED));
+        assert!(!flags.contains(StateFlags::VISIBLE));
+        assert!(!flags.contains(StateFlags::DECORATIONS));
+        assert!(!flags.contains(StateFlags::FULLSCREEN));
     }
 
     #[test]

--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -1,5 +1,7 @@
 use crate::WindowImpl;
 
+const MAIN_WINDOW_WIDTH: f64 = 910.0;
+const MAIN_WINDOW_HEIGHT: f64 = 600.0;
 const NOTE_WINDOW_WIDTH: f64 = 720.0;
 const NOTE_WINDOW_HEIGHT: f64 = 820.0;
 const NOTE_WINDOW_POSITION_TOLERANCE: f64 = 1.0;
@@ -201,10 +203,9 @@ impl WindowImpl for AppWindow {
                     .window_builder(app, "/app")
                     .maximizable(true)
                     .minimizable(true)
-                    .min_inner_size(500.0, 500.0);
-                let window = builder.build()?;
-                window.set_size(LogicalSize::new(910.0, 600.0))?;
-                window
+                    .min_inner_size(500.0, 500.0)
+                    .inner_size(MAIN_WINDOW_WIDTH, MAIN_WINDOW_HEIGHT);
+                builder.build()?
             }
             Self::Composer => {
                 let builder = self
@@ -226,10 +227,9 @@ impl WindowImpl for AppWindow {
                     .window_builder(app, format!("/app/note/{encoded_id}"))
                     .maximizable(true)
                     .minimizable(true)
-                    .min_inner_size(420.0, 500.0);
-                let window = builder.build()?;
-                window.set_size(LogicalSize::new(NOTE_WINDOW_WIDTH, NOTE_WINDOW_HEIGHT))?;
-                window
+                    .min_inner_size(420.0, 500.0)
+                    .inner_size(NOTE_WINDOW_WIDTH, NOTE_WINDOW_HEIGHT);
+                builder.build()?
             }
         };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Joey reported that the app forgets window size and position on almost every launch, and also jumps when going from a meeting to Settings. 1.4.11 only stopped recentering after updates, so the frame still reset.

## Cause

`tauri-plugin-window-state` keeps the saved frame in an in-memory cache. The main window was created, then immediately forced to 910×600, and the plugin’s resize listener wrote that default over the saved frame *before* restore ran. Re-showing an already-open window (tray, floating bar, Settings) applied that stale frame again. Leaving a meeting also restored temporary chat-panel width expansions even when chat was still open.

## Fix

- Use 910×600 as the builder default only (first launch), and restore size, position, and maximized on create before any later resize can clobber the cache.
- Do not re-apply saved state when showing an existing window; keep the live geometry.
- Save size, position, and maximized on quit (not size-only).
- Restore temporary width expansions when docked chat actually closes, not when switching from a meeting to Settings.

## Testing

- `pnpm -F desktop test src/shared/main/chat-panels.test.tsx`
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/shared/main/chat-panels.tsx apps/desktop/src/shared/main/chat-panels.test.tsx`

`cargo test -p tauri-plugin-windows` could not run here (GTK `gdk-3.0.pc` is not installed in this environment).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-174ad337-f848-461d-be8d-78dc93d7f861?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-174ad337-f848-461d-be8d-78dc93d7f861&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

