### PR TITLE
fix: lock the app on window close, not focus loss

### DIFF
--- a/apps/desktop/src/lock/gate.test.tsx
+++ b/apps/desktop/src/lock/gate.test.tsx
@@ -144,6 +144,49 @@ describe("AppLockGate", () => {
     expect(screen.queryByText("Anarlog is Locked")).toBeNull();
   });
 
+  it("reprompts on reopen if close interrupted an in-flight prompt", async () => {
+    let resolveAuth!: (value: boolean) => void;
+    mocks.authenticateDevice.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveAuth = resolve;
+      }),
+    );
+
+    render(
+      <AppLockGate>
+        <div>app content</div>
+      </AppLockGate>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+      expect(useAppLock.getState().authenticating).toBe(true);
+    });
+
+    const emit = getVisibilityHandler();
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: false } });
+    });
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: true } });
+    });
+
+    expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+    expect(useAppLock.getState().appUnlocked).toBe(false);
+    expect(screen.getByText("Anarlog is Locked")).toBeTruthy();
+
+    mocks.authenticateDevice.mockResolvedValue(true);
+    await act(async () => {
+      resolveAuth(true);
+    });
+
+    await waitFor(() => {
+      expect(mocks.authenticateDevice).toHaveBeenCalledTimes(2);
+      expect(useAppLock.getState().appUnlocked).toBe(true);
+    });
+    expect(screen.queryByText("Anarlog is Locked")).toBeNull();
+  });
+
   it("does not unlock from a prompt that finishes after close", async () => {
     let resolveAuth!: (value: boolean) => void;
     mocks.authenticateDevice.mockReturnValue(

--- a/apps/desktop/src/lock/gate.test.tsx
+++ b/apps/desktop/src/lock/gate.test.tsx
@@ -59,7 +59,8 @@ type VisibilityPayload = {
 };
 
 function getVisibilityHandler() {
-  const listener = mocks.visibilityListen.mock.calls.at(-1)?.[0] as
+  const calls = mocks.visibilityListen.mock.calls;
+  const listener = calls[calls.length - 1]?.[0] as
     | ((event: { payload: VisibilityPayload }) => void)
     | undefined;
   if (!listener) {

--- a/apps/desktop/src/lock/gate.test.tsx
+++ b/apps/desktop/src/lock/gate.test.tsx
@@ -1,0 +1,158 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  settingsReady: true,
+  lockAppEnabled: true,
+  authenticateDevice: vi.fn(),
+  isDeviceAuthAvailable: vi.fn(),
+  getCurrentWebviewWindowLabel: vi.fn(() => "main"),
+  visibilityListen: vi.fn(),
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children?: unknown }) => children,
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray) => strings[0],
+  }),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => "macos",
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  events: {
+    visibilityEvent: {
+      listen: mocks.visibilityListen,
+    },
+  },
+  getCurrentWebviewWindowLabel: mocks.getCurrentWebviewWindowLabel,
+}));
+
+vi.mock("~/settings/queries", () => ({
+  useSettingsReady: () => mocks.settingsReady,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: (key: string) =>
+    key === "lock_app" ? mocks.lockAppEnabled : undefined,
+}));
+
+vi.mock("./auth", () => ({
+  DEVICE_AUTH_REASON: {
+    openApp: "open",
+    lockNote: "lock this note",
+    unlockNote: "unlock this note",
+    changeLockSettings: "change lock settings",
+  },
+  authenticateDevice: mocks.authenticateDevice,
+  isDeviceAuthAvailable: mocks.isDeviceAuthAvailable,
+}));
+
+import { AppLockGate } from "./gate";
+import { useAppLock } from "./store";
+
+type VisibilityPayload = {
+  window: { type: string };
+  visible: boolean;
+};
+
+function getVisibilityHandler() {
+  const listener = mocks.visibilityListen.mock.calls.at(-1)?.[0] as
+    | ((event: { payload: VisibilityPayload }) => void)
+    | undefined;
+  if (!listener) {
+    throw new Error("visibility listener was not registered");
+  }
+  return listener;
+}
+
+async function renderLockedGate() {
+  render(
+    <AppLockGate>
+      <div>app content</div>
+    </AppLockGate>,
+  );
+
+  await waitFor(() => {
+    expect(mocks.authenticateDevice).toHaveBeenCalledWith("open");
+    expect(useAppLock.getState().appUnlocked).toBe(true);
+    expect(screen.getByText("app content")).toBeTruthy();
+  });
+}
+
+describe("AppLockGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settingsReady = true;
+    mocks.lockAppEnabled = true;
+    mocks.getCurrentWebviewWindowLabel.mockReturnValue("main");
+    mocks.isDeviceAuthAvailable.mockResolvedValue(true);
+    mocks.authenticateDevice.mockResolvedValue(true);
+    mocks.visibilityListen.mockResolvedValue(vi.fn());
+    useAppLock.setState({
+      available: true,
+      authenticating: false,
+      appUnlocked: false,
+      revealedNoteIds: {},
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("does not lock or prompt when the window stays open", async () => {
+    await renderLockedGate();
+
+    expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Anarlog is Locked")).toBeNull();
+  });
+
+  it("locks on main window close without prompting", async () => {
+    await renderLockedGate();
+    const emit = getVisibilityHandler();
+
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: false } });
+    });
+
+    expect(useAppLock.getState().appUnlocked).toBe(false);
+    expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Anarlog is Locked")).toBeTruthy();
+  });
+
+  it("prompts only after the closed window is opened again", async () => {
+    await renderLockedGate();
+    const emit = getVisibilityHandler();
+
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: false } });
+    });
+
+    expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Anarlog is Locked")).toBeTruthy();
+
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: true } });
+    });
+
+    await waitFor(() => {
+      expect(mocks.authenticateDevice).toHaveBeenCalledTimes(2);
+      expect(useAppLock.getState().appUnlocked).toBe(true);
+    });
+    expect(screen.queryByText("Anarlog is Locked")).toBeNull();
+  });
+
+  it("ignores visibility changes for other windows", async () => {
+    await renderLockedGate();
+    const emit = getVisibilityHandler();
+
+    await act(async () => {
+      emit({ payload: { window: { type: "composer" }, visible: false } });
+    });
+
+    expect(useAppLock.getState().appUnlocked).toBe(true);
+    expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Anarlog is Locked")).toBeNull();
+  });
+});

