### PR TITLE
Fix recurring desktop Sentry errors

### DIFF
--- a/apps/desktop/src-tauri/src/search_index.rs
+++ b/apps/desktop/src-tauri/src/search_index.rs
@@ -30,6 +30,13 @@ enum IndexAction {
     Skip,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[must_use]
+enum DrainOutcome {
+    Complete,
+    Deferred,
+}
+
 pub fn spawn(app: AppHandle, db: Arc<anlg_db_core::Db>) {
     tauri::async_runtime::spawn(async move {
         run(app, db).await;
@@ -43,7 +50,10 @@ async fn run(app: AppHandle, db: Arc<anlg_db_core::Db>) {
 
     loop {
         match initialize(&app, db.pool()).await {
-            Ok(()) => break,
+            Ok(DrainOutcome::Complete) => break,
+            Ok(DrainOutcome::Deferred) => {
+                tokio::time::sleep(RETRY_INTERVAL).await;
+            }
             Err(error) => {
                 tracing::error!(%error, "failed to initialize search index projection");
                 tokio::time::sleep(RETRY_INTERVAL).await;
@@ -52,8 +62,11 @@ async fn run(app: AppHandle, db: Arc<anlg_db_core::Db>) {
     }
 
     loop {
-        if let Err(error) = drain_queue(&app, db.pool()).await {
-            tracing::error!(%error, "failed to update search index projection");
+        match drain_queue(&app, db.pool()).await {
+            Ok(DrainOutcome::Complete | DrainOutcome::Deferred) => {}
+            Err(error) => {
+                tracing::error!(%error, "failed to update search index projection");
+            }
         }
 
         tokio::select! {
@@ -94,7 +107,7 @@ async fn wait_for_tantivy(app: &AppHandle) {
     }
 }
 
-async fn initialize(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
+async fn initialize(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<DrainOutcome> {
     let projection_version: i64 = sqlx::query_scalar(
         "SELECT projection_version FROM search_index_state WHERE id = 'default'",
     )
@@ -103,14 +116,17 @@ async fn initialize(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
     .unwrap_or(0);
 
     if projection_version != PROJECTION_VERSION {
-        return rebuild(app, pool).await;
+        rebuild(app, pool).await?;
+        return Ok(DrainOutcome::Complete);
     }
 
-    drain_queue(app, pool).await?;
+    if drain_queue(app, pool).await? == DrainOutcome::Deferred {
+        return Ok(DrainOutcome::Deferred);
+    }
 
     let (database_count, pending_count) = projection_consistency_snapshot(pool).await?;
     if pending_count > 0 {
-        return Ok(());
+        return Ok(DrainOutcome::Deferred);
     }
 
     let index_count_matches = wait_for_index_count(app, database_count as usize).await?;
@@ -124,7 +140,7 @@ async fn initialize(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
         rebuild(app, pool).await?;
     }
 
-    Ok(())
+    Ok(DrainOutcome::Complete)
 }
 
 async fn rebuild(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
@@ -139,7 +155,9 @@ async fn rebuild(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
 
     app.tantivy().reindex(None).await?;
     enqueue_all_entities(pool).await?;
-    drain_queue(app, pool).await?;
+    while drain_queue(app, pool).await? == DrainOutcome::Deferred {
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
 
     sqlx::query(
         "UPDATE search_index_state
@@ -195,10 +213,10 @@ async fn enqueue_all_entities(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     tx.commit().await
 }
 
-async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
+async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<DrainOutcome> {
     loop {
         let Some(mut connection) = pool.try_acquire() else {
-            return Ok(());
+            return Ok(DrainOutcome::Deferred);
         };
         let rows = sqlx::query(
             "SELECT entity_type, entity_id, generation
@@ -213,7 +231,7 @@ async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
         connection.return_to_pool().await;
 
         if rows.is_empty() {
-            return Ok(());
+            return Ok(DrainOutcome::Complete);
         }
 
         let dirty_entities = rows
@@ -243,7 +261,7 @@ async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
         }
 
         if processed_entities.is_empty() {
-            return Ok(());
+            return Ok(DrainOutcome::Deferred);
         }
 
         if !documents.is_empty() || !removals.is_empty() {
@@ -253,7 +271,7 @@ async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
         }
 
         if !try_acknowledge_dirty_entities(pool, &processed_entities).await? {
-            return Ok(());
+            return Ok(DrainOutcome::Deferred);
         }
 
         tokio::task::yield_now().await;

--- a/apps/desktop/src-tauri/src/search_index.rs
+++ b/apps/desktop/src-tauri/src/search_index.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use chrono::DateTime;
 use serde_json::{Map, Value};
-use sqlx::{Row, SqlitePool};
+use sqlx::{Connection, Row, SqlitePool};
 use tauri::AppHandle;
 use tauri_plugin_tantivy::{
     SearchDocument, SearchFilters, SearchOptions, SearchRequest, TantivyPluginExt,
@@ -197,6 +197,9 @@ async fn enqueue_all_entities(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 
 async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
     loop {
+        let Some(mut connection) = pool.try_acquire() else {
+            return Ok(());
+        };
         let rows = sqlx::query(
             "SELECT entity_type, entity_id, generation
              FROM search_index_dirty
@@ -205,8 +208,9 @@ async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
              LIMIT ?",
         )
         .bind(BATCH_SIZE)
-        .fetch_all(pool)
+        .fetch_all(&mut *connection)
         .await?;
+        connection.return_to_pool().await;
 
         if rows.is_empty() {
             return Ok(());
@@ -223,12 +227,23 @@ async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
 
         let mut documents = Vec::new();
         let mut removals = Vec::new();
-        for dirty in &dirty_entities {
-            match build_index_action(pool, dirty).await? {
+        let mut processed_entities = Vec::new();
+        for dirty in dirty_entities {
+            let Some(mut connection) = pool.try_acquire() else {
+                break;
+            };
+            let action = build_index_action(&mut connection, &dirty).await?;
+            connection.return_to_pool().await;
+            match action {
                 IndexAction::Upsert(document) => documents.push(document),
                 IndexAction::Remove(id) => removals.push(id),
                 IndexAction::Skip => {}
             }
+            processed_entities.push(dirty);
+        }
+
+        if processed_entities.is_empty() {
+            return Ok(());
         }
 
         if !documents.is_empty() || !removals.is_empty() {
@@ -237,17 +252,22 @@ async fn drain_queue(app: &AppHandle, pool: &SqlitePool) -> WorkerResult<()> {
                 .await?;
         }
 
-        acknowledge_dirty_entities(pool, &dirty_entities).await?;
+        if !try_acknowledge_dirty_entities(pool, &processed_entities).await? {
+            return Ok(());
+        }
 
         tokio::task::yield_now().await;
     }
 }
 
-async fn acknowledge_dirty_entities(
+async fn try_acknowledge_dirty_entities(
     pool: &SqlitePool,
     dirty_entities: &[DirtyEntity],
-) -> Result<(), sqlx::Error> {
-    let mut tx = pool.begin().await?;
+) -> Result<bool, sqlx::Error> {
+    let Some(mut connection) = pool.try_acquire() else {
+        return Ok(false);
+    };
+    let mut tx = connection.begin().await?;
     for dirty in dirty_entities {
         sqlx::query(
             "UPDATE search_index_dirty
@@ -263,14 +283,19 @@ async fn acknowledge_dirty_entities(
         .execute(&mut *tx)
         .await?;
     }
-    tx.commit().await
+    tx.commit().await?;
+    connection.return_to_pool().await;
+    Ok(true)
 }
 
-async fn build_index_action(pool: &SqlitePool, dirty: &DirtyEntity) -> WorkerResult<IndexAction> {
+async fn build_index_action(
+    connection: &mut sqlx::SqliteConnection,
+    dirty: &DirtyEntity,
+) -> WorkerResult<IndexAction> {
     match dirty.entity_type.as_str() {
-        "session" => build_session_document(pool, &dirty.entity_id).await,
-        "human" => build_human_document(pool, &dirty.entity_id).await,
-        "organization" => build_organization_document(pool, &dirty.entity_id).await,
+        "session" => build_session_document(connection, &dirty.entity_id).await,
+        "human" => build_human_document(connection, &dirty.entity_id).await,
+        "organization" => build_organization_document(connection, &dirty.entity_id).await,
         entity_type => {
             tracing::warn!(entity_type, "ignoring unknown search index entity type");
             Ok(IndexAction::Skip)
@@ -278,14 +303,17 @@ async fn build_index_action(pool: &SqlitePool, dirty: &DirtyEntity) -> WorkerRes
     }
 }
 
-async fn build_session_document(pool: &SqlitePool, id: &str) -> WorkerResult<IndexAction> {
+async fn build_session_document(
+    connection: &mut sqlx::SqliteConnection,
+    id: &str,
+) -> WorkerResult<IndexAction> {
     let Some(session) = sqlx::query(
         "SELECT title, created_at, event_json, locked
          FROM sessions
          WHERE id = ? AND deleted_at IS NULL",
     )
     .bind(id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *connection)
     .await?
     else {
         return Ok(IndexAction::Remove(id.to_string()));
@@ -316,7 +344,7 @@ async fn build_session_document(pool: &SqlitePool, id: &str) -> WorkerResult<Ind
     )
     .bind(id)
     .bind(id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *connection)
     .await?;
 
     let enhanced_bodies: Vec<String> = sqlx::query_scalar(
@@ -328,7 +356,7 @@ async fn build_session_document(pool: &SqlitePool, id: &str) -> WorkerResult<Ind
          ORDER BY sort_order, created_at, id",
     )
     .bind(id)
-    .fetch_all(pool)
+    .fetch_all(&mut *connection)
     .await?;
 
     let transcripts: Vec<String> = sqlx::query_scalar(
@@ -338,7 +366,7 @@ async fn build_session_document(pool: &SqlitePool, id: &str) -> WorkerResult<Ind
          ORDER BY started_at_ms, created_at, id",
     )
     .bind(id)
-    .fetch_all(pool)
+    .fetch_all(&mut *connection)
     .await?;
 
     let meeting_chat_messages: Vec<String> = sqlx::query_scalar(
@@ -348,7 +376,7 @@ async fn build_session_document(pool: &SqlitePool, id: &str) -> WorkerResult<Ind
          ORDER BY sort_order, created_at, id",
     )
     .bind(id)
-    .fetch_all(pool)
+    .fetch_all(&mut *connection)
     .await?;
 
     let mut content_parts = Vec::with_capacity(
@@ -384,14 +412,17 @@ async fn build_session_document(pool: &SqlitePool, id: &str) -> WorkerResult<Ind
     }))
 }
 
-async fn build_human_document(pool: &SqlitePool, id: &str) -> WorkerResult<IndexAction> {
+async fn build_human_document(
+    connection: &mut sqlx::SqliteConnection,
+    id: &str,
+) -> WorkerResult<IndexAction> {
     let Some(human) = sqlx::query(
         "SELECT name, email, job_title, linkedin_username, created_at, memo
          FROM humans
          WHERE id = ? AND deleted_at IS NULL",
     )
     .bind(id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *connection)
     .await?
     else {
         return Ok(IndexAction::Remove(id.to_string()));
@@ -419,14 +450,17 @@ async fn build_human_document(pool: &SqlitePool, id: &str) -> WorkerResult<Index
     }))
 }
 
-async fn build_organization_document(pool: &SqlitePool, id: &str) -> WorkerResult<IndexAction> {
+async fn build_organization_document(
+    connection: &mut sqlx::SqliteConnection,
+    id: &str,
+) -> WorkerResult<IndexAction> {
     let Some(organization) = sqlx::query(
         "SELECT name, created_at
          FROM organizations
          WHERE id = ? AND deleted_at IS NULL",
     )
     .bind(id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *connection)
     .await?
     else {
         return Ok(IndexAction::Remove(id.to_string()));
@@ -684,17 +718,21 @@ mod tests {
             .execute(db.pool())
             .await
             .unwrap();
+        let mut connection = db.pool().acquire().await.unwrap();
+        connection.return_to_pool().await;
 
-        acknowledge_dirty_entities(
-            db.pool(),
-            &[DirtyEntity {
-                entity_type: "session".to_string(),
-                entity_id: "session-1".to_string(),
-                generation: queued_generation,
-            }],
-        )
-        .await
-        .unwrap();
+        assert!(
+            try_acknowledge_dirty_entities(
+                db.pool(),
+                &[DirtyEntity {
+                    entity_type: "session".to_string(),
+                    entity_id: "session-1".to_string(),
+                    generation: queued_generation,
+                }],
+            )
+            .await
+            .unwrap()
+        );
 
         let (current_generation, acknowledged_generation): (i64, i64) = sqlx::query_as(
             "SELECT generation, acknowledged_generation FROM search_index_dirty
@@ -705,17 +743,21 @@ mod tests {
         .unwrap();
         assert_eq!(current_generation, queued_generation + 1);
         assert_eq!(acknowledged_generation, 0);
+        let mut connection = db.pool().acquire().await.unwrap();
+        connection.return_to_pool().await;
 
-        acknowledge_dirty_entities(
-            db.pool(),
-            &[DirtyEntity {
-                entity_type: "session".to_string(),
-                entity_id: "session-1".to_string(),
-                generation: current_generation,
-            }],
-        )
-        .await
-        .unwrap();
+        assert!(
+            try_acknowledge_dirty_entities(
+                db.pool(),
+                &[DirtyEntity {
+                    entity_type: "session".to_string(),
+                    entity_id: "session-1".to_string(),
+                    generation: current_generation,
+                }],
+            )
+            .await
+            .unwrap()
+        );
         let remaining: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM search_index_dirty
              WHERE entity_type = 'session'
@@ -735,6 +777,21 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(acknowledged_generation, current_generation);
+    }
+
+    #[tokio::test]
+    async fn acknowledgement_defers_when_the_database_pool_is_busy() {
+        let db = anlg_db_core::Db::connect_memory_plain().await.unwrap();
+        let mut held_connection = db.pool().acquire().await.unwrap();
+        let started = std::time::Instant::now();
+
+        let acknowledged = try_acknowledge_dirty_entities(db.pool(), &[])
+            .await
+            .unwrap();
+
+        assert!(!acknowledged);
+        assert!(started.elapsed() < Duration::from_millis(100));
+        held_connection.return_to_pool().await;
     }
 
     #[test]

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -39,6 +39,49 @@ fn client_build_error(args: &ListenerArgs, error: owhisper_client::Error) -> Act
     }
 }
 
+fn classify_ws_connect_failure(provider: &str, error: &anlg_ws_client::Error) -> DegradedError {
+    if error.is_auth_error() {
+        return DegradedError::AuthenticationFailed {
+            provider: provider.to_string(),
+        };
+    }
+
+    match error {
+        anlg_ws_client::Error::InvalidRequest { message }
+        | anlg_ws_client::Error::ConnectFailed {
+            message,
+            status_code: Some(400 | 402 | 404 | 422),
+            ..
+        } => DegradedError::ProviderConfiguration {
+            provider: provider.to_string(),
+            message: message.clone(),
+        },
+        _ => DegradedError::UpstreamUnavailable {
+            message: error.to_string(),
+        },
+    }
+}
+
+fn ws_connect_error(args: &ListenerArgs, error: anlg_ws_client::Error) -> ActorProcessingErr {
+    let provider =
+        AdapterKind::from_url_and_languages(&args.base_url, &args.languages, Some(&args.model))
+            .to_string();
+    let message = format!("listen_ws_connect_failed: {error:?}");
+
+    tracing::warn!(
+        anarlog.session.id = %args.session_id,
+        anarlog.stt.provider.name = %provider,
+        error.message = ?error,
+        "listen_ws_connect_failed"
+    );
+    args.runtime.emit_error(SessionErrorEvent::ConnectionError {
+        session_id: args.session_id.clone(),
+        error: message.clone(),
+    });
+
+    actor_error_with_degraded(message, classify_ws_connect_failure(&provider, &error))
+}
+
 pub(super) async fn spawn_rx_task(
     args: ListenerArgs,
     myself: ActorRef<ListenerMsg>,
@@ -504,21 +547,10 @@ async fn spawn_rx_task_single_with_adapter<A: RealtimeSttAdapter>(
 
     let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
 
-    let (listen_stream, handle) = match client.from_realtime_audio(outbound).await {
-        Err(e) => {
-            tracing::error!(
-                anarlog.session.id = %args.session_id,
-                error.message = ?e,
-                "listen_ws_connect_failed(single)"
-            );
-            args.runtime.emit_error(SessionErrorEvent::ConnectionError {
-                session_id: args.session_id.clone(),
-                error: format!("listen_ws_connect_failed: {:?}", e),
-            });
-            return Err(actor_error(format!("listen_ws_connect_failed: {:?}", e)));
-        }
-        Ok(res) => res,
-    };
+    let (listen_stream, handle) = client
+        .from_realtime_audio(outbound)
+        .await
+        .map_err(|error| ws_connect_error(&args, error))?;
 
     let rx_task = tokio::spawn(async move {
         futures_util::pin_mut!(listen_stream);
@@ -565,21 +597,10 @@ async fn spawn_rx_task_dual_with_adapter<A: RealtimeSttAdapter>(
 
     let outbound = tokio_stream::wrappers::ReceiverStream::new(rx);
 
-    let (listen_stream, handle) = match client.from_realtime_audio(outbound).await {
-        Err(e) => {
-            tracing::error!(
-                anarlog.session.id = %args.session_id,
-                error.message = ?e,
-                "listen_ws_connect_failed(dual)"
-            );
-            args.runtime.emit_error(SessionErrorEvent::ConnectionError {
-                session_id: args.session_id.clone(),
-                error: format!("listen_ws_connect_failed: {:?}", e),
-            });
-            return Err(actor_error(format!("listen_ws_connect_failed: {:?}", e)));
-        }
-        Ok(res) => res,
-    };
+    let (listen_stream, handle) = client
+        .from_realtime_audio(outbound)
+        .await
+        .map_err(|error| ws_connect_error(&args, error))?;
 
     let rx_task = tokio::spawn(async move {
         futures_util::pin_mut!(listen_stream);
@@ -714,6 +735,56 @@ mod tests {
 
         assert_eq!(params.num_speakers, Some(2));
         assert_eq!(params.max_speakers, Some(2));
+    }
+
+    #[test]
+    fn websocket_auth_failures_are_terminal() {
+        let error = anlg_ws_client::Error::ConnectFailed {
+            attempt: 1,
+            max_attempts: 3,
+            message: "HTTP 401 Unauthorized".to_string(),
+            is_auth: true,
+            status_code: Some(401),
+            retryable: false,
+            retry_after_secs: None,
+        };
+
+        assert!(matches!(
+            classify_ws_connect_failure("deepgram", &error),
+            DegradedError::AuthenticationFailed { provider } if provider == "deepgram"
+        ));
+    }
+
+    #[test]
+    fn websocket_request_failures_are_terminal() {
+        let error = anlg_ws_client::Error::ConnectFailed {
+            attempt: 1,
+            max_attempts: 3,
+            message: "HTTP 400 Bad Request".to_string(),
+            is_auth: false,
+            status_code: Some(400),
+            retryable: false,
+            retry_after_secs: None,
+        };
+
+        assert!(matches!(
+            classify_ws_connect_failure("deepgram", &error),
+            DegradedError::ProviderConfiguration { provider, message }
+                if provider == "deepgram" && message == "HTTP 400 Bad Request"
+        ));
+    }
+
+    #[test]
+    fn websocket_transient_failures_remain_retryable() {
+        let error = anlg_ws_client::Error::ConnectRetriesExhausted {
+            attempts: 3,
+            last_error: "HTTP 503 Service Unavailable".to_string(),
+        };
+
+        assert!(matches!(
+            classify_ws_connect_failure("deepgram", &error),
+            DegradedError::UpstreamUnavailable { .. }
+        ));
     }
 
     #[test]

--- a/crates/ws-client/src/retry.rs
+++ b/crates/ws-client/src/retry.rs
@@ -136,7 +136,7 @@ async fn try_connect(
     let (ws_stream, _) = match connect_result {
         Ok(Ok(stream)) => stream,
         Ok(Err(error)) => {
-            tracing::error!(
+            tracing::warn!(
                 attempt,
                 max_attempts,
                 request = %redacted_request,


### PR DESCRIPTION
Summary:
- classify terminal realtime STT connection failures so authentication and provider configuration errors stop retrying
- downgrade handled websocket connection failures from error-level reporting
- make search indexing yield immediately when the SQLite pool is busy and retry on its normal cadence

Validation:
- cargo check -p desktop --features direct-distribution
- cargo check -p desktop --features app-store
- cargo test -p desktop
- cargo test -p listener-core -p ws-client
- pnpm exec dprint check --allow-no-files apps/desktop/src-tauri/src/search_index.rs crates/listener-core/src/actors/listener/adapters.rs crates/ws-client/src/retry.rs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how live STT connection failures are classified (retry vs stop) and how the search worker shares the SQLite pool. Incorrect classification could stop retries too early or keep retrying bad credentials.
> 
> **Overview**
> Stops recurring desktop Sentry noise from two sources: realtime STT websocket connect failures and search-index SQLite pool contention.
> 
> Websocket connect errors are now classified as **terminal** (`AuthenticationFailed` / `ProviderConfiguration`) vs **retryable** (`UpstreamUnavailable`), so auth and 4xx config failures stop retrying. Handled connect failures are logged at **warn** instead of error.
> 
> Search indexing **non-blockingly** acquires SQLite connections (`try_acquire`). If the pool is busy it defers and retries on the existing cadence instead of waiting and erroring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01099db78ad3dadc5135a2ef70a76530204166e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->