### PR TITLE
Prepare Windows installer for Microsoft Store

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -757,6 +757,13 @@ jobs:
             throw "Expected app version $env:EXPECTED_VERSION, got $($config.version)"
           }
 
+          if ($env:RELEASE_CHANNEL -eq "stable") {
+            $stableConfig = Get-Content "apps/desktop/src-tauri/tauri.conf.stable.json" | ConvertFrom-Json
+            if ($stableConfig.bundle.windows.webviewInstallMode.type -ne "offlineInstaller") {
+              throw "Stable Windows releases must bundle the offline WebView2 installer for Microsoft Store compatibility"
+            }
+          }
+
           $bundleDir = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
           $installers = @(Get-ChildItem $bundleDir -Filter "*.exe")
           if ($installers.Count -ne 1) {

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -546,6 +546,19 @@ jobs:
           allowUpdates: true
           makeLatest: true
           replacesArtifacts: true
+      - name: Summarize Microsoft Store submission
+        if: ${{ needs.parse.outputs.include_windows == 'true' }}
+        env:
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          package_url="https://github.com/$GITHUB_REPOSITORY/releases/download/desktop_v$VERSION/anarlog-windows-x86_64-setup.exe"
+          package_sha256=$(sha256sum anarlog-windows-x86_64-setup.exe | cut -d ' ' -f 1)
+          {
+            echo "## Microsoft Store submission"
+            echo "- Package URL: \`$package_url\`"
+            echo "- SHA-256: \`$package_sha256\`"
+            echo "- Silent install argument: \`/S\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   linux-package-bump:
     needs: [parse, gh-release]

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -22,6 +22,11 @@
       "files": {
         "Resources/AppIcon.icns": "resources/stable/AppIcon.icns"
       }
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "offlineInstaller"
+      }
     }
   },
   "plugins": {


### PR DESCRIPTION
Bundle WebView2 offline and surface versioned release details for Partner Center.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stable Windows release packaging and CD gates. Installer size and Store submission behavior change, but auth and signing are unchanged.
> 
> **Overview**
> Stable Windows NSIS builds now ship the **offline WebView2 installer**, which Microsoft Store packaging requires.
> 
> CD fails the stable Windows job if `tauri.conf.stable.json` is not set to `offlineInstaller`. After GitHub release, publish writes Partner Center details (package URL, SHA-256, `/S`) to the job summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aabe59579bd660824cc334db954b741950ead2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->