### PR TITLE
Rename Sentry project references

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -261,7 +261,7 @@ jobs:
 
           sentry-cli debug-files upload \
             --org fastrepl \
-            --project hyprnote2 \
+            --project anarlog \
             --include-sources \
             "${{ steps.macos-symbols.outputs.path }}"
       - if: ${{ inputs.channel == 'stable' }}
@@ -441,7 +441,7 @@ jobs:
 
           sentry-cli debug-files upload \
             --org fastrepl \
-            --project hyprnote2 \
+            --project anarlog \
             --include-sources \
             "$binary"
       - run: |
@@ -671,7 +671,7 @@ jobs:
 
           sentry-cli debug-files upload \
             --org fastrepl \
-            --project hyprnote2 \
+            --project anarlog \
             --include-sources \
             "$release_dir/anarlog.exe" \
             "${pdbs[@]}"

--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -67,7 +67,7 @@ jobs:
           pnpm -F @anlg/web exec sentry-cli sourcemaps inject dist
           pnpm -F @anlg/web exec sentry-cli sourcemaps upload \
             --org fastrepl \
-            --project hyprnote2 \
+            --project anarlog \
             --release "$SENTRY_RELEASE" \
             dist
           find apps/web/dist -type f -name '*.map' -delete


### PR DESCRIPTION
Point desktop debug-file and web source-map uploads at the renamed Anarlog project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CI slug change; wrong project name would send symbols to the wrong Sentry project but does not change app or auth behavior.
> 
> **Overview**
> Updates CD Sentry uploads to use the renamed `anarlog` project instead of `hyprnote2`.
> 
> Desktop debug-file uploads (macOS, Linux, Windows) and web source-map uploads now target `--project anarlog` under org `fastrepl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f55631d0739d747dfb47285288171d37f240268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->