### PR TITLE
fix: enter Tokio for live queries and join Windows Hello futures

### DIFF
--- a/crates/db-sync/src/lib.rs
+++ b/crates/db-sync/src/lib.rs
@@ -16,6 +16,12 @@ pub fn set_runtime_handle(handle: tokio::runtime::Handle) {
     let _ = RUNTIME.set(handle);
 }
 
+pub fn runtime_handle() -> Option<tokio::runtime::Handle> {
+    tokio::runtime::Handle::try_current()
+        .ok()
+        .or_else(|| RUNTIME.get().cloned())
+}
+
 pub(crate) fn spawn_background(fut: impl std::future::Future<Output = ()> + Send + 'static) {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => {

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -204,6 +204,8 @@ fn ensure_db_sync_runtime() {
 impl PluginDbRuntime {
     pub fn new(db: std::sync::Arc<Db>) -> Self {
         ensure_db_sync_runtime();
+        let handle = anlg_db_sync::runtime_handle();
+        let _enter = handle.as_ref().map(|h| h.enter());
         let e2ee_sync_hook = std::sync::Arc::new(E2eeSyncHook::default());
         db.set_cloudsync_sync_hook(e2ee_sync_hook.clone());
         let witness_watch = witness_watch::spawn_witness_watch(

--- a/plugins/local-auth/src/windows.rs
+++ b/plugins/local-auth/src/windows.rs
@@ -8,7 +8,7 @@ use crate::Error;
 pub fn available() -> Result<bool, Error> {
     let availability = UserConsentVerifier::CheckAvailabilityAsync()
         .map_err(win_error)?
-        .get()
+        .join()
         .map_err(win_error)?;
     Ok(availability == UserConsentVerifierAvailability::Available)
 }
@@ -23,7 +23,7 @@ pub fn authenticate(reason: &str) -> Result<bool, Error> {
 
     let result = UserConsentVerifier::RequestVerificationAsync(&HSTRING::from(reason))
         .map_err(win_error)?
-        .get()
+        .join()
         .map_err(win_error)?;
 
     Ok(result == UserConsentVerificationResult::Verified)


### PR DESCRIPTION
## Summary
- Fresh 1.4.12 dry-run failed: Linux ARM smoke panicked in `LiveQueryRuntime::new` (`tokio::spawn` with no reactor)
- Windows failed to compile `tauri-plugin-local-auth` (`IAsyncOperation::get` removed in windows-rs 0.62)
- Enter the process-wide Tokio handle for the duration of `PluginDbRuntime::new`
- Wait on Windows Hello with `.join()` instead of `.get()`

## Test plan
- [ ] `cargo test -p db-sync --lib`
- [ ] Re-run desktop_cd Linux aarch64 smoke and Windows build after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Tokio context during DB plugin startup and Windows Hello blocking waits. Small, targeted, but runtime-enter mistakes can still panic or stall auth.
> 
> **Overview**
> Fixes two 1.4.12 dry-run failures: Linux ARM smoke panicking in `LiveQueryRuntime::new` (`tokio::spawn` with no reactor) and a Windows compile break in local-auth after windows-rs 0.62.
> 
> `PluginDbRuntime::new` now enters the process-wide Tokio handle (current runtime or the stored db-sync handle) for the rest of construction so live queries and background sync tasks can spawn. Windows Hello waits with `.join()` instead of the removed `.get()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d551f16c191da48bcd4de1af65e1e3b8a1adc1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->