### PR TITLE
Use immutable Microsoft Store package URLs

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -431,15 +431,42 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.candidate_sha }}
           persist-credentials: false
+      - id: crabnebula-release
+        uses: ./.github/actions/cn_release
+        with:
+          raw: >-
+            release show fastrepl/hyprnote2 ${{ needs.validate.outputs.version }}
+            --channel stable
+          key: ${{ secrets.CN_API_KEY }}
       - name: Download and verify stable Windows installer
         shell: pwsh
         env:
+          CRABNEBULA_RELEASE: ${{ steps.crabnebula-release.outputs.raw }}
           VERSION: ${{ needs.validate.outputs.version }}
           WINDOWS_SIGNER_ORGANIZATION: ${{ vars.WINDOWS_SIGNER_ORGANIZATION }}
         run: |
           $ErrorActionPreference = "Stop"
 
-          $packageUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/desktop_v$env:VERSION/anarlog-windows-x86_64-setup.exe"
+          $release = $env:CRABNEBULA_RELEASE | ConvertFrom-Json
+          if ([string]$release.version -ne $env:VERSION) {
+            throw "Expected CrabNebula release $env:VERSION, got $($release.version)"
+          }
+
+          $assets = @(
+            $release.assets | Where-Object {
+              $_.publicPlatform -eq "nsis-x86_64" -and [long]$_.size -gt 0
+            }
+          )
+          if ($assets.Count -ne 1) {
+            throw "Expected exactly one nonempty CrabNebula nsis-x86_64 asset"
+          }
+
+          $assetId = [string]$assets[0].id
+          if ($assetId -notmatch '^[A-Za-z0-9_-]+$') {
+            throw "Invalid CrabNebula asset ID '$assetId'"
+          }
+
+          $packageUrl = "https://cdn.crabnebula.app/asset/$assetId"
           Invoke-WebRequest -Uri $packageUrl -OutFile "anarlog-windows-x86_64-setup.exe"
 
           $signature = Get-AuthenticodeSignature "anarlog-windows-x86_64-setup.exe"


### PR DESCRIPTION
Resolve the versioned CrabNebula release to its immutable NSIS asset before validating or submitting Microsoft Store packages. This avoids the redirecting GitHub Release URL that Partner Center rejects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Microsoft Store installer is sourced and submitted (CDN URL vs GitHub). Wrong asset selection would ship the wrong package, but version/asset checks and existing signature verification remain.
> 
> **Overview**
> Microsoft Store submission now downloads the Windows NSIS installer from an **immutable CrabNebula CDN asset URL** instead of the GitHub Releases download link that Partner Center rejects as a redirect.
> 
> The `microsoft-store` job looks up the stable CrabNebula release, checks version and a single nonempty `nsis-x86_64` asset, then uses `https://cdn.crabnebula.app/asset/{id}` for download and the package JSON. Authenticode verification is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef170fab5e8595d6008e83fa84af3393f344edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->