### PR TITLE
Use the official GitHub mark on the homepage stars button

### DIFF
--- a/apps/web/src/components/home-page/index.tsx
+++ b/apps/web/src/components/home-page/index.tsx
@@ -1,4 +1,5 @@
-import { ArrowRight, GithubLogo } from "@phosphor-icons/react";
+import { Icon } from "@iconify-icon/react";
+import { ArrowRight } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -176,7 +177,13 @@ function OpenSourceSection({
           rel="noopener noreferrer"
           className="mt-6 inline-flex items-center gap-2 rounded-full border border-neutral-300 bg-white px-5 py-3 text-sm font-medium text-neutral-900 transition-colors hover:border-neutral-900 hover:bg-neutral-900 hover:text-white"
         >
-          <GithubLogo size={18} aria-hidden="true" />
+          <Icon
+            icon="simple-icons:github"
+            width={18}
+            height={18}
+            className="shrink-0"
+            aria-hidden="true"
+          />
           <span>{formattedGithubStars} stars on GitHub</span>
         </a>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The homepage "Open source by default" CTA used Phosphor's stylized cat outline, which doesn't read as GitHub.

This swaps it for Simple Icons' official GitHub mark via Iconify (same pattern as the download platform icons), so the logo stays recognizable and inherits the button's hover color.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03163-676f-718d-b802-ecce7999fdc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03163-676f-718d-b802-ecce7999fdc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

