### PR TITLE
fix: let Mistral transcribe sessions with regional locales like de-DE

### DIFF
--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -88,7 +88,7 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                           : providerId === "fireworks"
                             ? `Use [Fireworks AI](https://fireworks.ai) for transcriptions.`
                             : providerId === "mistral"
-                              ? `Use [Mistral](https://mistral.ai) for transcriptions.`
+                              ? `Use [Mistral](https://mistral.ai) for transcriptions. Keep the Base URL as \`https://api.mistral.ai/v1\` (Reset under Advanced if you pasted a transcriptions endpoint). **Voxtral Mini Transcribe 2** transcribes after recording; the realtime model is for live captions.`
                               : providerId === "cohere"
                                 ? `Use [Cohere Transcribe](https://docs.cohere.com/docs/transcribe) for batch transcription. Files must be 25 MB or smaller and use one selected language. Cohere does not return timestamps or speaker labels, so Anarlog estimates word timing.`
                                 : providerId === "google_cloud"

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -191,6 +191,10 @@ describe("getBatchProvider", () => {
     );
   });
 
+  test("maps Mistral to the batch transcription provider", () => {
+    expect(getBatchProvider("mistral", "voxtral-mini-2602")).toBe("mistral");
+  });
+
   test.each([
     ["aws_transcribe", "amazon-transcribe"],
     ["azure_speech", "fast-transcription"],
@@ -1267,6 +1271,35 @@ describe("useRunBatch", () => {
       }),
     );
   });
