### PR TITLE
fix(desktop): dismiss event notifications 5 minutes after start

### DIFF
--- a/crates/notification-interface/src/lib.rs
+++ b/crates/notification-interface/src/lib.rs
@@ -1,5 +1,23 @@
 use std::collections::BTreeSet;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+pub const STARTED_NOTIFICATION_LINGER: Duration = Duration::from_secs(5 * 60);
+
+pub fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+pub fn started_notification_remaining(start_time: i64, now_unix: i64) -> Duration {
+    let deadline = start_time.saturating_add(STARTED_NOTIFICATION_LINGER.as_secs() as i64);
+    Duration::from_secs(deadline.saturating_sub(now_unix).max(0) as u64)
+}
+
+pub fn should_dismiss_started_notification(start_time: i64, now_unix: i64) -> bool {
+    started_notification_remaining(start_time, now_unix).is_zero()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
 pub enum NotificationEvent {
@@ -320,6 +338,11 @@ impl Notification {
             .map(|details| details.what.as_str())
             .filter(|title| !title.is_empty())
             .unwrap_or(self.title.as_str())
+    }
+
+    pub fn should_dismiss_started(&self, now_unix: i64) -> bool {
+        self.start_time
+            .is_some_and(|start_time| should_dismiss_started_notification(start_time, now_unix))
     }
 
     pub fn compact_message(&self, remaining: Option<Duration>) -> String {
@@ -761,5 +784,32 @@ mod tests {
         );
         assert!((timer.progress_ratio(resumed + Duration::from_secs(2)) - 0.4).abs() < 1e-9);
         assert!(timer.is_expired(resumed + Duration::from_secs(6)));
+    }
+
+    #[test]
+    fn started_notifications_linger_five_minutes_after_start() {
+        let start_time = 1_700_000_000;
+        let notification = Notification::builder()
+            .title("Standup")
+            .message("Starting soon")
+            .source(NotificationSource::CalendarEvent {
+                event_id: "evt-1".to_string(),
+            })
+            .start_time(start_time)
+            .build();
+
+        assert!(!notification.should_dismiss_started(start_time + 4 * 60));
+        assert!(notification.should_dismiss_started(start_time + 5 * 60));
+        assert_eq!(
+            started_notification_remaining(start_time, start_time + 2 * 60),
+            Duration::from_secs(3 * 60)
+        );
+        assert!(
+            !Notification::builder()
+                .title("Mic")
+                .message("")
+                .build()
+                .should_dismiss_started(start_time + 5 * 60)
+        );
     }
 }

--- a/crates/notification-linux/src/impl.rs
+++ b/crates/notification-linux/src/impl.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use gdk::prelude::*;
 use gtk::gdk::NotifyType;
@@ -11,7 +11,7 @@ use gtk::{
 use indexmap::IndexMap;
 
 use anlg_notification_interface::{
-    DismissTimer, ParticipantStatus, PrimaryAction, expanded_schedule_text,
+    DismissTimer, ParticipantStatus, PrimaryAction, expanded_schedule_text, unix_now,
 };
 
 use crate::callbacks;
@@ -65,12 +65,8 @@ impl NotificationInstance {
 
     fn schedule_remaining(&self) -> Option<Duration> {
         let start_time = self.payload.start_time?;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
         Some(Duration::from_secs(
-            start_time.saturating_sub(now).max(0) as u64
+            start_time.saturating_sub(unix_now()).max(0) as u64,
         ))
     }
 
@@ -528,6 +524,15 @@ impl NotificationManager {
             .and_then(|instance| instance.dismiss_timer.as_ref())
             .is_some_and(|timer| timer.is_running() && timer.is_expired(now));
         if expired {
+            self.dismiss_key(key, DismissReason::Timeout);
+            return;
+        }
+
+        let started_expired = self
+            .active_notifications
+            .get(key)
+            .is_some_and(|instance| instance.payload.should_dismiss_started(unix_now()));
+        if started_expired {
             self.dismiss_key(key, DismissReason::Timeout);
             return;
         }

--- a/crates/notification-macos/swift-lib/src/Models.swift
+++ b/crates/notification-macos/swift-lib/src/Models.swift
@@ -207,6 +207,14 @@ enum NotificationActionVariant: String, Codable {
   case destructive = "destructive"
 }
 
+enum NotificationSchedule {
+  static let startedLinger: TimeInterval = 5 * 60
+
+  static func dismissDelay(afterStart startTime: Date, now: Date = Date()) -> TimeInterval {
+    startTime.addingTimeInterval(startedLinger).timeIntervalSince(now)
+  }
+}
+
 struct NotificationPayload: Codable {
   let key: String
   let title: String

--- a/crates/notification-macos/swift-lib/src/NotificationInstance.swift
+++ b/crates/notification-macos/swift-lib/src/NotificationInstance.swift
@@ -99,10 +99,27 @@ class NotificationInstance {
       timerLabel?.stringValue = "Started"
       countdownTimer?.invalidate()
       countdownTimer = nil
+      scheduleStartedDismiss()
     } else {
       compactMessageLabel?.stringValue = compactScheduleText(remaining)
       timerLabel?.stringValue = expandedScheduleText(remaining)
     }
+  }
+
+  private func scheduleStartedDismiss() {
+    guard timeoutSeconds <= 0 else { return }
+    guard dismissTimer == nil else { return }
+    guard let startTime = meetingStartTime else { return }
+
+    let delay = NotificationSchedule.dismissDelay(afterStart: startTime)
+    if delay <= 0 {
+      DispatchQueue.main.async { [weak self] in
+        self?.dismissWithTimeout()
+      }
+      return
+    }
+
+    scheduleDismissTimer(after: delay)
   }
 
   private func compactScheduleText(_ remaining: TimeInterval) -> String {

--- a/crates/notification-macos/swift-lib/tests/NotificationManagerTests.swift
+++ b/crates/notification-macos/swift-lib/tests/NotificationManagerTests.swift
@@ -75,6 +75,25 @@ final class NotificationManagerTests: XCTestCase {
     XCTAssertNil(manager.hoverStates[original.key])
   }
 
+  func testStartedNotificationsLingerFiveMinutesAfterStart() {
+    let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    XCTAssertEqual(
+      NotificationSchedule.dismissDelay(
+        afterStart: start, now: start.addingTimeInterval(2 * 60)),
+      3 * 60,
+      accuracy: 0.001)
+    XCTAssertEqual(
+      NotificationSchedule.dismissDelay(
+        afterStart: start, now: start.addingTimeInterval(5 * 60)),
+      0,
+      accuracy: 0.001)
+    XCTAssertLessThan(
+      NotificationSchedule.dismissDelay(
+        afterStart: start, now: start.addingTimeInterval(6 * 60)),
+      0)
+  }
+
   private func makeNotification(index: Int, key: String? = nil) -> NotificationInstance {
     let payload = NotificationPayload(
       key: key ?? "notification-\(index)",

--- a/crates/notification-windows/src/impl.rs
+++ b/crates/notification-windows/src/impl.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use indexmap::IndexMap;
 use windows::Win32::Foundation::{COLORREF, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
@@ -34,7 +34,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 use windows::core::{PCWSTR, w};
 
 use anlg_notification_interface::{
-    DismissTimer, Notification, PrimaryAction, expanded_schedule_text,
+    DismissTimer, Notification, PrimaryAction, expanded_schedule_text, unix_now,
 };
 
 use crate::callbacks;
@@ -190,6 +190,16 @@ impl NotificationManager {
                 .map(|_| instance.key.clone())
         });
         if let Some(key) = key {
+            self.dismiss(&key, DismissReason::Timeout);
+            return;
+        }
+        let started_key = self.instance_by_hwnd_mut(hwnd).and_then(|instance| {
+            instance
+                .payload
+                .should_dismiss_started(unix_now())
+                .then(|| instance.key.clone())
+        });
+        if let Some(key) = started_key {
             self.dismiss(&key, DismissReason::Timeout);
             return;
         }
@@ -696,12 +706,8 @@ fn expanded_body(notification: &Notification, remaining: Option<Duration>) -> St
 impl NotificationInstance {
     fn schedule_remaining(&self) -> Option<Duration> {
         let start_time = self.payload.start_time?;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
         Some(Duration::from_secs(
-            start_time.saturating_sub(now).max(0) as u64
+            start_time.saturating_sub(unix_now()).max(0) as u64,
         ))
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event notifications currently stay on screen after they flip to **Started**. This auto-dismisses them **5 minutes after the event start time**.

The existing `timeout` path is not a good fit here: it drives the action-button progress bar and pauses on hover, which would keep “Started” banners around if you mouse over them. This uses the notification’s `start_time` as a wall-clock deadline instead.

## Changes

- Shared policy in `notification-interface`: dismiss when `now >= start_time + 5 minutes`
- macOS overlay schedules a one-shot dismiss at that deadline (or immediately if already past)
- Linux and Windows overlay ticks apply the same deadline
- Tests for the linger math on the shared helper and the macOS schedule helper

## Validation

- `cargo test --locked -p notification-interface`
- `cargo fmt -p notification-interface --check`
- `pnpm exec dprint check` on the changed Rust files

Skipped compiling `notification-linux` here (`atk`/`gtk` pkg-config missing in this environment). Skipped Swift tests (macOS-only). Windows overlay is the same tick-path change as Linux and is not compiled on Linux.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb6b4dc3-f383-423d-936b-8751e549e63e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb6b4dc3-f383-423d-936b-8751e549e63e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

