### PR TITLE
chore(release): add desktop 1.4.12 changelog

### DIFF
--- a/packages/changelog/content/1.4.12.md
+++ b/packages/changelog/content/1.4.12.md
@@ -1,0 +1,76 @@
+---
+date: "2026-08-22"
+summary: "Anarlog 1.4.12 lets you lock the app and individual notes, connect existing ChatGPT, Claude, Grok, and Copilot subscriptions, and delivers pre-meeting briefs, plus Windows and Linux floating bars and notification overlays."
+---
+
+## Privacy
+
+- Lock Anarlog from Settings → Privacy so opening the app requires Touch ID,
+  Windows Hello, or your device password
+- Lock or unlock an individual note from the sidebar, then authenticate with
+  the same device prompt to view it
+- See a blurred preview of a locked note instead of a solid empty pane
+
+## Intelligence
+
+- Connect existing **ChatGPT**, **Claude**, **Grok**, **GitHub Copilot**, or
+  **Kimi** subscriptions from Settings → Intelligence instead of pasting an
+  API key
+- Sign in from the OpenAI, Anthropic, xAI, and Moonshot provider cards when
+  those services support a subscription
+
+## Meetings and notes
+
+- Get a concise pre-meeting brief in an upcoming note with timing, location,
+  attendees, and context from earlier meetings in the same series
+- Generate a short brief from an empty memo when related notes are available
+- Keep the **Transcript** tab during a live meeting, with **Stop** as its own
+  control next to the folder picker
+- Show the header title only on **Summary**; hide it on Memos, Transcript, and
+  during a live meeting
+- Edit transcript text and select segments for speaker changes or merges from
+  one **Edit** button
+- Keep recording through a brief network drop instead of ending the session,
+  then ask whether the meeting is over
+- Open a note with the editor already focused so you can start typing
+- Match **Record** to the **Join & record** call to action
+
+## Windows and Linux
+
+- Use the recording floating bar and live captions on Windows and Linux, not
+  only on macOS
+- See the same expandable notification overlays on Windows and Linux,
+  including meeting countdown and hover-to-pause dismiss
+- Capture visible meeting chat and post a recording disclosure into Zoom,
+  Google Meet, Teams, Slack, or Webex on Linux
+- Open the Linux AppImage without a black first frame or loud onboarding music
+
+## Calendars and settings
+
+- Disconnect Apple Calendar from the same context menu as Google and Outlook
+- See Google Calendar events immediately after connecting, without restarting
+- Keep **Team** visible in settings and locked behind Pro, while existing
+  workspace members can still open it
+- Keep the window size and position you left it in across ordinary launches,
+  not only after updates
+- Name this computer with the OS hostname instead of **Unnamed device**
+
+## Transcription and reliability
+
+- Download Apple Speech for your Mac's preferred language instead of hanging
+  at 0%, and finish Soniqo downloads once the model files are on disk
+- Load a cached Soniqo live model without contacting HuggingFace again
+- Dismiss a long-running download toast without cancelling the download
+- Dismiss event notifications five minutes after the meeting starts
+- Use about half as much extra memory while search indexes a large library
+- Avoid flashing a Sync issue while startup is still catching up
+- Keep summary corrections visible after Analog-to-Anarlog edits
+
+## Other improvements
+
+- Clear sidebar multi-select when you click the main pane
+- Keep share-invite fields rounded and folder-picker chrome aligned with the
+  rest of the toolbar
+- Keep transcript selection borders and leftover playback rows from being
+  clipped or misaligned
+- Match import provider icons to the same visual size


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the dated 1.4.12 changelog with a concise index preview
- cover desktop user-facing changes since `desktop_v1.4.11`, including app and note locks, subscription sign-in, pre-meeting briefs, and Windows/Linux floating bars and notification overlays
- exclude internal refactors, CI, enterprise fixtures, and packaging-only changes

## Test plan
- [x] `pnpm exec dprint fmt` scoped to the changelog (workspace-wide fmt hits known Linux rustfmt/swift gaps)
- [x] `pnpm -F @anlg/changelog typecheck`
- [x] `pnpm exec dprint check packages/changelog/content/1.4.12.md` (changelog markdown is not in dprint associations)

Release follow-up: merge this to `main`, then dispatch `desktop_cd.yaml` for stable 1.4.12. QA is waived for this release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-694995c0-74c0-4870-96e2-30cc71bfa89b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-694995c0-74c0-4870-96e2-30cc71bfa89b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

