### PR TITLE
Hide the note title next to tabs during a live meeting.

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -552,29 +552,40 @@ describe("OuterHeader", () => {
     ).not.toBeNull();
   });
 
-  it("keeps the title input while listening", () => {
-    mocks.sessionModes = { "session-1": "active" };
-    mocks.hasTranscriptBySession = { "session-1": true };
+  it.each(["active", "running_batch", "finalizing"] as const)(
+    "hides the title input during a live meeting (%s)",
+    (sessionMode) => {
+      mocks.sessionModes = { "session-1": sessionMode };
+      mocks.hasTranscriptBySession = { "session-1": true };
 
-    render(
-      <OuterHeader
-        sessionId="session-1"
-        currentView={{ type: "raw" } as EditorView}
-        tab={{
-          active: true,
-          id: "session-1",
-          pinned: false,
-          slotId: "slot-1",
-          state: { autoStart: null, view: { type: "raw" } },
-          type: "sessions",
-        }}
-      />,
-    );
+      render(
+        <OuterHeader
+          sessionId="session-1"
+          currentView={{ type: "raw" } as EditorView}
+          tab={{
+            active: true,
+            id: "session-1",
+            pinned: false,
+            slotId: "slot-1",
+            state: { autoStart: null, view: { type: "raw" } },
+            type: "sessions",
+          }}
+          viewSwitcher={
+            <div role="group" aria-label="Session note views">
+              Tabs
+            </div>
+          }
+        />,
+      );
 
-    expect(
-      screen.getByRole("textbox", { name: "Session title" }),
-    ).not.toBeNull();
-  });
+      expect(
+        screen.queryByRole("textbox", { name: "Session title" }),
+      ).toBeNull();
+      expect(
+        screen.getByRole("group", { name: "Session note views" }),
+      ).not.toBe(null);
+    },
+  );
 
   it("places stop immediately before the folder while listening", () => {
     mocks.sessionModes = { "session-1": "active" };

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -74,9 +74,12 @@ export function OuterHeader({
   const ended = !!endedAt && endedAt.getTime() <= now.getTime();
   const isRecording =
     sessionMode === "active" || sessionMode === "running_batch";
+  const isLiveMeeting = isRecording || sessionMode === "finalizing";
   const meetingOver = !isRecording && (ended || hasTranscript || audioExists);
   const showTitleInput =
-    Boolean(tab) && !(meetingOver && currentView.type === "enhanced");
+    Boolean(tab) &&
+    !isLiveMeeting &&
+    !(meetingOver && currentView.type === "enhanced");
 
   return (
     <div


### PR DESCRIPTION
The breadcrumb title is for pre-meeting naming; once recording starts the view tabs already occupy that slot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only visibility change with updated unit tests; no auth, data, or recording-control logic.
> 
> **Overview**
> Hides the session title field in `OuterHeader` once a meeting is live so view tabs can occupy that slot.
> 
> `showTitleInput` now also stays off for `active`, `running_batch`, and `finalizing`. Tests cover those modes and still expect the view switcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c5aa4d35348409d3aa59023068000bcf2e034d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->