### PR TITLE
Add Anarlog 1.4.13 changelog

### DIFF
--- a/packages/changelog/content/1.4.13.md
+++ b/packages/changelog/content/1.4.13.md
@@ -1,0 +1,36 @@
+---
+date: "2026-08-24"
+summary: "Anarlog 1.4.13 adds working custom automations, clickable chat context, easier summary regeneration, smoother subscription sign-in, and more reliable recording."
+---
+
+## Automations and chat
+
+- Build custom automations with a trigger and any combination of Slack,
+  Notion, Linear, and Markdown actions, then enable them to run when a meeting
+  ends or its summary is ready
+- Open meetings, contacts, organizations, calendar events, account settings,
+  and sync settings directly from their context chips in chat
+- Use context chips from contact, calendar, related-meeting, and meeting-content
+  tool results instead of receiving plain, non-interactive labels
+- Regenerate a summary from the template that produced it without switching
+  templates first
+
+## Intelligence
+
+- Connect an existing Claude subscription without Anthropic rejecting the
+  authorization request
+- Finish ChatGPT subscription sign-in automatically after the browser redirect,
+  without copying the callback URL into Anarlog
+- Open the authorization page only after Anarlog is ready to receive its
+  callback, while keeping manual paste available when the local port is busy
+- Stop repeatedly retrying invalid transcription credentials or provider
+  configurations and show the provider's useful error instead
+
+## Recording and reliability
+
+- On Linux, fall back to another usable microphone when the default input
+  cannot open instead of crashing or ending recording setup
+- Avoid PulseAudio and PipeWire monitor sources when choosing a Linux
+  microphone
+- Let search indexing retry later when the local database is busy instead of
+  competing with active app work


### PR DESCRIPTION
Summarizes the user-facing automation, chat context, subscription sign-in, recording, transcription, and indexing improvements included since 1.4.12.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no code, auth, or data-handling changes.
> 
> **Overview**
> Adds the **1.4.13** changelog entry covering user-facing work since 1.4.12: custom automations, clickable chat context chips, easier summary regeneration, Claude/ChatGPT subscription sign-in, Linux mic fallback, and search indexing retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bda2b82619cde5eb2e0d730f1e5a0a01cf9a03b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->