### PR TITLE
chore: remove yunhyungjo@yonsei.ac.kr from ADMIN_EMAILS

### DIFF
--- a/apps/web/src/lib/team.ts
+++ b/apps/web/src/lib/team.ts
@@ -39,7 +39,6 @@ export const AUTHORS = Object.values(EDITORS).map((m) => ({
 export const ADMIN_EMAILS = [
   "john@hyprnote.com",
   "marketing@hyprnote.com",
-  "yunhyungjo@yonsei.ac.kr",
   "artem@hyprnote.com",
   "stua@fastmail.com",
   "thestua@gmail.com",


### PR DESCRIPTION
Follow-up to #7044. Drops the last stale admin email; ADMIN_EMAILS now only contains John, marketing, and Artem addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the admin allowlist used for privileged access. Scope is a single intended email removal.
> 
> **Overview**
> Removes `yunhyungjo@yonsei.ac.kr` from `ADMIN_EMAILS` in `team.ts`, so that address no longer passes `isAdminEmail` / admin checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe58334b8ada332246f5e97bdb4bbc841406eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->