### PR TITLE
fix: leave Tokio before Linux single-instance plugin init

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -156,11 +156,6 @@ fn create_audio_provider(_bundle_id: &str) -> std::sync::Arc<dyn anlg_audio_actu
 
 pub fn main() {
     startup::apply_linux_webkit_workarounds();
-    async_main();
-}
-
-#[tokio::main]
-async fn async_main() {
     // Sentry minidump reporting re-execs this binary with --crash-reporter-server.
     // That helper must reach minidump::init instead of the launch lock, or it
     // shows "Anarlog is already starting" on every launch and never serves dumps.
@@ -168,7 +163,16 @@ async fn async_main() {
         run_crash_reporter_process();
     }
 
-    tauri::async_runtime::set(tokio::runtime::Handle::current());
+    // Keep a process-wide Tokio runtime for Tauri plugins, but leave it before
+    // Builder::build(). tauri-plugin-single-instance's Linux setup uses zbus's
+    // blocking Connection::build, which starts a nested runtime and panics if
+    // this thread is already inside #[tokio::main].
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    tauri::async_runtime::set(runtime.handle().clone());
+
     let context = tauri::generate_context!();
     let identifier = context.config().identifier.clone();
 
@@ -185,22 +189,31 @@ async fn async_main() {
         }
     };
 
-    let (root_supervisor_ctx, root_supervisor_handle) =
-        match supervisor::spawn_root_supervisor().await {
-            Some((ctx, handle)) => (Some(ctx), Some(handle)),
-            None => (None, None),
-        };
+    let (root_supervisor_ctx, root_supervisor_handle, db, crash_reporting_enabled) = runtime
+        .block_on(async {
+            let (root_supervisor_ctx, root_supervisor_handle) =
+                match supervisor::spawn_root_supervisor().await {
+                    Some((ctx, handle)) => (Some(ctx), Some(handle)),
+                    None => (None, None),
+                };
 
-    let startup_indicator = startup::SlowStartupIndicator::show_after_delay();
-    let db = match open_desktop_db(&identifier).await {
-        Ok(db) => db,
-        Err(error) => {
+            let startup_indicator = startup::SlowStartupIndicator::show_after_delay();
+            let db = match open_desktop_db(&identifier).await {
+                Ok(db) => db,
+                Err(error) => {
+                    startup_indicator.dismiss();
+                    exit_after_startup_failure(&identifier, &error)
+                }
+            };
             startup_indicator.dismiss();
-            exit_after_startup_failure(&identifier, &error)
-        }
-    };
-    startup_indicator.dismiss();
-    let crash_reporting_enabled = load_crash_reporting_consent(&db).await;
+            let crash_reporting_enabled = load_crash_reporting_consent(&db).await;
+            (
+                root_supervisor_ctx,
+                root_supervisor_handle,
+                db,
+                crash_reporting_enabled,
+            )
+        });
 
     let sentry_client = {
         let dsn = if std::env::var_os("ANARLOG_DISABLE_SENTRY").is_some() {
@@ -559,6 +572,7 @@ async fn async_main() {
         }
         _ => {}
     });
+    drop(runtime);
 }
 
 fn startup_failure_message(error: &impl std::fmt::Display) -> String {
@@ -711,6 +725,18 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn tokio_runtime_is_not_entered_after_block_on_returns() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            assert!(tokio::runtime::Handle::try_current().is_ok());
+        });
+        assert!(tokio::runtime::Handle::try_current().is_err());
+    }
 
     #[test]
     fn startup_failure_message_includes_the_original_error() {

--- a/apps/desktop/src/calendar/components/sidebar.test.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.test.tsx
@@ -5,9 +5,18 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { createElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { PermissionStatus } from "@anlg/plugin-permissions";
+
+// The real iconify-icon web component renders asynchronously via timers that
+// can fire after the test environment is torn down ("document is not
+// defined" unhandled errors), so render an inert element instead.
+vi.mock("@iconify-icon/react", () => ({
+  Icon: (props: Record<string, unknown>) =>
+    createElement("iconify-icon", props),
+}));
 
 type ContextMenuItem = {
   id?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Fresh 1.4.12 dry-run [`32584747942`](https://github.com/fastrepl/anarlog/actions/runs/32584747942) still failed Linux ARM smoke (exit 101). `RUST_BACKTRACE=1` shows the panic is **not** meeting AX. During `Builder::build()`:

```
tauri-plugin-single-instance-2.4.1/src/platform_impl/linux.rs:64
zbus Connection::build → tokio Runtime::block_on
Cannot start a runtime from within a runtime
```

`#[tokio::main]` keeps the main thread inside a runtime, so Linux single-instance plugin init panics. This run cannot be published (failed first attempt). Do not rerun it.

macOS Silicon also failed later on a CrabNebula upload `400` for the last DMG part; treat that as transient and retry only on a new first-attempt dry-run after this fix.

## Changes

- Create a process-wide multi-thread Tokio runtime and point `tauri::async_runtime` at it
- `block_on` only async setup (supervisor, DB, crash-reporting consent)
- Call `Builder::build()` / `app.run()` after that `block_on` returns, so this thread is not inside a runtime
- Add a unit test that `Handle::try_current()` is unset after `block_on` returns

The earlier AT-SPI dedicated-thread fix (#7029) stays; it is still required for Linux meeting-chat capture/send.

## Release

QA remains waived. After this merges, comment `/stable 1.4.12` on **this** merged PR so the next dry-run uses the new `main` SHA.

## Validation

- `pnpm exec dprint check apps/desktop/src-tauri/src/lib.rs`
- `cargo test -p desktop --lib` could not finish locally here (missing C++/knf-rs-sys link libs). Linux `desktop_ci` is the compile gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-694995c0-74c0-4870-96e2-30cc71bfa89b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-694995c0-74c0-4870-96e2-30cc71bfa89b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

