### PR TITLE
Skip flushSync when syncing comment-anchor decorations.

### DIFF
--- a/packages/editor/src/plugins/comment-anchors.test.ts
+++ b/packages/editor/src/plugins/comment-anchors.test.ts
@@ -1,4 +1,9 @@
-import { EditorState, TextSelection } from "prosemirror-state";
+import {
+  EditorState,
+  type Transaction,
+  TextSelection,
+} from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
 import { describe, expect, it } from "vitest";
 
 import { schema } from "../note/schema";
@@ -6,6 +11,8 @@ import {
   commentAnchorsPlugin,
   commentAnchorsPluginKey,
   getCommentAnchorRanges,
+  setActiveCommentAnchor,
+  setCommentAnchors,
 } from "./comment-anchors";
 
 const createState = () =>
@@ -148,6 +155,31 @@ describe("commentAnchorsPlugin", () => {
     expect(getCommentAnchorRanges(state).map((a) => a.commentId)).toEqual([
       "ok",
     ]);
+  });
+
+  it("marks view dispatches async so React effects skip flushSync", () => {
+    const dispatches: Transaction[] = [];
+    const view = {
+      state: createState(),
+      dispatch: (tr: Transaction) => {
+        dispatches.push(tr);
+      },
+    } as unknown as EditorView;
+
+    setCommentAnchors(view, [{ commentId: "c1", from: 1, to: 6 }]);
+    setActiveCommentAnchor(view, "c1");
+
+    expect(dispatches).toHaveLength(2);
+    expect(dispatches[0].getMeta("async")).toBe(true);
+    expect(dispatches[0].getMeta(commentAnchorsPluginKey)).toEqual({
+      type: "set",
+      anchors: [{ commentId: "c1", from: 1, to: 6 }],
+    });
+    expect(dispatches[1].getMeta("async")).toBe(true);
+    expect(dispatches[1].getMeta(commentAnchorsPluginKey)).toEqual({
+      type: "active",
+      commentId: "c1",
+    });
   });
 
   it("reports selection changes through the event callback", () => {

--- a/packages/editor/src/plugins/comment-anchors.ts
+++ b/packages/editor/src/plugins/comment-anchors.ts
@@ -134,28 +134,30 @@ export function commentAnchorsPlugin(options?: {
   });
 }
 
+function dispatchCommentAnchorsMeta(
+  view: EditorView,
+  meta: CommentAnchorsMeta,
+) {
+  // Callers push these from useEffect / callback refs. react-prosemirror
+  // wrap view.dispatch in flushSync unless the transaction is marked async;
+  // decorations do not need a synchronous React flush.
+  view.dispatch(
+    view.state.tr.setMeta("async", true).setMeta(commentAnchorsPluginKey, meta),
+  );
+}
+
 export function setCommentAnchors(
   view: EditorView,
   anchors: CommentAnchorInput[],
 ): void {
-  view.dispatch(
-    view.state.tr.setMeta(commentAnchorsPluginKey, {
-      type: "set",
-      anchors,
-    } satisfies CommentAnchorsMeta),
-  );
+  dispatchCommentAnchorsMeta(view, { type: "set", anchors });
 }
 
 export function setActiveCommentAnchor(
   view: EditorView,
   commentId: string | null,
 ): void {
-  view.dispatch(
-    view.state.tr.setMeta(commentAnchorsPluginKey, {
-      type: "active",
-      commentId,
-    } satisfies CommentAnchorsMeta),
-  );
+  dispatchCommentAnchorsMeta(view, { type: "active", commentId });
 }
 
 /** Current anchor ranges, mapped through any edits since they were set. */


### PR DESCRIPTION
These helpers are called from useEffect and callback refs; marking the transaction async lets react-prosemirror apply it without a mid-lifecycle flush.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small editor-plugin dispatch tweak with no auth, data, or API changes. Worst case is decoration timing, not document content.
> 
> **Overview**
> Marks comment-anchor update transactions as `async` so react-prosemirror does not wrap them in `flushSync`.
> 
> `setCommentAnchors` and `setActiveCommentAnchor` are called from effects and callback refs; decoration-only updates do not need a synchronous React flush. A test asserts both helpers set `async` meta on the dispatched transaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4baaddd64cea9737c5480dbcb3b6645d382f4954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->