### PR TITLE
Keep Team visible in settings and lock it behind Pro.

### DIFF
--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -27,7 +27,8 @@ const mocks = vi.hoisted(() => ({
   upgradeToPro: vi.fn(),
   updateSettingsTabState: vi.fn(),
   updateTemplatesTabState: vi.fn(),
-  workspaces: [] as Array<{ workspaceId: string }>,
+  workspaces: [] as Array<{ workspaceId: string }> | undefined,
+  workspacesLoading: false,
 }));
 
 const lingui = vi.hoisted(() => {
@@ -88,7 +89,8 @@ vi.mock("~/auth/billing-context", () => ({
 vi.mock("~/settings/team/mirror", () => ({
   useMyWorkspacesWithMirror: () => ({
     data: mocks.workspaces,
-    isPending: false,
+    isLoading: mocks.workspacesLoading,
+    isPending: mocks.workspacesLoading,
   }),
 }));
 
@@ -129,6 +131,7 @@ describe("SettingsNav", () => {
     mocks.updateSettingsTabState.mockClear();
     mocks.updateTemplatesTabState.mockClear();
     mocks.workspaces = [];
+    mocks.workspacesLoading = false;
   });
 
   it("renders every settings menu label", () => {
@@ -314,6 +317,24 @@ describe("SettingsNav", () => {
   it("opens Team for free members of an existing workspace", () => {
     mocks.isPro = false;
     mocks.workspaces = [{ workspaceId: "ws-1" }];
+
+    render(<SettingsNav />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Team" }));
+
+    expect(mocks.updateSettingsTabState).toHaveBeenCalledWith(
+      mocks.currentTab,
+      { tab: "team" },
+    );
+    expect(
+      screen.queryByRole("button", { name: "Upgrade to Pro for Team" }),
+    ).toBeNull();
+  });
+
+  it("does not lock Team while workspaces are still loading", () => {
+    mocks.isPro = false;
+    mocks.workspaces = undefined;
+    mocks.workspacesLoading = true;
 
     render(<SettingsNav />);
 

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   upgradeToPro: vi.fn(),
   updateSettingsTabState: vi.fn(),
   updateTemplatesTabState: vi.fn(),
+  workspaces: [] as Array<{ workspaceId: string }>,
 }));
 
 const lingui = vi.hoisted(() => {
@@ -84,6 +85,13 @@ vi.mock("~/auth/billing-context", () => ({
   }),
 }));
 
+vi.mock("~/settings/team/mirror", () => ({
+  useMyWorkspacesWithMirror: () => ({
+    data: mocks.workspaces,
+    isPending: false,
+  }),
+}));
+
 vi.mock("~/store/zustand/tabs", () => {
   const getState = () => ({
     currentTab: mocks.currentTab,
@@ -120,6 +128,7 @@ describe("SettingsNav", () => {
     mocks.upgradeToPro.mockClear();
     mocks.updateSettingsTabState.mockClear();
     mocks.updateTemplatesTabState.mockClear();
+    mocks.workspaces = [];
   });
 
   it("renders every settings menu label", () => {
@@ -300,6 +309,23 @@ describe("SettingsNav", () => {
     expect(
       screen.getByRole("button", { name: "Upgrade to Pro for Team" }),
     ).toBeTruthy();
+  });
+
+  it("opens Team for free members of an existing workspace", () => {
+    mocks.isPro = false;
+    mocks.workspaces = [{ workspaceId: "ws-1" }];
+
+    render(<SettingsNav />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Team" }));
+
+    expect(mocks.updateSettingsTabState).toHaveBeenCalledWith(
+      mocks.currentTab,
+      { tab: "team" },
+    );
+    expect(
+      screen.queryByRole("button", { name: "Upgrade to Pro for Team" }),
+    ).toBeNull();
   });
 
   it("opens Imports inside settings", () => {

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  session: { user: { id: "user-1" } } as { user: { id: string } } | null,
   currentTab: { type: "settings", state: { tab: "app" } } as {
     type: "settings";
     state: { tab?: string };
@@ -77,10 +76,6 @@ vi.mock("./custom-sidebar-header", () => ({
   CustomSidebarHeader: () => <div />,
 }));
 
-vi.mock("~/auth", () => ({
-  useAuth: () => ({ session: mocks.session }),
-}));
-
 vi.mock("~/auth/billing-context", () => ({
   useBillingAccess: () => ({
     isPro: mocks.isPro,
@@ -115,7 +110,6 @@ describe("SettingsNav", () => {
   afterEach(cleanup);
 
   beforeEach(() => {
-    mocks.session = { user: { id: "user-1" } };
     mocks.currentTab = { type: "settings", state: { tab: "app" } };
     mocks.tabs = [];
     mocks.isPro = true;
@@ -269,7 +263,6 @@ describe("SettingsNav", () => {
 
   it("shows locked Pro features and opens the upgrade flow", () => {
     mocks.isPro = false;
-    mocks.session = null;
 
     render(<SettingsNav />);
 
@@ -284,7 +277,7 @@ describe("SettingsNav", () => {
     expect(mocks.updateSettingsTabState).not.toHaveBeenCalled();
   });
 
-  it.each(["Automations", "Dictionary", "Sync"])(
+  it.each(["Team", "Automations", "Dictionary", "Sync"])(
     "does not open locked %s navigation",
     (label) => {
       mocks.isPro = false;
@@ -298,17 +291,15 @@ describe("SettingsNav", () => {
     },
   );
 
-  it("opens Team navigation for non-Pro members", () => {
+  it("shows Team with the Pro lock on the free plan", () => {
     mocks.isPro = false;
 
     render(<SettingsNav />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Team" }));
-
-    expect(mocks.updateSettingsTabState).toHaveBeenCalledWith(
-      mocks.currentTab,
-      { tab: "team" },
-    );
+    expect(screen.getByRole("button", { name: "Team" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Upgrade to Pro for Team" }),
+    ).toBeTruthy();
   });
 
   it("opens Imports inside settings", () => {

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -29,7 +29,6 @@ import { cn } from "@anlg/utils";
 
 import { CustomSidebarHeader } from "./custom-sidebar-header";
 
-import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { privacyMessages } from "~/settings/general/app-settings";
 import { type SettingsTab, type TabInput, useTabs } from "~/store/zustand/tabs";
@@ -53,7 +52,6 @@ type SettingsNavGroup = { label: string; items: SettingsNavItem[] };
 
 export function SettingsNav() {
   const { i18n, t } = useLingui();
-  const signedIn = Boolean(useAuth().session);
   const { isPro, upgradeToPro, isUpgradingToPro } = useBillingAccess();
   const [search, setSearch] = useState("");
   const currentTab = useTabs((state) => state.currentTab);
@@ -81,15 +79,12 @@ export function SettingsNav() {
       items: [
         { id: "app", label: t`General`, icon: Gear },
         { id: "account", label: t`Account`, icon: User },
-        ...(signedIn
-          ? [
-              {
-                id: "team" as const,
-                label: t`Team`,
-                icon: UsersThree,
-              },
-            ]
-          : []),
+        {
+          id: "team",
+          label: t`Team`,
+          icon: UsersThree,
+          requiresPro: true,
+        },
         { id: "appearance", label: t`Appearance`, icon: Sun },
         { id: "notifications", label: t`Notifications`, icon: Bell },
       ],

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -86,7 +86,7 @@ export function SettingsNav() {
           id: "team",
           label: t`Team`,
           icon: UsersThree,
-          requiresPro: !hasExistingWorkspace,
+          requiresPro: !workspaces.isLoading && !hasExistingWorkspace,
         },
         { id: "appearance", label: t`Appearance`, icon: Sun },
         { id: "notifications", label: t`Notifications`, icon: Bell },

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -31,6 +31,7 @@ import { CustomSidebarHeader } from "./custom-sidebar-header";
 
 import { useBillingAccess } from "~/auth/billing-context";
 import { privacyMessages } from "~/settings/general/app-settings";
+import { useMyWorkspacesWithMirror } from "~/settings/team/mirror";
 import { type SettingsTab, type TabInput, useTabs } from "~/store/zustand/tabs";
 
 type SettingsNavItem =
@@ -53,6 +54,8 @@ type SettingsNavGroup = { label: string; items: SettingsNavItem[] };
 export function SettingsNav() {
   const { i18n, t } = useLingui();
   const { isPro, upgradeToPro, isUpgradingToPro } = useBillingAccess();
+  const workspaces = useMyWorkspacesWithMirror();
+  const hasExistingWorkspace = (workspaces.data?.length ?? 0) > 0;
   const [search, setSearch] = useState("");
   const currentTab = useTabs((state) => state.currentTab);
   const updateSettingsTabState = useTabs(
@@ -83,7 +86,7 @@ export function SettingsNav() {
           id: "team",
           label: t`Team`,
           icon: UsersThree,
-          requiresPro: true,
+          requiresPro: !hasExistingWorkspace,
         },
         { id: "appearance", label: t`Appearance`, icon: Sun },
         { id: "notifications", label: t`Notifications`, icon: Bell },


### PR DESCRIPTION
Signed-out users no longer lose the item; it uses the same upgrade lock as Automations, Dictionary, and Sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings nav gating; no auth or billing backend changes. Temporary unlock while workspaces load is intentional to avoid flashing the Pro lock.
> 
> **Overview**
> Always shows **Team** in settings instead of hiding it for signed-out users. It uses the same Pro upgrade lock as Automations, Dictionary, and Sync.
> 
> The lock is skipped if the user already belongs to a workspace, or while workspaces are still loading, so existing members can still open Team on a free plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6b7ab6d4719f9fb5dc8e562fb1385c25631a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->