### PR TITLE
fix: spawn supervisor monitor on the process-wide Tokio handle

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -739,6 +739,24 @@ mod test {
     }
 
     #[test]
+    fn tauri_async_runtime_can_spawn_after_block_on_returns() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        tauri::async_runtime::set(runtime.handle().clone());
+        runtime.block_on(async {});
+        assert!(tokio::runtime::Handle::try_current().is_err());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        tauri::async_runtime::spawn(async move {
+            let _ = tx.send(());
+        });
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("spawned task should run on the process-wide runtime");
+    }
+
+    #[test]
     fn startup_failure_message_includes_the_original_error() {
         let message = startup_failure_message(&"legacy import did not pass parity verification");
 

--- a/apps/desktop/src-tauri/src/supervisor.rs
+++ b/apps/desktop/src-tauri/src/supervisor.rs
@@ -57,7 +57,9 @@ pub fn monitor_supervisor<R: tauri::Runtime>(
     is_exiting: Arc<AtomicBool>,
     app_handle: tauri::AppHandle<R>,
 ) {
-    tokio::spawn(async move {
+    // Main is outside a Tokio runtime during setup (so Linux single-instance
+    // zbus init can block_on). Spawn on the process-wide handle instead.
+    tauri::async_runtime::spawn(async move {
         match handle.await {
             Ok(()) => {
                 if !is_exiting.load(Ordering::SeqCst) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Bugbot on #7031: after leaving the Tokio runtime so Linux `tauri-plugin-single-instance` can `block_on` zbus, `setup` still calls `monitor_supervisor`, which used `tokio::spawn` and requires `Handle::current()`. On the normal path where the root supervisor starts, that panics during `Builder::build()` — the same nested-runtime class of failure #7031 aimed to avoid.

I merged #7031 without addressing that comment. This is the fix.

## Changes

- `monitor_supervisor` now uses `tauri::async_runtime::spawn` (the process-wide handle set in `main`)
- Test that spawn still works after `block_on` returns and `Handle::try_current()` is unset

## Release

Do **not** rerun or publish dry-run [`32588445736`](https://github.com/fastrepl/anarlog/actions/runs/32588445736) (`bf780c2f`). It started before this fix. After this merges, comment `/stable 1.4.12` on **this** merged PR.

QA remains waived.

## Validation

- `pnpm exec dprint check` on the two changed files
- `cargo fmt -p desktop` (scoped to these files)
- `cargo check -p desktop` still fails locally here (`knf-rs-sys` cmake). Linux `desktop_ci` is the compile gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-694995c0-74c0-4870-96e2-30cc71bfa89b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-694995c0-74c0-4870-96e2-30cc71bfa89b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

