### PR TITLE
Restore even left spacing for session view tabs.

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -265,7 +265,7 @@ describe("OuterHeader", () => {
     const header = container.firstElementChild;
     const spacer = header?.firstElementChild;
 
-    expect(header?.className).toContain("pl-[116px]");
+    expect(header?.className).toContain("pl-[156px]");
     expect(header?.className).toContain("h-12");
     expect(header?.className).not.toContain("pb-1");
     expect(spacer?.className).toContain("flex-1");
@@ -274,6 +274,22 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Show sidebar" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
+  });
+
+  it("uses the collapsed sidebar gutter without native window controls", () => {
+    mocks.leftsidebar.expanded = false;
+    mocks.windowControlsGutter = false;
+
+    const { container } = render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+      />,
+    );
+
+    expect(container.firstElementChild?.className).toContain("pl-[80px]");
+    expect(container.firstElementChild?.className).not.toContain("pl-[156px]");
+    expect(container.firstElementChild?.className).not.toContain("pl-2");
   });
 
   it("does not add a title offset while the sidebar is expanded", () => {
@@ -291,7 +307,9 @@ describe("OuterHeader", () => {
     expect(spacer?.className).toContain("flex-1");
     expect(spacer?.className).not.toContain("right-[140px]");
     expect(spacer?.className).not.toContain("justify-center");
+    expect(container.firstElementChild?.className).toContain("pl-2");
     expect(container.firstElementChild?.className).not.toContain("pl-[114px]");
+    expect(container.firstElementChild?.className).not.toContain("pl-[156px]");
   });
 
   it.each([
@@ -327,7 +345,8 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
-    expect(container.firstElementChild?.className).not.toContain("pl-[116px]");
+    expect(container.firstElementChild?.className).toContain("pl-2");
+    expect(container.firstElementChild?.className).not.toContain("pl-[156px]");
   });
 
   it("keeps the session header at 48px tall", () => {
@@ -447,7 +466,7 @@ describe("OuterHeader", () => {
 
     const header = container.firstElementChild;
 
-    expect(header?.className).not.toContain("pl-[116px]");
+    expect(header?.className).not.toContain("pl-[156px]");
     expect(header?.className).toContain("pl-[76px]");
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -72,8 +72,9 @@ export function OuterHeader({
         "relative flex w-full items-center",
         "h-12",
         standaloneWindow && (showWindowControlsGutter ? "pl-[76px]" : "pl-2"),
+        !standaloneWindow && leftsidebar.expanded && "pl-2",
         showSidebarTimelineHeaderGutter &&
-          (showWindowControlsGutter ? "pl-[116px]" : "pl-[48px]"),
+          (showWindowControlsGutter ? "pl-[156px]" : "pl-[80px]"),
       ])}
     >
       {viewSwitcher}


### PR DESCRIPTION
Give the Summary/Memos/Transcript pill the same breathing room it had before the toolbar tighten, both with the sidebar open and collapsed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only padding class changes on the session header; no logic, auth, or data handling impact.
> 
> **Overview**
> Restores even left spacing for the session Summary/Memos/Transcript pill after the toolbar tighten.
> 
> When the sidebar is collapsed, `OuterHeader` now uses the same gutter as other note headers (`pl-[156px]` with native window controls, `pl-[80px]` without). When the sidebar is expanded in the main window, it applies `pl-2` so the tabs sit off the left edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f7bfb0dfea8278ba495fcb6c1ab71f2e370a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->