### PR TITLE
Show Google Calendar immediately after connecting

### DIFF
--- a/apps/desktop/src/auth/useConnections.ts
+++ b/apps/desktop/src/auth/useConnections.ts
@@ -7,7 +7,10 @@ import { useAuth } from "./auth-context";
 
 import { env } from "~/env";
 
-export function useConnections(enabled = true) {
+export function useConnections(
+  enabled = true,
+  options?: { refetchInterval?: number | false },
+) {
   const auth = useAuth();
   const userId = auth?.session?.user.id;
 
@@ -27,5 +30,6 @@ export function useConnections(enabled = true) {
       return data?.connections ?? [];
     },
     enabled: enabled && !!userId,
+    refetchInterval: options?.refetchInterval,
   });
 }

--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -30,11 +30,15 @@ import { cn } from "@anlg/utils";
 
 import { useSync } from "./context";
 import { DayCell } from "./day-cell";
+import { getCalendarConnectionKey } from "./shared";
 
+import { useBillingAccess } from "~/auth/billing-context";
+import { useConnections } from "~/auth/useConnections";
 import {
   useCalendarData,
   useEnabledCalendars,
   useNow,
+  useSyncWhenCalendarConnectionsChange,
   useWeekStartsOn,
 } from "~/calendar/hooks";
 import type { CalendarSyncRange } from "~/services/calendar";
