### PR TITLE
Keep release builds source-clean

### DIFF
--- a/crates/api-client/openapi.gen.json
+++ b/crates/api-client/openapi.gen.json
@@ -536,6 +536,10 @@
       },
       "ConnectionItem": {
         "properties": {
+          "account_identity": {
+            "nullable": true,
+            "type": "string"
+          },
           "connection_id": {
             "type": "string"
           },


### PR DESCRIPTION
Regenerate the API client schema with the account identity field already emitted by the current OpenAPI source. This prevents desktop release builds from mutating tracked inputs and tripping exact-SHA QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated schema-only update with no logic, auth, or data-handling changes.
> 
> **Overview**
> Regenerates the tracked `crates/api-client/openapi.gen.json` so `ConnectionItem` includes the nullable `account_identity` field already present in the API OpenAPI source.
> 
> This keeps desktop release builds from rewriting generated schema files and failing exact-SHA QA. No runtime behavior is introduced in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb845c01ad93e6d1671796f407ee659d493be730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->