### PR TITLE
changelog: add newsletter section art to 1.4.9-1.4.11

### DIFF
--- a/packages/changelog/content/1.4.10.md
+++ b/packages/changelog/content/1.4.10.md
@@ -5,6 +5,8 @@ summary: "Anarlog 1.4.10 adds summary length control, voice input and meeting pr
 
 ## Summaries and chat
 
+![Summaries](/api/assets/changelog/1.4-summaries.jpg)
+
 - Choose how detailed AI summaries should be with the new **Crisp**,
   **Balanced**, and **Detailed** modes in Settings → Meetings
 - Dictate into chat with the new microphone control: short recordings are
@@ -16,6 +18,8 @@ summary: "Anarlog 1.4.10 adds summary length control, voice input and meeting pr
   scroll long context chip rows instead of losing them
 
 ## Performance
+
+![Performance](/api/assets/changelog/1.4-performance.jpg)
 
 - Use far less CPU and memory while idle: background work now wakes only when
   something is actually due instead of running on constant timers

--- a/packages/changelog/content/1.4.11.md
+++ b/packages/changelog/content/1.4.11.md
@@ -5,6 +5,8 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
 
 ## Cloud sync
 
+![Cloud sync](/api/assets/changelog/1.4-devices.jpg)
+
 - Approve a new device from another device that already has sync access instead
   of entering the recovery key again
 - See pending devices in Settings → Sync, remove them, or replace an old device
@@ -16,6 +18,8 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
   locks that could leave cloud sync stuck while connecting
 
 ## Imports
+
+![Imports](/api/assets/changelog/1.4-imports.jpg)
 
 - Connect Zoom, Fathom, Notion AI Meeting Notes, Webex, Microsoft Teams, or
   Google Meet with **Connect & import**, then keep new meetings importing in
@@ -80,6 +84,8 @@ summary: "Anarlog 1.4.11 adds trusted-device cloud sync approval, bulk transcrip
 - Get the bundled `anarlog` CLI installed automatically when it is missing
 
 ## Other improvements
+
+![Other improvements](/api/assets/changelog/1.4-small-things.jpg)
 
 - Use a Windows-style application title bar on Linux
 - Find Email and Slack sharing in the overflow menu while invitations stay

--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -5,6 +5,8 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 
 ## Transcription
 
+![Transcription](/api/assets/changelog/1.4-transcription.jpg)
+
 - Transcribe long recordings through OpenAI, OpenRouter, Groq, Together AI,
   and xAI without hitting upload limits by splitting them into smaller segments
   and merging the results back onto one timeline
@@ -21,6 +23,8 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
   stop automatic summary retries after a bounded backoff instead of retrying
   forever
 ## Teams and contacts
+
+![Teams](/api/assets/changelog/1.4-team.jpg)
 
 - Create and manage shared workspaces from the new **Team** settings page:
   invite people, manage roles and seats, transfer ownership, leave, or delete


### PR DESCRIPTION
Adds the Midjourney section art from the Aug 20 product-update newsletter to the matching changelog sections:

- 1.4.9: Transcription, Teams and contacts
- 1.4.10: Summaries and chat, Performance
- 1.4.11: Cloud sync, Imports, Other improvements

Images are uploaded to the public_images storage bucket under changelog/ and referenced as /api/assets/changelog/*.jpg, the same pattern as the v1.0.0 entry. Markdown-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markdown image embeds; no application, security, or data-handling changes.
> 
> **Overview**
> Adds newsletter section images to the 1.4.9–1.4.11 changelog entries so those headings match the Aug 20 product-update art.
> 
> Images sit under the relevant headings (transcription, teams, summaries, performance, cloud sync, imports, and other improvements) and use the same `/api/assets/changelog/*.jpg` pattern as the v1.0.0 entry. Markdown-only; no copy or product behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbed5c8a57acfbc555404bd6b9201061aa114787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->