### PR TITLE
Fix Google Calendar webhook identity test

### DIFF
--- a/crates/api-nango/src/routes/webhook.rs
+++ b/crates/api-nango/src/routes/webhook.rs
@@ -347,9 +347,9 @@ mod tests {
             .await;
 
         Mock::given(method("GET"))
-            .and(path_regex("/proxy/.*userinfo.*"))
+            .and(path("/proxy/calendar/v3/calendars/primary"))
             .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({"email": "user@example.com", "name": "Test User"}),
+                serde_json::json!({"id": "user@example.com", "summary": "Test User"}),
             ))
             .mount(&nango_mock)
             .await;


### PR DESCRIPTION
Update the webhook fixture to match the primary-calendar identity endpoint introduced in #7066. Verified the exact failing test and the full api-nango suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock path and JSON shape change; no production behavior is modified.
> 
> **Overview**
> Updates the `creation_upserts_connection_and_patches_identity` webhook test so its Nango proxy mock matches the Google Calendar identity fetch introduced in #7066.
> 
> The mock now hits `/proxy/calendar/v3/calendars/primary` and returns `id`/`summary` instead of the old userinfo `email`/`name` payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a480a52cdd5710a83a6ea7093e126f426462cc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->