### PR TITLE
fix(desktop): Linux AppImage black screen and loud onboarding music

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -154,8 +154,13 @@ fn create_audio_provider(_bundle_id: &str) -> std::sync::Arc<dyn anlg_audio_actu
     std::sync::Arc::new(anlg_audio_actual::ActualAudio)
 }
 
+pub fn main() {
+    startup::apply_linux_webkit_workarounds();
+    async_main();
+}
+
 #[tokio::main]
-pub async fn main() {
+async fn async_main() {
     // Sentry minidump reporting re-execs this binary with --crash-reporter-server.
     // That helper must reach minidump::init instead of the launch lock, or it
     // shows "Anarlog is already starting" on every launch and never serves dumps.

--- a/apps/desktop/src-tauri/src/startup.rs
+++ b/apps/desktop/src-tauri/src/startup.rs
@@ -5,6 +5,29 @@ use std::sync::{Arc, Mutex};
 const LAUNCH_LOCK_FILENAME: &str = "launch.lock";
 const SLOW_STARTUP_INDICATOR_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 const CRASH_REPORTER_SERVER_ARG: &str = "--crash-reporter-server";
+const WEBKIT_DISABLE_DMABUF_RENDERER: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+
+// WebKitGTK's DMA-BUF renderer leaves a blank window on NVIDIA/Wayland and
+// some other GPU/compositor combinations. Set the fallback before Tokio or
+// the webview start, and leave an explicit user override alone.
+pub(crate) fn apply_linux_webkit_workarounds() {
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+
+    if let Some(value) =
+        linux_webkit_dmabuf_override(std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER).as_deref())
+    {
+        // SAFETY: called from the process entrypoint before other threads start.
+        unsafe {
+            std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER, value);
+        }
+    }
+}
+
+fn linux_webkit_dmabuf_override(existing: Option<&std::ffi::OsStr>) -> Option<&'static str> {
+    existing.is_none().then_some("1")
+}
 
 // Startup migrations can hold the database for minutes before any window or
 // plugin exists, so single-instance semantics are enforced with an OS file
@@ -144,6 +167,23 @@ fn spawn_indicator_alert() -> Option<std::process::Child> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn linux_webkit_workaround_defaults_dmabuf_off_when_unset() {
+        assert_eq!(linux_webkit_dmabuf_override(None), Some("1"));
+    }
+
+    #[test]
+    fn linux_webkit_workaround_preserves_an_explicit_override() {
+        assert_eq!(
+            linux_webkit_dmabuf_override(Some(std::ffi::OsStr::new("0"))),
+            None
+        );
+        assert_eq!(
+            linux_webkit_dmabuf_override(Some(std::ffi::OsStr::new("1"))),
+            None
+        );
+    }
 
     #[test]
     fn crash_reporter_args_are_detected() {

--- a/packaging/aur/anarlog-bin/README.md
+++ b/packaging/aur/anarlog-bin/README.md
@@ -17,8 +17,9 @@ verifies its checksum, and installs it through pacman.
 ## Notes
 
 - Tray icons need `libayatana-appindicator`, which is an optional dependency.
-- On Wayland with NVIDIA, a blank window is a known WebKitGTK issue. Launch with
-  `WEBKIT_DISABLE_DMABUF_RENDERER=1 anarlog`.
+- On Wayland with NVIDIA, a blank window is a known WebKitGTK issue. The app
+  disables the DMA-BUF renderer by default. To override, launch with
+  `WEBKIT_DISABLE_DMABUF_RENDERER=0 anarlog`.
 
 ## Updating
 

--- a/plugins/sfx/src/ext.rs
+++ b/plugins/sfx/src/ext.rs
@@ -19,9 +19,19 @@ pub enum AppSounds {
     BGM,
 }
 
+const BGM_VOLUME: f32 = 0.2;
+
+fn initial_volume(sound: &AppSounds) -> f32 {
+    match sound {
+        AppSounds::BGM => BGM_VOLUME,
+        AppSounds::StartRecording | AppSounds::StopRecording => 1.0,
+    }
+}
+
 pub(crate) fn to_speaker(
     bytes: &'static [u8],
     looping: bool,
+    volume: f32,
 ) -> std::sync::mpsc::Sender<SoundControl> {
     use rodio::source::Source;
     use rodio::{Decoder, Player, stream::DeviceSinkBuilder};
@@ -39,6 +49,7 @@ pub(crate) fn to_speaker(
         };
 
         let player = Player::connect_new(stream.mixer());
+        player.set_volume(volume);
 
         if looping {
             player.append(source.repeat_infinite());
@@ -77,7 +88,7 @@ impl AppSounds {
 
         let bytes = self.get_sound_bytes();
         let looping = matches!(self, AppSounds::BGM);
-        let control_tx = to_speaker(bytes, looping);
+        let control_tx = to_speaker(bytes, looping, initial_volume(self));
 
         {
             let mut sounds = PLAYING_SOUNDS.lock().unwrap();
@@ -145,5 +156,17 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> SfxPluginExt<R> for T {
             manager: self,
             _runtime: std::marker::PhantomData,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bgm_starts_quiet_and_one_shots_stay_full() {
+        assert_eq!(initial_volume(&AppSounds::BGM), 0.2);
+        assert_eq!(initial_volume(&AppSounds::StartRecording), 1.0);
+        assert_eq!(initial_volume(&AppSounds::StopRecording), 1.0);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Report

Linux AppImage first launch: black window + very loud looping music, settings unreachable. Matches JohnWick’s report (Discord).

## Cause

Two stacked bugs:

1. **Black screen** — WebKitGTK’s DMA-BUF renderer paints a blank window on NVIDIA/Wayland (and some other GPU/compositor combos). Already documented for AUR as `WEBKIT_DISABLE_DMABUF_RENDERER=1`, but AppImage/`.deb` never set it. The mute control and settings live in that webview, so they are unusable.
2. **Loud music** — Onboarding auto-plays looping `BGM` (`plugins/sfx`). Playback started at rodio’s default volume `1.0`; JS then called `setVolume(0.2)`. If the webview never paints, that follow-up never lands and BGM stays at 100%.

## Fix

- Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` on Linux at process entry, before Tokio/webview start. An explicit user value is left alone.
- Start BGM at `0.2` before the first sample is appended.

## Workaround for current builds

```bash
WEBKIT_DISABLE_DMABUF_RENDERER=1 ./anarlog-linux-x86_64.AppImage
```

If the window is already open, kill the process first — BGM is native rodio, so closing a black window is the only stop.

## Test plan

- [x] Unit: DMA-BUF override only when unset
- [x] Unit: BGM initial volume is 0.2
- [x] `cargo test --locked -p desktop startup --lib`
- [x] `cargo test --locked -p tauri-plugin-sfx --lib`
- [ ] Linux AppImage first-run on NVIDIA/Wayland: window paints, BGM is quiet, mute works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0280a-d559-70ba-82b6-1dd13144f1d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0280a-d559-70ba-82b6-1dd13144f1d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

