### PR TITLE
fix/local-auth-rcblock-fn

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -70,19 +70,17 @@ function App() {
   const aiTaskStore = useMemo(() => createAITaskStore(), []);
 
   return (
-    <AppThemeProvider>
-      <AppI18nProvider>
-        <AITaskWindowSyncBridge store={aiTaskStore} />
-        <RouterProvider
-          router={router}
-          context={{
-            listenerStore,
-            aiTaskStore,
-            toolRegistry,
-          }}
-        />
-      </AppI18nProvider>
-    </AppThemeProvider>
+    <>
+      <AITaskWindowSyncBridge store={aiTaskStore} />
+      <RouterProvider
+        router={router}
+        context={{
+          listenerStore,
+          aiTaskStore,
+          toolRegistry,
+        }}
+      />
+    </>
   );
 }
 
@@ -108,18 +106,22 @@ function ReadyApp() {
   }, []);
 
   return (
-    <TaskSchedulerProvider scheduler={scheduler}>
-      <AppLockGate>
-        <App />
-        {isMainWindow ? <TaskManager /> : null}
-        {isMainWindow ? <FloatingMeetingWindowHost /> : null}
-        {isMainWindow ? <EventListeners /> : null}
-        {isMainWindow ? <TrayScheduleSync /> : null}
-        {isMainWindow ? <TrayRecordingSync /> : null}
-        {isMainWindow ? <UpdaterMeetingSync /> : null}
-        <Toaster position="bottom-right" theme={theme} />
-      </AppLockGate>
-    </TaskSchedulerProvider>
+    <AppThemeProvider>
+      <AppI18nProvider>
+        <TaskSchedulerProvider scheduler={scheduler}>
+          <AppLockGate>
+            <App />
+            {isMainWindow ? <TaskManager /> : null}
+            {isMainWindow ? <FloatingMeetingWindowHost /> : null}
+            {isMainWindow ? <EventListeners /> : null}
+            {isMainWindow ? <TrayScheduleSync /> : null}
+            {isMainWindow ? <TrayRecordingSync /> : null}
+            {isMainWindow ? <UpdaterMeetingSync /> : null}
+            <Toaster position="bottom-right" theme={theme} />
+          </AppLockGate>
+        </TaskSchedulerProvider>
+      </AppI18nProvider>
+    </AppThemeProvider>
   );
 }
 

--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -62,9 +62,11 @@ describe("FolderPicker", () => {
 
     const input = screen.getByPlaceholderText("Search or create folder");
     const content = input.closest("[data-radix-popper-content-wrapper] > *");
+    const classes = content?.className.split(/\s+/) ?? [];
 
-    expect(content?.className).toContain("w-85");
-    expect(content?.className).not.toContain("p-0");
+    expect(classes).toContain("w-85");
+    expect(classes).toContain("p-0.5");
+    expect(classes).not.toContain("p-0");
     expect(input.closest(".p-4")).not.toBeNull();
   });
 

--- a/crates/transcribe-soniqo/src/streaming_offline.rs
+++ b/crates/transcribe-soniqo/src/streaming_offline.rs
@@ -2,7 +2,10 @@ pub(crate) fn patch_parakeet_streaming_source(source: &str) -> Result<String, &'
     const SIGNATURE: &str = "    public static func fromPretrained(\n        modelId: String? = nil,\n        progressHandler: ((Double, String) -> Void)? = nil\n    ) async throws -> ParakeetStreamingASRModel {";
     const PATCHED_SIGNATURE: &str = "    public static func fromPretrained(\n        modelId: String? = nil,\n        offlineMode: Bool = false,\n        progressHandler: ((Double, String) -> Void)? = nil\n    ) async throws -> ParakeetStreamingASRModel {";
     const DOWNLOAD: &str = "            try await HuggingFaceDownloader.downloadWeights(\n                modelId: effectiveModelId,\n                to: cacheDir,\n                additionalFiles: [";
-    const PATCHED_DOWNLOAD: &str = "            try await HuggingFaceDownloader.downloadWeights(\n                modelId: effectiveModelId,\n                to: cacheDir,\n                offlineMode: offlineMode,\n                additionalFiles: [";
+    const MISORDERED_DOWNLOAD: &str = "            try await HuggingFaceDownloader.downloadWeights(\n                modelId: effectiveModelId,\n                to: cacheDir,\n                offlineMode: offlineMode,\n                additionalFiles: [";
+    const DOWNLOAD_CLOSE: &str =
+        "                    \"config.json\",\n                ]\n            ) { fraction in";
+    const PATCHED_DOWNLOAD_CLOSE: &str = "                    \"config.json\",\n                ],\n                offlineMode: offlineMode\n            ) { fraction in";
 
     let mut patched = source.to_string();
 
