### PR TITLE
Match folder icon optical size

### DIFF
--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -32,7 +32,7 @@ describe("FolderPicker", () => {
     cleanup();
   });
 
-  it("shows only a standard-sized folder icon when no folder is selected", () => {
+  it("optically sizes the folder icon when no folder is selected", () => {
     render(<FolderPicker sessionId="session-1" />);
 
     const trigger = screen.getByRole("combobox", { name: "Select folder" });
@@ -41,7 +41,7 @@ describe("FolderPicker", () => {
     expect(trigger.textContent).toBe("");
     expect(trigger.className).toContain("w-7");
     expect(icons).toHaveLength(1);
-    expect(icons[0]?.getAttribute("class")).toContain("size-4");
+    expect(icons[0]?.getAttribute("class")).toContain("size-[18px]");
   });
 
   it("shows the selected folder name without a chevron", () => {

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -107,7 +107,7 @@ export function FolderPicker({
             open && "bg-accent text-foreground",
           ])}
         >
-          <FolderSimple className="size-4 shrink-0" aria-hidden="true" />
+          <FolderSimple className="size-[18px] shrink-0" aria-hidden="true" />
           {currentPath ? (
             <span className="min-w-0 truncate text-xs text-neutral-600 dark:text-neutral-300">
               {currentPath}


### PR DESCRIPTION
Increase the header folder glyph to 18px while preserving its button footprint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon sizing only; no behavior, data, or security changes.
> 
> **Overview**
> Bumps the header `FolderPicker` glyph from `size-4` to `size-[18px]` so it matches optical size of nearby icons, while keeping the same `w-7`/`h-7` trigger footprint. The empty-state test now asserts the new class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924d859ff5a156db10610cc6bee4ea9f023d6562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->