### PR TITLE
fix(desktop): keep transcript playback aligned when leftover rows exist

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.test.tsx
@@ -2,7 +2,10 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TRANSCRIPT_RENDER_CACHE_TIME_MS } from "../cache";
-import { useRenderedTranscriptData } from "./data-hooks";
+import {
+  getTranscriptTimelineOffsetMs,
+  useRenderedTranscriptData,
+} from "./data-hooks";
 
 const mocks = vi.hoisted(() => ({
   getRenderTranscriptRequestKey: vi.fn((_request: unknown) => "request-key"),
@@ -236,5 +239,34 @@ describe("useRenderedTranscriptData", () => {
     ]);
     await nextCaptureQuery.queryFn();
     expect(mocks.renderTranscriptSegments).toHaveBeenLastCalledWith(requestD);
+  });
+});
+
+describe("getTranscriptTimelineOffsetMs", () => {
+  it("keeps a single transcript at audio time zero", () => {
+    expect(
+      getTranscriptTimelineOffsetMs(1_700_000_000_000, [
+        { startedAt: 1_700_000_000_000, hasWords: true },
+      ]),
+    ).toBe(0);
+  });
+
+  it("ignores empty leftover rows that default started_at_ms to zero", () => {
+    expect(
+      getTranscriptTimelineOffsetMs(1_700_000_000_500, [
+        { startedAt: 0, hasWords: false },
+        { startedAt: 1_700_000_000_500, hasWords: true },
+      ]),
+    ).toBe(0);
+  });
+
+  it("offsets later captures from the earliest transcript that has words", () => {
+    expect(
+      getTranscriptTimelineOffsetMs(1_700_000_060_000, [
+        { startedAt: 0, hasWords: false },
+        { startedAt: 1_700_000_000_000, hasWords: true },
+        { startedAt: 1_700_000_060_000, hasWords: true },
+      ]),
+    ).toBe(60_000);
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -99,6 +99,30 @@ export function useRenderedTranscriptData(
   return { maxSpeakerNumber, request, segments: data };
 }
 
+export function getTranscriptTimelineOffsetMs(
+  transcriptStartedAt: number,
+  sessionTranscripts: ReadonlyArray<{
+    startedAt: number;
+    hasWords: boolean;
+  }>,
+): number {
+  const candidates = sessionTranscripts.filter(
+    (current) => Number.isFinite(current.startedAt) && current.startedAt > 0,
+  );
+  const withWords = candidates.filter((current) => current.hasWords);
+  const pool = withWords.length > 0 ? withWords : candidates;
+  if (pool.length === 0) {
+    return 0;
+  }
+
+  const earliestStartedAt = Math.min(
+    ...pool.map((current) => current.startedAt),
+  );
+  return Number.isFinite(earliestStartedAt)
+    ? Math.max(0, transcriptStartedAt - earliestStartedAt)
+    : 0;
+}
+
 export function useTranscriptTimelineMetadata(transcriptId: string): {
   offsetMs: number;
   sessionId?: string;
@@ -111,14 +135,11 @@ export function useTranscriptTimelineMetadata(transcriptId: string): {
       return { offsetMs: 0 };
     }
 
-    const earliestStartedAt = Math.min(
-      ...transcripts.map((current) => current.startedAt),
-    );
-
     return {
-      offsetMs: Number.isFinite(earliestStartedAt)
-        ? transcript.startedAt - earliestStartedAt
-        : 0,
+      offsetMs: getTranscriptTimelineOffsetMs(
+        transcript.startedAt,
+        transcripts,
+      ),
       sessionId: transcript.sessionId,
     };
   }, [transcript, transcripts]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Customer report

eduardoaosorio (Discord help, Soniox 5 / `stt-rt-v5`, desktop **1.4.11** on macOS 26.6) said recording and transcription are no longer aligned after the latest update:

- Clicking a transcript word does not seek to the matching audio time
- Scrubbing audio does not highlight the matching transcript

Both directions failing means the **word clock and the playback clock disagree**, not a click-handler-only or virtualization-only bug.

Confirmed in PostHog: `eduardoaosorio95@gmail.com`, `current_stt_provider: soniox`, `current_stt_model: stt-rt-v5`, `app_version: 1.4.11`. No matching Linear or GitHub issue.

## What it is not

- **1.4.11 speaker-label PR (#6916).** Changelog line “keep speaker labels aligned with their words” is sticky-header / `translateY` → `top` layout only. It does not change timestamps.
- **Soniox timestamp units.** Current Soniox docs still use `start_ms` / `end_ms` relative to audio start. Our adapter still does `ms → seconds → persist as ms`. A float `start_ms` would fail the whole message parse; the user has a working transcript.
- **The 1.4.11 Select-mode / bulk-edit work.** That does not rewrite word times.

## Root cause

Seek and highlight both use:

`offsetMs + word.start_ms`

`offsetMs` comes from `useTranscriptTimelineMetadata`:

`transcript.startedAt - min(all session transcripts' startedAt)`

`transcripts.started_at_ms` is `INTEGER NOT NULL DEFAULT 0`. The session metadata query includes **every non-deleted row**, including empty leftovers. If any stub is at `0` and the real capture is `Date.now()` (~1.7e12), `offsetMs` becomes a unix timestamp.

- Seek jumps to billions of seconds
- Highlight never matches WaveSurfer time (`time.current * 1000`)

That matches the report exactly. It is easy to attribute to Soniox because that is what they use; the bug is in session timeline math, not the Soniox adapter.

1.4.10 made this more likely: live-delta writes and the switch to `useSessionTranscriptMetadata` (same min math, more leftover rows). 1.4.11 is the update they are on.

## Other real but weaker mismatches

These can shift alignment but do not produce a total bidirectional miss on a single fresh capture:

- Live STT `apply_offset` uses wall-clock `session_started_at.elapsed()` when `stream_offset_secs` is unset (connection delay, seconds).
- Resume / append uses wall-clock `startedAt` gaps in the UI, while `audioOffsetMs` is only applied in post-stop batch repair.

## Fix

When computing the session origin, ignore empty rows and `started_at_ms <= 0` (schema default / unset). Keep the existing wall-clock gap between real captures that have words.

## Follow-up (not in this PR)

- Ask whether the broken note is a single capture or a resumed / multi-transcript session.
- If it is still wrong on a **single** transcript with no leftover rows, next place to look is live `stream_offset_secs` vs audio samples, not Soniox JSON parsing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02281-76e6-7a54-8d2e-cf600b00aae7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02281-76e6-7a54-8d2e-cf600b00aae7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