@@ -13,12 +16,16 @@ pub(crate) fn patch_parakeet_streaming_source(source: &str) -> Result<String, &'
         patched = patched.replacen(SIGNATURE, PATCHED_SIGNATURE, 1);
     }
 
-    if patched.contains(PATCHED_DOWNLOAD) {
+    if patched.contains(MISORDERED_DOWNLOAD) {
+        patched = patched.replacen(MISORDERED_DOWNLOAD, DOWNLOAD, 1);
+    }
+
+    if patched.contains(PATCHED_DOWNLOAD_CLOSE) {
         return Ok(patched);
     }
 
-    if patched.contains(DOWNLOAD) {
-        return Ok(patched.replacen(DOWNLOAD, PATCHED_DOWNLOAD, 1));
+    if patched.contains(DOWNLOAD_CLOSE) {
+        return Ok(patched.replacen(DOWNLOAD_CLOSE, PATCHED_DOWNLOAD_CLOSE, 1));
     }
 
     Err("ParakeetStreamingASR downloadWeights call not found")
@@ -39,6 +46,29 @@ mod tests {
                 to: cacheDir,
                 additionalFiles: [
                     "encoder.mlmodelc/**",
+                    "config.json",
+                ]
+            ) { fraction in
+                progressHandler?(fraction * 0.7, "Downloading model...")
+            }
+        }
+    }
+"#;
+
+    const MISORDERED: &str = r#"    public static func fromPretrained(
+        modelId: String? = nil,
+        offlineMode: Bool = false,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) async throws -> ParakeetStreamingASRModel {
+        progressHandler?(0.0, "Downloading model...")
+        do {
+            try await HuggingFaceDownloader.downloadWeights(
+                modelId: effectiveModelId,
+                to: cacheDir,
+                offlineMode: offlineMode,
+                additionalFiles: [
+                    "encoder.mlmodelc/**",
+                    "config.json",
                 ]
             ) { fraction in
                 progressHandler?(fraction * 0.7, "Downloading model...")
@@ -52,10 +82,23 @@ mod tests {
         let patched = patch_parakeet_streaming_source(SOURCE).unwrap();
 
         assert!(patched.contains("offlineMode: Bool = false"));
-        assert!(patched.contains("offlineMode: offlineMode"));
+        assert!(patched.contains(
+            "                ],\n                offlineMode: offlineMode\n            ) { fraction in"
+        ));
         assert!(!patched.contains(
             "        modelId: String? = nil,\n        progressHandler: ((Double, String) -> Void)? = nil"
         ));
+        assert!(!patched.contains("offlineMode: offlineMode,\n                additionalFiles:"));
+    }
+
+    #[test]
+    fn rewrites_misordered_download_weights_arguments() {
+        let patched = patch_parakeet_streaming_source(MISORDERED).unwrap();
+
+        assert!(patched.contains(
+            "                ],\n                offlineMode: offlineMode\n            ) { fraction in"
+        ));
+        assert!(!patched.contains("offlineMode: offlineMode,\n                additionalFiles:"));
     }
 
     #[test]

--- a/plugins/local-auth/src/macos.rs
+++ b/plugins/local-auth/src/macos.rs
@@ -52,7 +52,7 @@ fn start_authentication(reason: &str, tx: mpsc::Sender<Result<bool, Error>>) {
     let keep_alive = context.clone();
     let localized_reason = NSString::from_str(reason);
     let reply = RcBlock::new(move |success: Bool, _error: *mut NSError| {
-        drop(keep_alive);
+        let _keep_alive = &keep_alive;
         let _ = tx.send(Ok(success.as_bool()));
     });
 


### PR DESCRIPTION
- Fix desktop LocalAuthentication reply block to remain Fn-compatible (avoid making closure FnOnce by droppingContext in the callback).
 Pass Soni offline after additionalFiles to match Swift6.3 required order for download.
- AppLockGate in the i18 provider to ensure useLingui is called inside AppI18nProvider and boot throwing (fix splash screen hang).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app-lock/i18n provider order (boot path) and macOS LocalAuthentication callback lifetime. Failures could hang splash or break device unlock, but the changes are small and targeted.
> 
> **Overview**
> Fixes three independent boot/runtime issues.
> 
> **Splash hang:** moves `AppThemeProvider` and `AppI18nProvider` above `AppLockGate` so `useLingui` in the lock screen runs inside the i18n provider instead of throwing during startup.
> 
> **macOS local auth:** keeps `LAContext` alive in the LocalAuthentication reply block without `drop()`, so the closure stays `Fn`/`RcBlock`-compatible.
> 
> **Parakeet streaming patch:** inserts `offlineMode` after `additionalFiles` (Swift 6.3 argument order) and rewrites previously misordered `downloadWeights` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c181f102d7aa87f6a3b8077db9b17bccafc8a5c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->