### PR TITLE
fix(linux): restore virtual-audio QA after PipeWire main-loop fallback

### DIFF
--- a/crates/audio-actual/src/speaker/linux.rs
+++ b/crates/audio-actual/src/speaker/linux.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::Once;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::thread;
 use std::time::Duration;
@@ -274,8 +275,7 @@ fn pipewire_capture_setup(
     shutdown_rx: pw::channel::Receiver<()>,
     init_tx: std::sync::mpsc::Sender<Result<()>>,
 ) -> Result<()> {
-    pw::init();
-    let _deinit_guard = PipeWireDeinitGuard;
+    ensure_pipewire_initialized();
 
     let mainloop =
         pw::main_loop::MainLoopRc::new(None).context("Failed to create PipeWire main loop")?;
@@ -438,12 +438,12 @@ fn pipewire_capture_setup(
     Ok(())
 }
 
-struct PipeWireDeinitGuard;
-
-impl Drop for PipeWireDeinitGuard {
-    fn drop(&mut self) {
-        unsafe { pw::deinit() };
-    }
+fn ensure_pipewire_initialized() {
+    // Permission probes and capture restarts create a second main loop in the
+    // same process. pw_deinit() is not safely reversible, so init once and leave
+    // the library loaded.
+    static INIT: Once = Once::new();
+    INIT.call_once(pw::init);
 }
 
 fn pulseaudio_capture_loop(

--- a/crates/device-monitor/src/linux.rs
+++ b/crates/device-monitor/src/linux.rs
@@ -12,6 +12,42 @@ use std::rc::Rc;
 use std::sync::mpsc;
 
 type PulseAudioHandles = (Rc<RefCell<Mainloop>>, Rc<RefCell<Context>>);
+type DeviceSwitchEmit = Rc<dyn Fn(DeviceSwitch)>;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DefaultDeviceChanges {
+    source_changed: bool,
+    sink_changed: bool,
+}
+
+#[derive(Debug, Default)]
+struct DefaultDevices {
+    source: Option<String>,
+    sink: Option<String>,
+    primed: bool,
+}
+
+impl DefaultDevices {
+    fn observe(&mut self, source: Option<&str>, sink: Option<&str>) -> DefaultDeviceChanges {
+        let source = source.map(str::to_owned);
+        let sink = sink.map(str::to_owned);
+        if !self.primed {
+            self.source = source;
+            self.sink = sink;
+            self.primed = true;
+            return DefaultDeviceChanges::default();
+        }
+
+        let source_changed = source.is_some() && source != self.source;
+        let sink_changed = sink.is_some() && sink != self.sink;
+        self.source = source;
+        self.sink = sink;
+        DefaultDeviceChanges {
+            source_changed,
+            sink_changed,
+        }
+    }
+}
 
 fn is_headphone_from_default_output_device() -> Option<bool> {
     anlg_audio_device::linux::is_headphone_from_default_output_device()
@@ -106,13 +142,44 @@ fn cleanup_pulseaudio(mainloop: Rc<RefCell<Mainloop>>, context: Rc<RefCell<Conte
     mainloop.borrow_mut().stop();
 }
 
-pub(crate) fn monitor_device_change(
-    event_tx: mpsc::SyncSender<DeviceSwitch>,
-    stop_rx: mpsc::Receiver<()>,
+fn refresh_default_devices(
+    context: &Rc<RefCell<Context>>,
+    tracker: &Rc<RefCell<DefaultDevices>>,
+    emit: &DeviceSwitchEmit,
 ) {
-    let Some((mainloop, context)) = setup_pulseaudio(&stop_rx) else {
+    let Ok(ctx) = context.try_borrow() else {
         return;
     };
+    let tracker = Rc::clone(tracker);
+    let emit = Rc::clone(emit);
+    ctx.introspect().get_server_info(move |info| {
+        let source = info.default_source_name.as_deref();
+        let sink = info.default_sink_name.as_deref();
+        let changes = tracker.borrow_mut().observe(source, sink);
+        if changes.source_changed {
+            tracing::info!(
+                anarlog.audio.default_source = source.unwrap_or(""),
+                "default_source_changed"
+            );
+            emit(DeviceSwitch::DefaultInputChanged);
+        }
+        if changes.sink_changed {
+            tracing::info!(
+                anarlog.audio.default_sink = sink.unwrap_or(""),
+                "default_sink_changed"
+            );
+            emit(DeviceSwitch::DefaultOutputChanged {
+                headphone: is_headphone_from_default_output_device(),
+            });
+        }
+    });
+}
+
+fn subscribe_pulse_device_events(context: &Rc<RefCell<Context>>, emit: DeviceSwitchEmit) {
+    let tracker = Rc::new(RefCell::new(DefaultDevices::default()));
+    let context_for_callback = Rc::clone(context);
+    let emit_for_callback = Rc::clone(&emit);
+    let tracker_for_callback = Rc::clone(&tracker);
 
     context.borrow_mut().subscribe(
         InterestMaskSet::SINK | InterestMaskSet::SOURCE | InterestMaskSet::SERVER,
@@ -123,32 +190,45 @@ pub(crate) fn monitor_device_change(
         },
     );
 
-    let event_tx_for_callback = event_tx.clone();
     context.borrow_mut().set_subscribe_callback(Some(Box::new(
         move |facility, operation, _index| match (facility, operation) {
-            (Some(Facility::Server), Some(Operation::Changed)) => {
-                let _ = event_tx_for_callback.try_send(DeviceSwitch::DefaultInputChanged);
-                let _ = event_tx_for_callback.try_send(DeviceSwitch::DefaultOutputChanged {
-                    headphone: is_headphone_from_default_output_device(),
-                });
+            (Some(Facility::Sink), Some(Operation::New | Operation::Removed))
+            | (Some(Facility::Source), Some(Operation::New | Operation::Removed)) => {
+                emit_for_callback(DeviceSwitch::DeviceListChanged);
+                refresh_default_devices(
+                    &context_for_callback,
+                    &tracker_for_callback,
+                    &emit_for_callback,
+                );
             }
-            (Some(Facility::Sink), Some(Operation::Changed)) => {
-                let _ = event_tx_for_callback.try_send(DeviceSwitch::DefaultOutputChanged {
-                    headphone: is_headphone_from_default_output_device(),
-                });
-            }
-            (Some(Facility::Sink), Some(Operation::New | Operation::Removed)) => {
-                let _ = event_tx_for_callback.try_send(DeviceSwitch::DeviceListChanged);
-            }
-            (Some(Facility::Source), Some(Operation::Changed)) => {
-                let _ = event_tx_for_callback.try_send(DeviceSwitch::DefaultInputChanged);
-            }
-            (Some(Facility::Source), Some(Operation::New | Operation::Removed)) => {
-                let _ = event_tx_for_callback.try_send(DeviceSwitch::DeviceListChanged);
+            (Some(Facility::Server), Some(Operation::Changed))
+            | (Some(Facility::Sink), Some(Operation::Changed))
+            | (Some(Facility::Source), Some(Operation::Changed)) => {
+                refresh_default_devices(
+                    &context_for_callback,
+                    &tracker_for_callback,
+                    &emit_for_callback,
+                );
             }
             _ => {}
         },
     )));
+
+    refresh_default_devices(context, &tracker, &emit);
+}
+
+pub(crate) fn monitor_device_change(
+    event_tx: mpsc::SyncSender<DeviceSwitch>,
+    stop_rx: mpsc::Receiver<()>,
+) {
+    let Some((mainloop, context)) = setup_pulseaudio(&stop_rx) else {
+        return;
+    };
+
+    let emit: DeviceSwitchEmit = Rc::new(move |switch| {
+        let _ = event_tx.try_send(switch);
+    });
+    subscribe_pulse_device_events(&context, emit);
 
     mainloop.borrow_mut().unlock();
 
@@ -174,49 +254,10 @@ pub(crate) fn monitor(event_tx: mpsc::SyncSender<DeviceEvent>, stop_rx: mpsc::Re
         return;
     };
 
-    context.borrow_mut().subscribe(
-        InterestMaskSet::SINK | InterestMaskSet::SOURCE | InterestMaskSet::SERVER,
-        |success| {
-            if !success {
-                tracing::error!("Failed to subscribe to PulseAudio events");
-            }
-        },
-    );
-
-    let event_tx_for_callback = event_tx.clone();
-    context.borrow_mut().set_subscribe_callback(Some(Box::new(
-        move |facility, operation, _index| match (facility, operation) {
-            (Some(Facility::Server), Some(Operation::Changed)) => {
-                let _ = event_tx_for_callback
-                    .try_send(DeviceEvent::Switch(DeviceSwitch::DefaultInputChanged));
-                let _ = event_tx_for_callback.try_send(DeviceEvent::Switch(
-                    DeviceSwitch::DefaultOutputChanged {
-                        headphone: is_headphone_from_default_output_device(),
-                    },
-                ));
-            }
-            (Some(Facility::Sink), Some(Operation::Changed)) => {
-                let _ = event_tx_for_callback.try_send(DeviceEvent::Switch(
-                    DeviceSwitch::DefaultOutputChanged {
-                        headphone: is_headphone_from_default_output_device(),
-                    },
-                ));
-            }
-            (Some(Facility::Sink), Some(Operation::New | Operation::Removed)) => {
-                let _ = event_tx_for_callback
-                    .try_send(DeviceEvent::Switch(DeviceSwitch::DeviceListChanged));
-            }
-            (Some(Facility::Source), Some(Operation::Changed)) => {
-                let _ = event_tx_for_callback
-                    .try_send(DeviceEvent::Switch(DeviceSwitch::DefaultInputChanged));
-            }
-            (Some(Facility::Source), Some(Operation::New | Operation::Removed)) => {
-                let _ = event_tx_for_callback
-                    .try_send(DeviceEvent::Switch(DeviceSwitch::DeviceListChanged));
-            }
-            _ => {}
-        },
-    )));
+    let emit: DeviceSwitchEmit = Rc::new(move |switch| {
+        let _ = event_tx.try_send(DeviceEvent::Switch(switch));
+    });
+    subscribe_pulse_device_events(&context, emit);
 
     mainloop.borrow_mut().unlock();
 
@@ -227,4 +268,66 @@ pub(crate) fn monitor(event_tx: mpsc::SyncSender<DeviceEvent>, stop_rx: mpsc::Re
     cleanup_pulseaudio(mainloop, context);
 
     tracing::info!("monitor_stopped");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_observe_establishes_baseline_without_emitting() {
+        let mut devices = DefaultDevices::default();
+
+        assert_eq!(
+            devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system")),
+            DefaultDeviceChanges::default()
+        );
+    }
+
+    #[test]
+    fn source_property_change_does_not_count_as_default_input_change() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
+
+        assert_eq!(
+            devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system")),
+            DefaultDeviceChanges::default()
+        );
+    }
+
+    #[test]
+    fn default_source_change_emits_only_source() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
+
+        assert_eq!(
+            devices.observe(Some("alsa_input.usb"), Some("qa_system")),
+            DefaultDeviceChanges {
+                source_changed: true,
+                sink_changed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn default_sink_change_emits_only_sink() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
+
+        assert_eq!(
+            devices.observe(Some("qa_mic_bus.monitor"), Some("alsa_output.usb")),
+            DefaultDeviceChanges {
+                source_changed: false,
+                sink_changed: true,
+            }
+        );
+    }
+
+    #[test]
+    fn missing_defaults_after_baseline_do_not_emit() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
+
+        assert_eq!(devices.observe(None, None), DefaultDeviceChanges::default());
+    }
 }

--- a/crates/device-monitor/src/linux.rs
+++ b/crates/device-monitor/src/linux.rs
@@ -24,27 +24,30 @@ struct DefaultDeviceChanges {
 struct DefaultDevices {
     source: Option<String>,
     sink: Option<String>,
-    primed: bool,
 }
 
 impl DefaultDevices {
     fn observe(&mut self, source: Option<&str>, sink: Option<&str>) -> DefaultDeviceChanges {
-        let source = source.map(str::to_owned);
-        let sink = sink.map(str::to_owned);
-        if !self.primed {
-            self.source = source;
-            self.sink = sink;
-            self.primed = true;
-            return DefaultDeviceChanges::default();
-        }
-
-        let source_changed = source.is_some() && source != self.source;
-        let sink_changed = sink.is_some() && sink != self.sink;
-        self.source = source;
-        self.sink = sink;
         DefaultDeviceChanges {
-            source_changed,
-            sink_changed,
+            source_changed: Self::observe_name(&mut self.source, source),
+            sink_changed: Self::observe_name(&mut self.sink, sink),
+        }
+    }
+
+    fn observe_name(stored: &mut Option<String>, incoming: Option<&str>) -> bool {
+        let Some(incoming) = incoming else {
+            return false;
+        };
+        match stored.as_deref() {
+            Some(previous) if previous != incoming => {
+                *stored = Some(incoming.to_owned());
+                true
+            }
+            None => {
+                *stored = Some(incoming.to_owned());
+                false
+            }
+            Some(_) => false,
         }
     }
 }
@@ -329,5 +332,43 @@ mod tests {
         devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
 
         assert_eq!(devices.observe(None, None), DefaultDeviceChanges::default());
+    }
+
+    #[test]
+    fn null_defaults_do_not_clear_baseline() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
+        devices.observe(None, None);
+
+        assert_eq!(
+            devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system")),
+            DefaultDeviceChanges::default()
+        );
+    }
+
+    #[test]
+    fn first_real_names_after_null_observation_are_baseline() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(None, None);
+
+        assert_eq!(
+            devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system")),
+            DefaultDeviceChanges::default()
+        );
+    }
+
+    #[test]
+    fn default_change_after_null_refresh_still_emits() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("qa_system"));
+        devices.observe(None, None);
+
+        assert_eq!(
+            devices.observe(Some("alsa_input.usb"), Some("qa_system")),
+            DefaultDeviceChanges {
+                source_changed: true,
+                sink_changed: false,
+            }
+        );
     }
 }

--- a/scripts/qa/linux_virtual_audio_smoke.sh
+++ b/scripts/qa/linux_virtual_audio_smoke.sh
@@ -110,6 +110,24 @@ EOF
   exec dbus-run-session -- "$script_path" "$deb_path"
 fi
 
+# dbus-run-session / systemd --user can reset XDG_RUNTIME_DIR back to the
+# host session. Pin the fixture again so pw-cli/pactl never talk to the
+# runner's system PipeWire, which answers load-module with "Failure: Not supported".
+qa_root=${QA_ROOT:?QA_ROOT is required inside the dbus session}
+export XDG_RUNTIME_DIR="$qa_root/runtime"
+export PIPEWIRE_RUNTIME_DIR="$qa_root/runtime"
+export PULSE_RUNTIME_PATH="$qa_root/runtime/pulse"
+export PULSE_SERVER="unix:$qa_root/runtime/pulse/native"
+unset PIPEWIRE_REMOTE
+mkdir -p "$XDG_RUNTIME_DIR" "$PULSE_RUNTIME_PATH"
+{
+  echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+  echo "PIPEWIRE_RUNTIME_DIR=$PIPEWIRE_RUNTIME_DIR"
+  echo "PULSE_RUNTIME_PATH=$PULSE_RUNTIME_PATH"
+  echo "PULSE_SERVER=$PULSE_SERVER"
+  echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS:-}"
+} > "$artifact_dir/audio-runtime-env.txt"
+
 for command in arecord pactl paplay pipewire pipewire-pulse pw-cli wireplumber; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "Missing required audio command: $command" >&2
@@ -144,6 +162,19 @@ wait_for() {
   return 1
 }
 
+load_null_sink() {
+  local sink_name=$1
+  local module
+  if ! module=$(pactl load-module module-null-sink \
+    sink_name="$sink_name" rate=48000 channels=1); then
+    echo "Failed to load module-null-sink $sink_name" >&2
+    pactl info > "$artifact_dir/pactl-info.txt" 2>&1 || true
+    exit 1
+  fi
+  printf '%s\n' "$module"
+}
+
+wait_for "isolated PipeWire socket" test -S "$XDG_RUNTIME_DIR/pipewire-0"
 wait_for "PipeWire core" pw-cli info 0
 
 wireplumber > "$artifact_dir/wireplumber.log" 2>&1 &
@@ -151,12 +182,11 @@ service_pids+=("$!")
 pipewire-pulse > "$artifact_dir/pipewire-pulse.log" 2>&1 &
 service_pids+=("$!")
 
+wait_for "isolated Pulse socket" test -S "$PULSE_RUNTIME_PATH/native"
 wait_for "PipeWire Pulse server" pactl info
 
-system_module=$(pactl load-module module-null-sink \
-  sink_name=qa_system rate=48000 channels=1)
-mic_module=$(pactl load-module module-null-sink \
-  sink_name=qa_mic_bus rate=48000 channels=1)
+system_module=$(load_null_sink qa_system)
+mic_module=$(load_null_sink qa_mic_bus)
 pactl set-default-sink qa_system
 pactl set-default-source qa_mic_bus.monitor
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [ANLG-293](https://linear.app/fastrepl-inc/issue/ANLG-293/linux-virtual-audio-qa-fails-recording-tail-after-pipewire-main-loop).

Linux 1.4.11 virtual-audio QA recorded usable mic/system tracks, then failed the recording-tail check (~−1.95s vs ±0.5s). Logs showed PipeWire initializing, a capture restart about a second later, `Failed to create PipeWire main loop`, and PulseAudio fallback. The WAV was short because that restart dropped the first second of capture and the verifier’s alignment offset then pushed the tail past the gate.

## Cause

Opening capture fires PulseAudio `Source Changed` (port/volume/use count). The Linux device monitor treated every source change as `DefaultInputChanged`. The source actor stopped and restarted after the 1s debounce. Dropping the first PipeWire stream called `pw_deinit()`, so the next `MainLoopRc::new` failed and capture fell back to PulseAudio.

The x64 retry also died earlier with `Failure: Not supported` from `pactl load-module` after talking to the runner’s system Pulse server instead of the isolated fixture.

## Changes

- Init PipeWire once per process and never deinit it, so permission probes and genuine restarts can create a second main loop.
- Emit `DefaultInputChanged` / `DefaultOutputChanged` only when the PulseAudio default source/sink **name** changes. Missing (`None`) refreshes keep the last known name, so a later identical name is not treated as a switch.
- Re-pin `XDG_RUNTIME_DIR` / `PIPEWIRE_RUNTIME_DIR` / `PULSE_SERVER` inside `dbus-run-session`, wait for the isolated sockets, and fail `load-module` against the fixture Pulse server.

## Gate restore

This does not itself re-run `desktop_linux_audio_qa.yaml`. That workflow still requires a 1.4.12 dry-run on current `main`. After this lands, run the QA workflow against that dry-run before publishing Linux 1.4.12.

## Validation

- `cargo test --locked -p device-monitor --lib`
- `cargo check --locked -p audio-actual -p device-monitor`
- `cargo clippy --locked -p device-monitor --lib -- -D warnings`
- `bash -n scripts/qa/linux_virtual_audio_smoke.sh`

`cargo test -p audio-actual --lib` could not link in this environment (`-lstdc++` missing). `cargo clippy -p audio-actual --lib -- -D warnings` reports existing dead-code / too-many-arguments lints unrelated to this change; CI does not apply that clippy gate to this crate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02233-f371-71de-a4f4-ed3b500fe676?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02233-f371-71de-a4f4-ed3b500fe676&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

