### PR TITLE
feat(enterprise): close Meet fixture reliability gate

### DIFF
--- a/.github/workflows/enterprise_ci.yaml
+++ b/.github/workflows/enterprise_ci.yaml
@@ -26,11 +26,13 @@ jobs:
     if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/rust_install
         with:
           platform: linux
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: enterprise
           prefix-key: v0-enterprise-capture-gate

--- a/.github/workflows/enterprise_ci.yaml
+++ b/.github/workflows/enterprise_ci.yaml
@@ -1,0 +1,39 @@
+name: enterprise_ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/enterprise_ci.yaml
+      - crates/meeting-capture/**
+      - enterprise/**
+      - rust-toolchain.toml
+  pull_request:
+    paths:
+      - .github/workflows/enterprise_ci.yaml
+      - crates/meeting-capture/**
+      - enterprise/**
+      - rust-toolchain.toml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture_gate:
+    if: ${{ !startsWith(github.head_ref || '', 'blog/') }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: linux
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: enterprise
+          prefix-key: v0-enterprise-capture-gate
+      - run: cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --test reliability_gate --test fixture_replay
+      - run: cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --lib
+      - run: cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-control-plane --test upgrade

--- a/.github/workflows/enterprise_ci.yaml
+++ b/.github/workflows/enterprise_ci.yaml
@@ -37,3 +37,4 @@ jobs:
       - run: cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --test reliability_gate --test fixture_replay
       - run: cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --lib
       - run: cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-control-plane --test upgrade
+      - run: cargo clippy --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --tests --lib -- -D warnings

--- a/enterprise/google-meet-worker/fixtures/vexa-v0.12.18/MATRIX.md
+++ b/enterprise/google-meet-worker/fixtures/vexa-v0.12.18/MATRIX.md
@@ -23,3 +23,14 @@ These fixtures are replayable snapshots of normalized Anarlog admission/runtime 
 | `runtime/long-duration.json` | `gmeet-capture/src/gmeet-capture.ts` | Active after two hours | — | — |
 
 Scenarios in `scenarios.json` replay the same snapshots through `WorkerLifecycle` and assert the provider-neutral terminal reason.
+
+Additional lifecycle scenarios (not a new classifier snapshot):
+
+| Scenario | Terminal reason | Retryable |
+| --- | --- | --- |
+| `everyone-left-after-participants` | `everyone_left` | no |
+| `silence-then-nobody-joined` | `no_one_joined` | yes |
+| `host-ended-after-long-capture` | `meeting_ended` | no |
+| `captcha-unsolved` | `authentication_failed` | no |
+| `error-page-before-join` | `provider_error` | no |
+| `stopped-by-request` | `stopped_by_request` | no |

--- a/enterprise/google-meet-worker/fixtures/vexa-v0.12.18/scenarios.json
+++ b/enterprise/google-meet-worker/fixtures/vexa-v0.12.18/scenarios.json
@@ -91,5 +91,74 @@
       { "action": "capture_started" },
       { "action": "runtime", "fixture": "runtime/nobody-joined.json" }
     ]
+  },
+  {
+    "id": "everyone-left-after-participants",
+    "expected_state": "completed",
+    "expected_terminal": "everyone_left",
+    "retryable": false,
+    "steps": [
+      { "action": "launch" },
+      { "action": "admission", "fixture": "admission/admitted.json" },
+      { "action": "capture_started" },
+      { "action": "runtime", "fixture": "runtime/overlapping-speakers.json" },
+      { "action": "runtime", "fixture": "runtime/nobody-joined.json" }
+    ]
+  },
+  {
+    "id": "silence-then-nobody-joined",
+    "expected_state": "failed",
+    "expected_terminal": "no_one_joined",
+    "retryable": true,
+    "steps": [
+      { "action": "launch" },
+      { "action": "admission", "fixture": "admission/admitted.json" },
+      { "action": "capture_started" },
+      { "action": "runtime", "fixture": "runtime/silence.json" },
+      { "action": "runtime", "fixture": "runtime/nobody-joined.json" }
+    ]
+  },
+  {
+    "id": "host-ended-after-long-capture",
+    "expected_state": "completed",
+    "expected_terminal": "meeting_ended",
+    "retryable": false,
+    "steps": [
+      { "action": "launch" },
+      { "action": "admission", "fixture": "admission/admitted.json" },
+      { "action": "capture_started" },
+      { "action": "runtime", "fixture": "runtime/long-duration.json" },
+      { "action": "runtime", "fixture": "runtime/meeting-ended.json" }
+    ]
+  },
+  {
+    "id": "captcha-unsolved",
+    "expected_state": "failed",
+    "expected_terminal": "authentication_failed",
+    "retryable": false,
+    "steps": [
+      { "action": "launch" },
+      { "action": "admission", "fixture": "admission/captcha-unsolved.json" }
+    ]
+  },
+  {
+    "id": "error-page-before-join",
+    "expected_state": "failed",
+    "expected_terminal": "provider_error",
+    "retryable": false,
+    "steps": [
+      { "action": "launch" },
+      { "action": "admission", "fixture": "admission/error-page.json" }
+    ]
+  },
+  {
+    "id": "stopped-by-request",
+    "expected_state": "completed",
+    "expected_terminal": "stopped_by_request",
+    "retryable": false,
+    "steps": [
+      { "action": "launch" },
+      { "action": "stopped_by_request" }
+    ]
   }
 ]

--- a/enterprise/google-meet-worker/src/supervisor.rs
+++ b/enterprise/google-meet-worker/src/supervisor.rs
@@ -786,6 +786,34 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn successor_supervisor_does_not_relaunch_after_interrupted_checkpoint() {
+        let first = harness(BotState::Capturing, 7, RuntimeMode::Wait, false);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let first_outcome = first.supervisor.run(shutdown_rx).await.unwrap();
+        assert_eq!(
+            first_outcome,
+            CaptureJobSupervisorOutcome::Terminal(BotState::Failed)
+        );
+        let CaptureEventPayload::Lifecycle(transition) = &first.events.lock().unwrap()[0].payload
+        else {
+            panic!("expected lifecycle event");
+        };
+        assert_eq!(
+            transition.reason.as_ref().unwrap().kind,
+            TerminalReasonKind::WorkerExited
+        );
+
+        let second = harness(BotState::Failed, 8, RuntimeMode::Wait, false);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let second_outcome = second.supervisor.run(shutdown_rx).await.unwrap();
+        assert_eq!(
+            second_outcome,
+            CaptureJobSupervisorOutcome::AlreadyTerminal(BotState::Failed)
+        );
+        assert!(second.events.lock().unwrap().is_empty());
+    }
+
     #[test]
     fn rejects_an_unsafe_renewal_configuration() {
         assert!(valid_identifier("worker-a.1"));

--- a/enterprise/google-meet-worker/src/supervisor.rs
+++ b/enterprise/google-meet-worker/src/supervisor.rs
@@ -795,14 +795,14 @@ mod tests {
             first_outcome,
             CaptureJobSupervisorOutcome::Terminal(BotState::Failed)
         );
-        let CaptureEventPayload::Lifecycle(transition) = &first.events.lock().unwrap()[0].payload
-        else {
-            panic!("expected lifecycle event");
+        let reason_kind = {
+            let events = first.events.lock().unwrap();
+            let CaptureEventPayload::Lifecycle(transition) = &events[0].payload else {
+                panic!("expected lifecycle event");
+            };
+            transition.reason.as_ref().unwrap().kind
         };
-        assert_eq!(
-            transition.reason.as_ref().unwrap().kind,
-            TerminalReasonKind::WorkerExited
-        );
+        assert_eq!(reason_kind, TerminalReasonKind::WorkerExited);
 
         let second = harness(BotState::Failed, 8, RuntimeMode::Wait, false);
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);

--- a/enterprise/google-meet-worker/tests/fixture_replay.rs
+++ b/enterprise/google-meet-worker/tests/fixture_replay.rs
@@ -237,10 +237,10 @@ fn replays_lifecycle_scenarios_to_provider_neutral_terminal_reasons() {
                 ),
                 other => panic!("{}: unknown action {other}", scenario.id),
             };
-            if let Some(event) = event {
-                if let CaptureEventPayload::Lifecycle(transition) = event.payload {
-                    last_terminal = transition.reason;
-                }
+            if let Some(event) = event
+                && let CaptureEventPayload::Lifecycle(transition) = event.payload
+            {
+                last_terminal = transition.reason;
             }
         }
 

--- a/enterprise/google-meet-worker/tests/fixture_replay.rs
+++ b/enterprise/google-meet-worker/tests/fixture_replay.rs
@@ -175,6 +175,14 @@ fn replays_lifecycle_scenarios_to_provider_neutral_terminal_reasons() {
         let started = Instant::now();
         let mut last_terminal = None;
         for step in &scenario.steps {
+            if step.action == "stopped_by_request" {
+                for event in lifecycle.stopped_by_request(now()).unwrap() {
+                    if let CaptureEventPayload::Lifecycle(transition) = event.payload {
+                        last_terminal = transition.reason;
+                    }
+                }
+                continue;
+            }
             let event = match step.action.as_str() {
                 "launch" => Some(lifecycle.launch_started(now()).unwrap()),
                 "admission" => {
@@ -182,8 +190,14 @@ fn replays_lifecycle_scenarios_to_provider_neutral_terminal_reasons() {
                         load_json(step.fixture.as_ref().expect("admission fixture"));
                     let snapshot: AdmissionSnapshot =
                         serde_json::from_value(fixture.snapshot).unwrap();
+                    let observed_at = started + Duration::from_millis(fixture.elapsed_ms);
+                    if fixture.elapsed_ms > 0 {
+                        let _ = lifecycle
+                            .observe_admission(&snapshot, started, now())
+                            .unwrap();
+                    }
                     lifecycle
-                        .observe_admission(&snapshot, started, now())
+                        .observe_admission(&snapshot, observed_at, now())
                         .unwrap()
                 }
                 "capture_started" => Some(lifecycle.capture_started(now()).unwrap()),

--- a/enterprise/google-meet-worker/tests/reliability_gate.rs
+++ b/enterprise/google-meet-worker/tests/reliability_gate.rs
@@ -41,10 +41,11 @@ fn assert_terminal(lifecycle: &WorkerLifecycle) {
 #[test]
 fn reliability_gate_covers_required_terminal_reasons() {
     let started = Instant::now();
-    let cases: [(
-        &str,
-        Box<dyn Fn(&mut WorkerLifecycle) -> TerminalReasonKind>,
-    ); 9] = [
+    type Case<'a> = (
+        &'a str,
+        Box<dyn Fn(&mut WorkerLifecycle) -> TerminalReasonKind + 'a>,
+    );
+    let cases: [Case<'_>; 9] = [
         (
             "admitted-kicked",
             Box::new(|lifecycle| {

--- a/enterprise/google-meet-worker/tests/reliability_gate.rs
+++ b/enterprise/google-meet-worker/tests/reliability_gate.rs
@@ -403,6 +403,9 @@ impl RecordingChunkStore for MemoryRecordingStore {
 
 #[tokio::test]
 async fn two_hour_capture_finalizes_recording_chunks_before_meeting_ended() {
+    let mut lifecycle = WorkerLifecycle::new("bot-long-recording");
+    join_and_capture(&mut lifecycle);
+
     let mut sink = ChunkedRecordingSink::new(
         ChunkedRecordingConfig {
             object_prefix: "recordings/job-reliability".into(),
@@ -413,10 +416,10 @@ async fn two_hour_capture_finalizes_recording_chunks_before_meeting_ended() {
     )
     .unwrap();
 
-    let mut output_count = 0;
+    let mut outputs = Vec::new();
     for minute in 0..120_u64 {
-        output_count += sink
-            .write_frame(AudioFrame {
+        outputs.extend(
+            sink.write_frame(AudioFrame {
                 sequence: minute + 1,
                 track_index: 0,
                 sample_rate: 16_000,
@@ -425,21 +428,29 @@ async fn two_hour_capture_finalizes_recording_chunks_before_meeting_ended() {
                 speaker: None,
             })
             .await
-            .unwrap()
-            .len();
+            .unwrap(),
+        );
     }
-    let finalized = sink.finish(Duration::from_secs(2 * 60 * 60)).await.unwrap();
-    output_count += finalized.len();
+    outputs.extend(sink.finish(Duration::from_secs(2 * 60 * 60)).await.unwrap());
 
-    assert_eq!(output_count, 120);
+    assert_eq!(outputs.len(), 120);
     assert!(
-        finalized
+        outputs
             .iter()
             .all(|output| matches!(output, AudioFrameSinkOutput::RecordingChunkReady(_)))
     );
 
-    let mut lifecycle = WorkerLifecycle::new("bot-long-recording");
-    join_and_capture(&mut lifecycle);
+    let chunk_events: Vec<_> = outputs
+        .into_iter()
+        .map(|output| lifecycle.emit_payload(output.into(), now()))
+        .collect();
+    assert!(
+        chunk_events
+            .iter()
+            .all(|event| matches!(event.payload, CaptureEventPayload::RecordingChunkReady(_)))
+    );
+    assert_eq!(lifecycle.state(), BotState::Capturing);
+
     let ended = lifecycle
         .observe_runtime(
             &RuntimeSnapshot {
@@ -451,6 +462,11 @@ async fn two_hour_capture_finalizes_recording_chunks_before_meeting_ended() {
         )
         .unwrap()
         .unwrap();
+    assert!(
+        chunk_events
+            .iter()
+            .all(|event| event.sequence < ended.sequence)
+    );
     assert_eq!(reason_kind(ended), TerminalReasonKind::MeetingEnded);
     assert_eq!(lifecycle.state(), BotState::Completed);
 }

--- a/enterprise/google-meet-worker/tests/reliability_gate.rs
+++ b/enterprise/google-meet-worker/tests/reliability_gate.rs
@@ -1,6 +1,10 @@
 use std::time::{Duration, Instant};
 
-use anarlog_enterprise_google_meet_worker::{AdmissionSnapshot, RuntimeSnapshot, WorkerLifecycle};
+use anarlog_enterprise_google_meet_worker::{
+    AdmissionSnapshot, AudioFrame, AudioFrameSink, AudioFrameSinkOutput, ChunkedRecordingConfig,
+    ChunkedRecordingSink, RecordingChunkStore, RuntimeSnapshot, StoredRecordingObject,
+    WorkerLifecycle,
+};
 use anlg_meeting_capture::{BotState, CaptureEventPayload, TerminalReasonKind};
 use chrono::{DateTime, Utc};
 
@@ -316,4 +320,136 @@ fn overlapping_and_unresolved_speakers_stay_non_terminal() {
             .is_none()
     );
     assert_eq!(lifecycle.state(), BotState::Capturing);
+}
+
+#[test]
+fn captcha_and_error_page_emit_distinct_admission_terminal_reasons() {
+    let started = Instant::now();
+    let mut captcha = WorkerLifecycle::new("bot-captcha");
+    captcha.launch_started(now()).unwrap();
+    assert!(
+        captcha
+            .observe_admission(
+                &AdmissionSnapshot {
+                    ambiguous_error_indicator: Some("Try again".into()),
+                    visible_recaptcha_challenge: true,
+                    ..Default::default()
+                },
+                started,
+                now(),
+            )
+            .unwrap()
+            .is_some()
+    );
+    let captcha_event = captcha
+        .observe_admission(
+            &AdmissionSnapshot {
+                ambiguous_error_indicator: Some("Try again".into()),
+                visible_recaptcha_challenge: true,
+                ..Default::default()
+            },
+            started + Duration::from_secs(120),
+            now(),
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        reason_kind(captcha_event),
+        TerminalReasonKind::AuthenticationFailed
+    );
+    assert_eq!(captcha.state(), BotState::Failed);
+
+    let mut error_page = WorkerLifecycle::new("bot-error-page");
+    error_page.launch_started(now()).unwrap();
+    let error_event = error_page
+        .observe_admission(
+            &AdmissionSnapshot {
+                ambiguous_error_indicator: Some("can't join this video call".into()),
+                ..Default::default()
+            },
+            Instant::now(),
+            now(),
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(reason_kind(error_event), TerminalReasonKind::ProviderError);
+    assert_eq!(error_page.state(), BotState::Failed);
+}
+
+#[derive(Default)]
+struct MemoryRecordingStore {
+    objects: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("memory recording store failed")]
+struct MemoryRecordingStoreError;
+
+#[async_trait::async_trait]
+impl RecordingChunkStore for MemoryRecordingStore {
+    type Error = MemoryRecordingStoreError;
+
+    async fn put(
+        &mut self,
+        key: &str,
+        _content_type: &str,
+        _body: Vec<u8>,
+    ) -> Result<StoredRecordingObject, Self::Error> {
+        self.objects.push(key.into());
+        Ok(StoredRecordingObject { uri: key.into() })
+    }
+}
+
+#[tokio::test]
+async fn two_hour_capture_finalizes_recording_chunks_before_meeting_ended() {
+    let mut sink = ChunkedRecordingSink::new(
+        ChunkedRecordingConfig {
+            object_prefix: "recordings/job-reliability".into(),
+            chunk_duration: Duration::from_secs(60),
+            max_lateness: Duration::from_secs(60),
+        },
+        MemoryRecordingStore::default(),
+    )
+    .unwrap();
+
+    let mut output_count = 0;
+    for minute in 0..120_u64 {
+        output_count += sink
+            .write_frame(AudioFrame {
+                sequence: minute + 1,
+                track_index: 0,
+                sample_rate: 16_000,
+                start_ms: minute * 60_000,
+                samples: vec![1],
+                speaker: None,
+            })
+            .await
+            .unwrap()
+            .len();
+    }
+    let finalized = sink.finish(Duration::from_secs(2 * 60 * 60)).await.unwrap();
+    output_count += finalized.len();
+
+    assert_eq!(output_count, 120);
+    assert!(
+        finalized
+            .iter()
+            .all(|output| matches!(output, AudioFrameSinkOutput::RecordingChunkReady(_)))
+    );
+
+    let mut lifecycle = WorkerLifecycle::new("bot-long-recording");
+    join_and_capture(&mut lifecycle);
+    let ended = lifecycle
+        .observe_runtime(
+            &RuntimeSnapshot {
+                meeting_ended_indicator: Some("the meeting has ended".into()),
+                ..Default::default()
+            },
+            Instant::now(),
+            now(),
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(reason_kind(ended), TerminalReasonKind::MeetingEnded);
+    assert_eq!(lifecycle.state(), BotState::Completed);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes more of [ANLG-230](https://linear.app/fastrepl-inc/issue/ANLG-230) without claiming live admitted Google Meet.

## What this does

The owned Meet worker already had classifier fixtures and a reliability gate. This slice closes the remaining **deterministic** gaps:

- Replay captcha, error-page, everyone-left, silence-then-empty, long-capture + host-ended, and stop-request through `WorkerLifecycle`
- Honor fixture `elapsed_ms` on admission steps so captcha’s 120s grace is actually exercised
- Treat `stopped_by_request` as a multi-event transition (Launching → Stopping → Completed)
- Assert two-hour recording chunks finalize before `meeting_ended`
- Assert a successor supervisor does not relaunch a Failed interrupted checkpoint
- Add `enterprise_ci` for the fixture gate, worker lib tests, additive control-plane migrations, and clippy on the worker tests

## Local checks

- `cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --test reliability_gate --test fixture_replay --lib`
- `cargo test --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-control-plane --test upgrade`
- `cargo clippy --manifest-path enterprise/Cargo.toml --locked -p anarlog-enterprise-google-meet-worker --tests --lib -- -D warnings`
- `dprint` on the changed files

## Still not Done

Live **admitted** Meet capture still needs a Google Workspace bot identity and an authenticated Chromium profile (Infisical `/meeting-capture/google`, profile on an encrypted volume — not Git). One live guest run already produced `AdmissionDenied` (“can't join this video call”) and cleaned up. Ignored live tests stay ignored.

Do not mark ANLG-230 Done from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a0bdb88-fc83-4746-9cbf-d7fd007c7664?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a0bdb88-fc83-4746-9cbf-d7fd007c7664&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

