### PR TITLE
fix(desktop): round share invite email field and button

### DIFF
--- a/apps/desktop/src/session-sharing/invite-recipients.test.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ShareInviteForm } from "./invite-recipients";
+
+vi.mock("~/contacts/queries", () => ({
+  useHumans: () => [],
+}));
+
+afterEach(cleanup);
+
+describe("ShareInviteForm", () => {
+  it("rounds the email field and invite button to match other share actions", () => {
+    render(
+      <ShareInviteForm
+        invite={createInvite()}
+        disabled={false}
+        pending={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const emailField = screen.getByRole("textbox", { name: "Invitee email" });
+    const inviteButton = screen.getByRole("button", { name: "Invite" });
+
+    expect(emailField.parentElement?.className).toContain("rounded-full");
+    expect(inviteButton.className).toContain("rounded-full");
+    expect(emailField.parentElement?.className).not.toContain("rounded-md");
+    expect(inviteButton.className).not.toContain("rounded-md");
+  });
+});
+
+function createInvite() {
+  return {
+    query: "",
+    setQuery: vi.fn(),
+    recipients: [],
+    emails: [],
+    canSubmit: false,
+    isSelectable: () => false,
+    add: vi.fn(),
+    commitQuery: vi.fn(),
+    remove: vi.fn(),
+    restore: vi.fn(),
+  };
+}

--- a/apps/desktop/src/session-sharing/invite-recipients.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.tsx
@@ -161,7 +161,7 @@ export function ShareInviteForm({
       >
         <div
           className={cn([
-            "border-input focus-within:ring-ring flex h-8 min-w-0 flex-1 items-center rounded-md border bg-transparent px-2 shadow-xs focus-within:ring-1",
+            "border-input focus-within:ring-ring flex h-8 min-w-0 flex-1 items-center rounded-full border bg-transparent px-3 shadow-xs focus-within:ring-1",
             disabled && "opacity-50",
           ])}
         >
@@ -186,7 +186,7 @@ export function ShareInviteForm({
           type="submit"
           size="sm"
           disabled={disabled || !invite.canSubmit}
-          className="h-8 shrink-0 rounded-md px-3"
+          className="h-8 shrink-0 rounded-full px-3"
         >
           {pending ? (
             <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The share popover’s email field and Invite button used `rounded-md`, so they looked sharper than the rest of that menu.

Both now use `rounded-full`, matching the app’s pill buttons.

## Test plan
- [x] `pnpm exec dprint fmt` on changed files
- [x] `pnpm exec oxlint --quiet --format=github` on changed files
- [x] `pnpm -F desktop typecheck`
- [x] `pnpm -F desktop exec vitest run src/session-sharing/invite-recipients.test.tsx`
- [ ] Open Share and confirm the email field and Invite button match the rounded share actions

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

