### PR TITLE
fix(ui): tighten app popover chrome gap to 2px

### DIFF
--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@anlg/utils";
 
 export const appFloatingContentClassName =
-  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-[22px] border p-1 shadow-lg";
+  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-[22px] border p-0.5 shadow-lg";
 
 export type FloatingContentVariant = "default" | "app";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
App floating menus used a 4px chrome inset (`p-1`) between the outer shell and inner panel. That gap is now 2px (`p-0.5`) for every `variant="app"` popover, dropdown, and hover card.

## Test plan
- [x] `pnpm exec dprint fmt` on the changed file
- [x] `pnpm -F @anlg/ui typecheck`
- [ ] Open the note overflow menu and other app popovers and confirm the chrome gap is 2px all around

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e08d34b6-cdfa-40f8-adf4-9cf48befdaf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

