### PR TITLE
fix: keep Linux meeting AX off the desktop Tokio runtime

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -509,6 +509,7 @@ jobs:
             --env DEB_PATH="/workspace/$deb" \
             --env BINARY_PATH="/usr/bin/$binary_name" \
             --env ANARLOG_DISABLE_SENTRY=1 \
+            --env RUST_BACKTRACE=1 \
             ubuntu:24.04 \
             bash -euxo pipefail -c '
               export DEBIAN_FRONTEND=noninteractive

--- a/crates/detect/Cargo.toml
+++ b/crates/detect/Cargo.toml
@@ -20,7 +20,7 @@ sysinfo = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 
-tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 tracing = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }

--- a/crates/detect/src/meeting_ax/linux.rs
+++ b/crates/detect/src/meeting_ax/linux.rs
@@ -43,15 +43,25 @@ struct LiveNode {
     path: String,
 }
 
-fn block_on_atspi<T>(future: impl Future<Output = T>) -> T {
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(future)),
-        Err(_) => tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("linux AT-SPI runtime")
-            .block_on(future),
-    }
+fn block_on_atspi<T>(future: impl Future<Output = T> + Send) -> T
+where
+    T: Send,
+{
+    // These sync entrypoints are invoked from async Tauri commands that already
+    // run on the desktop Tokio runtime. Handle::block_on / Runtime::block_on on
+    // that thread panics with "Cannot start a runtime from within a runtime".
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("linux AT-SPI runtime")
+                    .block_on(future)
+            })
+            .join()
+            .expect("linux AT-SPI thread panicked")
+    })
 }
 
 fn ax_role(role: Role) -> &'static str {

--- a/crates/detect/src/meeting_ax/tests/mod.rs
+++ b/crates/detect/src/meeting_ax/tests/mod.rs
@@ -87,3 +87,11 @@ fn inspect_meeting_accessibility_is_empty_without_ax_backend() {
 fn inspect_meeting_accessibility_does_not_panic_without_meeting_apps() {
     let _ = inspect_meeting_accessibility();
 }
+
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread")]
+async fn meeting_ax_sync_entrypoints_do_not_panic_inside_tokio_runtime() {
+    let _ = inspect_meeting_accessibility();
+    let _ = capture_meeting_chat_messages(vec!["us.zoom.Zoom".to_string()]);
+    let _ = send_meeting_chat_message("hello".to_string(), vec!["us.zoom.Zoom".to_string()]);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Stable 1.4.12 dry-run [`32581572144`](https://github.com/fastrepl/anarlog/actions/runs/32581572144) failed the Linux ARM smoke test (~180ms after launch, exit 101) with:

```
Cannot start a runtime from within a runtime.
This happens because a function (like `block_on`) attempted to block
the current thread while the thread is being used to drive asynchronous tasks.
```

macOS Silicon/Intel succeeded. Linux x64 was cancelled by fail-fast. Windows was still building. This run cannot be published (failed first attempt). Do not rerun it.

Linux meeting-chat AX (`#6992`) is new in 1.4.12. `block_on_atspi` called `Handle::block_on` from async Tauri commands that already run on the desktop Tokio runtime — the panic the smoke test hit.

## Changes

- Always run AT-SPI inspect/capture/send on a dedicated OS thread with its own current-thread runtime (same pattern as `crates/tauri-utils`).
- Add a multi-thread Tokio test so this cannot regress on Linux.
- Set `RUST_BACKTRACE=1` on the desktop CD Linux smoke container so the next early-exit is diagnosable.

## Release

QA remains waived. After this merges to `main`, comment `/stable 1.4.12` on **this** merged PR (not #7028) so `handle_release` uses the new `merge_commit_sha`. Then publish from that fresh first-attempt dry-run.

## Validation

- `cargo test -p detect --lib` (73 passed, including the new nested-runtime test)
- `cargo fmt -p detect`
- `pnpm exec dprint check` on the changed non-Swift files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-694995c0-74c0-4870-96e2-30cc71bfa89b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-694995c0-74c0-4870-96e2-30cc71bfa89b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

