### PR TITLE
fix: spawn db-sync watchers on the process-wide Tokio handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,6 +4890,7 @@ dependencies = [
  "chrono",
  "db-app",
  "db-core",
+ "db-sync",
  "dirs 6.0.0",
  "host",
  "intercept",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -90,6 +90,7 @@ anlg-audio-actual = { workspace = true }
 anlg-audio-mock = { workspace = true, optional = true }
 anlg-db-app = { workspace = true }
 anlg-db-core = { workspace = true }
+anlg-db-sync = { workspace = true }
 anlg-host = { workspace = true }
 anlg-storage = { workspace = true }
 anlg-supervisor = { workspace = true }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -172,6 +172,7 @@ pub fn main() {
         .build()
         .expect("tokio runtime");
     tauri::async_runtime::set(runtime.handle().clone());
+    anlg_db_sync::set_runtime_handle(runtime.handle().clone());
 
     let context = tauri::generate_context!();
     let identifier = context.config().identifier.clone();

--- a/crates/db-sync/src/lib.rs
+++ b/crates/db-sync/src/lib.rs
@@ -10,6 +10,23 @@ pub use replica_sync::{ReplicaSyncTask, spawn_replica_sync};
 pub use witness::{E2eeWitnessCancellation, E2eeWitnessClient, E2eeWitnessConfig};
 pub use witness_watch::{WitnessWatchTask, spawn_witness_watch};
 
+static RUNTIME: std::sync::OnceLock<tokio::runtime::Handle> = std::sync::OnceLock::new();
+
+pub fn set_runtime_handle(handle: tokio::runtime::Handle) {
+    let _ = RUNTIME.set(handle);
+}
+
+pub(crate) fn spawn_background(fut: impl std::future::Future<Output = ()> + Send + 'static) {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn(fut);
+        }
+        Err(_) => {
+            RUNTIME.get().expect("db-sync runtime handle").spawn(fut);
+        }
+    }
+}
+
 pub fn is_permanent_cloudsync_workspace_rejection(
     error: &anlg_db_app::CloudsyncWorkspaceError,
 ) -> bool {

--- a/crates/db-sync/src/replica_sync.rs
+++ b/crates/db-sync/src/replica_sync.rs
@@ -14,7 +14,7 @@ pub struct ReplicaSyncTask {
 
 pub fn spawn_replica_sync(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> ReplicaSyncTask {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    tokio::spawn(async move {
+    super::spawn_background(async move {
         loop {
             let witness_changed = hook.witness_changed.notified();
             tokio::pin!(witness_changed);

--- a/crates/db-sync/src/witness_watch.rs
+++ b/crates/db-sync/src/witness_watch.rs
@@ -20,7 +20,7 @@ pub struct WitnessWatchTask {
 /// hook's change notifications; dropping the returned handle stops it.
 pub fn spawn_witness_watch(db: Arc<Db>, hook: Arc<E2eeSyncHook>) -> WitnessWatchTask {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    tokio::spawn(async move {
+    super::spawn_background(async move {
         loop {
             let witness_changed = hook.witness_changed.notified();
             tokio::pin!(witness_changed);

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -188,8 +188,22 @@ impl CloudsyncOperationCancellation<'_> {
     }
 }
 
+fn ensure_db_sync_runtime() {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return;
+    }
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    tauri::async_runtime::spawn(async move {
+        let _ = tx.send(tokio::runtime::Handle::current());
+    });
+    if let Ok(handle) = rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        anlg_db_sync::set_runtime_handle(handle);
+    }
+}
+
 impl PluginDbRuntime {
     pub fn new(db: std::sync::Arc<Db>) -> Self {
+        ensure_db_sync_runtime();
         let e2ee_sync_hook = std::sync::Arc::new(E2eeSyncHook::default());
         db.set_cloudsync_sync_hook(e2ee_sync_hook.clone());
         let witness_watch = witness_watch::spawn_witness_watch(


### PR DESCRIPTION
## Summary
- Linux AppImage smoke test panicked at `spawn_witness_watch` with `there is no reactor running`
- Desktop leaves the Tokio runtime before `Builder::build` so single-instance zbus can init
- Witness watch and replica sync now use the stored process-wide handle when no current runtime exists

## Test plan
- [ ] `cargo test -p db-sync --lib`
- [ ] Re-run desktop_cd Linux aarch64 smoke after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CloudSync background task spawning and a process-wide Tokio handle (`OnceLock` + `expect`). Wrong or missing handle would still panic or leave watchers unstarted, but this is not auth or data-path logic.
> 
> **Overview**
> Fixes a Linux startup panic (`there is no reactor running`) when CloudSync witness-watch and replica-sync tasks spawn after desktop has left the process-wide Tokio runtime so zbus single-instance setup can run.
> 
> `db-sync` now stores that handle and `spawn_background` uses it when `Handle::try_current()` fails. Desktop sets the handle at runtime creation; the db plugin also tries to capture Tauri’s async runtime if construction happens off-runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193e8a0fc2d289934170cef2fb79e60e96a2ff21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->