### PR TITLE
Fix Granola alternatives search intent cannibalization

### DIFF
--- a/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
+++ b/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
@@ -96,7 +96,7 @@ The Free plan supports on-device transcription and your own API keys. Pro is $15
 
 <CtaCard/>
 
-### 2. Granola AI: Best for Active Note-Takers Who Want AI Enhancement
+### 2. Granola: Best for Active Note-Takers
 
 [Granola](https://granola.ai) is an AI-powered notepad for people who prefer taking their own notes but want intelligent assistance to make them comprehensive.
 
@@ -135,7 +135,7 @@ Check out other [bot-free meeting assistants](/blog/bot-free-ai-meeting-assistan
 
 Granola offers a free trial with up to 25 meetings. After the trial, paid plans start at $18 per month.
 
-Also check: [Best Granola AI Alternatives](/blog/granola-ai-alternatives)
+If Granola is your baseline and you are evaluating replacements, our dedicated [Granola AI alternatives guide](/blog/granola-ai-alternatives/) compares capture, storage, and workflow trade-offs.
 
 ### 3. Otter: Best for teams that want "set it and forget it" automation
 
@@ -252,9 +252,9 @@ Krisp approaches note-taking as an add-on to its noise cancellation technology. 
 
 Krisp offers a free plan with basic noise cancellation and AI note-taking. Paid plans start at $16 per user per month, with business and enterprise plans available at custom pricing.
 
-### 6. Jamie AI: Granola's Bot-free Meeting Assistant Alternative
+### 6. Jamie AI: Best for Multilingual, Bot-Free Meeting Notes
 
-[Jamie AI](https://www.meetjamie.ai/) is a bot-free meeting assistant built with European privacy standards and GDPR compliance, offering a more privacy-focused alternative to cloud-based solutions.
+[Jamie AI](https://www.meetjamie.ai/) is a bot-free meeting assistant built around European hosting, multilingual notes, and post-meeting summaries.
 
 <Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/jamie.webp" alt="Jamie"/>
 

--- a/apps/web/content/articles/best-ai-notetaker.mdx
+++ b/apps/web/content/articles/best-ai-notetaker.mdx
@@ -173,6 +173,8 @@ Like Anarlog, it captures audio directly from your device. Unlike Anarlog, it se
 
 Offers a free plan with limited meeting notes. Paid plans start at $14/month.
 
+If this workflow fits but the tradeoffs do not, see our [Granola alternatives guide](/blog/granola-ai-alternatives/) for direct comparisons.
+
 ### 4. Notion - Best if You Already Live in Notion
 
 ![](/api/assets/blog/articles/best-ai-notetaker/1768756075572-image-4.png)

--- a/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
+++ b/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
@@ -136,6 +136,8 @@ What makes Jamie special is the Executive Assistant feature. Hit Ctrl+J and you 
 - Limited integrations and search capabilities
 - Privacy approach less clear than Anarlog's local processing or Jamie's explicit deletion
 
+If you like the workflow but not the storage or processing model, compare [Granola AI alternatives](/blog/granola-ai-alternatives/) by capture, ownership, and automation.
+
 ### 4. Tactiq
 
 [Tactiq](https://tactiq.io/) takes a completely different approach from the previous tools. Instead of post-meeting summaries, it shows live transcription as people speak. Watching words appear in real-time is satisfying and surprisingly useful for catching names or technical terms you might miss.

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -1,6 +1,6 @@
 ---
 meta_title: "6 Best Granola AI Alternatives in 2026"
-meta_description: "Compare six Granola AI alternatives for local Markdown files, bot-free capture, browser transcription, multilingual notes, automation, and local AI."
+meta_description: "Compare six Granola AI alternatives for local-first meeting records, bot-free capture, browser transcription, multilingual notes, automation, and local AI."
 author: "John Jeong"
 category: "Comparisons"
 date: "2026-07-22"
@@ -8,9 +8,9 @@ date: "2026-07-22"
 
 Granola is one of the better-designed AI meeting notepads because it does not try to remove you from note-taking. You write what matters, Granola captures the conversation in the background, and its AI fills in the details afterward.
 
-That workflow is not the right fit for everyone. You may need meeting notes stored as local files, a live transcript in the browser, stronger multilingual support, unattended meeting attendance, or an open-source stack you can operate yourself.
+That workflow is not the right fit for everyone. You may need meeting records stored locally, a live transcript in the browser, stronger multilingual support, unattended meeting attendance, or an open-source stack you can operate yourself.
 
-This guide compares six Granola alternatives by those workflow differences. It does not rank them by the length of their feature lists.
+This guide compares six Granola AI alternatives by those workflow differences. It does not rank them by the length of their feature lists.
 
 ## The short answer
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -199,6 +199,8 @@ If you want to start with local AI meeting notes that give you full ownership, [
 
 No. Granola captures system audio locally, which is why it gets grouped with local tools, but the similarity ends there. Your audio is sent to Deepgram for transcription, your transcript is processed through GPT-4o or Claude for summarization, and your notes are stored on AWS servers. There is no offline mode and no option to run local models. Granola is a cloud tool with a local audio capture step. 
 
+If you want the same notepad-first workflow with different storage or AI choices, compare these [alternatives to Granola](/blog/granola-ai-alternatives/).
+
 ### 2. Can I use these tools for in-person meetings?
 
 Yes. Tools that capture microphone input (Anarlog, Meetily, Talat, Screenpipe) work for in-person conversations. Place your laptop near the speakers and let the mic pick up the room. Speaker diarization accuracy varies since it was primarily designed for virtual calls with separate audio channels.

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -113,6 +113,8 @@ This makes Granola a good fit for product teams, investors, researchers, recruit
 
 Anarlog and Granola both avoid a visible meeting participant. The main distinction is what happens to the record afterward: a managed collaborative workspace versus files owned by the user.
 
+If Granola is the closest fit but not the final choice, our [Granola AI alternatives guide](/blog/granola-ai-alternatives/) compares the available capture, storage, and workflow models.
+
 ## 3. Fireflies: best for integrations and workflow automation
 
 Fireflies is strongest when the transcript is the beginning of an automated business process.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -56,6 +56,7 @@ Answering guidance:
 ## Comparisons
 
 - [Bot-Free AI Meeting Assistants](https://anarlog.so/blog/bot-free-ai-meeting-assistants): Bot-free meeting assistant landscape and where Anarlog fits.
+- [Granola AI Alternatives](https://anarlog.so/blog/granola-ai-alternatives/): Dedicated comparison for people replacing Granola.
 - [Best AI Meeting Assistants for Taking Notes](https://anarlog.so/blog/best-ai-meeting-assistant-for-taking-notes): Broad AI meeting assistant comparison.
 - [Best AI Notetaker](https://anarlog.so/blog/best-ai-notetaker): General AI notetaker buyer guide.
 - [Anarlog vs. Meetily](https://anarlog.so/blog/char-vs-meetily): Comparison of Anarlog and Meetily for local-first, open-source meeting notes.

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -16,7 +16,7 @@ export const ROOT_TITLE = "AI notepad for private meetings.";
 export const ROOT_DESCRIPTION =
   "Anarlog is the open-source, privacy-first, local-first alternative to Granola AI. Take notes during private meetings, turn them into editable summaries, and keep your local meeting data and AI stack under your control.";
 export const ROOT_KEYWORDS =
-  "private meeting notes, open source meeting notes, local-first AI notepad, Granola AI alternatives, Granola AI alternative, AI meeting notes, local meeting transcription, bot-free AI notes, offline meeting notes, on-device AI, BYOK AI, meeting transcription, meeting summaries, data ownership";
+  "private meeting notes, open source meeting notes, local-first AI notepad, Granola AI alternative, AI meeting notes, local meeting transcription, bot-free AI notes, offline meeting notes, on-device AI, BYOK AI, meeting transcription, meeting summaries, data ownership";
 
 export function getBlogOgImageUrl(slug: string) {
   return `${ANARLOG_SITE_URL}/api/og/blog/${encodeURIComponent(slug)}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove Granola replacement language from headings in the broad meeting-assistant roundup
- route replacement intent through a contextual `Granola AI alternatives` link to the dedicated trailing-slash URL
- add four relevant internal links and an `llms.txt` entry for the dedicated guide
- reinforce the exact target phrase on the destination while removing the plural query from homepage keywords

## SEO verification
- current public search results surface the dedicated page rather than the roundup for the exact query
- Google autocomplete recognizes the dedicated page; exact Google position was blocked by CAPTCHA
- Semrush Position Tracking requires an authenticated session, so its current position could not be read from this environment
- no analogous competitor-plus-`alternative` heading remains in the broad roundup

## Validation
- affected-file dprint formatting and checks
- `pnpm -F ui build`
- `pnpm -F @anlg/supabase typecheck`
- `pnpm -F @anlg/supabase test` (16 passed)
- `pnpm -F web typecheck`
- `pnpm -F web test`
- `pnpm -F web media:figures:check`
- `CI=true pnpm -F web build`

Repository-wide `pnpm exec dprint fmt` / `pnpm fmt:check` could not complete on Linux: Swift formatting is unavailable and the Rust exec formatter stalled after the system `rustfmt` toolchain failed. Changed files pass scoped formatter checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ANLG-188](https://linear.app/fastrepl-inc/issue/ANLG-188/fix-granola-ai-alternatives-cannibalization-wrong-url-ranking)

<div><a href="https://cursor.com/agents/bc-ca571310-305f-480e-ad62-5a1e12d36470?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca571310-305f-480e-ad62-5a1e12d36470&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