--- a/apps/desktop/src/lock/gate.test.tsx
+++ b/apps/desktop/src/lock/gate.test.tsx
@@ -144,6 +144,52 @@ describe("AppLockGate", () => {
     expect(screen.queryByText("Anarlog is Locked")).toBeNull();
   });
 
+  it("does not unlock from a prompt that finishes after close", async () => {
+    let resolveAuth!: (value: boolean) => void;
+    mocks.authenticateDevice.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveAuth = resolve;
+      }),
+    );
+
+    render(
+      <AppLockGate>
+        <div>app content</div>
+      </AppLockGate>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.authenticateDevice).toHaveBeenCalledTimes(1);
+      expect(useAppLock.getState().authenticating).toBe(true);
+    });
+
+    const emit = getVisibilityHandler();
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: false } });
+    });
+
+    await act(async () => {
+      resolveAuth(true);
+    });
+
+    await waitFor(() => {
+      expect(useAppLock.getState().authenticating).toBe(false);
+    });
+    expect(useAppLock.getState().appUnlocked).toBe(false);
+    expect(screen.getByText("Anarlog is Locked")).toBeTruthy();
+
+    mocks.authenticateDevice.mockResolvedValue(true);
+    await act(async () => {
+      emit({ payload: { window: { type: "main" }, visible: true } });
+    });
+
+    await waitFor(() => {
+      expect(mocks.authenticateDevice).toHaveBeenCalledTimes(2);
+      expect(useAppLock.getState().appUnlocked).toBe(true);
+    });
+    expect(screen.queryByText("Anarlog is Locked")).toBeNull();
+  });
+
   it("ignores visibility changes for other windows", async () => {
     await renderLockedGate();
     const emit = getVisibilityHandler();

--- a/apps/desktop/src/lock/gate.tsx
+++ b/apps/desktop/src/lock/gate.tsx
@@ -1,6 +1,10 @@
 import { useLingui } from "@lingui/react/macro";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import {
+  events as windowsEvents,
+  getCurrentWebviewWindowLabel,
+} from "@anlg/plugin-windows";
 
 import { DEVICE_AUTH_REASON } from "./auth";
 import { LockScreen, useDeviceAuthHint } from "./screen";
@@ -49,24 +53,39 @@ export function AppLockGate({ children }: { children: ReactNode }) {
     if (!shouldLock) return;
 
     let unlisten: (() => void) | undefined;
-    void getCurrentWindow()
-      .onFocusChanged(({ payload: focused }) => {
-        if (focused) {
-          if (useAppLock.getState().appUnlocked) return;
-          if (useAppLock.getState().authenticating) return;
-          promptedRef.current = true;
-          void useAppLock.getState().unlockApp(DEVICE_AUTH_REASON.openApp);
+    let cancelled = false;
+    void windowsEvents.visibilityEvent
+      .listen(({ payload }) => {
+        if (
+          payload.window.type !== "main" ||
+          getCurrentWebviewWindowLabel() !== "main"
+        ) {
           return;
         }
+
+        if (!payload.visible) {
+          // Closing hides the main window. Lock now, but do not prompt until
+          // the user opens it again.
+          promptedRef.current = true;
+          lockApp();
+          return;
+        }
+
+        if (useAppLock.getState().appUnlocked) return;
         if (useAppLock.getState().authenticating) return;
-        promptedRef.current = false;
-        lockApp();
+        promptedRef.current = true;
+        void useAppLock.getState().unlockApp(DEVICE_AUTH_REASON.openApp);
       })
       .then((fn) => {
-        unlisten = fn;
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
       });
 
     return () => {
+      cancelled = true;
       unlisten?.();
     };
   }, [lockApp, shouldLock]);

--- a/apps/desktop/src/lock/gate.tsx
+++ b/apps/desktop/src/lock/gate.tsx
@@ -72,7 +72,12 @@ export function AppLockGate({ children }: { children: ReactNode }) {
         }
 
         if (useAppLock.getState().appUnlocked) return;
-        if (useAppLock.getState().authenticating) return;
+        if (useAppLock.getState().authenticating) {
+          // A close-invalidated prompt is still running. Let the auto-prompt
+          // effect start a new one once that auth settles.
+          promptedRef.current = false;
+          return;
+        }
         promptedRef.current = true;
         void useAppLock.getState().unlockApp(DEVICE_AUTH_REASON.openApp);
       })

--- a/apps/desktop/src/lock/store.test.ts
+++ b/apps/desktop/src/lock/store.test.ts
@@ -54,4 +54,46 @@ describe("app lock store", () => {
     expect(useAppLock.getState().isNoteRevealed("session-1")).toBe(false);
     expect(useAppLock.getState().appUnlocked).toBe(false);
   });
+
+  it("ignores an in-flight unlock after the app locks", async () => {
+    let resolveAuth!: (value: boolean) => void;
+    mocks.authenticateDevice.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveAuth = resolve;
+      }),
+    );
+
+    const pending = useAppLock.getState().unlockApp("open");
+    await waitForAuthenticating();
+    useAppLock.getState().lockApp();
+    resolveAuth(true);
+
+    await expect(pending).resolves.toBe(false);
+    expect(useAppLock.getState().appUnlocked).toBe(false);
+  });
+
+  it("unlocks after a later authentication that starts after lock", async () => {
+    let resolveAuth!: (value: boolean) => void;
+    mocks.authenticateDevice.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveAuth = resolve;
+      }),
+    );
+
+    const stale = useAppLock.getState().unlockApp("open");
+    await waitForAuthenticating();
+    useAppLock.getState().lockApp();
+    resolveAuth(true);
+    await expect(stale).resolves.toBe(false);
+
+    mocks.authenticateDevice.mockResolvedValue(true);
+    await expect(useAppLock.getState().unlockApp("open")).resolves.toBe(true);
+    expect(useAppLock.getState().appUnlocked).toBe(true);
+  });
 });
