### PR TITLE
Polish account connections and lazy-load tabs

### DIFF
--- a/apps/web/src/routes/_view/app/-account-integrations.tsx
+++ b/apps/web/src/routes/_view/app/-account-integrations.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@iconify-icon/react";
-import { Plugs, PuzzlePiece } from "@phosphor-icons/react";
+import { DotsThree, PuzzlePiece } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
@@ -7,12 +7,13 @@ import type { ReactNode } from "react";
 import { listConnections } from "@anlg/api-client";
 import { OutlookIcon } from "@anlg/ui/components/icons/outlook";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@anlg/ui/components/ui/tooltip";
-import { cn } from "@anlg/utils";
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@anlg/ui/components/ui/dropdown-menu";
 
 import {
   connectionIdentityLabel,
@@ -24,8 +25,7 @@ import { getAuthorizedApiClient } from "./-account-api";
 import { useAccountSession } from "./-account-session";
 import {
   accountCardClassName,
-  accountPillDangerClassName,
-  accountPillSecondaryClassName,
+  accountMenuTriggerClassName,
 } from "./-account-ui";
 
 const INTEGRATION_NAMES: Record<string, string> = {
@@ -101,82 +101,122 @@ export function IntegrationsSection() {
             : "Integrations come with a paid plan and connect from the desktop app."}
         </p>
       ) : (
-        <TooltipProvider delayDuration={0}>
-          <ul className="divide-y divide-[#ede7dc]">
-            {connections.map((connection) => {
-              const name =
-                INTEGRATION_NAMES[connection.integration_id] ??
-                connection.integration_id;
-              const needsReconnect = connectionNeedsReconnect(connection);
-              const reconnectError = connectionReconnectError(connection);
+        <ul className="divide-y divide-[#ede7dc]">
+          {connections.map((connection) => {
+            const name =
+              INTEGRATION_NAMES[connection.integration_id] ??
+              connection.integration_id;
+            const needsReconnect = connectionNeedsReconnect(connection);
+            const reconnectError = connectionReconnectError(connection);
 
-              return (
-                <li
-                  key={connection.connection_id}
-                  className="flex items-center justify-between gap-3 p-6 sm:px-8"
-                >
-                  <div className="flex min-w-0 items-center gap-4">
-                    <span
-                      aria-hidden="true"
-                      className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-[#ede7dc] bg-[#fffaf0]"
-                    >
-                      {INTEGRATION_ICONS[connection.integration_id] ?? (
-                        <PuzzlePiece size={20} className="text-[#756b5d]" />
-                      )}
-                    </span>
-                    <div className="min-w-0">
-                      <p className="text-base font-medium text-[#181613]">
-                        {name}
-                      </p>
-                      <p className="mt-1 truncate text-sm leading-6 text-[#756b5d]">
-                        {connectionIdentityLabel(connection)}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 flex-row items-center gap-2">
-                    {needsReconnect && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Link
-                            to="/app/integration/"
-                            search={{
-                              flow: "web",
-                              integration_id: connection.integration_id,
-                              connection_id: connection.connection_id,
-                              action: "reconnect",
-                            }}
-                            aria-label={`Reconnect ${name}. ${reconnectError}`}
-                            className={accountPillSecondaryClassName}
-                          >
-                            Reconnect
-                          </Link>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" className="max-w-xs">
-                          {reconnectError}
-                        </TooltipContent>
-                      </Tooltip>
+            return (
+              <li
+                key={connection.connection_id}
+                className="flex items-center justify-between gap-3 p-6 sm:px-8"
+              >
+                <div className="flex min-w-0 items-center gap-4">
+                  <span
+                    aria-hidden="true"
+                    className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-[#ede7dc] bg-[#fffaf0]"
+                  >
+                    {INTEGRATION_ICONS[connection.integration_id] ?? (
+                      <PuzzlePiece size={20} className="text-[#756b5d]" />
                     )}
-                    <Link
-                      to="/app/integration/"
-                      search={{
-                        flow: "web",
-                        integration_id: connection.integration_id,
-                        connection_id: connection.connection_id,
-                        action: "disconnect",
-                      }}
-                      aria-label={`Disconnect ${name}`}
-                      title="Disconnect"
-                      className={cn([accountPillDangerClassName, "w-9 px-0"])}
-                    >
-                      <Plugs size={16} aria-hidden="true" />
-                    </Link>
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-base font-medium text-[#181613]">
+                      {name}
+                    </p>
+                    <p className="mt-1 truncate text-sm leading-6 text-[#756b5d]">
+                      {connectionIdentityLabel(connection)}
+                    </p>
                   </div>
-                </li>
-              );
-            })}
-          </ul>
-        </TooltipProvider>
+                </div>
+                <IntegrationRowMenu
+                  name={name}
+                  integrationId={connection.integration_id}
+                  connectionId={connection.connection_id}
+                  needsReconnect={needsReconnect}
+                  reconnectError={reconnectError}
+                />
+              </li>
+            );
+          })}
+        </ul>
       )}
     </div>
+  );
+}
+
+function IntegrationRowMenu({
+  name,
+  integrationId,
+  connectionId,
+  needsReconnect,
+  reconnectError,
+}: {
+  name: string;
+  integrationId: string;
+  connectionId: string;
+  needsReconnect: boolean;
+  reconnectError: string;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Actions for ${name}`}
+          className={accountMenuTriggerClassName}
+        >
+          <DotsThree size={16} aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent variant="app" align="end" className="w-44">
+        <AppFloatingPanel className="overflow-hidden p-1">
+          {needsReconnect && (
+            <>
+              <DropdownMenuItem asChild className="cursor-pointer">
+                <Link
+                  to="/app/integration/"
+                  search={{
+                    flow: "web",
+                    integration_id: integrationId,
+                    connection_id: connectionId,
+                    action: "reconnect",
+                  }}
+                  aria-label={
+                    reconnectError
+                      ? `Reconnect ${name}. ${reconnectError}`
+                      : `Reconnect ${name}`
+                  }
+                  title={reconnectError}
+                >
+                  Reconnect
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          <DropdownMenuItem
+            asChild
+            className="cursor-pointer text-red-700 focus:bg-red-50 focus:text-red-800"
+          >
+            <Link
+              to="/app/integration/"
+              search={{
+                flow: "web",
+                integration_id: integrationId,
+                connection_id: connectionId,
+                action: "disconnect",
+              }}
+              aria-label={`Disconnect ${name}`}
+            >
+              Disconnect
+            </Link>
+          </DropdownMenuItem>
+        </AppFloatingPanel>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/src/routes/_view/app/-account-nav.tsx
+++ b/apps/web/src/routes/_view/app/-account-nav.tsx
@@ -5,9 +5,11 @@ import { ACCOUNT_TABS, type AccountTabId } from "@/lib/account-tabs";
 export function AccountTabs({
   activeId,
   onSelect,
+  onPreload,
 }: {
   activeId: AccountTabId;
   onSelect: (tabId: AccountTabId) => void;
+  onPreload?: (tabId: AccountTabId) => void;
 }) {
   return (
     <nav aria-label="Account sections">
@@ -23,6 +25,8 @@ export function AccountTabs({
               id={`account-tab-${tab.id}`}
               aria-selected={isActive}
               aria-controls={`account-tabpanel-${tab.id}`}
+              onPointerEnter={() => onPreload?.(tab.id)}
+              onFocus={() => onPreload?.(tab.id)}
               onClick={() => onSelect(tab.id)}
               className={cn([
                 "shrink-0 rounded-full px-3 py-1.5 text-sm whitespace-nowrap transition-colors",

--- a/apps/web/src/routes/_view/app/-account-shares.tsx
+++ b/apps/web/src/routes/_view/app/-account-shares.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import {
+  AppFloatingPanel,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -21,8 +22,8 @@ import {
 
 import {
   accountCardClassName,
+  accountMenuTriggerClassName,
   accountPillDangerClassName,
-  accountPillSecondaryClassName,
 } from "./-account-ui";
 
 const SCOPE_LABELS = {
@@ -96,23 +97,14 @@ export function SharedNotesSection() {
     restrict.isPending || stopSharing.isPending || stopSharingAll.isPending;
 
   return (
-    <div className={accountCardClassName}>
-      {sharesQuery.isPending ? (
-        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          Checking your shared notes...
-        </p>
-      ) : sharesQuery.isError ? (
-        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          Couldn't load your shared notes. Refresh to try again.
-        </p>
-      ) : shares.length === 0 ? (
-        <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
-          You haven't shared any notes yet. Notes you share from the desktop app
-          show up here.
-        </p>
-      ) : (
-        <>
-          <div className="flex justify-end border-b border-[#ede7dc] px-6 py-3 sm:px-8">
+    <>
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+          Shared notes
+        </h2>
+        {!sharesQuery.isPending &&
+          !sharesQuery.isError &&
+          shares.length > 0 && (
             <button
               type="button"
               onClick={() => {
@@ -131,7 +123,23 @@ export function SharedNotesSection() {
                   ? "You sure?"
                   : "Stop sharing all"}
             </button>
-          </div>
+          )}
+      </div>
+      <div className={cn([accountCardClassName, "mt-6"])}>
+        {sharesQuery.isPending ? (
+          <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+            Checking your shared notes...
+          </p>
+        ) : sharesQuery.isError ? (
+          <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+            Couldn't load your shared notes. Refresh to try again.
+          </p>
+        ) : shares.length === 0 ? (
+          <p className="p-6 text-sm leading-6 text-[#756b5d] sm:p-8">
+            You haven't shared any notes yet. Notes you share from the desktop
+            app show up here.
+          </p>
+        ) : (
           <ul className="divide-y divide-[#ede7dc]">
             {shares.map((share) => (
               <li
@@ -169,24 +177,25 @@ export function SharedNotesSection() {
               </li>
             ))}
           </ul>
-        </>
-      )}
-      {restrict.isError && (
-        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
-          {restrict.error?.message || "Failed to restrict shared note"}
-        </p>
-      )}
-      {stopSharing.isError && (
-        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
-          {stopSharing.error?.message || "Failed to stop sharing this note"}
-        </p>
-      )}
-      {stopSharingAll.isError && (
-        <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
-          {stopSharingAll.error?.message || "Failed to stop sharing your notes"}
-        </p>
-      )}
-    </div>
+        )}
+        {restrict.isError && (
+          <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+            {restrict.error?.message || "Failed to restrict shared note"}
+          </p>
+        )}
+        {stopSharing.isError && (
+          <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+            {stopSharing.error?.message || "Failed to stop sharing this note"}
+          </p>
+        )}
+        {stopSharingAll.isError && (
+          <p className="px-6 pb-6 text-sm text-red-600 sm:px-8">
+            {stopSharingAll.error?.message ||
+              "Failed to stop sharing your notes"}
+          </p>
+        )}
+      </div>
+    </>
   );
 }
 
@@ -224,38 +233,40 @@ function ShareRowMenu({
           type="button"
           disabled={disabled}
           aria-label={`Actions for ${title}`}
-          className={cn([accountPillSecondaryClassName, "w-9 px-0"])}
+          className={accountMenuTriggerClassName}
         >
           <DotsThree size={16} aria-hidden="true" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuItem asChild className="cursor-pointer">
-          <Link
-            to="/share/$shareId/"
-            params={{ shareId }}
-            search={{ scheme: "anarlog" }}
-          >
-            Open
-          </Link>
-        </DropdownMenuItem>
-        {canRestrict && (
-          <DropdownMenuItem
-            className="cursor-pointer"
-            disabled={restricting}
-            onSelect={onRestrict}
-          >
-            {restricting ? "Restricting..." : "Restrict"}
+      <DropdownMenuContent variant="app" align="end" className="w-44">
+        <AppFloatingPanel className="overflow-hidden p-1">
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <Link
+              to="/share/$shareId/"
+              params={{ shareId }}
+              search={{ scheme: "anarlog" }}
+            >
+              Open
+            </Link>
           </DropdownMenuItem>
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          className="cursor-pointer text-red-700 focus:bg-red-50 focus:text-red-800"
-          disabled={stopping}
-          onSelect={onStopSharing}
-        >
-          {stopping ? "Stopping..." : "Stop sharing"}
-        </DropdownMenuItem>
+          {canRestrict && (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              disabled={restricting}
+              onSelect={onRestrict}
+            >
+              {restricting ? "Restricting..." : "Restrict"}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer text-red-700 focus:bg-red-50 focus:text-red-800"
+            disabled={stopping}
+            onSelect={onStopSharing}
+          >
+            {stopping ? "Stopping..." : "Stop sharing"}
+          </DropdownMenuItem>
+        </AppFloatingPanel>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/routes/_view/app/-account-ui.tsx
+++ b/apps/web/src/routes/_view/app/-account-ui.tsx
@@ -25,3 +25,10 @@ export const accountPillDangerClassName = cn([
   "transition-colors hover:border-red-300 hover:text-red-800",
   "disabled:cursor-not-allowed disabled:opacity-50",
 ]);
+
+export const accountMenuTriggerClassName = cn([
+  "flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-full",
+  "text-[#756b5d] transition-colors hover:bg-[#f7f4ef] hover:text-[#181613]",
+  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#756b5d]",
+  "disabled:cursor-not-allowed disabled:opacity-50 data-[state=open]:bg-[#f7f4ef]",
+]);

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { jwtDecode } from "jwt-decode";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { z } from "zod";
 
 import { deriveBillingInfo, type SupabaseJwtPayload } from "@anlg/supabase";
@@ -20,17 +20,86 @@ import {
 } from "@/lib/account-tabs";
 import { checkoutSourceSchema } from "@/lib/checkout-source";
 
-import { AccountAccessSection } from "./-account-access";
-import { ApiKeysSection } from "./-account-api-keys";
-import { DangerAreaSection } from "./-account-danger";
-import { DevicesSection } from "./-account-devices";
-import { IntegrationsSection } from "./-account-integrations";
 import { AccountTabs } from "./-account-nav";
-import { PlanSection } from "./-account-plan";
-import { ProfileInfoSection } from "./-account-profile-info";
-import { ReferralSection } from "./-account-referrals";
 import { accountSessionQueryKey } from "./-account-session";
-import { SharedNotesSection } from "./-account-shares";
+
+const loadAccountAccessSection = () => import("./-account-access");
+const loadApiKeysSection = () => import("./-account-api-keys");
+const loadDangerAreaSection = () => import("./-account-danger");
+const loadDevicesSection = () => import("./-account-devices");
+const loadIntegrationsSection = () => import("./-account-integrations");
+const loadPlanSection = () => import("./-account-plan");
+const loadProfileInfoSection = () => import("./-account-profile-info");
+const loadReferralSection = () => import("./-account-referrals");
+const loadSharedNotesSection = () => import("./-account-shares");
+
+const AccountAccessSection = lazy(() =>
+  loadAccountAccessSection().then((module) => ({
+    default: module.AccountAccessSection,
+  })),
+);
+const ApiKeysSection = lazy(() =>
+  loadApiKeysSection().then((module) => ({ default: module.ApiKeysSection })),
+);
+const DangerAreaSection = lazy(() =>
+  loadDangerAreaSection().then((module) => ({
+    default: module.DangerAreaSection,
+  })),
+);
+const DevicesSection = lazy(() =>
+  loadDevicesSection().then((module) => ({ default: module.DevicesSection })),
+);
+const IntegrationsSection = lazy(() =>
+  loadIntegrationsSection().then((module) => ({
+    default: module.IntegrationsSection,
+  })),
+);
+const PlanSection = lazy(() =>
+  loadPlanSection().then((module) => ({ default: module.PlanSection })),
+);
+const ProfileInfoSection = lazy(() =>
+  loadProfileInfoSection().then((module) => ({
+    default: module.ProfileInfoSection,
+  })),
+);
+const ReferralSection = lazy(() =>
+  loadReferralSection().then((module) => ({
+    default: module.ReferralSection,
+  })),
+);
+const SharedNotesSection = lazy(() =>
+  loadSharedNotesSection().then((module) => ({
+    default: module.SharedNotesSection,
+  })),
+);
+
+const accountTabPreloaders: Record<AccountTabId, () => Promise<unknown>> = {
+  account: () =>
+    Promise.all([
+      loadProfileInfoSection(),
+      loadPlanSection(),
+      loadReferralSection(),
+      loadDangerAreaSection(),
+    ]),
+  connections: () =>
+    Promise.all([
+      loadIntegrationsSection(),
+      loadDevicesSection(),
+      loadSharedNotesSection(),
+    ]),
+  developer: () =>
+    Promise.all([loadApiKeysSection(), loadAccountAccessSection()]),
+};
+
+function preloadAccountTab(tabId: AccountTabId) {
+  void accountTabPreloaders[tabId]().catch(() => undefined);
+}
+
+function scrollHashSectionIntoView(element: HTMLElement | null) {
+  if (element && window.location.hash === `#${element.id}`) {
+    element.scrollIntoView({ block: "start" });
+  }
+}
 
 const validateSearch = z
   .object({
@@ -59,7 +128,9 @@ function Component() {
   const { identify: identifyPosthog, track } = useAnalytics();
   const queryClient = useQueryClient();
   const [hash, setHash] = useState("");
-  const activeTab = resolveAccountTab({ tab: search.tab, hash });
+  const [optimisticTab, setOptimisticTab] = useState<AccountTabId | null>(null);
+  const routeTab = resolveAccountTab({ tab: search.tab, hash });
+  const activeTab = optimisticTab ?? routeTab;
 
   useEffect(() => {
     if (!search.success && search.trial !== "started") {
@@ -132,6 +203,7 @@ function Component() {
 
   const selectTab = (tabId: AccountTabId) => {
     setHash("");
+    setOptimisticTab(tabId);
     void navigate({
       search: (prev) => ({
         ...prev,
@@ -140,6 +212,8 @@ function Component() {
       // Empty string is treated as omitted and would keep the current hash.
       hash: () => "",
       replace: true,
+    }).finally(() => {
+      setOptimisticTab((current) => (current === tabId ? null : current));
     });
   };
 
@@ -164,7 +238,11 @@ function Component() {
 
         <div className="mt-10 md:mt-12 lg:mt-16">
           <div className="sticky top-0 z-10 -mx-5 border-b border-[#ede7dc] bg-white px-5 py-3 md:-mx-8 md:px-8">
-            <AccountTabs activeId={activeTab} onSelect={selectTab} />
+            <AccountTabs
+              activeId={activeTab}
+              onSelect={selectTab}
+              onPreload={preloadAccountTab}
+            />
           </div>
 
           <div
@@ -173,20 +251,40 @@ function Component() {
             aria-labelledby={`account-tab-${activeTab}`}
             className="mt-10 flex min-w-0 flex-col gap-14"
           >
-            {sectionsForAccountTab(activeTab).map((section) => (
-              <AccountSection key={section.id} id={section.id}>
-                <AccountSectionBody
-                  id={section.id}
-                  email={user?.email}
-                  perk={search.perk}
-                  referralIneligible={search.referral === "ineligible"}
-                />
-              </AccountSection>
-            ))}
+            <Suspense fallback={<AccountTabFallback tabId={activeTab} />}>
+              {sectionsForAccountTab(activeTab).map((section) => (
+                <AccountSection key={section.id} id={section.id}>
+                  <AccountSectionBody
+                    id={section.id}
+                    email={user?.email}
+                    perk={search.perk}
+                    referralIneligible={search.referral === "ineligible"}
+                  />
+                </AccountSection>
+              ))}
+            </Suspense>
           </div>
         </div>
       </div>
     </main>
+  );
+}
+
+function AccountTabFallback({ tabId }: { tabId: AccountTabId }) {
+  return (
+    <>
+      <span role="status" className="sr-only">
+        Loading account sections...
+      </span>
+      {sectionsForAccountTab(tabId).map((section) => (
+        <section key={section.id} aria-hidden="true">
+          <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+            {section.label}
+          </h2>
+          <div className="mt-6 h-28 animate-pulse rounded-[24px] border border-[#e5ddcf] bg-[#faf8f4]" />
+        </section>
+      ))}
+    </>
   );
 }
 
@@ -200,11 +298,13 @@ function AccountSection({
   const title = ACCOUNT_SECTIONS.find((section) => section.id === id)?.label;
 
   return (
-    <section id={id} className="scroll-mt-20">
-      <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
-        {title}
-      </h2>
-      <div className="mt-6">{children}</div>
+    <section ref={scrollHashSectionIntoView} id={id} className="scroll-mt-20">
+      {id !== "shares" && (
+        <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
+          {title}
+        </h2>
+      )}
+      <div className={id === "shares" ? undefined : "mt-6"}>{children}</div>
     </section>
   );
 }

--- a/crates/api-nango/src/routes/identity.rs
+++ b/crates/api-nango/src/routes/identity.rs
@@ -1,6 +1,12 @@
 use anlg_nango::OwnedNangoProxy;
 
 #[derive(serde::Deserialize)]
+struct GoogleCalendarIdentity {
+    id: Option<String>,
+    summary: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
 struct GoogleUserInfo {
     email: Option<String>,
     name: Option<String>,
@@ -84,8 +90,25 @@ pub(crate) async fn fetch_identity(
     let proxy = OwnedNangoProxy::new(nango, integration_id.to_string(), connection_id.to_string());
 
     match integration_id {
+        // Calendar access does not include Google profile scopes. The primary
+        // calendar ID is the connected account email and is available with the
+        // existing calendar.readonly scope.
+        "google-calendar" => {
+            let resp = proxy
+                .get("/calendar/v3/calendars/primary")
+                .map_err(|e| e.to_string())?
+                .send()
+                .await
+                .map_err(|e| e.to_string())?
+                .error_for_status()
+                .map_err(|e| e.to_string())?;
+
+            let calendar: GoogleCalendarIdentity = resp.json().await.map_err(|e| e.to_string())?;
+            Ok((calendar.id, calendar.summary))
+        }
+
         // https://docs.cloud.google.com/identity-platform/docs/reference/rest/v1/UserInfo
-        "google-calendar" | "google-drive" | "google-meet" => {
+        "google-drive" | "google-meet" => {
             let request = if integration_id == "google-meet" {
                 proxy
                     .base_url_override("https://www.googleapis.com")
@@ -420,6 +443,26 @@ mod tests {
         tags.insert("account_identity".to_string(), "   ".to_string());
         assert_eq!(account_identity_from_tags(Some(&tags)), None);
         assert_eq!(account_identity_from_tags(None), None);
+    }
+
+    #[tokio::test]
+    async fn google_calendar_identity_uses_primary_calendar_email() {
+        let nango_mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/proxy/calendar/v3/calendars/primary"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "john@fastrepl.com",
+                "summary": "John Jeong"
+            })))
+            .mount(&nango_mock)
+            .await;
+
+        let nango = nango_client(&nango_mock).await;
+        let (identity, display_name) = fetch_identity(&nango, "google-calendar", "conn-google")
+            .await
+            .unwrap();
+        assert_eq!(identity.as_deref(), Some("john@fastrepl.com"));
+        assert_eq!(display_name.as_deref(), Some("John Jeong"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Polish account connections and lazy-load tabs

## Summary

- move **Stop sharing all** beside the Shared notes heading and standardize note and integration actions as borderless three-dot menus using the app floating-panel UI
- show the connected Google Calendar email by resolving the primary calendar ID with the existing calendar permission
- lazy-load account sections, preload tabs on hover or keyboard focus, and switch the tab shell optimistically

## Testing

- `pnpm -F @anlg/web typecheck`
- focused ESLint and dprint checks
- `node --test apps/web/src/lib/account-tabs.test.ts`
- `node --test apps/web/src/lib/integration-connection-label.test.ts`
- `cargo fmt --package api-nango -- --check`
- `cargo check -p api-nango`
- `cargo test -p api-nango --no-run`

The Vite client and server compilation completed and emitted separate account-section chunks. The final prerender step could not run locally because deployment environment variables are unavailable. The `api-nango` test binary is SIGKILLed by this environment at runtime, including unchanged tests, so it was compile-checked with `--no-run` instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Google Calendar identity lookup to a different Calendar API proxy path, which affects how connected-account emails are stored and shown. Account tab loading is UI-only but can briefly desync from the URL.
> 
> **Overview**
> Account tabs now **lazy-load** their sections, **preload on hover/focus**, and switch **optimistically** so the shell updates before the URL settles. A pulse fallback keeps layout while chunks load.
> 
> Connection and shared-note row actions move into **borderless three-dot menus** (`AppFloatingPanel`). **Stop sharing all** sits next to the Shared notes heading instead of inside the card.
> 
> Google Calendar identity no longer hits userinfo (which needs profile scopes). It reads the **primary calendar ID** via `calendar.readonly` so the connected email can display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bb65c497ce070e01b93f796aee417cecf5dc92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->