### PR TITLE
Tighten collapsed header spacing so note tabs sit 8px closer to the sidebar toggle.

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -269,7 +269,7 @@ describe("OuterHeader", () => {
     const header = container.firstElementChild;
     const spacer = header?.firstElementChild;
 
-    expect(header?.className).toContain("pl-[116px]");
+    expect(header?.className).toContain("pl-[108px]");
     expect(header?.className).toContain("h-12");
     expect(header?.className).not.toContain("pb-1");
     expect(spacer?.className).toContain("flex-1");
@@ -291,8 +291,8 @@ describe("OuterHeader", () => {
       />,
     );
 
-    expect(container.firstElementChild?.className).toContain("pl-[40px]");
-    expect(container.firstElementChild?.className).not.toContain("pl-[116px]");
+    expect(container.firstElementChild?.className).toContain("pl-[32px]");
+    expect(container.firstElementChild?.className).not.toContain("pl-[108px]");
     expect(container.firstElementChild?.className).not.toContain("pl-2");
   });
 
@@ -312,7 +312,7 @@ describe("OuterHeader", () => {
     expect(spacer?.className).not.toContain("right-[140px]");
     expect(spacer?.className).not.toContain("justify-center");
     expect(container.firstElementChild?.className).toContain("pl-2");
-    expect(container.firstElementChild?.className).not.toContain("pl-[114px]");
+    expect(container.firstElementChild?.className).not.toContain("pl-[108px]");
     expect(container.firstElementChild?.className).not.toContain("pl-[116px]");
   });
 
@@ -350,7 +350,7 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Go forward" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
     expect(container.firstElementChild?.className).toContain("pl-2");
-    expect(container.firstElementChild?.className).not.toContain("pl-[116px]");
+    expect(container.firstElementChild?.className).not.toContain("pl-[108px]");
   });
 
   it("keeps the session header at 48px tall", () => {
@@ -684,7 +684,7 @@ describe("OuterHeader", () => {
 
     const header = container.firstElementChild;
 
-    expect(header?.className).not.toContain("pl-[116px]");
+    expect(header?.className).not.toContain("pl-[108px]");
     expect(header?.className).toContain("pl-[76px]");
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -87,7 +87,7 @@ export function OuterHeader({
         standaloneWindow && (showWindowControlsGutter ? "pl-[76px]" : "pl-2"),
         !standaloneWindow && leftsidebar.expanded && "pl-2",
         showSidebarTimelineHeaderGutter &&
-          (showWindowControlsGutter ? "pl-[116px]" : "pl-[40px]"),
+          (showWindowControlsGutter ? "pl-[108px]" : "pl-[32px]"),
       ])}
     >
       {viewSwitcher}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic padding tweak in the session header only; no logic, auth, or data-handling changes.
> 
> **Overview**
> Reduces the collapsed-sidebar left padding on the session `OuterHeader` by 8px so note tabs sit closer to the sidebar toggle.
> 
> With native window controls the gutter is now `pl-[108px]` instead of `pl-[116px]`; without them it is `pl-[32px]` instead of `pl-[40px]`. Tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e72d563d7d70546d060282eb29440edec79d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->