+
+function waitForAuthenticating() {
+  return vi.waitFor(() => {
+    expect(useAppLock.getState().authenticating).toBe(true);
+  });
+}

--- a/apps/desktop/src/lock/store.ts
+++ b/apps/desktop/src/lock/store.ts
@@ -17,58 +17,69 @@ type AppLockState = {
   isNoteRevealed: (sessionId: string) => boolean;
 };
 
-export const useAppLock = create<AppLockState>((set, get) => ({
-  available: null,
-  authenticating: false,
-  appUnlocked: false,
-  revealedNoteIds: {},
-  refreshAvailability: async () => {
-    try {
-      const available = await isDeviceAuthAvailable();
-      set({ available });
-      return available;
-    } catch {
-      set({ available: false });
+export const useAppLock = create<AppLockState>((set, get) => {
+  let lockEpoch = 0;
+
+  return {
+    available: null,
+    authenticating: false,
+    appUnlocked: false,
+    revealedNoteIds: {},
+    refreshAvailability: async () => {
+      try {
+        const available = await isDeviceAuthAvailable();
+        set({ available });
+        return available;
+      } catch {
+        set({ available: false });
+        return false;
+      }
+    },
+    authenticate: async (reason) => {
+      if (get().authenticating) return false;
+      set({ authenticating: true });
+      try {
+        return await authenticateDevice(reason);
+      } finally {
+        set({ authenticating: false });
+      }
+    },
+    unlockApp: async (reason) => {
+      const epoch = lockEpoch;
+      const ok = await get().authenticate(reason);
+      if (ok && epoch === lockEpoch) {
+        set({ appUnlocked: true });
+        return true;
+      }
       return false;
-    }
-  },
-  authenticate: async (reason) => {
-    if (get().authenticating) return false;
-    set({ authenticating: true });
-    try {
-      return await authenticateDevice(reason);
-    } finally {
-      set({ authenticating: false });
-    }
-  },
-  unlockApp: async (reason) => {
-    const ok = await get().authenticate(reason);
-    if (ok) set({ appUnlocked: true });
-    return ok;
-  },
-  lockApp: () => {
-    set({ appUnlocked: false, revealedNoteIds: {} });
-  },
-  revealNote: async (sessionId, reason) => {
-    if (get().revealedNoteIds[sessionId]) return true;
-    const ok = await get().authenticate(reason);
-    if (ok) {
-      get().markNoteRevealed(sessionId);
-    }
-    return ok;
-  },
-  markNoteRevealed: (sessionId) => {
-    set((state) => ({
-      revealedNoteIds: { ...state.revealedNoteIds, [sessionId]: true },
-    }));
-  },
-  concealNote: (sessionId) => {
-    set((state) => {
-      if (!state.revealedNoteIds[sessionId]) return state;
-      const revealedNoteIds = { ...state.revealedNoteIds };
-      delete revealedNoteIds[sessionId];
-      return { revealedNoteIds };
-    });
-  },
-  isNoteRevealed: (sessionId) => Boolean(get().revealedNoteIds[sessionId]),
-}));
+    },
+    lockApp: () => {
+      lockEpoch += 1;
+      set({ appUnlocked: false, revealedNoteIds: {} });
+    },
+    revealNote: async (sessionId, reason) => {
+      if (get().revealedNoteIds[sessionId]) return true;
+      const epoch = lockEpoch;
+      const ok = await get().authenticate(reason);
+      if (ok && epoch === lockEpoch) {
+        get().markNoteRevealed(sessionId);
+        return true;
+      }
+      return false;
+    },
+    markNoteRevealed: (sessionId) => {
+      set((state) => ({
+        revealedNoteIds: { ...state.revealedNoteIds, [sessionId]: true },
+      }));
+    },
+    concealNote: (sessionId) => {
+      set((state) => {
+        if (!state.revealedNoteIds[sessionId]) return state;
+        const revealedNoteIds = { ...state.revealedNoteIds };
+        delete revealedNoteIds[sessionId];
+        return { revealedNoteIds };
+      });
+    },
+    isNoteRevealed: (sessionId) => Boolean(get().revealedNoteIds[sessionId]),
+  };
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

With **Lock app** enabled, switching to another app immediately locked Anarlog and popped the system password / Touch ID dialog on top of the other app.

## Change

The lock gate no longer treats window blur as a close.

- Switching away leaves the session unlocked and does not prompt.
- Closing the main window (which hides it) locks the app quietly.
- Reopening the window shows the locked view and prompts for authentication.

An in-flight Touch ID / password success that started before close is discarded, so it cannot unlock the hidden session. If the window is reopened while that dialog is still pending, a new prompt starts once the stale auth settles.

This matches the Privacy setting copy: require device auth when **opening** Anarlog.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4735b54-0b5f-4b47-8daa-62b49de1e59f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4735b54-0b5f-4b47-8daa-62b49de1e59f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

