### PR TITLE
Restore download dropdown layering and platform brand icons

### DIFF
--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -1,10 +1,5 @@
-import {
-  AppleLogo,
-  ArrowRight,
-  CaretDown,
-  LinuxLogo,
-  WindowsLogo,
-} from "@phosphor-icons/react";
+import { Icon } from "@iconify-icon/react";
+import { ArrowRight, CaretDown } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 import { useRef, useState } from "react";
 
@@ -27,7 +22,7 @@ import { CredibilityLogoMarquee } from "./social-proof-sections";
 
 export function HeroSection() {
   return (
-    <section className="pt-10 pb-2 md:pt-12 md:pb-4">
+    <section className="isolate pt-10 pb-2 md:pt-12 md:pb-4">
       <Link to="/" aria-label="Anarlog home" className="inline-flex">
         <AnarlogLogo className="h-8 w-auto md:h-9" />
       </Link>
@@ -407,7 +402,7 @@ function DownloadButton() {
       {open && (
         <div
           role="menu"
-          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-0 w-72 max-w-[calc(100vw-2.5rem)] rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
+          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-0 z-10 w-72 max-w-[calc(100vw-2.5rem)] rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
         >
           {orderedSections.map((section) =>
             section.downloads.map((download) => {
@@ -460,13 +455,21 @@ function DownloadButton() {
 }
 
 function getPlatformIcon(platform: DesktopPlatform, size: number) {
-  const Icon =
+  const icon =
     platform === "windows"
-      ? WindowsLogo
+      ? "simple-icons:windows11"
       : platform === "linux"
-        ? LinuxLogo
-        : AppleLogo;
-  return <Icon size={size} className="shrink-0" aria-hidden="true" />;
+        ? "simple-icons:linux"
+        : "simple-icons:apple";
+  return (
+    <Icon
+      icon={icon}
+      width={size}
+      height={size}
+      className="shrink-0"
+      aria-hidden="true"
+    />
+  );
 }
 
 function getDownloadOptionLabel(

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,10 +1,5 @@
-import {
-  AppleLogo,
-  ArrowSquareOut,
-  DownloadSimple,
-  LinuxLogo,
-  WindowsLogo,
-} from "@phosphor-icons/react";
+import { Icon } from "@iconify-icon/react";
+import { ArrowSquareOut, DownloadSimple } from "@phosphor-icons/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -13,9 +8,9 @@ import { comingSoonPlatforms, desktopDownloadSections } from "@/lib/download";
 import { getCanonicalUrl } from "@/lib/seo";
 
 const platformIcons = {
-  macOS: AppleLogo,
-  Windows: WindowsLogo,
-  Linux: LinuxLogo,
+  macOS: "simple-icons:apple",
+  Windows: "simple-icons:windows",
+  Linux: "simple-icons:linux",
 } as const;
 
 export const Route = createFileRoute("/_view/download/")({
@@ -56,7 +51,6 @@ function Component() {
         <div className="grid gap-14 pb-12">
           {desktopDownloadSections.map((section) => {
             const headingId = `${section.name.toLowerCase()}-downloads`;
-            const PlatformIcon = platformIcons[section.name];
 
             return (
               <section key={section.name} aria-labelledby={headingId}>
@@ -64,7 +58,11 @@ function Component() {
                   id={headingId}
                   className="font-hand mb-5 flex items-center gap-2.5 text-3xl leading-none font-semibold tracking-normal"
                 >
-                  <PlatformIcon size={24} aria-hidden="true" />
+                  <Icon
+                    icon={platformIcons[section.name]}
+                    className="text-2xl"
+                    aria-hidden="true"
+                  />
                   {section.name}
                   {section.status && (
                     <span className="border-color-subtle text-color-muted rounded-full border px-2.5 py-1 font-sans text-xs leading-none font-medium tracking-wide uppercase">


### PR DESCRIPTION
## What happened

- #6689 removed `z-10` from the hero download dropdown menu while flattening local z-indexes. The hero workflow demo sits later in source order (and is its own stacking context via its transform), so the open menu now paints underneath the animation.
- #7013 swapped the platform brand icons from Iconify Simple Icons to Phosphor's stylized `AppleLogo`/`WindowsLogo`/`LinuxLogo` glyphs, which read as custom drawings rather than the actual brand marks.

## Fix

- Restore `z-10` on the dropdown menu and add `isolate` to the hero section so the layering stays inside a bounded stacking context (per the AGENTS.md layering rule).
- Restore `simple-icons:apple` / `simple-icons:windows11` / `simple-icons:linux` via Iconify in the hero download button and dropdown, and the matching icons on the /download page headings.
- Generic UI icon changes from #7013 (GitHub, X, arrows) are left untouched.

Typecheck and eslint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/layering and icon-source tweaks on marketing download UI only; no auth, data, or backend changes.
> 
> **Overview**
> Fixes the homepage download dropdown painting under the hero workflow demo, and restores official platform brand marks instead of Phosphor’s stylized logos.
> 
> Adds `isolate` on the hero section and `z-10` on the menu so stacking stays local. Switches Apple/Windows/Linux icons back to Iconify Simple Icons on the hero download control and `/download` headings. Generic Phosphor UI icons are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30e26219010a2bb2572959b7a6ae521fab5e6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->