### PR TITLE
fix(desktop): match folder picker popover to metadata chrome

### DIFF
--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -55,6 +55,19 @@ describe("FolderPicker", () => {
     expect(trigger.querySelectorAll("svg")).toHaveLength(1);
   });
 
+  it("uses the same floating chrome as note metadata", () => {
+    render(<FolderPicker sessionId="session-1" />);
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Select folder" }));
+
+    const input = screen.getByPlaceholderText("Search or create folder");
+    const content = input.closest("[data-radix-popper-content-wrapper] > *");
+
+    expect(content?.className).toContain("w-85");
+    expect(content?.className).not.toContain("p-0");
+    expect(input.closest(".p-4")).not.toBeNull();
+  });
+
   it("lets the user select an existing folder for the current note", async () => {
     render(<FolderPicker sessionId="session-1" />);
 

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -115,74 +115,80 @@ export function FolderPicker({
           ) : null}
         </button>
       </PopoverTrigger>
-      <PopoverContent variant="app" align={align} className="w-64 p-0">
+      <PopoverContent
+        variant="app"
+        align={align}
+        className="w-85 overflow-hidden"
+      >
         <AppFloatingPanel className="overflow-hidden">
           <Command
             filter={filterFolders}
-            className="rounded-[inherit] border-0 bg-transparent"
+            className="rounded-[inherit] border-0 bg-transparent **:[[cmdk-input-wrapper]]:h-7 **:[[cmdk-input-wrapper]]:border-0 **:[[cmdk-input-wrapper]]:px-0"
           >
-            <CommandInput
-              placeholder={t`Search or create folder`}
-              value={query}
-              onValueChange={setQuery}
-            />
-            <CommandList>
-              <CommandEmpty>
-                <div className="text-muted-foreground px-2 py-1.5 text-sm">
+            <div className="flex flex-col gap-4 p-4">
+              <CommandInput
+                placeholder={t`Search or create folder`}
+                value={query}
+                onValueChange={setQuery}
+                className="h-7 py-0"
+              />
+              <div className="bg-accent h-px" />
+              <CommandList>
+                <CommandEmpty className="text-muted-foreground py-0 text-left text-sm">
                   {trimmedQuery
                     ? normalizedQuery === null
                       ? t`Enter a valid folder name.`
                       : t`No folders found.`
                     : t`No folders yet.`}
-                </div>
-              </CommandEmpty>
-              {currentPath ? (
-                <CommandGroup>
-                  <CommandItem
-                    value={`no-folder ${t`No folder`}`}
-                    onSelect={() => handleSelect("")}
-                    className="cursor-pointer"
-                  >
-                    <span className="flex-1 truncate">{t`No folder`}</span>
-                  </CommandItem>
-                </CommandGroup>
-              ) : null}
-              {currentPath && (folders.length > 0 || canCreateFolder) ? (
-                <CommandSeparator />
-              ) : null}
-              {folders.length > 0 ? (
-                <CommandGroup>
-                  {folders.map((path) => (
+                </CommandEmpty>
+                {currentPath ? (
+                  <CommandGroup>
                     <CommandItem
-                      key={path}
-                      value={path}
-                      onSelect={() => handleSelect(path)}
+                      value={`no-folder ${t`No folder`}`}
+                      onSelect={() => handleSelect("")}
                       className="cursor-pointer"
                     >
-                      <Folder className="size-4 shrink-0 opacity-70" />
-                      <span className="min-w-0 flex-1 truncate">{path}</span>
-                      {path === currentPath ? (
-                        <Check className="size-4 shrink-0" />
-                      ) : null}
+                      <span className="flex-1 truncate">{t`No folder`}</span>
                     </CommandItem>
-                  ))}
-                </CommandGroup>
-              ) : null}
-              {canCreateFolder && normalizedQuery ? (
-                <CommandGroup>
-                  <CommandItem
-                    value={`create-folder ${normalizedQuery}`}
-                    onSelect={() => handleSelect(normalizedQuery)}
-                    className="cursor-pointer"
-                  >
-                    <Plus className="size-4 shrink-0" />
-                    <span className="min-w-0 flex-1 truncate">
-                      {t`Create "${folderName}"`}
-                    </span>
-                  </CommandItem>
-                </CommandGroup>
-              ) : null}
-            </CommandList>
+                  </CommandGroup>
+                ) : null}
+                {currentPath && (folders.length > 0 || canCreateFolder) ? (
+                  <CommandSeparator />
+                ) : null}
+                {folders.length > 0 ? (
+                  <CommandGroup>
+                    {folders.map((path) => (
+                      <CommandItem
+                        key={path}
+                        value={path}
+                        onSelect={() => handleSelect(path)}
+                        className="cursor-pointer"
+                      >
+                        <Folder className="size-4 shrink-0 opacity-70" />
+                        <span className="min-w-0 flex-1 truncate">{path}</span>
+                        {path === currentPath ? (
+                          <Check className="size-4 shrink-0" />
+                        ) : null}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                ) : null}
+                {canCreateFolder && normalizedQuery ? (
+                  <CommandGroup>
+                    <CommandItem
+                      value={`create-folder ${normalizedQuery}`}
+                      onSelect={() => handleSelect(normalizedQuery)}
+                      className="cursor-pointer"
+                    >
+                      <Plus className="size-4 shrink-0" />
+                      <span className="min-w-0 flex-1 truncate">
+                        {t`Create "${folderName}"`}
+                      </span>
+                    </CommandItem>
+                  </CommandGroup>
+                ) : null}
+              </CommandList>
+            </div>
           </Command>
         </AppFloatingPanel>
       </PopoverContent>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The folder picker popover used `p-0` and a tight cmdk search row, so it didn’t match the calendar metadata popover’s inset chrome, padding, or divider.

This reuses that shell: same width, inner `p-4` layout, search row height, and `bg-accent` divider.

## Test plan
- [x] `pnpm exec dprint fmt` on changed files
- [x] `pnpm exec oxlint --quiet --format=github` on changed files
- [x] `pnpm -F desktop typecheck`
- [x] `pnpm -F desktop exec vitest run src/session/components/folder-picker.test.tsx`
- [ ] Open the folder picker next to the calendar metadata popover and confirm matching chrome, padding, and divider

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

