### PR TITLE
Make Record match the Join & record CTA.

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -522,6 +522,7 @@ describe("OuterHeader", () => {
     expect(joinButton.className).toContain("dark:text-black");
     expect(joinButton.className).toContain("hover:bg-primary/90");
     expect(joinButton.className).toContain("dark:hover:bg-white/90");
+    expect(joinButton.querySelector("img")?.className).toContain("size-3.5");
     expect(joinButton.getAttribute("aria-label")).toBe("Join & record");
     expect(joinButton.textContent).toContain("Join & record");
     expect(joinButton.getAttribute("data-tauri-drag-region")).toBe("false");
@@ -559,6 +560,7 @@ describe("OuterHeader", () => {
 
     expect(logo?.getAttribute("src")).toBe("/assets/anarlog-icon.png");
     expect(logo?.getAttribute("alt")).toBe("");
+    expect(logo?.className).toContain("size-3.5");
     expect(mocks.startListening).toHaveBeenCalledOnce();
     await vi.waitFor(() => {
       expect(mocks.startCallbackServer).toHaveBeenCalledWith("anarlog-dev");
@@ -870,8 +872,11 @@ describe("OuterHeader", () => {
 
     const recordButton = screen.getByRole("button", { name: "Record" });
 
-    expect(recordButton.className).toContain("bg-card");
-    expect(recordButton.className).not.toContain("bg-primary");
+    expect(recordButton.className).toContain("bg-primary");
+    expect(recordButton.className).toContain("dark:bg-white");
+    expect(recordButton.className).toContain("dark:text-black");
+    expect(recordButton.className).toContain("hover:bg-primary/90");
+    expect(recordButton.className).toContain("dark:hover:bg-white/90");
     expect(recordButton.querySelector("span")?.className).not.toContain(
       "@max-[480px]:sr-only",
     );

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -302,7 +302,11 @@ function HeaderMeetingActionPill({
         label: t`Join & record`,
         title: t`Join meeting and record`,
         icon: isWelcomeDemo ? (
-          <img src="/assets/anarlog-icon.png" alt="" className="size-4" />
+          <img
+            src="/assets/anarlog-icon.png"
+            alt=""
+            className="size-3.5 shrink-0"
+          />
         ) : remote ? (
           getMeetingDisplay(remote.type).icon
         ) : undefined,
@@ -320,7 +324,7 @@ function HeaderMeetingActionPill({
     };
   })();
   const disabled = sessionMode === "finalizing" || joiningMeeting;
-  const isJoinAction = canJoinFromHeader && sessionMode === "inactive";
+  const isPrimaryCta = sessionMode === "inactive";
   const showCountdown =
     Boolean(countdown.label) &&
     sessionMode !== "active" &&
@@ -344,14 +348,14 @@ function HeaderMeetingActionPill({
             disabled={disabled}
             onClick={action.onClick}
             className={cn([
-              "flex h-7 max-w-56 shrink-0 items-center gap-1.5 overflow-hidden rounded-full border px-1.5",
+              "flex h-7 max-w-56 shrink-0 items-center gap-1.5 overflow-hidden rounded-full border pr-2.5 pl-1.5",
               "text-sm font-medium",
               "transition-colors",
-              isJoinAction
+              isPrimaryCta
                 ? "border-primary bg-primary text-primary-foreground shadow-sm dark:border-white dark:bg-white dark:text-black"
                 : "border-border bg-card text-foreground",
               !disabled &&
-                (isJoinAction
+                (isPrimaryCta
                   ? "hover:bg-primary/90 dark:hover:bg-white/90"
                   : "hover:bg-accent"),
               disabled && "cursor-default opacity-60",
@@ -402,34 +406,48 @@ function getMeetingDisplay(type: RemoteMeeting["type"]) {
     case "zoom":
       return {
         name: "Zoom",
-        icon: <img src="/assets/zoom-icon.svg" alt="" width={18} height={18} />,
+        icon: (
+          <img
+            src="/assets/zoom-icon.svg"
+            alt=""
+            className="size-3.5 shrink-0"
+          />
+        ),
       };
     case "google-meet":
       return {
         name: "Meet",
         icon: (
-          <img src="/assets/google-meet.svg" alt="" width={18} height={18} />
+          <img
+            src="/assets/google-meet.svg"
+            alt=""
+            className="size-3.5 shrink-0"
+          />
         ),
       };
     case "webex":
       return {
         name: "Webex",
-        icon: <img src="/assets/webex.png" alt="" width={18} height={18} />,
+        icon: (
+          <img src="/assets/webex.png" alt="" className="size-3.5 shrink-0" />
+        ),
       };
     case "teams":
       return {
         name: "Teams",
-        icon: <img src="/assets/teams.png" alt="" width={18} height={18} />,
+        icon: (
+          <img src="/assets/teams.png" alt="" className="size-3.5 shrink-0" />
+        ),
       };
     case "cal-com":
       return {
         name: "Cal.com",
-        icon: <VideoCamera size={18} />,
+        icon: <VideoCamera className="size-3.5 shrink-0" />,
       };
     default:
       return {
         name: "Meeting",
-        icon: <Headset size={18} />,
+        icon: <Headset className="size-3.5 shrink-0" />,
       };
   }
 }


### PR DESCRIPTION
Shrink meeting icons to toolbar scale and give Record/Resume the same primary pill as Join & record.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header styling; no behavior, auth, or data-path changes.
> 
> **Overview**
> Gives **Record** and **Resume** the same primary pill as **Join & record** whenever the session is inactive, instead of the quieter card style.
> 
> Meeting provider icons (and the demo logo) shrink to `size-3.5` with `shrink-0` so they sit at toolbar scale, and the pill gets slightly more right padding. Tests now expect the primary styles on Record and the smaller icon class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07538470574f5dae79c9dff4e2fa67d3e3decb5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->