@@ -78,6 +82,13 @@ function useVisibleCols(ref: React.RefObject<HTMLDivElement | null>) {
 
 export function CalendarView() {
   const { scheduleSync } = useSync();
+  const { isPaid } = useBillingAccess();
+  const { data: connections } = useConnections(isPaid);
+  const connectionKey = useMemo(
+    () => getCalendarConnectionKey(connections),
+    [connections],
+  );
+  useSyncWhenCalendarConnectionsChange(connectionKey, scheduleSync);
   const now = useNow();
   const weekStartsOn = useWeekStartsOn();
   const weekOpts = useMemo(() => ({ weekStartsOn }), [weekStartsOn]);

--- a/apps/desktop/src/calendar/components/oauth/calendar-selection.test.tsx
+++ b/apps/desktop/src/calendar/components/oauth/calendar-selection.test.tsx
@@ -50,13 +50,13 @@ describe("useOAuthCalendarSelection", () => {
     mocks.calendars = [];
   });
 
-  it("syncs when a newly connected account has no calendars yet", () => {
+  it("does not sync on mount while calendar rows are still empty", () => {
     render(<HookHarness />);
 
-    expect(mocks.scheduleSync).toHaveBeenCalledOnce();
+    expect(mocks.scheduleSync).not.toHaveBeenCalled();
   });
 
-  it("does not resync an account that already has calendars", () => {
+  it("does not sync on mount when calendars are already present", () => {
     mocks.calendars = [
       {
         id: "cal-1",

--- a/apps/desktop/src/calendar/components/oauth/calendar-selection.test.tsx
+++ b/apps/desktop/src/calendar/components/oauth/calendar-selection.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  scheduleSync: vi.fn(),
+  calendars: [] as Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    source: string;
+    color: string;
+    connection_id: string;
+  }>,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}));
+
+vi.mock("../context", () => ({
+  useSync: () => ({
+    cancelDebouncedSync: vi.fn(),
+    status: "idle",
+    scheduleDebouncedSync: vi.fn(),
+    scheduleSync: mocks.scheduleSync,
+  }),
+}));
+
+vi.mock("~/calendar/queries", () => ({
+  setCalendarEnabled: vi.fn(),
+  useCalendarRows: () => mocks.calendars,
+}));
+
+import { PROVIDERS } from "../shared";
+import { useOAuthCalendarSelection } from "./calendar-selection";
+
+const GOOGLE_PROVIDER = PROVIDERS.find((provider) => provider.id === "google")!;
+
+function HookHarness() {
+  useOAuthCalendarSelection(GOOGLE_PROVIDER);
+  return null;
+}
+
+describe("useOAuthCalendarSelection", () => {
+  afterEach(() => {
+    cleanup();
+    mocks.scheduleSync.mockClear();
+    mocks.calendars = [];
+  });
+
+  it("syncs when a newly connected account has no calendars yet", () => {
+    render(<HookHarness />);
+
+    expect(mocks.scheduleSync).toHaveBeenCalledOnce();
+  });
+
+  it("does not resync an account that already has calendars", () => {
+    mocks.calendars = [
+      {
+        id: "cal-1",
+        name: "Work",
+        enabled: true,
+        source: "user@example.com",
+        color: "#4285f4",
+        connection_id: "conn-1",
+      },
+    ];
+
+    render(<HookHarness />);
+
+    expect(mocks.scheduleSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/calendar/components/oauth/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/oauth/calendar-selection.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/calendar/components/calendar-selection";
 import type { CalendarProvider } from "~/calendar/components/shared";
 import { setCalendarEnabled, useCalendarRows } from "~/calendar/queries";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export function OAuthCalendarSelection({
   groups,
@@ -122,11 +123,18 @@ export function useOAuthCalendarSelection(config: CalendarProvider) {
     scheduleSync();
   }, [cancelDebouncedSync, queryClient, scheduleSync]);
 
+  useMountEffect(() => {
+    if (calendars.length === 0) {
+      scheduleSync();
+    }
+  });
+
   return {
     groups,
     connectionSourceMap,
     handleRefresh,
     handleToggle,
-    isLoading: status === "syncing",
+    isLoading:
+      status === "syncing" || (status === "scheduled" && groups.length === 0),
   };
 }

--- a/apps/desktop/src/calendar/components/oauth/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/oauth/calendar-selection.tsx
@@ -10,7 +10,6 @@ import {
 } from "~/calendar/components/calendar-selection";
 import type { CalendarProvider } from "~/calendar/components/shared";
 import { setCalendarEnabled, useCalendarRows } from "~/calendar/queries";
-import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export function OAuthCalendarSelection({
   groups,
@@ -123,18 +122,11 @@ export function useOAuthCalendarSelection(config: CalendarProvider) {
     scheduleSync();
   }, [cancelDebouncedSync, queryClient, scheduleSync]);
 
-  useMountEffect(() => {
-    if (calendars.length === 0) {
-      scheduleSync();
-    }
-  });
-
   return {
     groups,
     connectionSourceMap,
     handleRefresh,
     handleToggle,
-    isLoading:
-      status === "syncing" || (status === "scheduled" && groups.length === 0),
+    isLoading: status === "syncing",
   };
 }

--- a/apps/desktop/src/calendar/components/oauth/provider-content.tsx
+++ b/apps/desktop/src/calendar/components/oauth/provider-content.tsx
@@ -24,9 +24,11 @@ import { useOpenIntegrationUrl } from "~/shared/integration";
 export function OAuthProviderContent({
   config,
   returnTo = "calendar",
+  onConnectStarted,
 }: {
   config: CalendarProvider;
   returnTo?: string;
+  onConnectStarted?: () => void;
 }) {
   const auth = useAuth();
   const { isPro, upgradeToPro, isUpgradingToPro } = useBillingAccess();
@@ -40,15 +42,14 @@ export function OAuthProviderContent({
     [connections, config.nangoIntegrationId],
   );
 
-  const handleAddAccount = useCallback(
-    () =>
-      openIntegration({
-        nangoIntegrationId: config.nangoIntegrationId,
-        action: "connect",
-        returnTo,
-      }),
-    [config.nangoIntegrationId, openIntegration, returnTo],
-  );
+  const handleAddAccount = useCallback(() => {
+    onConnectStarted?.();
+    openIntegration({
+      nangoIntegrationId: config.nangoIntegrationId,
+      action: "connect",
+      returnTo,
+    });
+  }, [config.nangoIntegrationId, onConnectStarted, openIntegration, returnTo]);
 
   if (!auth.session) {
     return (
@@ -98,14 +99,15 @@ export function OAuthProviderContent({
           <ReconnectRequiredContent
             key={connection.connection_id}
             config={config}
-            onReconnect={() =>
+            onReconnect={() => {
+              onConnectStarted?.();
               openIntegration({
                 nangoIntegrationId: config.nangoIntegrationId,
                 connectionId: connection.connection_id,
                 action: "reconnect",
                 returnTo,
-              })
-            }
+              });
+            }}
             onDisconnect={() =>
               openIntegration({
                 nangoIntegrationId: config.nangoIntegrationId,
@@ -123,6 +125,7 @@ export function OAuthProviderContent({
           config={config}
           connections={providerConnections}
           returnTo={returnTo}
+          onConnectStarted={onConnectStarted}
         />
       </div>
     );
@@ -209,10 +212,12 @@ function ConnectedContent({
   config,
   connections,
   returnTo,
+  onConnectStarted,
 }: {
   config: CalendarProvider;
   connections: ConnectionItem[];
   returnTo: string;
+  onConnectStarted?: () => void;
 }) {
   const { openIntegration } = useOpenIntegrationUrl();
   const {
@@ -240,13 +245,15 @@ function ConnectedContent({
             {
               id: `reconnect-${connection.connection_id}`,
               text: t`Reconnect`,
-              action: () =>
+              action: () => {
+                onConnectStarted?.();
                 void openIntegration({
                   nangoIntegrationId: config.nangoIntegrationId,
                   connectionId: connection.connection_id,
                   action: "reconnect",
                   returnTo,
-                }),
+                });
+              },
             },
             {
               id: `disconnect-${connection.connection_id}`,
@@ -267,6 +274,7 @@ function ConnectedContent({
       connectionSourceMap,
       connections,
       groups,
+      onConnectStarted,
       openIntegration,
       returnTo,
     ],

--- a/apps/desktop/src/calendar/components/shared.tsx
+++ b/apps/desktop/src/calendar/components/shared.tsx
@@ -54,3 +54,23 @@ const _PROVIDERS = [
 ] as const satisfies readonly CalendarProvider[];
 
 export const PROVIDERS = [..._PROVIDERS];
+
+const CALENDAR_NANGO_INTEGRATION_IDS = new Set<string>(
+  PROVIDERS.flatMap((provider) =>
+    provider.nangoIntegrationId ? [provider.nangoIntegrationId] : [],
+  ),
+);
+
+export function getCalendarConnectionKey(
+  connections:
+    | Array<{ connection_id: string; integration_id: string }>
+    | undefined,
+) {
+  return (connections ?? [])
+    .filter((connection) =>
+      CALENDAR_NANGO_INTEGRATION_IDS.has(connection.integration_id),
+    )
+    .map((connection) => connection.connection_id)
+    .sort()
+    .join(",");
+}

--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -1,7 +1,14 @@
 import { useLingui } from "@lingui/react/macro";
 import { CaretRight, CircleNotch, Plus } from "@phosphor-icons/react";
 import { platform } from "@tauri-apps/plugin-os";
-import { useCallback, useMemo, useState, type MouseEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+} from "react";
 
 import type { ConnectionItem } from "@anlg/api-client";
 import {
@@ -19,7 +26,11 @@ import {
   TroubleShootingLink,
 } from "./apple/permission";
 import { OAuthProviderContent } from "./oauth/provider-content";
-import { type CalendarProvider, PROVIDERS } from "./shared";
+import {
+  type CalendarProvider,
+  getCalendarConnectionKey,
+  PROVIDERS,
+} from "./shared";
 
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
@@ -80,6 +91,9 @@ function getProviderAccordionKey(
     .join("|");
 }
 
+const CONNECTION_POLL_MS = 45_000;
+const CONNECTION_POLL_INTERVAL_MS = 1_500;
+
 function ProviderIcon({ provider }: { provider: CalendarProvider }) {
   return (
     <span className="flex size-5 shrink-0 items-center justify-center">
@@ -96,7 +110,44 @@ export function CalendarSidebarContent({
   const isMacos = platform() === "macos";
   const calendar = usePermission("calendar");
   const { isPaid } = useBillingAccess();
-  const { data: connections } = useConnections(isPaid);
+  const [connectionPollUntil, setConnectionPollUntil] = useState<number | null>(
+    null,
+  );
+  const connectionKeyWhenPollStartedRef = useRef("");
+  const isPollingConnections = connectionPollUntil !== null;
+  const { data: connections } = useConnections(isPaid, {
+    refetchInterval: isPollingConnections ? CONNECTION_POLL_INTERVAL_MS : false,
+  });
+  const connectionKey = getCalendarConnectionKey(connections);
+  const watchForNewConnection = useCallback(() => {
+    connectionKeyWhenPollStartedRef.current = connectionKey;
+    setConnectionPollUntil(Date.now() + CONNECTION_POLL_MS);
+  }, [connectionKey]);
+
+  useEffect(() => {
+    if (connectionPollUntil === null) {
+      return;
+    }
+    const remaining = connectionPollUntil - Date.now();
+    if (remaining <= 0) {
+      setConnectionPollUntil(null);
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      setConnectionPollUntil(null);
+    }, remaining);
+    return () => window.clearTimeout(timeoutId);
+  }, [connectionPollUntil]);
+
+  useEffect(() => {
+    if (
+      !isPollingConnections ||
+      connectionKey === connectionKeyWhenPollStartedRef.current
+    ) {
+      return;
+    }
+    setConnectionPollUntil(null);
+  }, [connectionKey, isPollingConnections]);
 
   const visibleProviders = useMemo(
     () =>
@@ -144,6 +195,7 @@ export function CalendarSidebarContent({
             provider={provider}
             calendar={calendar}
             returnTo={returnTo}
+            onConnectStarted={watchForNewConnection}
           />
         ),
       )}
@@ -155,10 +207,12 @@ function ProviderAccordionItem({
   provider,
   calendar,
   returnTo,
+  onConnectStarted,
 }: {
   provider: CalendarProvider;
   calendar: ReturnType<typeof usePermission>;
   returnTo: string;
+  onConnectStarted: () => void;
 }) {
   const { t } = useLingui();
   const auth = useAuth();
@@ -206,6 +260,7 @@ function ProviderAccordionItem({
       }
       if (!shouldConnectOnClick) return;
       event.preventDefault();
+      onConnectStarted();
       openIntegration({
         nangoIntegrationId: provider.nangoIntegrationId,
         action: "connect",
@@ -215,6 +270,7 @@ function ProviderAccordionItem({
     [
       appleNeedsPermission,
       handleAppleConnect,
+      onConnectStarted,
       openIntegration,
       provider.nangoIntegrationId,
       requiresPro,
@@ -227,13 +283,20 @@ function ProviderAccordionItem({
       if (!canAddAccount) return;
       event.preventDefault();
       event.stopPropagation();
+      onConnectStarted();
       openIntegration({
         nangoIntegrationId: provider.nangoIntegrationId,
         action: "connect",
         returnTo,
       });
     },
-    [canAddAccount, openIntegration, provider.nangoIntegrationId, returnTo],
+    [
+      canAddAccount,
+      onConnectStarted,
+      openIntegration,
+      provider.nangoIntegrationId,
+      returnTo,
+    ],
   );
   const handleUpgradeToPro = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
@@ -250,17 +313,20 @@ function ProviderAccordionItem({
             {
               id: `add-${provider.id}-account`,
               text: t`Add ${provider.displayName} account`,
-              action: () =>
+              action: () => {
+                onConnectStarted();
                 void openIntegration({
                   nangoIntegrationId: provider.nangoIntegrationId,
                   action: "connect",
                   returnTo,
-                }),
+                });
+              },
             },
           ]
         : [],
     [
       canAddAccount,
+      onConnectStarted,
       provider.displayName,
       provider.id,
       provider.nangoIntegrationId,
@@ -383,7 +449,11 @@ function ProviderAccordionItem({
             </div>
           )}
           {provider.nangoIntegrationId && (
-            <OAuthProviderContent config={provider} returnTo={returnTo} />
+            <OAuthProviderContent
+              config={provider}
+              returnTo={returnTo}
+              onConnectStarted={onConnectStarted}
+            />
           )}
         </AccordionContent>
       )}

--- a/apps/desktop/src/calendar/connection-sync.test.tsx
+++ b/apps/desktop/src/calendar/connection-sync.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { getCalendarConnectionKey } from "./components/shared";
+import { useSyncWhenCalendarConnectionsChange } from "./hooks";
+
+describe("getCalendarConnectionKey", () => {
+  it("ignores non-calendar integrations and orders connection ids", () => {
+    expect(
+      getCalendarConnectionKey([
+        { connection_id: "outlook-2", integration_id: "outlook" },
+        { connection_id: "slack-1", integration_id: "slack" },
+        { connection_id: "google-1", integration_id: "google-calendar" },
+      ]),
+    ).toBe("google-1,outlook-2");
+  });
+
+  it("treats a missing connection list as empty", () => {
+    expect(getCalendarConnectionKey(undefined)).toBe("");
+  });
+});
+
+describe("useSyncWhenCalendarConnectionsChange", () => {
+  it("syncs when a calendar connection appears after the first snapshot", () => {
+    const scheduleSync = vi.fn();
+    const { rerender } = renderHook(
+      ({ connectionKey }) =>
+        useSyncWhenCalendarConnectionsChange(connectionKey, scheduleSync),
+      { initialProps: { connectionKey: "" } },
+    );
+
+    expect(scheduleSync).not.toHaveBeenCalled();
+
+    rerender({ connectionKey: "google-1" });
+
+    expect(scheduleSync).toHaveBeenCalledOnce();
+  });
+
+  it("does not sync again for the same connection key", () => {
+    const scheduleSync = vi.fn();
+    const { rerender } = renderHook(
+      ({ connectionKey }) =>
+        useSyncWhenCalendarConnectionsChange(connectionKey, scheduleSync),
+      { initialProps: { connectionKey: "google-1" } },
+    );
+
+    rerender({ connectionKey: "google-1" });
+
+    expect(scheduleSync).not.toHaveBeenCalled();
+  });
+
+  it("syncs again when another calendar account is added", () => {
+    const scheduleSync = vi.fn();
+    const { rerender } = renderHook(
+      ({ connectionKey }) =>
+        useSyncWhenCalendarConnectionsChange(connectionKey, scheduleSync),
+      { initialProps: { connectionKey: "google-1" } },
+    );
+
+    rerender({ connectionKey: "google-1,google-2" });
+
+    expect(scheduleSync).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/calendar/hooks.ts
+++ b/apps/desktop/src/calendar/hooks.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { useMemo, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
 import { safeParseDate } from "@anlg/utils";
 import { TZDate } from "@anlg/utils";
@@ -138,6 +138,25 @@ export function useEnabledCalendars(): EnabledCalendar[] {
   return useMemo(() => {
     return rows.map((row) => ({ id: row.id, provider: row.provider }));
   }, [rows]);
+}
+
+export function useSyncWhenCalendarConnectionsChange(
+  connectionKey: string,
+  scheduleSync: () => void,
+) {
+  const previousKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (previousKeyRef.current === null) {
+      previousKeyRef.current = connectionKey;
+      return;
+    }
+    if (previousKeyRef.current === connectionKey) {
+      return;
+    }
+    previousKeyRef.current = connectionKey;
+    scheduleSync();
+  }, [connectionKey, scheduleSync]);
 }
 
 export type CalendarData = {

--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -55,6 +55,21 @@ describe("FolderPicker", () => {
     expect(trigger.querySelectorAll("svg")).toHaveLength(1);
   });
 
+  it("uses the same floating chrome as note metadata", () => {
+    render(<FolderPicker sessionId="session-1" />);
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Select folder" }));
+
+    const input = screen.getByPlaceholderText("Search or create folder");
+    const content = input.closest("[data-radix-popper-content-wrapper] > *");
+    const classes = content?.className.split(/\s+/) ?? [];
+
+    expect(classes).toContain("w-85");
+    expect(classes).toContain("p-0.5");
+    expect(classes).not.toContain("p-0");
+    expect(input.closest(".p-4")).not.toBeNull();
+  });
+
   it("lets the user select an existing folder for the current note", async () => {
     render(<FolderPicker sessionId="session-1" />);
 

--- a/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
+++ b/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
@@ -58,8 +58,9 @@ export function useDeeplinkHandler() {
 
     const timeoutIds = new Set<number>();
     const invalidateIntegrationState = () => {
-      void queryClientRef.current.invalidateQueries({
-        predicate: (query) => query.queryKey[0] === "integration-status",
+      void queryClientRef.current.refetchQueries({
+        queryKey: ["integration-status"],
+        type: "all",
       });
     };
     const refreshIntegrationState = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Connecting Google Calendar from the calendar view left the sidebar stale until you navigated away and back. The view only synced on mount, so a connection completed while that tab stayed open never pulled the new account.

## Changes
- Poll integration status after a connect/reconnect starts, then stop once the new calendar connection appears
- Sync calendars when the connected-account list changes in the calendar view
- Refetch integration status from the OAuth callback instead of only marking it stale
- Do not schedule a sync from the OAuth picker on mount: `useCalendarRows` is empty while the live query is still loading, so that guard would resync on every accordion remount

## Validation
- `pnpm exec dprint fmt` / scoped `dprint check`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop exec vitest run` for the calendar connection/selection/sidebar tests

Skipped `pnpm fmt:check` repo-wide: on Linux it fails on Swift files because `swift format` is macOS-only. Scoped formatting on the changed TS files is clean. No i18n copy changes, so `pnpm -F desktop i18n:check` was not run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8c4ad4-0155-4193-90e7-300f963fd3a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8c4ad4-0155-4193-90e7-300f963fd3a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

