### PR TITLE
Document Anarlog's AI models and refresh app setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,114 @@
 # Contributing
 
-Development documentation is available at [docs.anarlog.so](https://docs.anarlog.so).
+Issues, pull requests, bug reports, and documentation fixes are welcome.
+
+## Before you start
+
+- Search existing issues and pull requests before starting a large change.
+- Keep changes focused. Add tests for behavior that can regress.
+- Never commit credentials, customer configuration, meeting content, or other private data.
+- Use [docs.anarlog.so](https://docs.anarlog.so) for product, CLI, and MCP behavior. Use this file and the repository's `AGENTS.md` files for development guidance.
+
+## Set up the repository
+
+You need:
+
+- Node.js 22 or later
+- pnpm 11.1.1
+- Rust 1.94.0
+- The [Tauri v2 system dependencies](https://v2.tauri.app/start/prerequisites/)
+
+On Debian or Ubuntu, install the supported toolchains and system packages with:
+
+```bash
+bash scripts/setup-linux.sh
+```
+
+Then install the workspace:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+The desktop app and website start without secrets for local-first workflows.
+
+## Run the apps
+
+```bash
+# Tauri desktop app
+pnpm exec turbo dev:desktop
+
+# Website
+pnpm exec turbo dev:web
+```
+
+Turbo builds shared UI packages before starting either app.
+
+CloudSync, hosted AI, authentication, billing, and connected integrations require the optional local services:
+
+```bash
+task supabase-start
+cargo run -p api
+```
+
+The Supabase stack requires Docker. Provider credentials and service-specific configuration are not required for local notes, recording, or on-device features.
+
+## Find the right code
+
+| Path | Scope |
+| --- | --- |
+| `apps/desktop` | React desktop UI and Tauri application |
+| `apps/web` | Website and account-backed web surfaces |
+| `apps/api` | Hosted API routes |
+| `apps/cli` | CLI and MCP server |
+| `plugins/*` | Tauri plugin boundaries |
+| `crates/*` | Rust libraries and services |
+| `packages/*` | Shared TypeScript packages |
+| `crates/db-app` | SQLite schema and migrations |
+| `docs` | Mintlify product and reference documentation |
+
+Sessions are the core data entity. Notes, transcripts, and summaries are all backed by sessions. ProseMirror documents use the TipTap JSON dialect.
+
+## Validate your change
+
+Always format before committing:
+
+```bash
+pnpm exec dprint fmt
+pnpm fmt:check
+```
+
+On Linux, the full format check cannot run the macOS-only Swift formatter. Run a scoped dprint check for every changed non-Swift path and report the skipped Swift check.
+
+Run checks for every package you changed. Common commands include:
+
+```bash
+# Desktop TypeScript
+pnpm -F desktop typecheck
+pnpm -F desktop test
+pnpm exec oxlint --quiet --format=github apps/desktop/src/
+
+# Changes spanning TypeScript packages
+pnpm -r typecheck
+
+# Rust
+cargo check
+cargo test -p <affected-package>
+```
+
+For documentation changes:
+
+```bash
+pnpm exec dprint fmt 'docs/**/*'
+pnpm exec dprint check 'docs/**/*'
+cd docs
+mint validate
+mint broken-links --check-anchors --check-redirects
+```
+
+Check the affected workflow under `.github/workflows/` for stricter package-specific commands.
+
+## Licensing and contribution boundary
 
 By submitting a contribution outside `enterprise/`, you agree that it may be distributed under the repository's [MIT License](LICENSE). Only submit material you have the right to license this way.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,17 @@ The Supabase stack requires Docker. Provider credentials and service-specific co
 | Path | Scope |
 | --- | --- |
 | `apps/desktop` | React desktop UI and Tauri application |
-| `apps/web` | Website and account-backed web surfaces |
+| `apps/web` | Marketing site, account portal, and shared-note pages |
 | `apps/api` | Hosted API routes |
 | `apps/cli` | CLI and MCP server |
+| `apps/mobile` | Expo mobile client |
 | `plugins/*` | Tauri plugin boundaries |
 | `crates/*` | Rust libraries and services |
 | `packages/*` | Shared TypeScript packages |
 | `crates/db-app` | SQLite schema and migrations |
+| `supabase` | Hosted database schema, functions, and tests |
+| `skills/anarlog` | Published CLI and MCP agent skill |
+| `enterprise` | Commercially licensed capture and deployment components |
 | `docs` | Mintlify product and reference documentation |
 
 Sessions are the core data entity. Notes, transcripts, and summaries are all backed by sessions. ProseMirror documents use the TipTap JSON dialect.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
     &nbsp;•&nbsp;
     <a href="https://docs.anarlog.so">Docs</a>
     &nbsp;•&nbsp;
-    <a href="https://github.com/fastrepl/anarlog/releases/latest">Download</a>
+    <a href="https://anarlog.so/download">Download</a>
     &nbsp;•&nbsp;
-    <a href="https://discord.gg/Vk882WS3gF">Discord</a>
+    <a href="https://anarlog.so/discord">Discord</a>
     &nbsp;•&nbsp;
     <a href="https://www.reddit.com/r/anarlog/">r/anarlog</a>
     &nbsp;•&nbsp;
@@ -31,7 +31,7 @@
   <p>
     <a href="https://github.com/fastrepl/anarlog/stargazers"><img src="https://img.shields.io/github/stars/fastrepl/anarlog?style=flat&color=ffe09d" alt="GitHub stars" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-black" alt="MIT license" /></a>
-    <a href="https://discord.gg/Vk882WS3gF"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+    <a href="https://anarlog.so/discord"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
     <a href="https://deepwiki.com/fastrepl/anarlog"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
   </p>
 
@@ -48,12 +48,12 @@ It is built for people who want AI meeting notes without handing their conversat
 ## Why anarlog
 
 - **No bot joins your call.** anarlog captures audio directly on your device. Nothing appears in the participant list, and nothing records from inside the meeting.
-- **Local when you choose it.** On supported Apple Silicon Macs, built-in transcription runs on-device. Local Intelligence providers keep summaries and chat on your computer too.
+- **Local when you choose it.** On supported Macs, available built-in transcription models run on-device. Local Intelligence providers keep summaries and chat on your computer too.
 - **Your data, in a format you can read.** Sessions, notes, and transcripts live in local SQLite. Recordings and attachments are plain local files. Export Markdown whenever it fits your workflow.
 - **Bring your own AI.** Use a supported hosted provider, your own API key, or an OpenAI-compatible local server such as Ollama, LM Studio, or Unsloth.
-- **Readable source, MIT.** The community application is MIT-licensed. Fork it, audit it, sell it, or self-host it.
+- **Readable source, MIT.** The community application is MIT-licensed. Fork it, audit it, sell it, or build it yourself.
 - **Cloud is opt-in, not required.** Hosted AI, encrypted CloudSync, and sharing exist when you want them. Nothing depends on them.
-- **A front door for your org.** Self-hosting and source-visible enterprise components give security and IT teams a real path to yes.
+- **A front door for your org.** Source-visible enterprise components and commercial deployment options give security and IT teams a real path to yes.
 
 ## What runs where
 
@@ -71,32 +71,36 @@ anarlog keeps audio transcription separate from the language model used for summ
 
 | Stage | App setting | Anarlog Cloud | Local or bring your own |
 | --- | --- | --- | --- |
-| Audio → transcript | **Transcription** | A managed route chooses by language and live or batch mode. Current primary paths include Deepgram Nova and Soniox 5. | Built-in on-device models on Apple Silicon, or your selected transcription provider and model |
+| Audio → transcript | **Transcription** | A managed route chooses by language and live or batch mode. Current primary paths include Deepgram Nova and Soniox 5. | Soniqo or Apple Speech when available, or your selected transcription provider and model |
 | Transcript + memo → summary, title, or chat | **Intelligence** | Auto currently uses the latest Claude Sonnet alias through OpenRouter. | Your selected API, subscription, OpenAI-compatible server, or eligible Apple Intelligence |
 
 The active provider and model are always visible under **Settings → Transcription** and **Settings → Intelligence**. Read [Models and providers](https://docs.anarlog.so/models-and-providers) for the current routes, local model list, and privacy boundaries.
 
 ## Get started
 
-1. Download the latest release for macOS (Apple Silicon or Intel), Windows, or Linux from [releases](https://github.com/fastrepl/anarlog/releases/latest).
+1. [Download Anarlog](https://anarlog.so/download) for macOS, Windows, or Linux.
 2. Open it and join a meeting. anarlog records on your device and transcribes with the model you selected.
 3. Generate a note, edit it like a document, and export Markdown when you need it.
 4. Optional: connect an LLM provider or a local model in settings for summaries and chat.
 
-Product docs live at [docs.anarlog.so](https://docs.anarlog.so). To self-host, clone the repo, build it, and run it.
+Product docs live at [docs.anarlog.so](https://docs.anarlog.so). To build the desktop app or website from source, follow [Local development](#local-development).
 
 ## Repository map
 
 | Path | What lives there |
 | --- | --- |
 | `apps/desktop` | Tauri v2 desktop app: React and TypeScript UI, Rust backend |
-| `apps/web` | anarlog.so website and account-backed web surfaces |
+| `apps/web` | anarlog.so website, account portal, and shared-note pages; not the desktop notepad |
 | `apps/api` | Optional hosted services for AI, sync, sharing, and integrations |
 | `apps/cli` | Local CLI and MCP server |
 | `apps/mobile` | Mobile client source; no mobile app is currently distributed |
+| `apps/stripe` | Billing integration |
+| `apps/watch/apple` | watchOS companion source built with the mobile app |
 | `plugins/*` | Tauri capabilities such as local STT, database access, calendar, export, and notifications |
 | `crates/*` | Rust libraries for audio capture, transcription, diarization, storage, and services |
 | `packages/*` | Shared TypeScript packages for the editor, database, UI, and plugin SDK |
+| `supabase/` | Hosted authentication, sharing, sync, billing, and Cloud API data |
+| `skills/anarlog` | Published agent skill for the CLI and MCP server |
 | `enterprise/` | Source-visible enterprise components, commercially licensed |
 
 ## Local development
@@ -126,7 +130,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) for validation commands, code ownership,
 
 We later split the work into two projects. **[char](https://char.com)** is the team's current productivity app. **anarlog** is this open-source, local-first meeting notetaker.
 
-This repository is not the current char codebase, and anarlog is not being retired. Its community application stays MIT-licensed, forkable, self-hostable, and built for local notes you control.
+This repository is not the current char codebase, and anarlog is not being retired. Its community application stays MIT-licensed, forkable, buildable from source, and built for local notes you control.
 
 If you came here from Granola, welcome. If you came here from Hyprnote, welcome back.
 
@@ -137,7 +141,7 @@ Either way, it's yours.
 Issues, pull requests, bug reports, and docs fixes are all welcome.
 
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
-- Join the community on [Discord](https://discord.gg/Vk882WS3gF) or [r/anarlog](https://www.reddit.com/r/anarlog/).
+- Join the community on [Discord](https://anarlog.so/discord) or [r/anarlog](https://www.reddit.com/r/anarlog/).
 
 Contributions outside `enterprise/` are distributed under the MIT license.
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@
 
 <br />
 
-anarlog is an open-source alternative to Granola. It takes notes in your meetings without sending a bot to join the call: it listens to your device audio, transcribes on your machine, and keeps everything in a local SQLite database you can open yourself.
+anarlog is an open-source alternative to Granola. It takes notes in your meetings without sending a bot to join the call: it listens to your device audio, can transcribe on your machine, and keeps app data in a local SQLite database.
 
 It is built for people who want AI meeting notes without handing their conversations to someone else's cloud, and for anyone who needs to get a notetaker past a security review with a straight face.
 
 ## Why anarlog
 
 - **No bot joins your call.** anarlog captures audio directly on your device. Nothing appears in the participant list, and nothing records from inside the meeting.
-- **Local by default.** Transcription runs on-device, so meeting audio never has to leave your machine.
+- **Local when you choose it.** On supported Apple Silicon Macs, built-in transcription runs on-device. Local Intelligence providers keep summaries and chat on your computer too.
 - **Your data, in a format you can read.** Sessions, notes, and transcripts live in local SQLite. Recordings and attachments are plain local files. Export Markdown whenever it fits your workflow.
-- **Bring your own AI.** Use OpenAI, Anthropic, Gemini, OpenRouter, Ollama, LM Studio, Unsloth, or anything OpenAI-compatible, including fully local models.
+- **Bring your own AI.** Use a supported hosted provider, your own API key, or an OpenAI-compatible local server such as Ollama, LM Studio, or Unsloth.
 - **Readable source, MIT.** The community application is MIT-licensed. Fork it, audit it, sell it, or self-host it.
 - **Cloud is opt-in, not required.** Hosted AI, encrypted CloudSync, and sharing exist when you want them. Nothing depends on them.
 - **A front door for your org.** Self-hosting and source-visible enterprise components give security and IT teams a real path to yes.
@@ -60,15 +60,26 @@ It is built for people who want AI meeting notes without handing their conversat
 | Part of the workflow | Where it happens |
 | --- | --- |
 | Audio capture and recording | Your device |
-| Transcription | Your device, on-device models |
+| Transcription | Your device with an on-device model, or the provider you select |
 | Notes and transcript storage | Local SQLite plus local files |
 | AI summaries and chat | Your choice: local model, your own API key, or optional hosted AI |
 | Sync and sharing | Off by default, opt-in encrypted CloudSync |
 
+## How AI works
+
+anarlog keeps audio transcription separate from the language model used for summaries and chat. You can change either one without changing the other.
+
+| Stage | App setting | Anarlog Cloud | Local or bring your own |
+| --- | --- | --- | --- |
+| Audio → transcript | **Transcription** | A managed route chooses by language and live or batch mode. Current primary paths include Deepgram Nova and Soniox 5. | Built-in on-device models on Apple Silicon, or your selected transcription provider and model |
+| Transcript + memo → summary, title, or chat | **Intelligence** | Auto currently uses the latest Claude Sonnet alias through OpenRouter. | Your selected API, subscription, OpenAI-compatible server, or eligible Apple Intelligence |
+
+The active provider and model are always visible under **Settings → Transcription** and **Settings → Intelligence**. Read [Models and providers](https://docs.anarlog.so/models-and-providers) for the current routes, local model list, and privacy boundaries.
+
 ## Get started
 
 1. Download the latest release for macOS (Apple Silicon or Intel), Windows, or Linux from [releases](https://github.com/fastrepl/anarlog/releases/latest).
-2. Open it and join a meeting. anarlog records and transcribes locally as you go.
+2. Open it and join a meeting. anarlog records on your device and transcribes with the model you selected.
 3. Generate a note, edit it like a document, and export Markdown when you need it.
 4. Optional: connect an LLM provider or a local model in settings for summaries and chat.
 
@@ -79,18 +90,35 @@ Product docs live at [docs.anarlog.so](https://docs.anarlog.so). To self-host, c
 | Path | What lives there |
 | --- | --- |
 | `apps/desktop` | Tauri v2 desktop app: React and TypeScript UI, Rust backend |
-| `apps/web` | anarlog.so web app |
-| `apps/api` | API server |
-| `apps/cli` | CLI |
-| `apps/mobile` | Mobile app |
-| `plugins/*` | ~50 Tauri plugins: local STT, local LLM, calendar, export, notifications, and more |
-| `crates/*` | ~180 Rust crates: audio capture, transcription, diarization, storage, and more |
-| `packages/*` | Shared TypeScript packages: editor, database, UI, plugin SDK |
+| `apps/web` | anarlog.so website and account-backed web surfaces |
+| `apps/api` | Optional hosted services for AI, sync, sharing, and integrations |
+| `apps/cli` | Local CLI and MCP server |
+| `apps/mobile` | Mobile client source; no mobile app is currently distributed |
+| `plugins/*` | Tauri capabilities such as local STT, database access, calendar, export, and notifications |
+| `crates/*` | Rust libraries for audio capture, transcription, diarization, storage, and services |
+| `packages/*` | Shared TypeScript packages for the editor, database, UI, and plugin SDK |
 | `enterprise/` | Source-visible enterprise components, commercially licensed |
 
 ## Local development
 
-Ask [DeepWiki](https://deepwiki.com/fastrepl/anarlog) — it stays current with the codebase and can answer setup, architecture, and where-does-X-live questions directly.
+The local-first desktop app and website start without secrets. Hosted AI, CloudSync, authentication, billing, and connected integrations need their optional local services and configuration.
+
+You need Node.js 22 or later, pnpm 11.1.1, Rust 1.94.0, and the [Tauri v2 system dependencies](https://v2.tauri.app/start/prerequisites/). On Debian or Ubuntu, the repository can install the required toolchains and system packages:
+
+```bash
+bash scripts/setup-linux.sh
+```
+
+Install the workspace and start the app you want to work on:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm exec turbo dev:desktop
+# or
+pnpm exec turbo dev:web
+```
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for validation commands, code ownership, and the contribution workflow. Ask [DeepWiki](https://deepwiki.com/fastrepl/anarlog) for a code-indexed explanation of a subsystem.
 
 ## Name history
 

--- a/docs/ai-setup.mdx
+++ b/docs/ai-setup.mdx
@@ -19,7 +19,7 @@ Open **Settings → Transcription** or **Settings → Intelligence** to choose a
     Sign in and choose Anarlog for the quickest setup. Hosted models require Pro.
   </Card>
   <Card title="On-device transcription" icon="laptop">
-    Download a supported local model from Transcription. Local models are available on supported Apple Silicon Macs.
+    Download Soniqo on a supported Apple Silicon Mac, or use Apple Speech when macOS 26 reports it available.
   </Card>
   <Card title="Your API key" icon="key">
     Configure a provider, enter its API key, then select it under Model being used.

--- a/docs/ai-setup.mdx
+++ b/docs/ai-setup.mdx
@@ -10,6 +10,8 @@ Anarlog uses two model settings:
 
 Open **Settings → Transcription** or **Settings → Intelligence** to choose a provider and model.
 
+[Models and providers](/models-and-providers) explains the current Anarlog Cloud routes, built-in on-device models, and how bring-your-own-provider requests work.
+
 ## Choose a setup
 
 <CardGroup cols={2}>
@@ -23,13 +25,23 @@ Open **Settings → Transcription** or **Settings → Intelligence** to choose a
     Configure a provider, enter its API key, then select it under Model being used.
   </Card>
   <Card title="Local language model" icon="server">
-    Connect LM Studio, Ollama, or Unsloth to generate summaries on your computer.
+    Connect LM Studio, Ollama, or Unsloth, or use Apple Intelligence on an eligible Mac.
   </Card>
 </CardGroup>
 
 Models labeled **Live** show text during the meeting. Models labeled **After recording** transcribe after you stop.
 
 To keep transcription, summaries, and chat on your computer, follow [Use Anarlog offline](/offline).
+
+## Apple Intelligence
+
+On an eligible Mac running macOS 26 or later:
+
+1. Turn on Apple Intelligence in **System Settings** and wait for its model to finish downloading.
+2. In Anarlog, open **Settings → Intelligence → Configure Providers → Apple Intelligence**.
+3. Select **System Language Model** under **Model being used**.
+
+Apple Intelligence support is experimental and currently handles text only.
 
 ## LM Studio
 

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -25,10 +25,12 @@ The destination depends on the feature you choose:
 
 Anarlog Cloud, your own API-key providers, and local providers are separate choices. Review the provider's own retention and training policies before sending sensitive content.
 
+See [Models and providers](/models-and-providers) for the current Anarlog Cloud routes and how direct provider requests work.
+
 ## Keep a meeting fully local
 
 1. Select an on-device model under **Settings → Transcription**.
-2. Select LM Studio or Ollama under **Settings → Intelligence**.
+2. Select LM Studio, Ollama, Unsloth, or eligible Apple Intelligence under **Settings → Intelligence**.
 3. Avoid cloud sync, share links, Cloud API & Connectors, and hosted providers for that content.
 
 See [Use Anarlog offline](/offline) for the full setup.

--- a/docs/desktop-installation.mdx
+++ b/docs/desktop-installation.mdx
@@ -77,7 +77,7 @@ chmod +x ./anarlog-*.AppImage
 ## Platform differences
 
 - Apple Calendar integration is available on macOS. Google Calendar works through your Anarlog account on every supported platform.
-- Built-in on-device transcription is currently available only on Apple Silicon. On other platforms, choose Anarlog Cloud or configure a supported transcription provider.
+- Soniqo on-device transcription requires Apple Silicon. Apple Speech appears only when a compatible Mac running macOS 26 reports the required system assets. On other systems, choose Anarlog Cloud or configure a supported transcription provider.
 - Windows and Linux support are in beta. Include your operating system and Anarlog version when you report a platform-specific problem.
 - Anarlog does not currently offer a mobile app.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,7 +38,12 @@
       },
       {
         "group": "AI and privacy",
-        "pages": ["ai-setup", "offline", "data-and-privacy"]
+        "pages": [
+          "models-and-providers",
+          "ai-setup",
+          "offline",
+          "data-and-privacy"
+        ]
       },
       {
         "group": "CLI and agents",

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -29,7 +29,11 @@ Yes. Upload one audio, SRT, or VTT file to an empty note, or use **Settings → 
 
 ### Can I use Anarlog offline?
 
-Yes, if you prepare local models before disconnecting. Built-in on-device transcription is currently available only on Apple Silicon. LM Studio and Ollama can provide local Intelligence models on supported platforms. See [Use Anarlog offline](/offline).
+Yes, if you prepare local models before disconnecting. Built-in on-device transcription is currently available only on Apple Silicon. LM Studio, Ollama, Unsloth, and eligible Apple Intelligence can provide local Intelligence models. See [Use Anarlog offline](/offline).
+
+### Which AI models does Anarlog use?
+
+There is no single hidden model. Your Transcription selection handles audio, and your Intelligence selection handles summaries, titles, and chat. Anarlog Cloud currently routes transcription by language and mode and routes text Intelligence tasks through the latest Claude Sonnet alias on OpenRouter. See [Models and providers](/models-and-providers) for the current routes and local options.
 
 ### Where is my data stored?
 

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -29,7 +29,7 @@ Yes. Upload one audio, SRT, or VTT file to an empty note, or use **Settings → 
 
 ### Can I use Anarlog offline?
 
-Yes, if you prepare local models before disconnecting. Built-in on-device transcription is currently available only on Apple Silicon. LM Studio, Ollama, Unsloth, and eligible Apple Intelligence can provide local Intelligence models. See [Use Anarlog offline](/offline).
+Yes, if you prepare local models before disconnecting. Soniqo transcription requires a supported Apple Silicon Mac; Apple Speech is available when macOS 26 reports compatible system assets. LM Studio, Ollama, Unsloth, and eligible Apple Intelligence can provide local Intelligence models. See [Use Anarlog offline](/offline).
 
 ### Which AI models does Anarlog use?
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,6 +26,9 @@ Anarlog records your microphone and computer audio without joining the call as a
 ## Popular questions
 
 <CardGroup cols={2}>
+  <Card title="Which models does Anarlog use?" icon="microchip" href="/models-and-providers">
+    See the current cloud routes, on-device models, and bring-your-own-provider behavior.
+  </Card>
   <Card title="Can I use Anarlog offline?" icon="wifi-slash" href="/offline">
     Record, transcribe, summarize, and chat with local models.
   </Card>

--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -1,0 +1,94 @@
+---
+title: "Models and providers"
+description: "See which models Anarlog uses for transcription, summaries, and chat."
+---
+
+Anarlog does not hide one model behind the whole app. It keeps two independent selections:
+
+- **Transcription** turns meeting audio into text.
+- **Intelligence** turns text into summaries, titles, and chat responses.
+
+Open **Settings → Transcription** and **Settings → Intelligence** to see the exact provider and model active on your computer. Changing one selection does not change the other.
+
+## How a meeting moves through AI
+
+| Stage | Input | Output | Controlled by |
+| --- | --- | --- | --- |
+| Capture | Microphone and computer audio | A local recording | **Settings → Meetings** |
+| Transcription | Meeting audio | Live or after-recording transcript | **Settings → Transcription** |
+| Intelligence | Transcript, memo, meeting details, and your instructions | Summary, title, or chat response | **Settings → Intelligence** |
+
+Recording, editing, and local storage do not require an AI model. A hosted Transcription provider receives audio. A hosted Intelligence provider receives the text and other context needed for that request.
+
+## Anarlog Cloud
+
+Anarlog Cloud uses managed routes. The **Cloud** and **Auto** labels let Anarlog choose a suitable upstream model and retry a compatible provider when needed.
+
+<Note>
+  The routes below describe the current implementation, not a permanently pinned model contract. Anarlog may update a managed route to improve quality, language coverage, latency, or availability. Select your own provider and model when you need a fixed model ID.
+</Note>
+
+### Cloud transcription
+
+The managed Transcription route chooses a provider from the meeting's languages and whether Anarlog needs live or after-recording transcription.
+
+- Deepgram currently resolves the route to **Nova 3** or **Nova 2**, depending on language support.
+- Soniox currently resolves it to **Soniox 5**: `stt-rt-v5` for live transcription and `stt-async-v5` after recording.
+- After-recording transcription prefers Soniox when it supports the selected languages.
+- The eligible fallback pool also includes configured routes for AssemblyAI, Gladia, ElevenLabs, Fireworks, OpenAI, Mistral, and Alibaba Cloud Model Studio.
+
+Only configured providers that support the requested mode and languages enter the route. If one returns a retryable error, Anarlog can try the next eligible provider.
+
+### Cloud Intelligence
+
+For text tasks, **Anarlog → Auto** currently routes summaries, chat, and generated titles through the `~anthropic/claude-sonnet-latest` alias on OpenRouter.
+
+The alias tracks the current Claude Sonnet release instead of pinning a dated model. OpenRouter receives the prompt and chooses an available endpoint for that model.
+
+Hosted Intelligence requests that contain audio use a separate ordered model pool:
+
+1. `google/gemini-3.1-pro-preview`
+2. `google/gemini-3.6-flash`
+3. `mistralai/voxtral-small-24b-2507`
+
+This audio-capable Intelligence route is separate from normal meeting transcription.
+
+## On-device models
+
+Built-in on-device transcription currently requires an Apple Silicon Mac. Anarlog shows only models available for your computer and release.
+
+| Model | When it runs | Notes |
+| --- | --- | --- |
+| Parakeet Streaming | During the meeting | Live transcription for 25 European languages |
+| Parakeet Batch | After recording | Speaker-labeled transcription for 25 European languages |
+| Apple Speech | During the meeting | Uses the system model and language assets built into macOS 26 |
+| Parakeet V2 | After recording | English-focused |
+| Parakeet V3 | After recording | English and European languages |
+| Whisper Large V3 | After recording | Broad multilingual coverage |
+
+If you select Parakeet Streaming and also download Parakeet Batch, Anarlog can refine speaker labels on-device after a meeting with multiple remote participants.
+
+For local summaries and chat, connect **LM Studio**, **Ollama**, or **Unsloth** and choose any compatible model they serve. Anarlog does not silently substitute another model. **Apple Intelligence** is also available as an experimental, text-only Intelligence provider on eligible Macs running macOS 26 or later.
+
+If a selected local model or server is unavailable, Anarlog reports a connection error instead of sending the request to Anarlog Cloud.
+
+## Your own provider
+
+When you configure a provider with your own API key:
+
+- Anarlog sends requests directly from the desktop app to the configured base URL.
+- The provider and exact model shown in Settings handle the request.
+- Anarlog stores the API key in your operating system's secure credential store, not in the app's SQLite database.
+- The provider's pricing, retention, and training policies apply.
+
+Anarlog supports dedicated provider integrations and OpenAI-compatible endpoints. Intelligence model lists are loaded from the provider when its API supports discovery, so **Settings → Intelligence** is the current source of truth for available model IDs.
+
+## Choose a setup
+
+| Goal | Transcription | Intelligence |
+| --- | --- | --- |
+| Keep meeting content on your computer | Download an on-device model | Use LM Studio, Ollama, Unsloth, or eligible Apple Intelligence |
+| Pin exact model IDs | Configure your own provider | Configure your own provider |
+| Minimize setup | Anarlog Cloud | Anarlog Cloud |
+
+For a fully local checklist, see [Use Anarlog offline](/offline). For the data sent by each feature, see [Data, privacy, and retention](/data-and-privacy).

--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -8,7 +8,7 @@ Anarlog does not hide one model behind the whole app. It keeps two independent s
 - **Transcription** turns meeting audio into text.
 - **Intelligence** turns text into summaries, titles, and chat responses.
 
-Open **Settings → Transcription** and **Settings → Intelligence** to see the exact provider and model active on your computer. Changing one selection does not change the other.
+Open **Settings → Transcription** and **Settings → Intelligence** to see the selection active on your computer. Changing one selection does not change the other. For managed **Cloud** and **Auto** selections, this page explains the current upstream route.
 
 ## How a meeting moves through AI
 
@@ -55,22 +55,35 @@ This audio-capable Intelligence route is separate from normal meeting transcript
 
 ## On-device models
 
-Built-in on-device transcription currently requires an Apple Silicon Mac. Anarlog shows only models available for your computer and release.
+Anarlog currently offers two built-in on-device Transcription providers. Settings shows each provider only when it is supported by your Mac and release.
 
-| Model | When it runs | Notes |
-| --- | --- | --- |
-| Parakeet Streaming | During the meeting | Live transcription for 25 European languages |
-| Parakeet Batch | After recording | Speaker-labeled transcription for 25 European languages |
-| Apple Speech | During the meeting | Uses the system model and language assets built into macOS 26 |
-| Parakeet V2 | After recording | English-focused |
-| Parakeet V3 | After recording | English and European languages |
-| Whisper Large V3 | After recording | Broad multilingual coverage |
+| Provider | Model | When it runs | Requirements |
+| --- | --- | --- | --- |
+| Soniqo | Parakeet Streaming | During the meeting | Apple Silicon; live transcription for 25 European languages |
+| Soniqo | Parakeet Batch | After recording | Apple Silicon; speaker-labeled transcription for 25 European languages |
+| Apple Speech | Apple Speech | During the meeting | macOS 26 with a supported language added in System Settings |
+
+<Note>
+  Compatibility code still recognizes some older local model IDs, but they are not offered as new choices. The table above is the current user-facing model list.
+</Note>
 
 If you select Parakeet Streaming and also download Parakeet Batch, Anarlog can refine speaker labels on-device after a meeting with multiple remote participants.
 
 For local summaries and chat, connect **LM Studio**, **Ollama**, or **Unsloth** and choose any compatible model they serve. Anarlog does not silently substitute another model. **Apple Intelligence** is also available as an experimental, text-only Intelligence provider on eligible Macs running macOS 26 or later.
 
 If a selected local model or server is unavailable, Anarlog reports a connection error instead of sending the request to Anarlog Cloud.
+
+## Other model-backed features
+
+Not every AI-adjacent feature is controlled by AI Settings:
+
+| Feature | Implementation | Where it runs |
+| --- | --- | --- |
+| Meeting search | Tantivy full-text index, not an LLM or embedding search | On your computer |
+| Speaker voiceprints | `wespeaker-embedding-onnx-1` voice embeddings | On your computer |
+| Audio cleanup and speech detection | Bundled ONNX models | On your computer |
+
+When chat uses web search, Anarlog sends the search query to its hosted research endpoint, which currently uses Exa. The returned text can then become context for your selected Intelligence model.
 
 ## Your own provider
 
@@ -87,7 +100,7 @@ Anarlog supports dedicated provider integrations and OpenAI-compatible endpoints
 
 | Goal | Transcription | Intelligence |
 | --- | --- | --- |
-| Keep meeting content on your computer | Download an on-device model | Use LM Studio, Ollama, Unsloth, or eligible Apple Intelligence |
+| Keep meeting content on your computer | Select Soniqo or Apple Speech when available | Use LM Studio, Ollama, Unsloth, or eligible Apple Intelligence |
 | Pin exact model IDs | Configure your own provider | Configure your own provider |
 | Minimize setup | Anarlog Cloud | Anarlog Cloud |
 

--- a/docs/offline.mdx
+++ b/docs/offline.mdx
@@ -10,7 +10,7 @@ Anarlog can record meetings and manage notes without an internet connection. To 
 - Create and edit notes.
 - Record and play meeting audio.
 - Export memos, summaries, and transcripts already on your computer.
-- Transcribe with a downloaded on-device model on a supported Apple Silicon Mac.
+- Transcribe with Soniqo on a supported Apple Silicon Mac or Apple Speech when available on macOS 26.
 - Generate summaries and chat with LM Studio, Ollama, Unsloth, or eligible Apple Intelligence.
 
 Hosted models, Google and Outlook calendar sync, cloud sync, and share links need a network connection.
@@ -18,9 +18,10 @@ Hosted models, Google and Outlook calendar sync, cloud sync, and share links nee
 ## Prepare offline transcription
 
 1. Open **Settings → Transcription**.
-2. Download a supported on-device model.
-3. Select it under **Model being used**.
-4. Run a short test recording before going offline.
+2. Choose Soniqo, or choose Apple Speech if it appears.
+3. Download the Soniqo model. For Apple Speech, add the supported language in macOS System Settings.
+4. Select the model under **Model being used**.
+5. Run a short test recording before going offline.
 
 The model's **Live** or **After recording** label tells you when text will appear. On-device model availability depends on your Mac and the current Anarlog release.
 

--- a/docs/offline.mdx
+++ b/docs/offline.mdx
@@ -11,7 +11,7 @@ Anarlog can record meetings and manage notes without an internet connection. To 
 - Record and play meeting audio.
 - Export memos, summaries, and transcripts already on your computer.
 - Transcribe with a downloaded on-device model on a supported Apple Silicon Mac.
-- Generate summaries and chat with a local LM Studio or Ollama server.
+- Generate summaries and chat with LM Studio, Ollama, Unsloth, or eligible Apple Intelligence.
 
 Hosted models, Google and Outlook calendar sync, cloud sync, and share links need a network connection.
 
@@ -26,15 +26,17 @@ The model's **Live** or **After recording** label tells you when text will appea
 
 ## Prepare offline summaries and chat
 
-Use [LM Studio](https://lmstudio.ai/download) or [Ollama](https://ollama.com/download) as your local Intelligence provider. Download the model in advance, start the local server, and select that model in **Settings → Intelligence**.
+Use [LM Studio](https://lmstudio.ai/download), [Ollama](https://ollama.com/download), or [Unsloth](https://unsloth.ai/docs/desktop) as your local Intelligence provider. Download the model in advance, start the local server, and select that model in **Settings → Intelligence**.
 
 Anarlog must be able to reach the local server while you work. The server can run on the same computer without internet access.
+
+On an eligible Mac running macOS 26 or later, you can instead select the experimental **Apple Intelligence → System Language Model** after its system model finishes downloading.
 
 ## Check that nothing uses a hosted provider
 
 Before a sensitive meeting, confirm both selections:
 
 - **Settings → Transcription → Model being used** points to an on-device model.
-- **Settings → Intelligence → Model being used** points to LM Studio or Ollama.
+- **Settings → Intelligence → Model being used** points to LM Studio, Ollama, Unsloth, or Apple Intelligence.
 
-Choosing a local model for only one setting does not make the other setting local. See [Data, privacy, and retention](/data-and-privacy) for what each provider receives.
+Choosing a local model for only one setting does not make the other setting local. See [Models and providers](/models-and-providers) for the current model paths and [Data, privacy, and retention](/data-and-privacy) for what each provider receives.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- document the independent Transcription and Intelligence pipelines, including current managed cloud routes
- distinguish selectable Soniqo and Apple Speech models from compatibility-only local model IDs
- explain local meeting search, speaker voiceprints, audio ML, direct provider requests, and hosted web search
- clarify desktop, web, mobile, and enterprise repository surfaces and replace the placeholder contributor guide
- link model transparency guidance from setup, privacy, offline, and FAQ pages

## Validation
- scoped dprint formatting check passes for every changed file
- `npx --yes mint@latest validate`
- `npx --yes mint@latest broken-links --check-anchors --check-redirects`
- `pnpm fmt:check` attempted; the full check cannot start the macOS-only Swift formatter on Linux, while all changed files pass the scoped check
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02809-e1e2-78ce-90d6-e0ee42ba28b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02809-e1e2-78ce-90d6-e0ee42ba28b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

