### PR TITLE
Clear sidebar multi-select when clicking the main pane.

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -610,6 +610,78 @@ describe("TimelineView", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
+  it("clears selected notes when clicking main pane actions", () => {
+    mocks.timelineSelectionSelectedIds = [
+      "session-selected-note",
+      "session-other-note",
+    ];
+
+    render(
+      <>
+        <TimelineView />
+        <button type="button">Transcript</button>
+      </>,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Transcript" }));
+
+    expect(mocks.clearSelection).toHaveBeenCalledOnce();
+  });
+
+  it("keeps selected notes when clicking inside the timeline", () => {
+    mocks.timelineSelectionSelectedIds = [
+      "session-selected-note",
+      "session-other-note",
+    ];
+
+    const { container } = render(<TimelineView />);
+    const timelineRoot = container.querySelector(
+      "[data-sidebar-timeline-root]",
+    );
+
+    expect(timelineRoot).not.toBeNull();
+    fireEvent.pointerDown(timelineRoot!);
+
+    expect(mocks.clearSelection).not.toHaveBeenCalled();
+  });
+
+  it("keeps selected notes when clicking the delete confirmation dialog", () => {
+    mocks.timelineSelectionSelectedIds = ["session-selected-note"];
+    mocks.timelineSessionsTable = {
+      "selected-note": {
+        title: "Selected note",
+        created_at: "2024-01-15T12:00:00.000Z",
+      },
+    };
+
+    render(<TimelineView />);
+
+    fireEvent.keyDown(window, { key: "Backspace" });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mocks.clearSelection).not.toHaveBeenCalled();
+  });
+
+  it("keeps selected notes when dismissing the delete confirmation overlay", () => {
+    mocks.timelineSelectionSelectedIds = ["session-selected-note"];
+    mocks.timelineSessionsTable = {
+      "selected-note": {
+        title: "Selected note",
+        created_at: "2024-01-15T12:00:00.000Z",
+      },
+    };
+
+    render(<TimelineView />);
+
+    fireEvent.keyDown(window, { key: "Backspace" });
+    const overlay = document.querySelector("[data-dialog-overlay]");
+
+    expect(overlay).not.toBeNull();
+    fireEvent.pointerDown(overlay!);
+
+    expect(mocks.clearSelection).not.toHaveBeenCalled();
+  });
+
   it("shows Backspace beside Delete Selected in the context menu", () => {
     mocks.timelineSelectionSelectedIds = [
       "session-selected-note",

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -25,6 +25,7 @@ import {
   isTextEditingShortcutTarget,
   isTimelineItemVisible,
   scrollTimelineItemIntoView,
+  shouldClearTimelineSelectionOnPointerDown,
 } from "./interaction";
 import { ManagedSharedSessionIdsContext } from "./item";
 import { useCurrentTimeMs } from "./realtime";
@@ -189,6 +190,7 @@ export const TimelineView = memo(function TimelineView({
   );
   const shortcutStateRef = useRef({
     anchorId,
+    clearSelection,
     flatSessionItemKeys,
     handleRequestDeleteSelected,
     selectedIds,
@@ -197,6 +199,7 @@ export const TimelineView = memo(function TimelineView({
   });
   shortcutStateRef.current = {
     anchorId,
+    clearSelection,
     flatSessionItemKeys,
     handleRequestDeleteSelected,
     selectedIds,
@@ -363,9 +366,28 @@ export const TimelineView = memo(function TimelineView({
       }
     };
 
+    const handlePointerDown = (event: PointerEvent) => {
+      const { clearSelection, selectedIds } = shortcutStateRef.current;
+
+      if (
+        selectedIds.length === 0 ||
+        !shouldClearTimelineSelectionOnPointerDown(event.target)
+      ) {
+        return;
+      }
+
+      clearSelection();
+    };
+
     window.addEventListener("keydown", handleKeyDown, { capture: true });
+    window.addEventListener("pointerdown", handlePointerDown, {
+      capture: true,
+    });
     return () => {
       window.removeEventListener("keydown", handleKeyDown, { capture: true });
+      window.removeEventListener("pointerdown", handlePointerDown, {
+        capture: true,
+      });
     };
   });
 

--- a/apps/desktop/src/sidebar/timeline/interaction.test.ts
+++ b/apps/desktop/src/sidebar/timeline/interaction.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldClearTimelineSelectionOnPointerDown } from "./interaction";
+
+describe("shouldClearTimelineSelectionOnPointerDown", () => {
+  it("clears when the click is outside the timeline", () => {
+    const button = document.createElement("button");
+    button.textContent = "Transcript";
+    document.body.append(button);
+
+    expect(shouldClearTimelineSelectionOnPointerDown(button)).toBe(true);
+
+    button.remove();
+  });
+
+  it("keeps selection for clicks inside the timeline", () => {
+    const root = document.createElement("div");
+    root.dataset.sidebarTimelineRoot = "";
+    const item = document.createElement("button");
+    root.append(item);
+    document.body.append(root);
+
+    expect(shouldClearTimelineSelectionOnPointerDown(item)).toBe(false);
+
+    root.remove();
+  });
+
+  it("keeps selection for clicks inside a dialog", () => {
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    const cancel = document.createElement("button");
+    dialog.append(cancel);
+    document.body.append(dialog);
+
+    expect(shouldClearTimelineSelectionOnPointerDown(cancel)).toBe(false);
+
+    dialog.remove();
+  });
+
+  it("keeps selection for clicks on a dialog overlay", () => {
+    const overlay = document.createElement("div");
+    overlay.dataset.dialogOverlay = "";
+    document.body.append(overlay);
+
+    expect(shouldClearTimelineSelectionOnPointerDown(overlay)).toBe(false);
+
+    overlay.remove();
+  });
+});

--- a/apps/desktop/src/sidebar/timeline/interaction.ts
+++ b/apps/desktop/src/sidebar/timeline/interaction.ts
@@ -35,6 +35,27 @@ export function hasSidebarNoteSelectionContext({
   return anchorId === currentSessionKey || selectedIds.some(isSessionItemKey);
 }
 
+const TIMELINE_SELECTION_PRESERVE_SELECTOR = [
+  "[data-sidebar-timeline-root]",
+  "[role='dialog']",
+  "[data-dialog-overlay]",
+].join(",");
+
+export function shouldClearTimelineSelectionOnPointerDown(
+  target: EventTarget | null,
+) {
+  const element =
+    target instanceof Element
+      ? target
+      : target instanceof Node
+        ? target.parentElement
+        : null;
+
+  return (
+    element === null || !element.closest(TIMELINE_SELECTION_PRESERVE_SELECTOR)
+  );
+}
+
 export function isTextEditingShortcutTarget(target: EventTarget | null) {
   const element =
     target instanceof Element

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -23,6 +23,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
+    data-dialog-overlay
     className={cn([
       "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
       className,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI selection-clearing only. Shared dialog overlay gets a data attribute, which is a small cross-app markup change with no auth or data-handling impact.
> 
> **Overview**
> Sidebar note multi-select now clears when the user clicks outside the timeline (e.g. main pane actions), so selection no longer sticks after leaving the sidebar.
> 
> A capture-phase `pointerdown` listener calls `clearSelection` unless the target is inside the timeline, a dialog, or a dialog overlay. Shared `DialogOverlay` gets `data-dialog-overlay` so delete confirmation clicks do not wipe the selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1b44f84b35ac64ec45016b6ab480d7e476e333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->