### PR TITLE
Refresh corrected note content immediately

### DIFF
--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -346,7 +346,7 @@ describe("browser-safe editor controls", () => {
     toJSON.mockRestore();
   });
 
-  it("does not serialize ignored content echoes while focused", async () => {
+  it("defers external content until focus leaves the editor", async () => {
     const ref = createRef<NoteEditorRef>();
     const props = {
       ref,
@@ -373,7 +373,48 @@ describe("browser-safe editor controls", () => {
 
     expect(ref.current?.view?.state.doc.textContent).toBe("old");
     expect(toJSON).not.toHaveBeenCalled();
+
+    act(() => ref.current?.view?.dom.blur());
+
+    expect(ref.current?.view?.state.doc.textContent).toBe("new");
     toJSON.mockRestore();
+  });
+
+  it("keeps external content deferred while focus is in editor popups", async () => {
+    const ref = createRef<NoteEditorRef>();
+    const props = {
+      ref,
+      handleChange: vi.fn(),
+      enforceTitleHeading: false,
+    };
+    const rendered = render(
+      createElement(NoteEditor, {
+        ...props,
+        initialContent: baseDoc,
+      }),
+    );
+    await waitFor(() => expect(ref.current?.view).not.toBeNull());
+    act(() => ref.current?.view?.focus());
+
+    rendered.rerender(
+      createElement(NoteEditor, {
+        ...props,
+        initialContent: nextDoc,
+      }),
+    );
+
+    const popup = document.createElement("div");
+    popup.dataset.editorEscapeConsumer = "";
+    const popupButton = document.createElement("button");
+    popup.append(popupButton);
+    document.body.append(popup);
+
+    act(() => popupButton.focus());
+    expect(ref.current?.view?.state.doc.textContent).toBe("old");
+
+    act(() => popupButton.blur());
+    expect(ref.current?.view?.state.doc.textContent).toBe("new");
+    popup.remove();
   });
 
   it("flushes the current document through the change handler immediately", async () => {

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -821,8 +821,22 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
 
     useEffect(() => {
       let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+      let deferredPopup: HTMLElement | undefined;
+      let deferredView: EditorView | undefined;
 
-      const syncContent = () => {
+      const syncContent = (event?: FocusEvent) => {
+        const popup =
+          event?.relatedTarget instanceof Element
+            ? event.relatedTarget.closest<HTMLElement>(
+                "[data-editor-escape-consumer]",
+              )
+            : null;
+        if (popup) {
+          deferredPopup = popup;
+          popup.addEventListener("focusout", syncContent, { once: true });
+          return;
+        }
+
         const view = viewRef.current;
         if (!view) return;
         if (previousContentRef.current === reconciledInitialContent) return;
@@ -835,6 +849,8 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         }
 
         if (view.hasFocus() && !syncContentWhenFocused) {
+          deferredView = view;
+          view.dom.addEventListener("blur", syncContent, { once: true });
           return;
         }
 
@@ -889,6 +905,8 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         if (retryTimeout) {
           clearTimeout(retryTimeout);
         }
+        deferredPopup?.removeEventListener("focusout", syncContent);
+        deferredView?.dom.removeEventListener("blur", syncContent);
       };
     }, [
       reconciledInitialContent,


### PR DESCRIPTION
Apply deferred external content as soon as editor focus moves away, with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small editor-sync tweak with a regression test. Risk is limited to content replacement timing on blur, not auth or persistence.
> 
> **Overview**
> External `initialContent` updates that arrive while the note editor is focused now apply as soon as focus leaves, instead of waiting for a later prop change.
> 
> `syncContent` registers a one-time `blur` listener when replacement is skipped due to focus, and removes it on effect cleanup. The test now blurs the editor and asserts the document switches from `"old"` to `"new"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a13d6ad35d83780b27b1b1602b358e153b2fa44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->