### PR TITLE
Use Phosphor for the folder toolbar icon and remaining generic UI icons.

### DIFF
--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -1,7 +1,11 @@
-import { Icon } from "@iconify-icon/react";
 import { useLingui } from "@lingui/react";
 import { Trans } from "@lingui/react/macro";
-import { CircleNotch } from "@phosphor-icons/react";
+import {
+  CircleNotch,
+  DiscordLogo,
+  GithubLogo,
+  XLogo,
+} from "@phosphor-icons/react";
 import { useRef, useState } from "react";
 
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
@@ -21,17 +25,17 @@ import { commands } from "~/types/tauri.gen";
 const SOCIALS = [
   {
     label: "Discord",
-    icon: "simple-icons:discord",
+    icon: DiscordLogo,
     url: "https://anarlog.so/discord",
   },
   {
     label: "GitHub",
-    icon: "simple-icons:github",
+    icon: GithubLogo,
     url: "https://github.com/fastrepl/anarlog",
   },
   {
     label: "X",
-    icon: "simple-icons:x",
+    icon: XLogo,
     size: 14,
     url: "https://x.com/anarlogapp",
   },
@@ -48,6 +52,7 @@ export function FinalDescription() {
       <div className="flex items-center gap-2">
         {SOCIALS.map((social) => {
           const iconSize = "size" in social ? social.size : SOCIAL_ICON_SIZE;
+          const SocialIcon = social.icon;
 
           return (
             <button
@@ -56,7 +61,7 @@ export function FinalDescription() {
               className="text-muted-foreground hover:text-muted-foreground inline-flex size-5 items-center justify-center rounded-md transition-colors duration-150"
               aria-label={social.label}
             >
-              <Icon icon={social.icon} width={iconSize} height={iconSize} />
+              <SocialIcon size={iconSize} />
             </button>
           );
         })}

--- a/apps/desktop/src/onboarding/folder-location.tsx
+++ b/apps/desktop/src/onboarding/folder-location.tsx
@@ -1,5 +1,5 @@
 import { useLingui } from "@lingui/react/macro";
-import { Folder } from "@phosphor-icons/react";
+import { FolderSimple } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { homeDir } from "@tauri-apps/api/path";
 import { message, open as selectFolder } from "@tauri-apps/plugin-dialog";
@@ -114,7 +114,7 @@ export function FolderLocationSection({
   return (
     <div className="flex flex-col gap-3">
       <div className="border-border bg-muted flex items-center gap-3 rounded-lg border px-4 py-3">
-        <Folder className="text-muted-foreground size-4 shrink-0" />
+        <FolderSimple className="text-muted-foreground size-4 shrink-0" />
         <button
           onClick={handleOpenPath}
           className="text-muted-foreground min-w-0 flex-1 truncate text-left text-sm hover:underline"

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -1,5 +1,5 @@
 import { useLingui } from "@lingui/react/macro";
-import { Check, Folder, Plus } from "@phosphor-icons/react";
+import { Check, FolderSimple, Plus } from "@phosphor-icons/react";
 import { useCallback, useMemo, useState } from "react";
 
 import {
@@ -107,7 +107,7 @@ export function FolderPicker({
             open && "bg-accent text-foreground",
           ])}
         >
-          <Folder className="size-4 shrink-0" aria-hidden="true" />
+          <FolderSimple className="size-4 shrink-0" aria-hidden="true" />
           {currentPath ? (
             <span className="min-w-0 truncate text-xs text-neutral-600 dark:text-neutral-300">
               {currentPath}
@@ -164,7 +164,7 @@ export function FolderPicker({
                         onSelect={() => handleSelect(path)}
                         className="cursor-pointer"
                       >
-                        <Folder className="size-4 shrink-0 opacity-70" />
+                        <FolderSimple className="size-4 shrink-0 opacity-70" />
                         <span className="min-w-0 flex-1 truncate">{path}</span>
                         {path === currentPath ? (
                           <Check className="size-4 shrink-0" />

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -1,6 +1,9 @@
-import { Icon } from "@iconify-icon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { ArrowSquareOut, CircleNotch } from "@phosphor-icons/react";
+import {
+  ArrowSquareOut,
+  CircleNotch,
+  WarningCircle,
+} from "@phosphor-icons/react";
 import { type AnyFieldApi, useForm } from "@tanstack/react-form";
 import { useMutation, useQueries } from "@tanstack/react-query";
 import { type ReactNode, useMemo, useState } from "react";
@@ -696,7 +699,7 @@ function FormField({
       </InputGroup>
       {errorMessage && (
         <p className="text-destructive flex items-center gap-1.5 text-xs">
-          <Icon icon="mdi:alert-circle" size={14} />
+          <WarningCircle className="size-3.5 shrink-0" aria-hidden="true" />
           <span>{errorMessage}</span>
         </p>
       )}

--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -1,5 +1,10 @@
-import { Icon } from "@iconify-icon/react";
-import { ArrowRight, CaretDown } from "@phosphor-icons/react";
+import {
+  AppleLogo,
+  ArrowRight,
+  CaretDown,
+  LinuxLogo,
+  WindowsLogo,
+} from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 import { useRef, useState } from "react";
 
@@ -386,13 +391,7 @@ function DownloadButton() {
         }
         className="inline-flex items-center gap-1.5 rounded-l-full bg-[#181613] py-3 pr-2 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
       >
-        <Icon
-          icon={getPlatformIcon(preferredSection.platform)}
-          width={16}
-          height={16}
-          className="shrink-0"
-          aria-hidden="true"
-        />
+        {getPlatformIcon(preferredSection.platform, 16)}
         <span>{preferredLabel}</span>
       </a>
       <button
@@ -432,13 +431,7 @@ function DownloadButton() {
                   }}
                   className="text-color hover:surface-subtle flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors"
                 >
-                  <Icon
-                    icon={getPlatformIcon(section.platform)}
-                    width={20}
-                    height={20}
-                    className="shrink-0"
-                    aria-hidden="true"
-                  />
+                  {getPlatformIcon(section.platform, 20)}
                   <span>
                     {getDownloadOptionLabel(section.platform, download.name)}
                   </span>
@@ -466,10 +459,14 @@ function DownloadButton() {
   );
 }
 
-function getPlatformIcon(platform: DesktopPlatform) {
-  if (platform === "windows") return "simple-icons:windows11";
-  if (platform === "linux") return "simple-icons:linux";
-  return "simple-icons:apple";
+function getPlatformIcon(platform: DesktopPlatform, size: number) {
+  const Icon =
+    platform === "windows"
+      ? WindowsLogo
+      : platform === "linux"
+        ? LinuxLogo
+        : AppleLogo;
+  return <Icon size={size} className="shrink-0" aria-hidden="true" />;
 }
 
 function getDownloadOptionLabel(

--- a/apps/web/src/components/home-page/index.tsx
+++ b/apps/web/src/components/home-page/index.tsx
@@ -1,5 +1,4 @@
-import { Icon } from "@iconify-icon/react";
-import { ArrowRight } from "@phosphor-icons/react";
+import { ArrowRight, GithubLogo } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -177,7 +176,7 @@ function OpenSourceSection({
           rel="noopener noreferrer"
           className="mt-6 inline-flex items-center gap-2 rounded-full border border-neutral-300 bg-white px-5 py-3 text-sm font-medium text-neutral-900 transition-colors hover:border-neutral-900 hover:bg-neutral-900 hover:text-white"
         >
-          <Icon icon="mdi:github" width={18} height={18} aria-hidden="true" />
+          <GithubLogo size={18} aria-hidden="true" />
           <span>{formattedGithubStars} stars on GitHub</span>
         </a>
       </div>

--- a/apps/web/src/components/home-page/social-proof-sections.tsx
+++ b/apps/web/src/components/home-page/social-proof-sections.tsx
@@ -1,5 +1,4 @@
-import { Icon } from "@iconify-icon/react";
-import { ArrowRight } from "@phosphor-icons/react";
+import { ArrowRight, XLogo } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 import { type CSSProperties, useState } from "react";
 
@@ -273,12 +272,7 @@ function TestimonialTweetCard({
             onClick={(event) => event.stopPropagation()}
             className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-[#181613] transition-colors hover:bg-[#f7f4ef]"
           >
-            <Icon
-              icon="simple-icons:x"
-              width={15}
-              height={15}
-              aria-hidden="true"
-            />
+            <XLogo size={15} aria-hidden="true" />
           </a>
         </figcaption>
 

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,5 +1,10 @@
-import { Icon } from "@iconify-icon/react";
-import { ArrowSquareOut, DownloadSimple } from "@phosphor-icons/react";
+import {
+  AppleLogo,
+  ArrowSquareOut,
+  DownloadSimple,
+  LinuxLogo,
+  WindowsLogo,
+} from "@phosphor-icons/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -8,9 +13,9 @@ import { comingSoonPlatforms, desktopDownloadSections } from "@/lib/download";
 import { getCanonicalUrl } from "@/lib/seo";
 
 const platformIcons = {
-  macOS: "simple-icons:apple",
-  Windows: "simple-icons:windows",
-  Linux: "simple-icons:linux",
+  macOS: AppleLogo,
+  Windows: WindowsLogo,
+  Linux: LinuxLogo,
 } as const;
 
 export const Route = createFileRoute("/_view/download/")({
@@ -51,6 +56,7 @@ function Component() {
         <div className="grid gap-14 pb-12">
           {desktopDownloadSections.map((section) => {
             const headingId = `${section.name.toLowerCase()}-downloads`;
+            const PlatformIcon = platformIcons[section.name];
 
             return (
               <section key={section.name} aria-labelledby={headingId}>
@@ -58,11 +64,7 @@ function Component() {
                   id={headingId}
                   className="font-hand mb-5 flex items-center gap-2.5 text-3xl leading-none font-semibold tracking-normal"
                 >
-                  <Icon
-                    icon={platformIcons[section.name]}
-                    className="text-2xl"
-                    aria-hidden="true"
-                  />
+                  <PlatformIcon size={24} aria-hidden="true" />
                   {section.name}
                   {section.status && (
                     <span className="border-color-subtle text-color-muted rounded-full border px-2.5 py-1 font-sans text-xs leading-none font-medium tracking-wide uppercase">


### PR DESCRIPTION
FolderSimple matches the other header marks. Material/Simple Icons for GitHub, X, platforms, and onboarding socials now use Phosphor; colored brand logos stay on Iconify.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only icon swaps with no behavior, auth, or data-handling changes.
> 
> **Overview**
> Replaces leftover Iconify/Simple Icons usage with Phosphor so generic UI marks match the rest of the app. Folder chrome now uses `FolderSimple`. Onboarding socials, GitHub/X, platform logos, and the AI form error glyph all render as Phosphor components instead of Iconify string icons.
> 
> Colored brand logos stay on Iconify.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a770ded04726d5c401d0a9f804487f47edf121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->