### PR TITLE
Lock Microsoft publisher-domain app IDs so production Outlook is not dropped from the association file.

### DIFF
--- a/apps/web/src/functions/microsoft-identity-association.test.ts
+++ b/apps/web/src/functions/microsoft-identity-association.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const PRODUCTION_OUTLOOK_APP_ID = "22bc6342-cd6a-4784-8d66-3242113fe7fb";
+const ANARLOG_OUTLOOK_APP_ID = "3d7c41ea-a814-489f-9d57-9a4bbe780ddb";
+
+test("publisher-domain association keeps both Outlook Entra apps", () => {
+  const association = JSON.parse(
+    readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../../public/.well-known/microsoft-identity-association.json",
+      ),
+      "utf8",
+    ),
+  ) as { associatedApplications?: { applicationId?: string }[] };
+
+  const applicationIds = (association.associatedApplications ?? []).map(
+    (application) => application.applicationId,
+  );
+
+  assert.deepEqual(applicationIds, [
+    PRODUCTION_OUTLOOK_APP_ID,
+    ANARLOG_OUTLOOK_APP_ID,
+  ]);
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that asserts existing well-known JSON contents; no runtime or auth behavior is modified.
> 
> **Overview**
> Adds a regression test so `microsoft-identity-association.json` must keep **both** Outlook Entra app IDs (production and Anarlog). That prevents the production publisher-domain association from being dropped accidentally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d07f9566b0c84de7802ba8f8906bada9f6896a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->