### PR TITLE
Show blurred locked-note content instead of a solid pane

### DIFF
--- a/apps/desktop/src/lock/screen.tsx
+++ b/apps/desktop/src/lock/screen.tsx
@@ -11,19 +11,22 @@ export function LockScreen({
   action,
   authenticating,
   onUnlock,
+  className,
 }: {
   title: string;
   description?: string;
   action?: string;
   authenticating: boolean;
   onUnlock: () => void;
+  className?: string;
 }) {
   return (
     <div
       data-lock-screen
       data-tauri-drag-region
       className={cn([
-        "bg-background flex h-full min-h-0 w-full flex-1 flex-col items-center justify-center",
+        "flex h-full min-h-0 w-full flex-1 flex-col items-center justify-center",
+        className ?? "bg-background",
       ])}
     >
       <div className="flex max-w-sm flex-col items-center px-6 text-center">
@@ -83,6 +86,7 @@ export function NoteLockScreen({
       action={t`View Note`}
       authenticating={authenticating}
       onUnlock={onUnlock}
+      className="bg-transparent"
     />
   );
 }

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -1,23 +1,50 @@
+import { cn } from "@anlg/utils";
+
 import { StandardContentWrapper } from "~/shared/main";
 
 export function SessionSurface({
   header,
   children,
   floatingButton,
+  overlay,
 }: {
   header?: React.ReactNode;
   children: React.ReactNode;
   floatingButton?: React.ReactNode;
+  overlay?: React.ReactNode;
 }) {
   return (
     <StandardContentWrapper floatingButton={floatingButton}>
-      <div data-session-surface className="flex h-full flex-col">
-        {header ? (
-          <div data-tauri-drag-region className="px-1">
-            {header}
+      <div
+        data-session-surface
+        className="relative isolate flex h-full flex-col"
+      >
+        <div
+          className={cn([
+            "flex h-full min-h-0 flex-1 flex-col",
+            overlay ? "relative z-0 overflow-hidden" : null,
+          ])}
+          {...(overlay ? { inert: true, "aria-hidden": true } : {})}
+        >
+          <div
+            className={cn([
+              "flex h-full min-h-0 flex-1 flex-col",
+              overlay
+                ? "origin-center scale-[1.03] blur-[22px] select-none"
+                : null,
+            ])}
+          >
+            {header ? (
+              <div data-tauri-drag-region className="px-1">
+                {header}
+              </div>
+            ) : null}
+            <div className="min-h-0 flex-1 px-2">{children}</div>
           </div>
+        </div>
+        {overlay ? (
+          <div className="absolute inset-0 z-10 overflow-hidden">{overlay}</div>
         ) : null}
-        <div className="min-h-0 flex-1 px-2">{children}</div>
       </div>
     </StandardContentWrapper>
   );

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -83,32 +83,34 @@ function LockedNoteGate({
     Boolean(state.revealedNoteIds[tab.id]),
   );
   const authenticating = useAppLock((state) => state.authenticating);
-
-  if (session && locked && !revealed) {
-    return (
-      <SessionSurface>
-        <NoteLockScreen
-          sessionTitle={session.title}
-          authenticating={authenticating}
-          onUnlock={() => {
-            void revealLockedNote(tab.id);
-          }}
-        />
-      </SessionSurface>
-    );
-  }
+  const lockOverlay =
+    session && locked && !revealed ? (
+      <NoteLockScreen
+        sessionTitle={session.title}
+        authenticating={authenticating}
+        onUnlock={() => {
+          void revealLockedNote(tab.id);
+        }}
+      />
+    ) : null;
 
   return (
-    <UnlockedTabContentNote tab={tab} standaloneWindow={standaloneWindow} />
+    <UnlockedTabContentNote
+      tab={tab}
+      standaloneWindow={standaloneWindow}
+      lockOverlay={lockOverlay}
+    />
   );
 }
 
 function UnlockedTabContentNote({
   standaloneWindow,
   tab,
+  lockOverlay,
 }: {
   standaloneWindow: boolean;
   tab: Extract<Tab, { type: "sessions" }>;
+  lockOverlay: React.ReactNode;
 }) {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
   const audioExists = AudioPlayer.useAudioExists(tab.id);
@@ -128,7 +130,7 @@ function UnlockedTabContentNote({
 
   return (
     <>
-      {tab.state.autoStart && !standaloneWindow ? (
+      {tab.state.autoStart && !standaloneWindow && !lockOverlay ? (
         <AutoStartListening tab={tab} />
       ) : null}
       <SearchProvider>
@@ -138,6 +140,7 @@ function UnlockedTabContentNote({
             standaloneWindow={standaloneWindow}
             audioUrlReady={Boolean(audioUrl)}
             audioExists={audioExists}
+            lockOverlay={lockOverlay}
           />
         </AudioPlayer.Provider>
       </SearchProvider>
@@ -211,11 +214,13 @@ function TabContentNoteInner({
   standaloneWindow,
   audioUrlReady,
   audioExists,
+  lockOverlay,
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
   standaloneWindow: boolean;
   audioUrlReady: boolean;
   audioExists: boolean;
+  lockOverlay: React.ReactNode;
 }) {
   const noteInputRef = React.useRef<NoteInputHandle>(null);
 
@@ -223,7 +228,7 @@ function TabContentNoteInner({
   const [editingTranscriptSessionId, setEditingTranscriptSessionId] =
     React.useState<string | null>(null);
   const transcriptEditMode = editingTranscriptSessionId === sessionId;
-  usePendingUpload(sessionId);
+  usePendingUpload(sessionId, !lockOverlay);
 
   const hasTranscript = useHasTranscript(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
@@ -245,7 +250,7 @@ function TabContentNoteInner({
   const contentHydrated = session !== null;
   useEnsureDefaultSummaryFromState({
     batchError: Boolean(batchError),
-    enabled: contentHydrated,
+    enabled: contentHydrated && !lockOverlay,
     enhancedNoteCount: enhancedNoteIds.length,
     hasTranscript,
     memoTemplateId: session?.raw_template_id,
@@ -274,7 +279,11 @@ function TabContentNoteInner({
       canShowTranscript,
     );
   }, [tab.state.view, isLiveSessionActive, enhancedNoteIds, canShowTranscript]);
-  useAutoFocusTitle({ sessionId, noteInputRef });
+  useAutoFocusTitle({
+    sessionId,
+    noteInputRef,
+    enabled: !lockOverlay,
+  });
 
   const showTopAudioPlayer = shouldShowSessionTopAudioPlayer({
     audioExists,
@@ -306,36 +315,41 @@ function TabContentNoteInner({
   return (
     <>
       <SessionSurface
+        overlay={lockOverlay}
         header={
-          <OuterHeader
-            sessionId={sessionId}
-            currentView={currentView}
-            standaloneWindow={standaloneWindow}
-            transcriptEditMode={transcriptEditMode}
-            onTranscriptEditModeChange={handleTranscriptEditModeChange}
-            viewSwitcher={
-              <SessionViewSwitcher
-                sessionId={sessionId}
-                editorTabs={editorTabs}
-                currentTab={currentView}
-                handleTabChange={handleTabChange}
-                isTranscribing={isTranscribing}
-              />
-            }
-          />
+          lockOverlay ? undefined : (
+            <OuterHeader
+              sessionId={sessionId}
+              currentView={currentView}
+              standaloneWindow={standaloneWindow}
+              transcriptEditMode={transcriptEditMode}
+              onTranscriptEditModeChange={handleTranscriptEditModeChange}
+              viewSwitcher={
+                <SessionViewSwitcher
+                  sessionId={sessionId}
+                  editorTabs={editorTabs}
+                  currentTab={currentView}
+                  handleTabChange={handleTabChange}
+                  isTranscribing={isTranscribing}
+                />
+              }
+            />
+          )
         }
         floatingButton={
-          <FloatingActionButton
-            allowListening={!standaloneWindow}
-            audioExists={audioExists}
-            currentView={currentView}
-            skipReason={skipReason}
-            tab={tab}
-          />
+          lockOverlay ? undefined : (
+            <FloatingActionButton
+              allowListening={!standaloneWindow}
+              audioExists={audioExists}
+              currentView={currentView}
+              skipReason={skipReason}
+              tab={tab}
+            />
+          )
         }
       >
         <div className="flex h-full min-h-0 flex-col">
-          {showTopAudioPlayer ? (
+          {showTopAudioPlayer && !lockOverlay ? (
             <div
               data-session-top-audio-player
               className="shrink-0 px-1 pt-1 pb-2"
@@ -391,35 +405,39 @@ function SessionContentLoading() {
   );
 }
 
-function usePendingUpload(sessionId: string) {
+function usePendingUpload(sessionId: string, enabled = true) {
   const { processFile } = useUploadFile(sessionId);
   const processFileRef = useRef(processFile);
   processFileRef.current = processFile;
 
   useEffect(() => {
+    if (!enabled) return;
     const pending = consumePendingUpload(sessionId);
     if (pending) {
       processFileRef.current(pending.filePath, pending.kind);
     }
-  }, [sessionId]);
+  }, [enabled, sessionId]);
 }
 
 function useAutoFocusTitle({
   sessionId,
   noteInputRef,
+  enabled = true,
 }: {
   sessionId: string;
   noteInputRef: React.RefObject<NoteInputHandle | null>;
+  enabled?: boolean;
 }) {
   const autoFocusedSessionRef = useRef<string | null>(null);
   const title = useSession(sessionId)?.title;
 
   useEffect(() => {
+    if (!enabled) return;
     if (autoFocusedSessionRef.current === sessionId) return;
 
     if (!title) {
       noteInputRef.current?.focusAtStart();
       autoFocusedSessionRef.current = sessionId;
     }
-  }, [sessionId, title]);
+  }, [enabled, sessionId, title]);
 }

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   },
   windowShow: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
   authAvailable: false as boolean | null,
+  revealedNoteIds: {} as Record<string, true>,
 }));
 
 vi.mock("@tauri-apps/plugin-os", () => ({
@@ -85,8 +86,16 @@ vi.mock("~/lock/notes", () => ({
 }));
 
 vi.mock("~/lock/store", () => ({
-  useAppLock: (selector: (state: { available: boolean | null }) => unknown) =>
-    selector({ available: mocks.authAvailable }),
+  useAppLock: (
+    selector: (state: {
+      available: boolean | null;
+      revealedNoteIds: Record<string, true>;
+    }) => unknown,
+  ) =>
+    selector({
+      available: mocks.authAvailable,
+      revealedNoteIds: mocks.revealedNoteIds,
+    }),
 }));
 
 vi.mock("~/shared/hooks/useNativeContextMenu", () => ({
@@ -176,6 +185,7 @@ describe("TimelineItemComponent", () => {
     mocks.openNew.mockClear();
     mocks.platform = "macos";
     mocks.authAvailable = false;
+    mocks.revealedNoteIds = {};
     mocks.windowShow.mockClear();
     mocks.nativeContextMenus = [];
     mocks.timelineSelection.selectedIds = [];
@@ -678,5 +688,31 @@ describe("TimelineItemComponent", () => {
     );
 
     expect(screen.getByLabelText("Locked note")).toBeTruthy();
+  });
+
+  it("marks a revealed locked note with an unlocked icon", () => {
+    mocks.revealedNoteIds = { "session-locked": true };
+
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "session",
+          id: "session-locked",
+          data: {
+            title: "Secret",
+            created_at: "2024-01-15T10:30:00.000Z",
+            locked: 1,
+          },
+        }}
+        precision="time"
+        selected={true}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["session-session-locked"]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Unlock Note")).toBeTruthy();
+    expect(screen.queryByLabelText("Locked note")).toBeNull();
   });
 });

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -1,5 +1,5 @@
 import { useLingui } from "@lingui/react/macro";
-import { Lock, Square, Users } from "@phosphor-icons/react";
+import { Lock, LockOpen, Square, Users } from "@phosphor-icons/react";
 import { platform } from "@tauri-apps/plugin-os";
 import {
   createContext,
@@ -59,6 +59,7 @@ type ItemBaseProps = {
   showSpinner?: boolean;
   isShared?: boolean;
   isLocked?: boolean;
+  isLockRevealed?: boolean;
   selected: boolean;
   ignored?: boolean;
   muted?: boolean;
@@ -149,6 +150,7 @@ const ItemBase = memo(function ItemBase({
   showSpinner,
   isShared,
   isLocked,
+  isLockRevealed,
   selected,
   ignored,
   muted,
@@ -247,11 +249,19 @@ const ItemBase = memo(function ItemBase({
             )}
           </div>
           {isLocked ? (
-            <Lock
-              aria-label={t`Locked note`}
-              className="text-muted-foreground size-3.5 shrink-0"
-              weight="fill"
-            />
+            isLockRevealed ? (
+              <LockOpen
+                aria-label={t`Unlock Note`}
+                className="text-muted-foreground size-3.5 shrink-0"
+                weight="fill"
+              />
+            ) : (
+              <Lock
+                aria-label={t`Locked note`}
+                className="text-muted-foreground size-3.5 shrink-0"
+                weight="fill"
+              />
+            )
           ) : null}
           {isShared ? (
             <Users
@@ -331,6 +341,7 @@ function itemBasePropsAreEqual(prev: ItemBaseProps, next: ItemBaseProps) {
     prev.showSpinner === next.showSpinner &&
     prev.isShared === next.isShared &&
     prev.isLocked === next.isLocked &&
+    prev.isLockRevealed === next.isLockRevealed &&
     prev.selected === next.selected &&
     prev.ignored === next.ignored &&
     prev.muted === next.muted &&
@@ -549,6 +560,9 @@ const SessionItem = memo(
     const sessionId = item.id;
     const title = useSessionTitle(sessionId, item.data.title ?? undefined);
     const noteLocked = isLockedFlag(item.data.locked);
+    const noteRevealed = useAppLock((state) =>
+      Boolean(state.revealedNoteIds[sessionId]),
+    );
     const authAvailable = useAppLock((state) => state.available) === true;
 
     const { sessionMode, stop, amplitude } = useListener((state) => {
@@ -690,6 +704,7 @@ const SessionItem = memo(
         showSpinner={showSpinner}
         isShared={managedSharedSessionIds.has(sessionId)}
         isLocked={noteLocked}
+        isLockRevealed={noteRevealed}
         selected={selected}
         muted={muted}
         multiSelected={multiSelected}


### PR DESCRIPTION
## Summary
- Keep locked note content mounted under a blur overlay so you can tell there is a note without reading it
- Show an open lock in the sidebar while that note is revealed, and a closed lock when it is still concealed

## Test plan
- [ ] Open a locked note and confirm the editor is blurred, not a solid white/empty pane
- [ ] Click View Note / authenticate and confirm the overlay disappears and the note is usable
- [ ] Confirm the sidebar lock icon is closed while concealed and open after the note is revealed
- [ ] Switch away and back to a still-revealed locked note and confirm the open lock stays until the note is concealed again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches locked-note presentation: content is now in the DOM (blurred) rather than unmounted, which is a privacy-sensitive change even with inert/overlay gating.
> 
> **Overview**
> Locked notes now stay mounted under a transparent lock overlay instead of swapping to a solid empty pane. `SessionSurface` blurs and slightly scales the editor, marks it `inert`/`aria-hidden`, and hides chrome (header, FAB, audio player) plus auto-start, pending upload, and title autofocus while the overlay is up.
> 
> The sidebar lock icon switches to an open lock while a note is revealed, so you can tell concealed vs authenticated-open without reading the note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa58235a859dd4bdeedfa794b5c694f35b3229cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->