### PR TITLE
fix: Claude and ChatGPT subscription connect OAuth

### DIFF
--- a/apps/desktop/src/settings/ai/llm/subscriptions/connect.tsx
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/connect.tsx
@@ -178,7 +178,10 @@ export function ConnectSubscriptionDialog({
               scheme,
               CHATGPT_CALLBACK_PORT,
             );
-            if (started.status === "ok") {
+            if (
+              started.status === "ok" &&
+              started.data === CHATGPT_CALLBACK_PORT
+            ) {
               if (cancelled) {
                 await deeplink2Commands.stopCallbackServer();
                 return;

--- a/apps/desktop/src/settings/ai/llm/subscriptions/oauth.test.ts
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/oauth.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, test } from "vitest";
 import {
   assertAuthorizationState,
   authorizationInputFromParsed,
+  chatgptAuthorizeUrl,
   chatgptCodexUrl,
   chatgptResponsesBody,
+  CHATGPT_CALLBACK_PORT,
+  claudeAuthorizeUrl,
   claudeMessagesUrl,
+  encodeAuthorizeQuery,
   isSubscriptionProviderId,
   looksLikeAuthorizationInput,
   parseAuthorizationInput,
@@ -19,6 +23,65 @@ describe("subscription OAuth helpers", () => {
     expect(isSubscriptionProviderId("claude")).toBe(true);
     expect(isSubscriptionProviderId("github_copilot")).toBe(true);
     expect(isSubscriptionProviderId("anthropic")).toBe(false);
+  });
+
+  test("encodes authorize query spaces as %20 so macOS open does not split the URL", () => {
+    expect(
+      encodeAuthorizeQuery([["scope", "user:profile user:inference"]]),
+    ).toBe("scope=user%3Aprofile%20user%3Ainference");
+    expect(
+      encodeAuthorizeQuery([["scope", "user:profile user:inference"]]),
+    ).not.toContain("+");
+  });
+
+  test("builds a Claude authorize URL Anthropic accepts before showing a code", () => {
+    const href = claudeAuthorizeUrl({
+      challenge: "pkce-challenge",
+      state: "oauth-state",
+    });
+    const url = new URL(href);
+    expect(
+      href.startsWith("https://claude.ai/oauth/authorize?code=true&"),
+    ).toBe(true);
+    expect(href).not.toContain("+");
+    expect(href).toContain(
+      "scope=user%3Aprofile%20user%3Ainference%20user%3Asessions%3Aclaude_code%20user%3Amcp_servers",
+    );
+    expect(href).not.toContain("user%3Afile_upload");
+    expect(url.searchParams.get("code")).toBe("true");
+    expect(url.searchParams.get("client_id")).toBe(
+      "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    );
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://platform.claude.com/oauth/code/callback",
+    );
+    expect(url.searchParams.get("scope")).toBe(
+      "user:profile user:inference user:sessions:claude_code user:mcp_servers",
+    );
+    expect(url.searchParams.get("code_challenge")).toBe("pkce-challenge");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe("oauth-state");
+  });
+
+  test("builds a ChatGPT authorize URL that returns to the Codex loopback port", () => {
+    const href = chatgptAuthorizeUrl({
+      challenge: "pkce-challenge",
+      state: "oauth-state",
+    });
+    const url = new URL(href);
+    expect(href).not.toContain("+");
+    expect(href).toContain(
+      `redirect_uri=http%3A%2F%2Flocalhost%3A${CHATGPT_CALLBACK_PORT}%2Fauth%2Fcallback`,
+    );
+    expect(url.origin + url.pathname).toBe(
+      "https://auth.openai.com/oauth/authorize",
+    );
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      `http://localhost:${CHATGPT_CALLBACK_PORT}/auth/callback`,
+    );
+    expect(url.searchParams.get("originator")).toBe("codex_cli_rs");
+    expect(url.searchParams.get("codex_cli_simplified_flow")).toBe("true");
   });
 
   test("parses Claude code#state values", () => {

--- a/apps/desktop/src/settings/ai/llm/subscriptions/oauth.ts
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/oauth.ts
@@ -53,8 +53,10 @@ const CLAUDE = {
   authorizeUrl: "https://claude.ai/oauth/authorize",
   tokenUrl: "https://platform.claude.com/v1/oauth/token",
   redirectUri: "https://platform.claude.com/oauth/code/callback",
+  // Match Claude Code's authorize-time scopes. `user:file_upload` is granted
+  // on the token but rejected if requested here ("Invalid request format").
   scope:
-    "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+    "user:profile user:inference user:sessions:claude_code user:mcp_servers",
 } as const;
 
 export const CHATGPT_CALLBACK_PORT = 1455;
@@ -204,6 +206,49 @@ export function authorizationInputFromParsed(parsed: {
   return parsed.state ? `${parsed.code}#${parsed.state}` : parsed.code;
 }
 
+export function encodeAuthorizeQuery(params: Array<[string, string]>) {
+  return params
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+    )
+    .join("&");
+}
+
+export function claudeAuthorizeUrl(input: {
+  challenge: string;
+  state: string;
+}) {
+  return `${CLAUDE.authorizeUrl}?${encodeAuthorizeQuery([
+    ["code", "true"],
+    ["client_id", CLAUDE.clientId],
+    ["response_type", "code"],
+    ["redirect_uri", CLAUDE.redirectUri],
+    ["scope", CLAUDE.scope],
+    ["code_challenge", input.challenge],
+    ["code_challenge_method", "S256"],
+    ["state", input.state],
+  ])}`;
+}
+
+export function chatgptAuthorizeUrl(input: {
+  challenge: string;
+  state: string;
+}) {
+  return `${CHATGPT.authorizeUrl}?${encodeAuthorizeQuery([
+    ["response_type", "code"],
+    ["client_id", CHATGPT.clientId],
+    ["redirect_uri", CHATGPT.redirectUri],
+    ["scope", CHATGPT.scope],
+    ["code_challenge", input.challenge],
+    ["code_challenge_method", "S256"],
+    ["state", input.state],
+    ["id_token_add_organizations", "true"],
+    ["codex_cli_simplified_flow", "true"],
+    ["originator", "codex_cli_rs"],
+  ])}`;
+}
+
 export function assertAuthorizationState(
   session: CodeConnectSession,
   parsed: { state?: string },
@@ -289,18 +334,12 @@ export async function refreshOAuthCredential(
 async function startClaudeConnect(): Promise<CodeConnectSession> {
   const pkce = await createPkce();
   const state = randomUrlToken(16);
-  const url = new URL(CLAUDE.authorizeUrl);
-  url.searchParams.set("code", "true");
-  url.searchParams.set("client_id", CLAUDE.clientId);
-  url.searchParams.set("response_type", "code");
-  url.searchParams.set("redirect_uri", CLAUDE.redirectUri);
-  url.searchParams.set("scope", CLAUDE.scope);
-  url.searchParams.set("code_challenge", pkce.challenge);
-  url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("state", state);
   return {
     kind: "code",
-    url: url.toString(),
+    url: claudeAuthorizeUrl({
+      challenge: pkce.challenge,
+      state,
+    }),
     verifier: pkce.verifier,
     state,
   };
@@ -309,20 +348,12 @@ async function startClaudeConnect(): Promise<CodeConnectSession> {
 async function startChatgptConnect(): Promise<CodeConnectSession> {
   const pkce = await createPkce();
   const state = randomUrlToken(16);
-  const url = new URL(CHATGPT.authorizeUrl);
-  url.searchParams.set("response_type", "code");
-  url.searchParams.set("client_id", CHATGPT.clientId);
-  url.searchParams.set("redirect_uri", CHATGPT.redirectUri);
-  url.searchParams.set("scope", CHATGPT.scope);
-  url.searchParams.set("code_challenge", pkce.challenge);
-  url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("state", state);
-  url.searchParams.set("id_token_add_organizations", "true");
-  url.searchParams.set("codex_cli_simplified_flow", "true");
-  url.searchParams.set("originator", "codex_cli_rs");
   return {
     kind: "code",
-    url: url.toString(),
+    url: chatgptAuthorizeUrl({
+      challenge: pkce.challenge,
+      state,
+    }),
     verifier: pkce.verifier,
     state,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Both Settings → Intelligence “Connect existing subscription” flows were failing in 1.4.12.

## ChatGPT
[#7046](https://github.com/fastrepl/anarlog/pull/7046) already landed on `main`: we listen on the official Codex loopback (`localhost:1455`) and bounce `code`/`state` through `anarlog://auth/callback`. This PR keeps that path and only opens the browser after the listener is actually bound to port 1455 (paste stays as fallback).

## Claude
Anthropic was rejecting the authorize URL with **Authorization failed — Invalid request format** before showing a code.

- Stop requesting `user:file_upload` at authorize time. Claude Code grants that scope on the token; asking for it on `/oauth/authorize` is rejected.
- Build the query with `encodeURIComponent` (`%20` for spaces) instead of `URLSearchParams` (`+`). macOS Launch Services treats `+` as a space and splits the URL, so Anthropic never sees a valid request.

Grok and GitHub Copilot are unchanged (device-code polling).

## Verification
- `pnpm exec dprint fmt` + scoped `dprint check` on the changed files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/settings/ai/llm/subscriptions/`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test` (3428 passed)

Could not live-click Claude/ChatGPT OAuth in this environment (Cloudflare challenge on `claude.ai`; no signed-in desktop session).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f98ad53-8df7-4028-84e9-bb62cb30d2ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f98ad53-8df7-4028-84e9-bb62cb30d2ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

