### PR TITLE
Refresh Zoom meeting and chat history guide

### DIFF
--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -82,7 +82,16 @@
   "fireflies-ai-alternatives": [],
   "free-ai-notetakers": [],
   "free-transcription-software": [],
-  "google-gemini-data-retention-policy": [],
+  "google-gemini-data-retention-policy": [
+    {
+      "filename": "gemini-retention-by-tier.png",
+      "content": "Title: Gemini Data Retention by Tier\nConsumer Gemini: 18 month default retention, human review up to 3 years, training on by default with opt out\nGemini API: 55 day abuse monitoring retention only, no human review, no training\nWorkspace Enterprise: admin defined retention, no human review by default, no training",
+      "context": "Three-column reference figure comparing how Google handles Gemini data across the consumer app, the API, and Workspace Enterprise. Each column is one tier with its data-handling facts. Do not frame as pros versus cons.",
+      "visualQuery": "three column comparison",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "google-gemini-meeting-notes": [],
   "granola-ai-alternatives": [],
   "hipaa-compliant-ai-notetaker": [
@@ -132,7 +141,16 @@
   "local-ai-meeting-notes": [],
   "local-ai-privacy-tools": [],
   "mac-productivity-apps": [],
-  "markdown-note-taking-apps": [],
+  "markdown-note-taking-apps": [
+    {
+      "filename": "markdown-app-fit.png",
+      "content": "Title: Which Markdown Note App Fits You\nMeeting notes with AI summaries: Anarlog\nPersonal knowledge management: Obsidian\nDaily journaling and outlining: Logseq\nCross device sync with privacy: Joplin\nDeveloper focused workflow: Inkdrop",
+      "context": "Mapping figure for an Anarlog blog post pairing five user needs with five markdown note apps. Each need maps to exactly one app. Neutral tone, not a ranking.",
+      "visualQuery": "mapping diagram",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "meetgeek-alternatives": [],
   "meetily-review": [
     {
@@ -216,7 +234,16 @@
   "otter-ai-review": [],
   "plaud-ai-alternatives": [],
   "read-ai-alternatives": [],
-  "see-zoom-meeting-history": [],
+  "see-zoom-meeting-history": [
+    {
+      "filename": "zoom-history-map.png",
+      "content": "Title: Where Zoom Keeps Your History\nPast scheduled meetings: Web portal, Meetings, Previous, past 30 days\nJoined meeting shortcut: Desktop app, Join field\nAttendance and usage: Analytics and Reports, paid accounts\nChat messages: Desktop app Team Chat search\nCloud recordings: Web portal, Recordings and Transcripts",
+      "context": "Five-destination map for an Anarlog guide showing where to look for different kinds of Zoom history. Each history type maps to exactly one Zoom location. Neutral reference diagram. Do not add pros, cons, scores, or invented features.",
+      "visualQuery": "mapping diagram",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "selfhosted-ai-notetakers": [],
   "tactiq-alternatives": [],
   "tldv-alternatives": [

--- a/apps/web/content/articles/google-gemini-data-retention-policy.mdx
+++ b/apps/web/content/articles/google-gemini-data-retention-policy.mdx
@@ -24,6 +24,7 @@ Here is the full picture.
 | Model Training    | Yes (opt-out)      | No                              | No                   |
 | Gmail Access      | Default ON in US   | No                              | Admin-controlled     |
 
+<Image src="/api/assets/blog/articles/google-gemini-data-retention-policy/gemini-retention-by-tier.png" alt="Gemini data retention differences across the consumer app, API, and Workspace Enterprise" />
 
 ## What Gemini Stores by Default?
 

--- a/apps/web/content/articles/markdown-note-taking-apps.mdx
+++ b/apps/web/content/articles/markdown-note-taking-apps.mdx
@@ -26,6 +26,7 @@ This list covers five apps, each strong for a specific use case, so you can find
 | Joplin   | Cross-device sync with privacy | ✅               | ✅               | Free / 2.99€/mo   |
 | Inkdrop  | Developers                     | ❌               | ❌               | $8.31/mo          |
 
+<Image src="/api/assets/blog/articles/markdown-note-taking-apps/markdown-app-fit.png" alt="Five Markdown note-taking apps mapped to their best-fit use cases" />
 
 ## The best markdown note-taking apps, reviewed
 

--- a/apps/web/content/articles/see-zoom-meeting-history.mdx
+++ b/apps/web/content/articles/see-zoom-meeting-history.mdx
@@ -1,132 +1,278 @@
 ---
-meta_title: "How to View Zoom Meeting History (Updated 2026)"
-display_title: "How to See Your Zoom Meeting History (And Actually Make It Useful)"
-meta_description: "Step-by-step guide to viewing Zoom meeting history. See what Zoom shows (and what it doesn't), plus how to make your meeting history actually searchable."
+meta_title: "How to View Zoom Meeting and Chat History (2026)"
+display_title: "How to See Your Zoom Meeting History (And Find What You Actually Need)"
+meta_description: "Find past Zoom meetings, chat messages, reports, and recordings. Updated steps for hosts, participants, and admins, plus current retention limits."
 author: "John Jeong"
 category: "Guides"
-date: "2025-11-05"
+date: "2026-08-24"
 ---
 
-Need to find a past Zoom meeting? Whether you're tracking attendance, checking when a call happened, or looking up a meeting ID, Zoom's meeting history can help. Here's how to access it.
+Trying to find a past Zoom meeting can mean several different things. You might need the meeting ID, attendance list, chat messages, recording, or an actual record of what people discussed.
+
+Zoom stores each of those in a different place. There is no single page containing your complete Zoom history.
+
+This guide shows where to look, what each history view includes, and the limits you should know before depending on it.
 
 ## How to access your Zoom meeting history
 
-Zoom offers a few ways to view your meeting history, depending on whether you hosted or joined the meeting.
+The right method depends on whether you hosted the meeting, joined it, or administer the Zoom account.
 
 ### For meetings you hosted
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-1.png" alt="Zoom dashboard" />
 
-If you're the meeting host, accessing your history is straightforward:
+For a meeting you scheduled or hosted:
 
-1. Sign in to the [Zoom web portal](https://zoom.us/)
-2. Click **Meetings** in the navigation menu, then select **Previous**
-3. Use the date range filters if you're looking for something specific
+1. Sign in to the [Zoom web portal](https://zoom.us/).
+2. Click **Meetings** in the navigation menu.
+3. Open the **Previous** tab.
+4. Select the meeting to view its available details.
 
-Your account admin and owner can also see this information. If a meeting ID has expired (which happens based on [Zoom's expiration rules](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0060761)), it won't show up in your list anymore.
+Zoom says the Previous tab lists scheduled meetings from the [past 30 days](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0058317). It is useful for finding a recent topic or meeting ID, but it is not a permanent meeting archive.
+
+If an older meeting is missing, check reports, recordings, calendar history, or your notes before assuming it never happened.
+
+Meeting IDs also expire. According to [Zoom's current meeting ID rules](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0065196):
+
+- An instant meeting ID expires when the meeting ends.
+- A scheduled, non-recurring meeting ID expires 30 days after its scheduled date.
+- Restarting that scheduled meeting within the 30-day window resets the timer.
+- A recurring meeting ID expires after 365 days without an occurrence.
+- A personal meeting ID can also expire after 365 days without use.
+
+These expiration rules affect whether a meeting remains available to start. They are separate from report, chat, and recording retention.
 
 ### For meetings you joined
 
-You can only see meetings you've joined through the Zoom desktop app, with significant limitations:
+Zoom does not provide ordinary participants with the same complete history that hosts and account admins can access.
 
-1. Open the Zoom desktop app
-2. Click **Join**
-3. Click the dropdown arrow in the Meeting ID field
+The desktop app offers a quick local shortcut:
 
-You'll see your last 10 meetings with a partial meeting topic and the meeting ID. There are no full details, no reliable timestamps, and this list doesn't sync across devices. If you joined a meeting on your laptop, you won't see it in your phone's history.
+1. Open the Zoom desktop app.
+2. Click **Join**.
+3. Open the dropdown in the Meeting ID field.
+4. Look for the recent meeting topic or ID.
 
-### Using Zoom reporting for advanced history
+This list is best treated as a convenience, not an authoritative record. It shows a short selection of recently joined meetings, may omit useful timestamps, and can vary by app version or device. Zoom does not document it as a durable cross-device meeting archive.
 
-If you're on a Pro, Business, Enterprise, or Education account, you can access Zoom's reporting features. Account owners and admins can generate reports showing:
+If the meeting is not there, try these sources:
 
-- Active meetings during specific time ranges (up to one month)
-- Meeting minutes and participant lists
-- User activity reports
+- Your calendar event
+- The original Zoom invitation
+- Email search for the host, topic, or meeting ID
+- Zoom Chat search
+- A shared recording or transcript
+- Your company's Zoom administrator, if account policy permits access
 
-These reports can go back 12 months, which helps with compliance or attendance tracking. Meetings must be hosted by a paid account, and upgrading your account won't retroactively create reports for past meetings.
+Account admins may also have attendee reports showing meetings a managed user joined as a participant. Regular participants cannot generate those reports for the wider account.
 
-## What information does Zoom meeting history actually show?
+### Using Zoom reports for longer history
 
-Zoom's meeting history tells you when meetings happened, who attended, how long they lasted, and the meeting IDs and basic settings.
+For attendance, duration, and account usage, reports are more useful than the Previous tab.
 
-It doesn't tell you what was actually discussed, what decisions were made, what action items came up, or the context of any conversation.
+Zoom reporting is available for paid accounts, including Pro, Business, Enterprise, Education, and API plans. The meeting must have been hosted by a paid account for Zoom to create the relevant report.
 
-You can see that you had a meeting with Sarah on October 15th at 2 PM, but unless you took detailed notes during the call, you have no way to remember what was discussed. Meeting history shows proof that a meeting occurred—metadata—but not what actually happened in it.
+Depending on your role, open **Analytics & Reports** or the reporting area in **Admin Center**, then choose the appropriate usage or meeting history report.
 
-Zoom was designed to help admins track usage and generate compliance reports. It wasn't designed to help you remember meeting content. If you spend hours in meetings every day—in customer success, sales, consulting, recruiting, or similar roles—you need more than proof of meetings. You need to remember what was actually said. This is where [AI note-takers for Zoom](/blog/best-ai-notetaker-for-zoom), like Anarlog, can help.
+Zoom's [reporting documentation](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0060623) says meeting reports can be retrieved for the previous **15 months**, with a maximum search range of one month per query. Reports can include:
+
+- Meeting topic and ID
+- Start time and duration
+- Host information
+- Participant names and email addresses when available
+- Meeting minutes
+- Polling or registration details for supported meetings
+
+Recently ended meetings may take 15 to 30 minutes to appear with complete data.
+
+Cloud recording reports have a different limit. Zoom says those reports are available for the previous **12 months**, even though ordinary meeting reports extend to 15 months.
+
+Upgrading later does not reconstruct reports Zoom never created. If you need a reliable attendance trail, confirm reporting access before the meetings happen.
+
+## Where Zoom keeps each kind of history
+
+<Image src="/api/assets/blog/articles/see-zoom-meeting-history/zoom-history-map.png" alt="Map of where Zoom stores scheduled meetings, chat messages, reports, and recordings" />
+
+Use this map when you know what you are looking for but not where Zoom put it:
+
+| You need | Where to look | Main limitation |
+| --- | --- | --- |
+| A recent hosted meeting or ID | Web portal, **Meetings > Previous** | Previous tab covers the past 30 days |
+| A recently joined meeting ID | Desktop app, **Join** dropdown | Short local list, not a complete archive |
+| Attendance and duration | **Analytics & Reports** or Admin Center | Paid-account and role requirements |
+| Messages and shared links | Desktop app, **Team Chat** search | Subject to account retention policy |
+| A cloud recording or transcript | Web portal, **Recordings & Transcripts** | Only recordings made to Zoom Cloud appear |
+| What was actually discussed | Recording, transcript, or meeting notes | Meeting metadata alone does not contain content |
+
+The distinction matters. Zoom's meeting list proves that a scheduled meeting existed. A report can prove who joined. Neither one necessarily tells you what the team decided.
+
+## How to find Zoom chat history
+
+Zoom chat history is separate from meeting history. If you remember a link, file, decision, or follow-up message, search chat before digging through meeting reports.
+
+### Search your Zoom chat messages
+
+In the Zoom desktop app:
+
+1. Open the **Team Chat** tab.
+2. Use the search field.
+3. Search for a person, channel, phrase, link, or filename.
+4. Apply message, contact, channel, or date filters if available.
+5. Open a result to return to its original conversation.
+
+Zoom's [chat search guide](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0058396) says search covers chats, channels, messages, and contacts. This is usually the fastest route when you remember a fragment of the conversation but not its date.
+
+Search only returns messages that still exist under your account's retention rules. A missing result may mean the wording is different, the message belonged to another account, or the message has already been deleted.
+
+### Understand Zoom chat retention
+
+Zoom's [message storage documentation](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0060329) separates cloud and local retention.
+
+For cloud-stored Zoom Chat messages:
+
+- The default retention period is two years.
+- Owners and admins of paid accounts can set it from one day to ten years.
+- Changing the retention period applies to new messages rather than rebuilding deleted history.
+- If cloud message storage is disabled, messages for offline users may remain in the cloud for up to seven days before deletion.
+
+For local message storage:
+
+- Paid-account admins can configure a separate local retention policy.
+- Local deletion is disabled by default on configurable paid accounts, so local messages are not automatically removed unless an admin sets a limit.
+- On free accounts, the local retention control cannot be changed, and messages may remain on that device for up to one year unless the Zoom app is deleted.
+
+Retention can also depend on conversation ownership. A one-to-one chat may follow the shorter policy between the two users, while a group chat or channel can follow its owner's policy.
+
+If your organization needs chat as a formal record, ask the Zoom admin what policy is actually configured. The product default is not proof of your account's settings.
+
+### Admin access to chat history
+
+Admins with the required chat history permissions can use Zoom's Chat History Report to view, download, or delete eligible messages stored in the cloud.
+
+The current administrative path starts from the profile menu and **Admin Center**, then the Zoom Chat storage and reporting settings. Exact labels can vary with the account's enabled products and Zoom's navigation updates.
+
+Admin access does not override retention. Once a message has been removed under the configured policy, the history report cannot recover it.
+
+## How to find Zoom cloud recordings and transcripts
+
+Cloud recordings are stored separately from meeting lists and reports.
+
+To find your own:
+
+1. Sign in to the Zoom web portal.
+2. Open **Recordings & Transcripts**.
+3. Search or filter by date, meeting topic, meeting ID, or recording status.
+4. Open the meeting to view its recording files, audio transcript, or other generated assets.
+
+Zoom documents the current locations in its guide to [finding computer and cloud recordings](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0058006).
+
+A few rules explain many missing recordings:
+
+- Cloud recording requires an eligible paid account.
+- A computer recording stays on the computer that created it, usually under the local Zoom folder.
+- A recording started by a co-host appears in the original host's cloud recording list.
+- Account admins use **Recording and Transcript Management** to review recordings across the account.
+- A meeting can appear in history without having any recording.
+
+Cloud recording retention is controlled by the account owner or admin. Organizations often set their own automatic deletion periods, so do not assume a cloud recording will remain available indefinitely.
+
+## What Zoom meeting history actually shows
+
+Zoom history is good at operational metadata. Depending on the view and your permissions, you may be able to find:
+
+- When a meeting was scheduled or started
+- Who hosted it
+- Who attended
+- How long participants stayed
+- The meeting ID
+- Chat messages
+- Cloud recording files
+- A transcript or AI Companion summary, if those features were enabled
+
+But a basic meeting-history entry does not contain the substance of the conversation.
+
+It usually cannot answer:
+
+- What decision did we make?
+- Why did the customer reject the proposal?
+- Which action item did I accept?
+- What exact wording did the engineer use?
+- Where did the project requirement change?
+- Which earlier meeting covered the same issue?
+
+For those questions, you need a recording, transcript, or notes created during the meeting. History metadata can tell you which meeting to inspect, but it cannot recreate content that was never captured.
+
+This is the practical dividing line:
+
+- Use Zoom history for IDs, dates, attendance, messages, and recordings.
+- Use a meeting-memory system for searchable discussion, decisions, and follow-up context.
 
 <CtaCard/>
 
-## How Anarlog changes meeting history
+## How Anarlog turns meetings into searchable history
 
-Anarlog is an open-source [AI notepad](/) for meetings that gives you control over your data and AI stack. Instead of just logging when meetings happened, it captures what occurred in a local SQLite meeting record, with Markdown export when you need it.
+Anarlog is an open-source AI meeting notetaker. It captures system and microphone audio without sending a visible bot into the Zoom call, then keeps the canonical meeting record in local SQLite.
 
-### 1. Search through actual conversations
+Instead of relying on Zoom's account history as your memory, you get the notes, transcript, summary, and meeting metadata together.
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-2.png" alt="Search" />
+### Search actual conversations
 
-With Anarlog, you can search for any keyword and find it within your meeting transcripts. Press `cmd + k` to open the search palette and type anything—a person's name, a project code, a specific topic.
 
-The search shows you the actual context: what was said, by whom, and when in the conversation. You can filter by person to see all meetings with a specific colleague or client.
+Search for a person's name, customer, project code, or phrase to find the relevant meeting and transcript context.
 
-If you search for "budget," you're not getting a list of 47 meetings that might have mentioned budget somewhere. You're getting the exact moments where budget was discussed, with full context around each mention.
+A search for "budget" can take you to the part of the conversation where the budget changed. You are not limited to a list of meetings that might have contained the topic.
 
-### 2. Ask questions about your meetings
+### Ask questions across meeting records
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-3.png" alt="Chat" />
 
-Sometimes you don't know the exact keyword to search for. You just have a vague memory that someone said something important.
-
-Anarlog's AI Chat lets you ask natural language questions like:
+When you do not remember the exact phrase, AI Chat can help retrieve the context through natural-language questions:
 
 - "What are my action items from this week's meetings?"
-- "What did Richard say about installing more servers?"
-- "Bring up notes related to the product launch"
+- "What did Richard say about the server migration?"
+- "Which meetings mentioned the launch delay?"
 
-The AI searches through your transcripts and summaries to answer. You can mention specific people or notes using "@" to pull them into context.
+The answer is grounded in the meeting records available to Anarlog. You can return to the source transcript when exact wording matters.
 
-### 3. Visual meeting organization
+### Browse history by date or relationship
 
-Anarlog's Finder feature includes three views:
+Anarlog's meeting views provide different ways to navigate the same locally stored records.
 
-**Calendar View:** See your meetings laid out visually by date, just like your calendar app. Click any event to see the full note and transcript.
+**Calendar View** organizes meetings by date.
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-4.png" alt="Calendar" />
 
-**Table View:** A spreadsheet-style layout for scanning through large amounts of meeting data quickly.
+**Table View** makes it easier to scan a larger history.
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-5.png" alt="Table" />
 
-**Contacts View:** See all your contacts and filter meetings by organization. Want to see every conversation you've had with a particular company? It's all there.
+**Contacts View** groups meetings by person or organization.
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-6.png" alt="Contacts" />
 
-Each view gives you a different way to approach your conversation history: by time, by relationship, or by project.
+These views help when you remember the week, the company, or the project but not the meeting title.
 
-### 4. Verify what was actually said
+### Verify summaries against the transcript
 
-<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-7.webp" alt="Annotation" />
 
-Ever read an AI summary and wonder if someone really said that? Anarlog's Source Analysis feature lets you hover over any part of your meeting summary to see the exact quote from the transcript.
+AI summaries are useful, but they should not become an unverifiable record. Source analysis lets you check summary statements against the underlying transcript when a requirement, quote, or commitment needs confirmation.
 
-This matters for client meetings where you need to quote exact requirements, negotiations where precise wording matters, or compliance situations where you need to verify what was discussed. You get AI summarization with the accuracy of checking the source.
+That does not make transcription infallible. It gives you a direct path back to the captured source instead of forcing you to trust a generated summary in isolation.
 
-## How Anarlog works with Zoom (and every other platform)
+## How Anarlog works with Zoom
 
-Anarlog runs entirely on your Mac, capturing audio from both your microphone and your system audio. This means it works with Zoom, Teams, Google Meet, or any other platform without bots or meeting interruptions.
+Anarlog captures system audio and microphone input on your machine, so it works with Zoom without joining as another participant. The same approach works with Teams, Google Meet, phone calls, and in-person conversations.
 
-During your meeting, real-time transcription powered by Whisper models captures everything being said. When the meeting ends, Anarlog generates a structured summary with action items, key decisions, and discussion points using our custom HyperLLM-V1 model. Everything stays local on your device—no audio uploaded, no transcripts sent to external servers, no compliance concerns about where your data lives.
+Anarlog is available on macOS, with Windows and Linux in beta.
 
-Key features for Zoom users:
+Its data model is local-first:
 
-- **Bot-free recording** works silently in the background without joining your meeting as a participant
-- **Universal compatibility** captures both virtual Zoom calls and in-person meetings
-- **Offline capable** -- Transcription and summarization work even without internet connection
-- **Privacy-first** -- Makes HIPAA, GDPR, SOC 2 compliance simple by eliminating cloud dependencies
-- **Flexible AI options** -- Go fully local, connect to OpenAI/Mistral/Ollama, or use custom endpoints
+- Canonical sessions, notes, transcripts, and meeting metadata live in local SQLite.
+- Attachments and recordings remain separate local files.
+- Markdown is available as an export format when you need portability.
+- The code is MIT-licensed and auditable.
+- You choose how AI processes the meeting: local models, your own provider keys, or a hosted option.
+- Optional CloudSync encrypts data before it leaves the device, with explicit data paths for sharing and hosted features.
 
-For organizations in healthcare, legal, finance, or any compliance-sensitive industry, this approach matters. You can have AI-powered meeting intelligence while meeting regulatory requirements. For everyone else, you get meeting history that actually works the way your brain works—by content and context.
+A fully local AI setup can keep processing on your machine. If you choose a cloud transcription or language-model provider, the relevant content is sent to that provider under its terms. Anarlog's advantage is control over that decision, not a blanket claim that data can never leave your device.
 
-[Download Anarlog](/download) and start building meeting history that's actually useful.
+Zoom remains the meeting platform. Anarlog becomes the meeting memory you own.
+
+[Download Anarlog](/download) if you want searchable meeting history without tying your canonical records to a vendor-hosted workspace.
 
 <CtaCard/>


### PR DESCRIPTION
## Target

- URL: `/blog/see-zoom-meeting-history`
- Primary keyword: `zoom meeting history` — US volume 260, KD 22, current position 10
- Supporting keyword: `zoom chat history` — US volume 260, KD 32, current position 14
- Rationale: near-win refresh with 520 combined monthly volume and rankings already within positions 10-14.

## What changed

- Rewrote the guide around the actual places Zoom stores history: hosted meetings, joined meeting shortcuts, reports, chat, recordings, and transcripts.
- Added a dedicated Zoom chat-history section and current retention rules.
- Corrected reporting retention from 12 to 15 months (cloud-recording reports remain 12 months).
- Updated meeting-ID expiration rules and current `Recordings & Transcripts` / Admin Center navigation.
- Updated Anarlog positioning for local SQLite canonical storage, macOS plus Windows/Linux beta, AI-provider choice, and explicit hosted/local data paths.
- Removed seven legacy screenshot references that return 502 in production rather than retaining broken or stale product UI.
- Added and visually reviewed `zoom-history-map.png` via the figures batch pipeline.
- Completed pending figure backfills for `google-gemini-data-retention-policy` and `markdown-note-taking-apps`.

## Validation

- `pnpm exec dprint check --config dprint.json <changed files>`
- `pnpm -F @anlg/web typecheck`
- `pnpm -F @anlg/web media:figures:check` — 24 figures across 65 articles
- All three new production asset-proxy URLs return 200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only blog and figure-metadata updates with no application logic, auth, or data-handling changes.
> 
> **Overview**
> Rewrites the Zoom meeting-history guide so readers can find **meetings, chat, reports, recordings, and transcripts** in the right Zoom surfaces, with current retention and meeting-ID expiration rules.
> 
> The rewrite adds a dedicated chat-history section, corrects meeting-report lookback to **15 months** (cloud-recording reports stay 12), drops broken screenshot assets, and recasts the Anarlog pitch around local SQLite records and explicit local vs hosted AI paths.
> 
> Also backfills generated figures for this guide plus Gemini retention-by-tier and Markdown app-fit diagrams, and embeds those images in the corresponding posts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dbcfa6fdea3716e48895c309edc04a6daf891d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->