+
+  test.each(["windows", "linux"] as const)(
+    "reports a language mismatch instead of a platform gap when Mistral is configured on %s",
+    async (currentPlatform) => {
+      platformMock.mockReturnValue(currentPlatform);
+      isSupportedLanguagesBatchMock.mockResolvedValue(false);
+      useSTTConnectionMock.mockReturnValue({
+        conn: {
+          provider: "mistral",
+          model: "voxtral-mini-2602",
+          baseUrl: "https://api.mistral.ai/v1",
+          apiKey: "mistral-key",
+        },
+      });
+
+      const { result } = renderHook(() => useRunBatch("session-1"));
+
+      await expect(
+        act(async () => {
+          await result.current("/tmp/session.wav");
+        }),
+      ).rejects.toThrow(
+        "voxtral-mini-2602 is not available for batch transcription with the selected languages",
+      );
+
+      expect(startTranscriptionMock).not.toHaveBeenCalled();
+      expect(sonnerToastWarningMock).not.toHaveBeenCalled();
+    },
+  );
 
   test.each(["windows", "linux"] as const)(
     "does not invoke Soniqo as a batch fallback on %s",

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -732,10 +732,13 @@ export const useRunBatch = (sessionId: string) => {
               label: selectedModel,
             }
           : null;
-      const selectedTargetSupported =
+      const selectedOnDeviceUnsupported = !!(
         selectedTarget &&
-        (!isOnDeviceSttModel(selectedProviderId, selectedModel) ||
-          isDesktopLocalSttAvailable(currentPlatform, currentArch))
+        isOnDeviceSttModel(selectedProviderId, selectedModel) &&
+        !isDesktopLocalSttAvailable(currentPlatform, currentArch)
+      );
+      const selectedTargetSupported =
+        selectedTarget && !selectedOnDeviceUnsupported
           ? await canUseBatchTarget(
               selectedTarget.provider,
               selectedTarget.model,
@@ -758,7 +761,9 @@ export const useRunBatch = (sessionId: string) => {
 
       if (!target) {
         throw new Error(
-          `${selectedProviderLabel(conn, selectedModel)} is not available for batch transcription on this platform. Configure a batch-capable speech-to-text provider.`,
+          selectedTarget && !selectedOnDeviceUnsupported
+            ? `${selectedProviderLabel(conn, selectedModel)} is not available for batch transcription with the selected languages. Choose languages it supports, or configure another speech-to-text provider.`
+            : `${selectedProviderLabel(conn, selectedModel)} is not available for batch transcription on this platform. Configure a batch-capable speech-to-text provider.`,
         );
       }
 

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -222,6 +222,15 @@ mod tests {
     }
 
     #[test]
+    fn mistral_batch_accepts_regional_locales_for_documented_languages() {
+        let languages = vec!["de-DE".parse().unwrap(), "en-US".parse().unwrap()];
+
+        assert!(
+            is_supported_languages_batch("mistral", Some("voxtral-mini-2602"), &languages).unwrap()
+        );
+    }
+
+    #[test]
     fn apple_speech_language_support_reflects_installed_framework() {
         // Drives the settings warning that names unsupported spoken languages.
         let available = anlg_transcribe_speechanalyzer::availability()

--- a/crates/owhisper-client/src/adapter/mistral/mod.rs
+++ b/crates/owhisper-client/src/adapter/mistral/mod.rs
@@ -24,7 +24,9 @@ impl Default for MistralAdapter {
 
 impl MistralAdapter {
     fn is_language_supported(lang: &anlg_language::Language) -> bool {
-        lang.matches_any_code(SUPPORTED_LANGUAGES)
+        // Voxtral documents ISO-639-1 codes only. OS locales like de-DE must
+        // still match; matches_any_code does not fall back across alpha regions.
+        SUPPORTED_LANGUAGES.contains(&lang.iso639().code())
     }
 
     fn language_support_impl(languages: &[anlg_language::Language]) -> LanguageSupport {
@@ -103,5 +105,17 @@ mod tests {
         assert!(Provider::Mistral.is_host("api.mistral.ai"));
         assert!(Provider::Mistral.is_host("mistral.ai"));
         assert!(!Provider::Mistral.is_host("api.openai.com"));
+    }
+
+    #[test]
+    fn regional_locales_match_documented_iso639_codes() {
+        let de_de: anlg_language::Language = "de-DE".parse().unwrap();
+        let en_us: anlg_language::Language = "en-US".parse().unwrap();
+        let ja_jp: anlg_language::Language = "ja-JP".parse().unwrap();
+        let pl: anlg_language::Language = "pl".parse().unwrap();
+
+        assert!(MistralAdapter::is_supported_languages_batch(&[de_de]));
+        assert!(MistralAdapter::is_supported_languages_live(&[en_us, ja_jp]));
+        assert!(!MistralAdapter::is_supported_languages_batch(&[pl]));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Investigation (Florian / 1.4.12)

Florian configured Mistral, recorded sessions, and re-transcription failed with:

> voxtral-mini-2602 is not available for batch transcription on this platform. Configure a batch-capable speech-to-text provider.

That toast is **not** an API/auth failure. It is thrown in `useRunBatch` before any upload, when:

1. The selected provider fails the batch language preflight, and
2. There is no fallback (not Pro / no session token, and not Apple Silicon local Soniqo).

`voxtral-mini-2602` **is** the Mistral batch model and **is** wired as a direct batch provider in 1.4.12. The preflight failed because Mistral’s support list is ISO-639-1 (`de`, `en`, …) while first-run `ai_language` is the OS locale (`de-DE`, `en-US`, …). `Language::matches_any_code` intentionally does not treat `de-DE` as `de`, so a correctly configured Mistral key was rejected.

That matches “it records but would not transcribe”: `voxtral-mini-2602` is batch-only, so live captions never start, and post-recording batch is blocked by the locale check.

The Advanced Base URL in the screenshot (`https://api.mistral.ai/v1/audio/transcriptions#stream`) is a **separate** misconfiguration (docs/endpoint paste). The default is `https://api.mistral.ai/v1`. The fragment is not sent on HTTP, so this is unlikely to be the cause of *this* error. After the language fix he should still click **Reset** under Advanced.

## Suggested reply

> Mistral is the right provider. Keep **Voxtral Mini Transcribe 2** (`voxtral-mini-2602`) selected — that model transcribes after you stop recording, which is expected.
>
> Under Advanced, click **Reset** so Base URL is `https://api.mistral.ai/v1` (not the `/audio/transcriptions#stream` endpoint).
>
> 1.4.12 can refuse Mistral when the app language is a regional locale such as German (`de-DE`). That is a bug; a fix is in progress. Until it ships, set the transcription language in Settings → General to `de` (or `en`) rather than a regional tag, then regenerate the transcript.

## Fix

- Match Mistral languages on ISO-639-1, same as Cartesia/ElevenLabs, so `de-DE` / `en-US` work.
- Distinguish “unsupported languages” from “unavailable on this platform” in the batch error.
- Clarify Mistral settings copy: default Base URL, Reset, batch vs realtime model.

## Tests

- `cargo test --locked -p owhisper-client regional_locales`
- `cargo test --locked -p listener2-core mistral_batch`
- `pnpm -F desktop exec vitest run src/stt/useRunBatch.test.ts`
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` (changed files; one pre-existing exhaustive-deps warning in `useRunBatch.ts`)
- `pnpm exec dprint check` on the changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fad2725b-52c5-48af-9c41-0f5903a31eff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fad2725b-52c5-48af-9c41-0f5903a31eff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

