### PR TITLE
Show note title before recording

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -499,7 +499,30 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("textbox", { name: "Session title" })).toBeNull();
   });
 
-  it("hides the title input on the memo tab", () => {
+  it("shows an editable title on the memo tab before recording", () => {
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        tab={{
+          active: true,
+          id: "session-1",
+          pinned: false,
+          slotId: "slot-1",
+          state: { autoStart: null, view: { type: "raw" } },
+          type: "sessions",
+        }}
+      />,
+    );
+
+    const title = screen.getByRole("textbox", { name: "Session title" });
+
+    expect(title.getAttribute("placeholder")).toBe("Untitled");
+  });
+
+  it("hides the title input on the memo tab after recording", () => {
+    mocks.hasTranscriptBySession = { "session-1": true };
+
     render(
       <OuterHeader
         sessionId="session-1"

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -76,11 +76,7 @@ export function OuterHeader({
     sessionMode === "active" || sessionMode === "running_batch";
   const isLiveMeeting = isRecording || sessionMode === "finalizing";
   const meetingOver = !isRecording && (ended || hasTranscript || audioExists);
-  const showTitleInput =
-    Boolean(tab) &&
-    !isLiveMeeting &&
-    currentView.type === "enhanced" &&
-    !meetingOver;
+  const showTitleInput = Boolean(tab) && !isLiveMeeting && !meetingOver;
 
   return (
     <div


### PR DESCRIPTION
Display the editable session title on pre-recording memo views and cover the visibility rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small header visibility tweak with no auth, data, or recording-flow changes.
> 
> **Overview**
> Shows the editable session title in the header on pre-recording memo views, not only on the summary tab.
> 
> `showTitleInput` no longer requires `currentView.type === "enhanced"`. The title still hides during live meetings and after recording. Tests now cover memo-tab visibility before vs after a transcript exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc0f9f4794dd9033a7b0f2facc0cc6cacbbb57fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->