### PR TITLE
chore: remove departed members from admin emails and author mapping

### DIFF
--- a/apps/web/src/functions/github-content/shared.ts
+++ b/apps/web/src/functions/github-content/shared.ts
@@ -36,7 +36,6 @@ const GITHUB_USERNAME_TO_AUTHOR: Record<
   string,
   { name: string; email: string }
 > = {
-  yujonglee: { name: "Yujong Lee", email: "yujonglee@hyprnote.com" },
   ComputelessComputer: { name: "John Jeong", email: "john@hyprnote.com" },
 };
 

--- a/apps/web/src/lib/team.ts
+++ b/apps/web/src/lib/team.ts
@@ -37,12 +37,9 @@ export const AUTHORS = Object.values(EDITORS).map((m) => ({
 }));
 
 export const ADMIN_EMAILS = [
-  "yujonglee@hyprnote.com",
-  "yujonglee.dev@gmail.com",
   "john@hyprnote.com",
   "marketing@hyprnote.com",
   "yunhyungjo@yonsei.ac.kr",
-  "goranmoomin@daum.net",
   "artem@hyprnote.com",
   "stua@fastmail.com",
   "thestua@gmail.com",


### PR DESCRIPTION
Follow-up to #7042. Removes the remaining internal references to departed team members:

- ADMIN_EMAILS: removed yujonglee@hyprnote.com, yujonglee.dev@gmail.com, goranmoomin@daum.net
- github-content/shared.ts: removed the yujonglee commit-author mapping (author lookup already falls back to undefined)

yunhyungjo@yonsei.ac.kr left in place: no commits under that address and it does not match either departing member.

Type-checked @anlg/web.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who is treated as an admin via the email allowlist, which is authorization-related even though it is a small, intentional revocation.
> 
> **Overview**
> Removes remaining references to departed team members.
> 
> Drops three emails from `ADMIN_EMAILS` (used by `isAdminEmail`), so those accounts no longer pass the admin allowlist. Also removes the `yujonglee` GitHub username → commit-author mapping; unmatched usernames still fall back to no author metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02ebbf39b579564e465cdf73d761878c1982cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->