### PR TITLE
Restore even left spacing for session view tabs

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -265,15 +265,34 @@ describe("OuterHeader", () => {
     const header = container.firstElementChild;
     const spacer = header?.firstElementChild;
 
-    expect(header?.className).toContain("pl-[116px]");
+    expect(header?.className).toContain("pl-[156px]");
     expect(header?.className).toContain("h-12");
     expect(header?.className).not.toContain("pb-1");
+    expect(header?.className).not.toContain("pl-1");
     expect(spacer?.className).toContain("flex-1");
     expect(spacer?.className).not.toContain("-translate-y-1");
     expect(spacer?.className).not.toContain("right-[140px]");
     expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+  });
+
+  it("uses the collapsed sidebar gutter without native chrome", () => {
+    mocks.leftsidebar.expanded = false;
+    mocks.windowControlsGutter = false;
+
+    const { container } = render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+      />,
+    );
+
+    const header = container.firstElementChild;
+
+    expect(header?.className).toContain("pl-[80px]");
+    expect(header?.className).not.toContain("pl-[156px]");
+    expect(header?.className).not.toContain("pl-1");
   });
 
   it("does not add a title offset while the sidebar is expanded", () => {
@@ -286,12 +305,15 @@ describe("OuterHeader", () => {
       />,
     );
 
-    const spacer = container.firstElementChild?.firstElementChild;
+    const header = container.firstElementChild;
+    const spacer = header?.firstElementChild;
 
     expect(spacer?.className).toContain("flex-1");
     expect(spacer?.className).not.toContain("right-[140px]");
     expect(spacer?.className).not.toContain("justify-center");
-    expect(container.firstElementChild?.className).not.toContain("pl-[114px]");
+    expect(header?.className).toContain("pl-1");
+    expect(header?.className).not.toContain("pl-[114px]");
+    expect(header?.className).not.toContain("pl-[156px]");
   });
 
   it.each([
@@ -327,7 +349,8 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
-    expect(container.firstElementChild?.className).not.toContain("pl-[116px]");
+    expect(container.firstElementChild?.className).toContain("pl-1");
+    expect(container.firstElementChild?.className).not.toContain("pl-[156px]");
   });
 
   it("keeps the session header at 48px tall", () => {
@@ -447,7 +470,7 @@ describe("OuterHeader", () => {
 
     const header = container.firstElementChild;
 
-    expect(header?.className).not.toContain("pl-[116px]");
+    expect(header?.className).not.toContain("pl-[156px]");
     expect(header?.className).toContain("pl-[76px]");
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -62,6 +62,7 @@ export function OuterHeader({
   const showWindowControlsGutter = useWindowControlsGutter();
   const showSidebarTimelineHeaderGutter =
     !standaloneWindow && !leftsidebar.expanded;
+  const showExpandedSidebarTabInset = !standaloneWindow && leftsidebar.expanded;
   const embedStopInViewSwitcher =
     viewSwitcher != null && isMeetingStopAction(sessionMode);
 
@@ -73,7 +74,8 @@ export function OuterHeader({
         "h-12",
         standaloneWindow && (showWindowControlsGutter ? "pl-[76px]" : "pl-2"),
         showSidebarTimelineHeaderGutter &&
-          (showWindowControlsGutter ? "pl-[116px]" : "pl-[48px]"),
+          (showWindowControlsGutter ? "pl-[156px]" : "pl-[80px]"),
+        showExpandedSidebarTabInset && "pl-1",
       ])}
     >
       {viewSwitcher}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The last toolbar pass tightened the collapsed-sidebar gutter and left the three note tabs flush against the main-card edge when the sidebar is open. That made the left side of the toolbar feel tighter and less even than the earlier left-aligned layout.

This restores the previous collapsed gutter (`156px` / `80px`, matching changelog) and adds a `4px` left inset when the sidebar is expanded so the tab pill lines up with the right-side action padding and the note content.

## Changes
- Restore collapsed-sidebar header gutter to `pl-[156px]` / `pl-[80px]`
- Inset left-aligned Summary / Memos / Transcript tabs by `pl-1` while the sidebar is expanded
- Cover both sidebar states in outer-header tests

Calendar, folder, and share stay in the right-hand action row. This only puts the tab spacing back.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37c25b97-220d-487f-909b-b26d94b35a59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37c25b97-220d-487f-909b-b26d94b35a59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

