### PR TITLE
Update desktop 1.4.12 changelog

### DIFF
--- a/packages/changelog/content/1.4.12.md
+++ b/packages/changelog/content/1.4.12.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-08-22"
+date: "2026-08-23"
 summary: "Anarlog 1.4.12 lets you lock the app and individual notes, connect existing ChatGPT, Claude, Grok, and Copilot subscriptions, and delivers pre-meeting briefs, plus Windows and Linux floating bars and notification overlays."
 ---
 
@@ -7,6 +7,8 @@ summary: "Anarlog 1.4.12 lets you lock the app and individual notes, connect exi
 
 - Lock Anarlog from Settings → Privacy so opening the app requires Touch ID,
   Windows Hello, or your device password
+- Switching away no longer locks immediately; the app locks when you close
+  the window, and the prompt appears when you open it again
 - Lock or unlock an individual note from the sidebar, then authenticate with
   the same device prompt to view it
 - See a blurred preview of a locked note instead of a solid empty pane
@@ -44,6 +46,8 @@ summary: "Anarlog 1.4.12 lets you lock the app and individual notes, connect exi
 - Capture visible meeting chat and post a recording disclosure into Zoom,
   Google Meet, Teams, Slack, or Webex on Linux
 - Open the Linux AppImage without a black first frame or loud onboarding music
+- Open Anarlog on Linux without crashing at launch or during meeting-chat
+  capture
 
 ## Calendars and settings
 


### PR DESCRIPTION
## Summary
- Document lock-on-close: switching away no longer locks immediately
- Note Linux launch and meeting-chat capture crash fixes that landed after the first 1.4.12 notes
- Set the changelog date to 2026-08-23

## Test plan
- [ ] Confirm `packages/changelog/content/1.4.12.md` frontmatter still has date and summary
- [ ] Confirm the Privacy and Windows/Linux sections match the commits on main after #7028

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no product, security, or runtime impact.
> 
> **Overview**
> Updates the **1.4.12** changelog date to 2026-08-23 and documents two late-landing behaviors.
> 
> Privacy now states that the app no longer locks immediately on switch-away; it locks on window close and prompts on reopen. Windows/Linux notes add crash fixes for Linux launch and meeting-chat capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a43d41353535df762a300d8f45a9c4ecd10262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->