### PR TITLE
fix(desktop): unblock Apple Speech and Soniqo model downloads

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -48,6 +48,7 @@ import {
 } from "./selection";
 import {
   displayModelLabel,
+  formatDownloadProgress,
   formatModelSize,
   type ProviderId,
   PROVIDERS,
@@ -863,7 +864,7 @@ function ModelSelectItem({
         >
           <CircleNotch className="size-3 animate-spin" />
           {downloadInfo ? (
-            <span>{Math.round(downloadInfo.progress)}%</span>
+            formatDownloadProgress(downloadInfo.progress)
           ) : (
             <Trans>Starting</Trans>
           )}

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 
-import { displayModelLabel, PROVIDERS } from "./shared";
+import { displayModelLabel, formatDownloadProgress, PROVIDERS } from "./shared";
 
 describe("STT providers", () => {
   test("orders providers by popularity", () => {
@@ -130,5 +130,12 @@ describe("STT model display labels", () => {
     expect(displayModelLabel("apple-speech")).toBe("Apple Speech");
     expect(displayModelLabel("soniqo-parakeet-batch")).toBe("Parakeet Batch");
     expect(displayModelLabel("soniqo-omnilingual")).toBe("Omnilingual ASR");
+  });
+
+  test("hides unknown or zero download percent", () => {
+    expect(formatDownloadProgress(null)).toBeNull();
+    expect(formatDownloadProgress(0)).toBeNull();
+    expect(formatDownloadProgress(12.4)).toBe("12%");
+    expect(formatDownloadProgress(100)).toBe("100%");
   });
 });

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -267,6 +267,14 @@ export function displayModelLabel(model: string, displayName?: string) {
   return displayName ?? displayModelId(model);
 }
 
+export function formatDownloadProgress(progress?: number | null) {
+  if (progress == null || progress <= 0) {
+    return null;
+  }
+
+  return `${Math.round(progress)}%`;
+}
+
 export function formatModelSize(sizeBytes?: number | null) {
   if (!sizeBytes) {
     return null;

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -245,7 +245,47 @@ describe("ToastNotifications", () => {
       expect.objectContaining({
         id: "downloading-model",
         duration: Infinity,
-        closeButton: false,
+        closeButton: true,
+      }),
+    );
+  });
+
+  it("lets users dismiss a model download toast until the next download", () => {
+    mocks.notifications.hasActiveDownload = true;
+    mocks.notifications.downloadingModel = "apple-speech";
+    mocks.notifications.activeDownloads = [
+      { model: "apple-speech", displayName: "apple-speech", progress: 0 },
+    ];
+
+    const view = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    const options = mocks.loading.mock.calls[0][1];
+    expect(options.closeButton).toBe(true);
+    act(() => options.onDismiss());
+
+    mocks.loading.mockClear();
+    view.rerender(<ToastNotifications />);
+    expect(mocks.loading).not.toHaveBeenCalled();
+
+    mocks.notifications.hasActiveDownload = false;
+    mocks.notifications.downloadingModel = null;
+    mocks.notifications.activeDownloads = [];
+    view.rerender(<ToastNotifications />);
+
+    mocks.notifications.hasActiveDownload = true;
+    mocks.notifications.downloadingModel = "apple-speech";
+    mocks.notifications.activeDownloads = [
+      { model: "apple-speech", displayName: "apple-speech", progress: 12 },
+    ];
+    mocks.loading.mockClear();
+    view.rerender(<ToastNotifications />);
+
+    expect(mocks.loading).toHaveBeenCalledWith(
+      "Downloading apple-speech",
+      expect.objectContaining({
+        id: "downloading-model",
+        closeButton: true,
       }),
     );
   });

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { sonnerToast, TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
 
@@ -52,6 +52,22 @@ export function ToastNotifications() {
       );
     }
   }
+
+  useEffect(() => {
+    if (hasActiveDownload) {
+      return;
+    }
+
+    setSessionDismissedToastIds((current) => {
+      if (!current.has("downloading-model")) {
+        return current;
+      }
+
+      const next = new Set(current);
+      next.delete("downloading-model");
+      return next;
+    });
+  }, [hasActiveDownload]);
 
   const isAuthenticated = !!auth?.session;
   const isAuthLoading = auth.session === undefined;

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -240,6 +240,27 @@ describe("sidebar toast registry", () => {
     expect(toast).toBeNull();
   });
 
+  it("lets users dismiss a model download toast for the current download", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        hasActiveDownload: true,
+        downloadingModel: "apple-speech",
+        activeDownloads: [
+          { model: "apple-speech", displayName: "apple-speech", progress: 0 },
+        ],
+      }),
+      () => false,
+    );
+
+    expect(toast).toMatchObject({
+      id: "downloading-model",
+      description: "Downloading apple-speech",
+      lifecycle: { type: "persistent", dismissal: "session" },
+      loading: true,
+    });
+  });
+
   it("keeps desktop update progress in the toast", () => {
     const toast = getToastToShow(
       createToastRegistry({
@@ -257,7 +278,7 @@ describe("sidebar toast registry", () => {
     expect(toast).toMatchObject({
       id: "desktop-update:1.0.34:downloading",
       description: "Downloading Anarlog 1.0.34 (58%)",
-      lifecycle: { type: "condition-bound" },
+      lifecycle: { type: "persistent", dismissal: "session" },
       loading: true,
     });
     expect(toast?.primaryAction).toBeUndefined();
@@ -317,5 +338,9 @@ describe("sidebar toast registry", () => {
     });
     expect(downloadToast.id).toBe("devtools-downloading-model");
     expect(downloadToast.loading).toBe(true);
+    expect(downloadToast.lifecycle).toEqual({
+      type: "persistent",
+      dismissal: "session",
+    });
   });
 });

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -83,7 +83,7 @@ export function createToastRegistry({
       toast: {
         id: "downloading-model",
         description: downloadTitle,
-        lifecycle: { type: "condition-bound" },
+        lifecycle: { type: "persistent", dismissal: "session" },
         loading: true,
       },
       condition: () => hasActiveDownload,
@@ -237,7 +237,7 @@ export function createDesktopUpdateToast(
     return {
       id: `${id}:downloading`,
       description: t`Downloading Anarlog ${update.version}${progress}`,
-      lifecycle: { type: "condition-bound" },
+      lifecycle: { type: "persistent", dismissal: "session" },
       loading: true,
     };
   }
@@ -322,7 +322,7 @@ export function createDevtoolsToastPreview({
       return {
         id: "devtools-downloading-model",
         description: t`Downloading model`,
-        lifecycle: { type: "condition-bound" },
+        lifecycle: { type: "persistent", dismissal: "session" },
         loading: true,
       };
     case "pro":

--- a/crates/local-model/src/lib.rs
+++ b/crates/local-model/src/lib.rs
@@ -307,10 +307,13 @@ impl DownloadableModel for LocalModel {
         match self {
             LocalModel::Soniqo(model) => anlg_transcribe_soniqo::is_model_downloaded(*model)
                 .map_err(|e| Error::OperationFailed(e.to_string())),
-            LocalModel::AppleSpeech(_) => {
-                { anlg_transcribe_speechanalyzer::is_model_downloaded(APPLE_SPEECH_DEFAULT_LOCALE) }
-                    .map_err(|e| Error::OperationFailed(e.to_string()))
-            }
+            LocalModel::AppleSpeech(_) => match anlg_transcribe_speechanalyzer::settings_locale() {
+                Ok(locale) => anlg_transcribe_speechanalyzer::is_model_downloaded(&locale)
+                    .map_err(|e| Error::OperationFailed(e.to_string())),
+                Err(anlg_transcribe_speechanalyzer::Error::NoSupportedSystemLanguage)
+                | Err(anlg_transcribe_speechanalyzer::Error::UnsupportedPlatform) => Ok(false),
+                Err(error) => Err(Error::OperationFailed(error.to_string())),
+            },
             LocalModel::Whisper(model) => {
                 Ok(models_base.join("stt").join(model.file_name()).exists())
             }
@@ -346,7 +349,9 @@ impl DownloadableModel for LocalModel {
                 .map_err(|e| Error::DeleteFailed(e.to_string())),
             // Only the reservation is ours to give back; macOS owns the asset files.
             LocalModel::AppleSpeech(_) => {
-                anlg_transcribe_speechanalyzer::release_locale(APPLE_SPEECH_DEFAULT_LOCALE)
+                let locale = anlg_transcribe_speechanalyzer::settings_locale()
+                    .map_err(|e| Error::DeleteFailed(e.to_string()))?;
+                anlg_transcribe_speechanalyzer::release_locale(&locale)
                     .map_err(|e| Error::DeleteFailed(e.to_string()))
             }
             LocalModel::Whisper(model) => {

--- a/crates/transcribe-soniqo/src/model.rs
+++ b/crates/transcribe-soniqo/src/model.rs
@@ -100,7 +100,7 @@ impl SoniqoModel {
     pub const fn repo(self) -> &'static str {
         match self {
             Self::ParakeetStreaming => "aufklarer/Parakeet-EOU-120M-CoreML-INT8",
-            Self::ParakeetBatch => "aufklarer/Parakeet-TDT-v3-CoreML-INT8",
+            Self::ParakeetBatch => "aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s",
             Self::Omnilingual => "aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s",
             Self::Qwen3Small => "aufklarer/Qwen3-ASR-0.6B-MLX-4bit",
             Self::Qwen3Large => "aufklarer/Qwen3-ASR-1.7B-MLX-8bit",
@@ -176,6 +176,15 @@ impl SoniqoModel {
             .iter()
             .all(|language| self.supports_language(language))
     }
+
+    fn matches_identifier(self, value: &str) -> bool {
+        value == self.as_str()
+            || value == self.repo()
+            || matches!(
+                (self, value),
+                (Self::ParakeetBatch, "aufklarer/Parakeet-TDT-v3-CoreML-INT8")
+            )
+    }
 }
 
 impl std::fmt::Display for SoniqoModel {
@@ -191,7 +200,7 @@ impl FromStr for SoniqoModel {
         Self::KNOWN
             .iter()
             .copied()
-            .find(|model| value == model.as_str() || value == model.repo())
+            .find(|model| model.matches_identifier(value))
             .ok_or_else(|| Error::UnsupportedModel(value.to_string()))
     }
 }

--- a/crates/transcribe-soniqo/src/tests.rs
+++ b/crates/transcribe-soniqo/src/tests.rs
@@ -20,6 +20,26 @@ fn parses_model_ids() {
 }
 
 #[test]
+fn parakeet_batch_repo_matches_30s_coreml_artifact() {
+    assert_eq!(
+        SoniqoModel::ParakeetBatch.repo(),
+        "aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s"
+    );
+    assert_eq!(
+        "aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s"
+            .parse::<SoniqoModel>()
+            .unwrap(),
+        SoniqoModel::ParakeetBatch
+    );
+    assert_eq!(
+        "aufklarer/Parakeet-TDT-v3-CoreML-INT8"
+            .parse::<SoniqoModel>()
+            .unwrap(),
+        SoniqoModel::ParakeetBatch
+    );
+}
+
+#[test]
 fn all_includes_available_model_variants() {
     assert_eq!(
         SoniqoModel::all(),

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -124,13 +124,8 @@ private enum SpeechModelKind: String, CaseIterable {
     case .omnilingual:
       return Self.regularFileExists(at: directory.appendingPathComponent("config.json"))
         && Self.regularFileExists(at: directory.appendingPathComponent("tokenizer.model"))
-        && (
-          Self.compiledCoreMLModelReady(
-            at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlmodelc")
-          )
-            || Self.directoryContainsRegularFile(
-              at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlpackage")
-            )
+        && Self.compiledCoreMLModelReady(
+          at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlmodelc")
         )
     case .qwen3Small, .qwen3Large:
       return Self.regularFileExists(at: directory.appendingPathComponent("vocab.json"))

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -124,8 +124,13 @@ private enum SpeechModelKind: String, CaseIterable {
     case .omnilingual:
       return Self.regularFileExists(at: directory.appendingPathComponent("config.json"))
         && Self.regularFileExists(at: directory.appendingPathComponent("tokenizer.model"))
-        && Self.directoryContainsRegularFile(
-          at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlpackage")
+        && (
+          Self.compiledCoreMLModelReady(
+            at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlmodelc")
+          )
+            || Self.directoryContainsRegularFile(
+              at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlpackage")
+            )
         )
     case .qwen3Small, .qwen3Large:
       return Self.regularFileExists(at: directory.appendingPathComponent("vocab.json"))
@@ -179,6 +184,68 @@ private enum SpeechModelKind: String, CaseIterable {
       )
     case .qwen3Small, .qwen3Large:
       throw SoniqoBridgeError.message("\(label) requires macOS 15 or newer.")
+    }
+  }
+
+  func downloadAssets(progressHandler: ((Double, String) -> Void)?) async throws {
+    let directory = try cacheDirectoryURL()
+    let speechWeight = self == .parakeetBatch ? 0.9 : 1.0
+    try await HuggingFaceDownloader.downloadWeights(
+      modelId: repo,
+      to: directory,
+      additionalFiles: additionalDownloadFiles,
+      offlineMode: speechFilesReady()
+    ) { fraction in
+      progressHandler?(fraction * speechWeight, "Downloading \(label)...")
+    }
+
+    if self == .parakeetBatch {
+      let diarizationDirectory = try HuggingFaceDownloader.getCacheDirectory(
+        for: community1DiarizationRepo
+      )
+      try await HuggingFaceDownloader.downloadWeights(
+        modelId: community1DiarizationRepo,
+        to: diarizationDirectory,
+        additionalFiles: [
+          "segmentation.mlmodelc/**",
+          "embedding.mlmodelc/**",
+          "plda.safetensors",
+          "config.json",
+        ],
+        offlineMode: Self.community1FilesReady()
+      ) { fraction in
+        progressHandler?(0.9 + fraction * 0.1, "Downloading speaker model...")
+      }
+    }
+
+    guard filesReady() else {
+      throw SoniqoBridgeError.message("Downloaded \(label) files are incomplete.")
+    }
+  }
+
+  private var additionalDownloadFiles: [String] {
+    switch self {
+    case .parakeetStreaming, .parakeetBatch:
+      return [
+        "encoder.mlmodelc/**",
+        "decoder.mlmodelc/**",
+        "joint.mlmodelc/**",
+        "vocab.json",
+        "config.json",
+      ]
+    case .omnilingual:
+      return [
+        "omnilingual-ctc-300m-int8.mlmodelc/**",
+        "omnilingual-ctc-300m-int8.mlpackage/**",
+        "tokenizer.model",
+        "config.json",
+      ]
+    case .qwen3Small, .qwen3Large:
+      return [
+        "vocab.json",
+        "merges.txt",
+        "tokenizer_config.json",
+      ]
     }
   }
 
@@ -527,12 +594,24 @@ private actor SoniqoBridge {
     nextModelLoadGeneration &+= 1
     let generation = nextModelLoadGeneration
     let task = Task.detached(priority: .utility) {
-      try await kind.load { fraction, status in
+      try await kind.downloadAssets { fraction, status in
         Task {
           await SoniqoBridge.shared.updateDownloadProgress(
             kind: kind,
             generation: generation,
             fraction: fraction,
+            status: status
+          )
+        }
+      }
+      // Files are enough for the settings download to succeed. Loading
+      // warms CoreML; a compile failure must not look like a download miss.
+      return try await kind.load { fraction, status in
+        Task {
+          await SoniqoBridge.shared.updateDownloadProgress(
+            kind: kind,
+            generation: generation,
+            fraction: max(fraction, 0.99),
             status: status
           )
         }
@@ -1038,7 +1117,9 @@ private actor SoniqoBridge {
 
     let percent = Int(max(0.0, min(1.0, fraction)) * 100.0)
     let statusText = status.trimmingCharacters(in: .whitespacesAndNewlines)
-    state.progressPercent = percent
+    if percent > 0 {
+      state.progressPercent = percent
+    }
     state.currentFile = statusText.isEmpty ? "Preparing \(kind.label)..." : statusText
     downloadStates[kind] = state
   }
@@ -1074,10 +1155,15 @@ private actor SoniqoBridge {
 
     var state = downloadState(for: kind)
     state.localPath = kind.cacheDirectoryPath()
-    state.status = "error"
     state.currentFile = nil
     state.progressPercent = nil
-    state.error = error.localizedDescription
+    if kind.filesReady() {
+      state.status = "ready"
+      state.error = nil
+    } else {
+      state.status = "error"
+      state.error = error.localizedDescription
+    }
     downloadStates[kind] = state
   }
 

--- a/crates/transcribe-speechanalyzer/src/lib.rs
+++ b/crates/transcribe-speechanalyzer/src/lib.rs
@@ -336,6 +336,17 @@ pub fn resolve_session_locale(languages: &[anlg_language::Language]) -> Option<S
     })
 }
 
+/// Locale the Settings download row installs: the user's primary System Settings
+/// language that Apple Speech can transcribe. Hardcoding `en-US` leaves the
+/// installer queued forever when that language is not in System Settings.
+pub fn settings_locale() -> Result<String> {
+    if !cfg!(target_os = "macos") {
+        return Err(Error::UnsupportedPlatform);
+    }
+
+    resolve_session_locale(&[]).ok_or(Error::NoSupportedSystemLanguage)
+}
+
 pub fn installed_locales() -> Result<Vec<String>> {
     if !cfg!(target_os = "macos") {
         return Err(Error::UnsupportedPlatform);

--- a/crates/transcribe-speechanalyzer/src/tests.rs
+++ b/crates/transcribe-speechanalyzer/src/tests.rs
@@ -52,6 +52,14 @@ fn session_locale_requires_a_system_settings_language() {
 
         // No requested language falls back to the primary System Settings language.
         assert_eq!(resolve_session_locale(&[]).as_deref(), Some(first.as_str()));
+        assert_eq!(settings_locale().unwrap(), *first);
+    }
+}
+
+#[test]
+fn settings_locale_requires_macos_system_languages() {
+    if !cfg!(target_os = "macos") {
+        assert!(matches!(settings_locale(), Err(Error::UnsupportedPlatform)));
     }
 }
 

--- a/crates/transcribe-speechanalyzer/swift-lib/src/lib.swift
+++ b/crates/transcribe-speechanalyzer/swift-lib/src/lib.swift
@@ -169,6 +169,83 @@ private func preferredSupportedLocales() async -> [String] {
   return resolved
 }
 
+/// `maximumReservedLocales` is a hard cap, so make room by releasing a locale
+/// that is not the one being installed.
+@available(macOS 26.0, *)
+private func reserveSupportedLocale(_ locale: Locale) async throws {
+  let reserved = await AssetInventory.reservedLocales
+  if reserved.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+    return
+  }
+
+  if reserved.count >= AssetInventory.maximumReservedLocales,
+    let evictable = reserved.first(where: {
+      $0.identifier(.bcp47) != locale.identifier(.bcp47)
+    })
+  {
+    _ = await AssetInventory.release(reservedLocale: evictable)
+  }
+
+  _ = try await AssetInventory.reserve(locale: locale)
+}
+
+@available(macOS 26.0, *)
+private func reportedProgressPercent(_ progress: Progress) -> Int? {
+  guard !progress.isIndeterminate, progress.totalUnitCount > 0, progress.fractionCompleted > 0
+  else {
+    return nil
+  }
+
+  return Int(min(1.0, progress.fractionCompleted) * 100.0)
+}
+
+/// Installs assets off the bridge actor. `downloadAndInstall()` can return after a
+/// queued first attempt, so we keep watching `AssetInventory.status` until the
+/// locale is actually installed.
+@available(macOS 26.0, *)
+private func installLocaleAssets(key: String, identifier: String) async throws {
+  let locale = try await resolveLocale(identifier)
+  let tag = locale.identifier(.bcp47)
+  let preferred = await preferredSupportedLocales()
+  guard preferred.contains(where: { $0.compare(tag, options: [.caseInsensitive]) == .orderedSame })
+  else {
+    throw SpeechAnalyzerBridgeError.message(
+      "Apple Speech can only install languages added in System Settings.")
+  }
+
+  let transcriber = makeTranscriber(locale: locale)
+  try await reserveSupportedLocale(locale)
+
+  if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+    let progressTask = Task.detached(priority: .utility) { [progress = request.progress] in
+      while !Task.isCancelled && !progress.isFinished {
+        await SpeechAnalyzerBridge.shared.updateDownloadProgress(
+          key: key, percent: reportedProgressPercent(progress))
+        try? await Task.sleep(nanoseconds: 300_000_000)
+      }
+    }
+
+    try await request.downloadAndInstall()
+    progressTask.cancel()
+  }
+
+  for _ in 0..<3600 {
+    try Task.checkCancellation()
+    switch await AssetInventory.status(forModules: [transcriber]) {
+    case .installed:
+      return
+    case .unsupported:
+      throw SpeechAnalyzerBridgeError.message("Apple Speech does not support \(tag).")
+    case .downloading, .supported:
+      try await Task.sleep(nanoseconds: 500_000_000)
+    @unknown default:
+      try await Task.sleep(nanoseconds: 500_000_000)
+    }
+  }
+
+  throw SpeechAnalyzerBridgeError.message("Apple Speech asset install timed out.")
+}
+
 /// Volatile results carry a single run spanning the whole hypothesis, so per-word
 /// timings only materialize on finalized results.
 @available(macOS 26.0, *)
@@ -334,10 +411,6 @@ private actor SpeechAnalyzerBridge {
 
     let key = normalizedKey(identifier)
 
-    if downloadTasks[key] != nil {
-      return encodeJSON(downloadState(for: key))
-    }
-
     do {
       let locale = try await resolveLocale(identifier)
       let transcriber = makeTranscriber(locale: locale)
@@ -353,7 +426,11 @@ private actor SpeechAnalyzerBridge {
       case .downloading:
         state.status = "downloading"
       case .supported:
-        state.status = "idle"
+        if downloadTasks[key] != nil {
+          state.status = "downloading"
+        } else {
+          state.status = "idle"
+        }
       case .unsupported:
         state.status = "error"
         state.error = "Apple Speech does not support this language."
@@ -384,62 +461,25 @@ private actor SpeechAnalyzerBridge {
     state.error = nil
     downloadStates[key] = state
 
+    // AssetInventory work stays off the actor so progress polls can hop back in.
     let task = Task.detached(priority: .utility) {
-      await SpeechAnalyzerBridge.shared.performDownload(key: key, identifier: identifier)
+      do {
+        try await installLocaleAssets(key: key, identifier: identifier)
+        await SpeechAnalyzerBridge.shared.finishDownload(key: key, error: nil)
+      } catch {
+        await SpeechAnalyzerBridge.shared.finishDownload(
+          key: key, error: error.localizedDescription)
+      }
     }
     downloadTasks[key] = task
   }
 
-  @available(macOS 26.0, *)
-  private func performDownload(key: String, identifier: String) async {
-    do {
-      let locale = try await resolveLocale(identifier)
-      let transcriber = makeTranscriber(locale: locale)
-
-      let reserved = await AssetInventory.reservedLocales
-      if !reserved.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
-        try await reserveLocale(locale, reserved: reserved)
-      }
-
-      if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber])
-      {
-        let progressTask = Task.detached(priority: .utility) { [progress = request.progress] in
-          while !Task.isCancelled && !progress.isFinished {
-            await SpeechAnalyzerBridge.shared.updateDownloadProgress(
-              key: key, fraction: progress.fractionCompleted)
-            try? await Task.sleep(nanoseconds: 300_000_000)
-          }
-        }
-
-        try await request.downloadAndInstall()
-        progressTask.cancel()
-      }
-
-      await finishDownload(key: key, error: nil)
-    } catch {
-      await finishDownload(key: key, error: error.localizedDescription)
-    }
-  }
-
-  /// `maximumReservedLocales` is a hard cap, so make room by releasing a locale
-  /// that is not the one being installed.
-  @available(macOS 26.0, *)
-  private func reserveLocale(_ locale: Locale, reserved: [Locale]) async throws {
-    if reserved.count >= AssetInventory.maximumReservedLocales,
-      let evictable = reserved.first(where: {
-        $0.identifier(.bcp47) != locale.identifier(.bcp47)
-      })
-    {
-      _ = await AssetInventory.release(reservedLocale: evictable)
-    }
-
-    _ = try await AssetInventory.reserve(locale: locale)
-  }
-
-  private func updateDownloadProgress(key: String, fraction: Double) {
+  func updateDownloadProgress(key: String, percent: Int?) {
     var state = downloadState(for: key)
     state.status = "downloading"
-    state.progressPercent = Int(max(0.0, min(1.0, fraction)) * 100.0)
+    if let percent {
+      state.progressPercent = percent
+    }
     state.currentFile = "Downloading \(key)..."
     state.error = nil
     downloadStates[key] = state
@@ -562,10 +602,7 @@ private actor SpeechAnalyzerBridge {
 
   @available(macOS 26.0, *)
   private func ensureAssetsInstalled(locale: Locale, transcriber: SpeechTranscriber) async throws {
-    let reserved = await AssetInventory.reservedLocales
-    if !reserved.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
-      try await reserveLocale(locale, reserved: reserved)
-    }
+    try await reserveSupportedLocale(locale)
 
     if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
       try await request.downloadAndInstall()

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -12,7 +12,7 @@ use anlg_model_downloader::{DownloadStatus, ModelDownloadManager, ModelDownloade
 use crate::server::internal;
 use crate::{
     download_pollers::{DownloadPoller, DownloadPollers},
-    model::{APPLE_SPEECH_DEFAULT_LOCALE, LocalModel},
+    model::LocalModel,
     server::{ServerInfo, ServerStatus, ServerType, external, supervisor},
     types::DownloadProgressPayload,
 };
@@ -369,6 +369,7 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
         }
 
         if matches!(model, LocalModel::AppleSpeech(_)) {
+            let locale = apple_speech_settings_locale()?;
             let pollers = self.download_pollers().await;
             let Some(poller) = pollers.reserve(model.clone()) else {
                 return Ok(());
@@ -376,19 +377,22 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
             let Some(native_job) = poller.acquire_native_job().await else {
                 return Ok(());
             };
-
             run_apple_speech_blocking_with_permit(
                 native_job,
-                move || {
-                    anlg_transcribe_speechanalyzer::start_model_download(
-                        APPLE_SPEECH_DEFAULT_LOCALE,
-                    )
+                {
+                    let locale = locale.clone();
+                    move || anlg_transcribe_speechanalyzer::start_model_download(&locale)
                 },
                 crate::Error::ServerStartFailed,
             )
             .await?;
 
-            spawn_apple_speech_progress_poller(self.manager.app_handle().clone(), model, poller);
+            spawn_apple_speech_progress_poller(
+                self.manager.app_handle().clone(),
+                model,
+                locale,
+                poller,
+            );
             return Ok(());
         }
 
@@ -456,8 +460,9 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
 
         if matches!(model, LocalModel::AppleSpeech(_)) {
             self.download_pollers().await.cancel(model);
+            let locale = apple_speech_settings_locale()?;
             return run_apple_speech_blocking(
-                move || anlg_transcribe_speechanalyzer::release_locale(APPLE_SPEECH_DEFAULT_LOCALE),
+                move || anlg_transcribe_speechanalyzer::release_locale(&locale),
                 crate::Error::ServerStopFailed,
             )
             .await;
@@ -543,10 +548,39 @@ where
     .map_err(|e| map_error(e.to_string()))
 }
 
+fn apple_speech_settings_locale() -> Result<String, crate::Error> {
+    anlg_transcribe_speechanalyzer::settings_locale()
+        .map_err(|error| crate::Error::ServerStartFailed(error.to_string()))
+}
+
 async fn apple_speech_download_state()
 -> Result<anlg_transcribe_speechanalyzer::ModelDownloadState, crate::Error> {
+    let locale = match anlg_transcribe_speechanalyzer::settings_locale() {
+        Ok(locale) => locale,
+        Err(anlg_transcribe_speechanalyzer::Error::NoSupportedSystemLanguage) => {
+            return Ok(anlg_transcribe_speechanalyzer::ModelDownloadState {
+                status: "error".to_string(),
+                current_file: None,
+                progress_percent: None,
+                local_path: String::new(),
+                error: Some(
+                    anlg_transcribe_speechanalyzer::Error::NoSupportedSystemLanguage.to_string(),
+                ),
+            });
+        }
+        Err(anlg_transcribe_speechanalyzer::Error::UnsupportedPlatform) => {
+            return Ok(anlg_transcribe_speechanalyzer::ModelDownloadState {
+                status: "idle".to_string(),
+                current_file: None,
+                progress_percent: None,
+                local_path: String::new(),
+                error: None,
+            });
+        }
+        Err(error) => return Err(crate::Error::ServerStartFailed(error.to_string())),
+    };
     run_apple_speech_blocking(
-        move || anlg_transcribe_speechanalyzer::model_download_state(APPLE_SPEECH_DEFAULT_LOCALE),
+        move || anlg_transcribe_speechanalyzer::model_download_state(&locale),
         crate::Error::ServerStartFailed,
     )
     .await
@@ -555,6 +589,7 @@ async fn apple_speech_download_state()
 fn spawn_apple_speech_progress_poller<R: Runtime>(
     app_handle: tauri::AppHandle<R>,
     model: LocalModel,
+    locale: String,
     poller: DownloadPoller,
 ) {
     tokio::spawn(async move {
@@ -566,9 +601,10 @@ fn spawn_apple_speech_progress_poller<R: Runtime>(
             let Some(native_job) = poller.acquire_native_job().await else {
                 return;
             };
+            let locale = locale.clone();
             let status = tokio::task::spawn_blocking(move || {
                 let _native_job = native_job;
-                anlg_transcribe_speechanalyzer::model_download_state(APPLE_SPEECH_DEFAULT_LOCALE)
+                anlg_transcribe_speechanalyzer::model_download_state(&locale)
             })
             .await;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On-device STT downloads were failing in two ways: Apple Speech stayed on a spinner at **0%**, and Soniqo models reported a failed download even after HuggingFace files landed. The download toast also had no close control, so a stuck or long-running “Downloading …” notice could not be dismissed.

Apple Speech stays on 0% because the settings download always installed `en-US`. Apple only installs languages added in System Settings, so a Mac whose preferred language is not English US queues the request and never reports progress.

Soniqo treated a later CoreML compile/load error as a failed download. Settings “Download” should succeed once the HuggingFace files are on disk.

## Changes
- Install and poll the user's primary System Settings language instead of hardcoded `en-US`
- Run `AssetInventory` work off the Swift bridge actor so progress/status polls are not blocked
- Keep watching system install status after `downloadAndInstall()` returns (Apple can queue a later retry)
- Hide indeterminate **0%** in the model picker until a backend reports real progress
- Download Soniqo HuggingFace weights first and mark the model ready once those files verify, even if CoreML warmup fails
- Point Parakeet Batch at the `INT8-30s` artifact already used by the Swift bridge
- Let users dismiss “Downloading …” toasts (model downloads and desktop-update downloads) for the current session; the download keeps running, and a later model download can show the toast again

## How to verify
1. On macOS 26, open Settings → Transcription
2. Download Apple Speech
3. The row should spin without a fake 0%, then complete (or show a real percent if Apple reports one)
4. If no supported language is in System Settings, the download should fail with that message instead of hanging
5. Download Parakeet Streaming and Parakeet Batch
6. The download should complete when the model files are on disk (toast should not say the download failed just because CoreML compile is slow or fails)
7. While a download toast is showing, click the X — the toast should close, the download should continue, and the picker should still show progress
8. After that download finishes, start another download — the toast should appear again
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55864dc7-bcf2-4a61-befc-fbde923e26f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55864dc7-bcf2-4a61-befc-fbde923e26f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

