### PR TITLE
Reduce past note opening delay

### DIFF
--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -25,6 +25,7 @@ export {
 } from "./queries/participants";
 export {
   loadSessionEvent,
+  preloadSession,
   updateSession,
   useSession,
   useSessionHasTranscript,

--- a/apps/desktop/src/session/queries/sessions.test.tsx
+++ b/apps/desktop/src/session/queries/sessions.test.tsx
@@ -2,8 +2,10 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
   options: null as null | {
     enabled?: boolean;
+    mapRows?: (rows: Array<Record<string, unknown>>) => unknown;
     params?: unknown[];
     sql: string;
   },
@@ -13,26 +15,76 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("~/db", () => ({
   executeTransaction: vi.fn(),
-  liveQueryClient: { execute: vi.fn() },
+  liveQueryClient: { execute: mocks.execute },
   useLiveQuery: (options: {
     enabled?: boolean;
+    mapRows?: (rows: Array<Record<string, unknown>>) => unknown;
     params?: unknown[];
     sql: string;
   }) => {
     mocks.options = options;
     return {
-      data: options.enabled === false || mocks.loading ? undefined : mocks.rows,
+      data:
+        options.enabled === false || mocks.loading
+          ? undefined
+          : options.mapRows
+            ? options.mapRows(mocks.rows)
+            : mocks.rows,
     };
   },
 }));
 
-import { useSessionSummariesByIds } from "./sessions";
+import {
+  preloadSession,
+  useSession,
+  useSessionSummariesByIds,
+} from "./sessions";
 
 describe("session SQLite queries", () => {
   beforeEach(() => {
     mocks.options = null;
     mocks.rows = [];
     mocks.loading = false;
+    mocks.execute.mockReset();
+  });
+
+  it("uses prefetched content while the live subscription starts", async () => {
+    mocks.loading = true;
+    mocks.execute.mockResolvedValue([
+      {
+        id: "prefetched-session",
+        owner_user_id: "user-1",
+        created_at: "2026-08-24T09:00:00.000Z",
+        folder_path: "",
+        event_json: "{}",
+        title: "Planning",
+        raw_body:
+          '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Ready immediately"}]}]}',
+        raw_body_format: "prosemirror_json",
+        raw_template_id: "",
+        locked: 0,
+      },
+    ]);
+
+    await preloadSession("prefetched-session");
+    const { result } = renderHook(() => useSession("prefetched-session"));
+
+    expect(result.current?.raw_md).toContain("Ready immediately");
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining("FROM sessions"),
+      ["prefetched-session"],
+    );
+  });
+
+  it("deduplicates concurrent session preloads", async () => {
+    mocks.execute.mockResolvedValue([]);
+
+    await Promise.all([
+      preloadSession("deduplicated-session"),
+      preloadSession("deduplicated-session"),
+    ]);
+
+    expect(mocks.execute).toHaveBeenCalledOnce();
   });
 
   it("loads deduplicated summaries only for referenced ids", () => {

--- a/apps/desktop/src/session/queries/sessions.ts
+++ b/apps/desktop/src/session/queries/sessions.ts
@@ -39,6 +39,16 @@ type SessionTranscriptStateSqlRow = {
 type SessionEventSqlRow = { event_json: string };
 
 const EMPTY_SESSION_SUMMARIES: SessionSummaryRecord[] = [];
+const SESSION_PREFETCH_TTL_MS = 5_000;
+const MAX_PREFETCHED_SESSIONS = 1;
+
+type PrefetchedSession = {
+  createdAt: number;
+  promise: Promise<SessionRecord | null>;
+  value?: SessionRecord | null;
+};
+
+const prefetchedSessions = new Map<string, PrefetchedSession>();
 
 const SESSION_SELECT_SQL = `
   SELECT
@@ -62,7 +72,7 @@ const SESSION_SELECT_SQL = `
 `;
 
 export function useSession(sessionId: string): SessionRecord | null {
-  const { data = null } = useLiveQuery<SessionSqlRow, SessionRecord | null>({
+  const { data } = useLiveQuery<SessionSqlRow, SessionRecord | null>({
     sql: SESSION_SELECT_SQL,
     params: [sessionId],
     enabled: Boolean(sessionId),
@@ -71,7 +81,48 @@ export function useSession(sessionId: string): SessionRecord | null {
       return row ? mapSessionRow(row) : null;
     },
   });
-  return sessionId ? data : null;
+  if (!sessionId) return null;
+  if (data !== undefined) {
+    prefetchedSessions.delete(sessionId);
+    return data;
+  }
+
+  const prefetched = getPrefetchedSession(sessionId);
+  return prefetched && "value" in prefetched
+    ? (prefetched.value ?? null)
+    : null;
+}
+
+export function preloadSession(
+  sessionId: string,
+): Promise<SessionRecord | null> {
+  if (!sessionId) return Promise.resolve(null);
+
+  const existing = getPrefetchedSession(sessionId);
+  if (existing) return existing.promise;
+
+  let entry: PrefetchedSession;
+  const promise = liveQueryClient
+    .execute<SessionSqlRow>(SESSION_SELECT_SQL, [sessionId])
+    .then((rows) => {
+      const row = rows[0];
+      const value = row ? mapSessionRow(row) : null;
+      if (prefetchedSessions.get(sessionId) === entry) {
+        entry.value = value;
+      }
+      return value;
+    })
+    .catch((error) => {
+      if (prefetchedSessions.get(sessionId) === entry) {
+        prefetchedSessions.delete(sessionId);
+      }
+      throw error;
+    });
+
+  entry = { createdAt: Date.now(), promise };
+  prefetchedSessions.set(sessionId, entry);
+  trimPrefetchedSessions();
+  return promise;
 }
 
 export function useSessionSummary(
@@ -273,6 +324,22 @@ function useHeldLiveQueryRows<T>(
     return empty;
   }
   return data ?? previous.current;
+}
+
+function getPrefetchedSession(sessionId: string) {
+  const entry = prefetchedSessions.get(sessionId);
+  if (!entry) return undefined;
+  if (Date.now() - entry.createdAt <= SESSION_PREFETCH_TTL_MS) return entry;
+  prefetchedSessions.delete(sessionId);
+  return undefined;
+}
+
+function trimPrefetchedSessions() {
+  while (prefetchedSessions.size > MAX_PREFETCHED_SESSIONS) {
+    const oldestSessionId = prefetchedSessions.keys().next().value;
+    if (!oldestSessionId) return;
+    prefetchedSessions.delete(oldestSessionId);
+  }
 }
 
 function mapSessionRow(row: SessionSqlRow): SessionRecord {

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -11,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   openCurrent: vi.fn(),
   openNew: vi.fn(),
   platform: "macos",
+  preloadSession: vi.fn(() => Promise.resolve(null)),
   sessionMode: "inactive",
   stop: vi.fn(),
   getOrCreateSessionForEventId: vi.fn(() => Promise.resolve("session-event")),
@@ -78,6 +85,7 @@ vi.mock("~/session/hooks/useEnhancedNotes", () => ({
 
 vi.mock("~/session/queries", () => ({
   getOrCreateSessionForEventId: mocks.getOrCreateSessionForEventId,
+  preloadSession: mocks.preloadSession,
 }));
 
 vi.mock("~/lock/notes", () => ({
@@ -184,6 +192,8 @@ describe("TimelineItemComponent", () => {
     mocks.openCurrent.mockClear();
     mocks.openNew.mockClear();
     mocks.platform = "macos";
+    mocks.preloadSession.mockReset();
+    mocks.preloadSession.mockResolvedValue(null);
     mocks.authAvailable = false;
     mocks.revealedNoteIds = {};
     mocks.windowShow.mockClear();
@@ -528,7 +538,7 @@ describe("TimelineItemComponent", () => {
     expect(sharedIcon.parentElement?.lastElementChild).toBe(sharedIcon);
   });
 
-  it("opens the current tab after a single-click on a session row", () => {
+  it("preloads a session before opening it in the current tab", async () => {
     render(
       <TimelineItemComponent
         item={{
@@ -548,18 +558,62 @@ describe("TimelineItemComponent", () => {
     );
 
     const rowButton = screen.getByText("Live Note").closest("button");
+    fireEvent.pointerDown(rowButton!);
     fireEvent.click(rowButton!, { detail: 1 });
 
     expect(mocks.timelineSelection.setAnchor).toHaveBeenCalledWith(
       "session-session-note",
     );
-    expect(mocks.openCurrent).toHaveBeenCalledWith({
-      id: "session-note",
-      type: "sessions",
+    expect(mocks.preloadSession).toHaveBeenCalledWith("session-note");
+    await waitFor(() => {
+      expect(mocks.openCurrent).toHaveBeenCalledWith({
+        id: "session-note",
+        type: "sessions",
+      });
     });
   });
 
-  it("opens a standalone note window when a session row is double-clicked", () => {
+  it("keeps the current note open until the target session is preloaded", async () => {
+    let finishPreload: ((value: null) => void) | undefined;
+    mocks.preloadSession.mockReturnValue(
+      new Promise((resolve) => {
+        finishPreload = resolve;
+      }),
+    );
+
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "session",
+          id: "slow-session",
+          data: {
+            title: "Slow note",
+            created_at: "2024-01-15T10:30:00.000Z",
+          },
+        }}
+        precision="time"
+        selected={false}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["session-slow-session"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Live Note").closest("button")!);
+
+    expect(mocks.openCurrent).not.toHaveBeenCalled();
+    expect(screen.getByTestId("spinner")).toBeTruthy();
+
+    finishPreload?.(null);
+    await waitFor(() => {
+      expect(mocks.openCurrent).toHaveBeenCalledWith({
+        id: "slow-session",
+        type: "sessions",
+      });
+    });
+  });
+
+  it("opens a standalone note window when a session row is double-clicked", async () => {
     render(
       <TimelineItemComponent
         item={{
@@ -583,10 +637,12 @@ describe("TimelineItemComponent", () => {
     fireEvent.click(rowButton!, { detail: 2 });
     fireEvent.doubleClick(rowButton!);
 
-    expect(mocks.openCurrent).toHaveBeenCalledTimes(1);
-    expect(mocks.openCurrent).toHaveBeenCalledWith({
-      id: "session-note-window",
-      type: "sessions",
+    await waitFor(() => {
+      expect(mocks.openCurrent).toHaveBeenCalledTimes(1);
+      expect(mocks.openCurrent).toHaveBeenCalledWith({
+        id: "session-note-window",
+        type: "sessions",
+      });
     });
     expect(mocks.timelineSelection.setAnchor).toHaveBeenCalledTimes(1);
     expect(mocks.timelineSelection.setAnchor).toHaveBeenCalledWith(

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -34,7 +34,10 @@ import { revealLockedNote, setSessionLocked } from "~/lock/notes";
 import { useAppLock } from "~/lock/store";
 import { useDeleteSession } from "~/session/hooks/useDeleteSession";
 import { useIsSessionEnhancing } from "~/session/hooks/useEnhancedNotes";
-import { getOrCreateSessionForEventId } from "~/session/queries";
+import {
+  getOrCreateSessionForEventId,
+  preloadSession,
+} from "~/session/queries";
 import { getSessionEvent } from "~/session/utils";
 import { openStandaloneNoteWindow } from "~/session/window";
 import type { MenuItemDef } from "~/shared/hooks/useNativeContextMenu";
@@ -77,6 +80,7 @@ type ItemBaseProps = {
   timelineSessionId?: string;
   isUpcoming?: boolean;
   upcomingProgress?: number;
+  onPreload?: () => void;
 };
 
 export const TimelineItemComponent = memo(
@@ -168,6 +172,7 @@ const ItemBase = memo(function ItemBase({
   timelineSessionId,
   isUpcoming,
   upcomingProgress,
+  onPreload,
 }: ItemBaseProps) {
   const { t } = useLingui();
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
@@ -194,6 +199,8 @@ const ItemBase = memo(function ItemBase({
     <div
       ref={setItemRef}
       data-sidebar-timeline-session-id={timelineSessionId}
+      onFocus={onPreload}
+      onPointerDown={onPreload}
       className="group/sidebar-live-item relative [contain-intrinsic-size:auto_56px] [content-visibility:auto]"
     >
       <InteractiveButton
@@ -358,7 +365,8 @@ function itemBasePropsAreEqual(prev: ItemBaseProps, next: ItemBaseProps) {
     prev.itemNodeRef === next.itemNodeRef &&
     prev.timelineSessionId === next.timelineSessionId &&
     prev.isUpcoming === next.isUpcoming &&
-    prev.upcomingProgress === next.upcomingProgress
+    prev.upcomingProgress === next.upcomingProgress &&
+    prev.onPreload === next.onPreload
   );
 }
 
@@ -577,8 +585,11 @@ const SessionItem = memo(
     const isLive = sessionMode === "active";
     const isFinalizing = sessionMode === "finalizing";
     const isBatching = sessionMode === "running_batch";
+    const [isOpening, setIsOpening] = useState(false);
     const showSpinner =
-      !selected && !isLive && (isFinalizing || isEnhancing || isBatching);
+      !selected &&
+      !isLive &&
+      (isFinalizing || isEnhancing || isBatching || isOpening);
 
     const sessionEvent = getSessionEvent(item.data);
 
@@ -595,16 +606,32 @@ const SessionItem = memo(
 
     const itemKey = `session-${item.id}`;
 
+    const handlePreload = useCallback(() => {
+      if (!noteLocked) void preloadSession(sessionId).catch(() => {});
+    }, [noteLocked, sessionId]);
+
+    const openSession = useCallback(async () => {
+      setIsOpening(true);
+      try {
+        await preloadSession(sessionId);
+      } catch (error) {
+        console.error("[timeline] failed to preload session", error);
+      } finally {
+        openCurrent({ id: sessionId, type: "sessions" });
+        setIsOpening(false);
+      }
+    }, [openCurrent, sessionId]);
+
     const handleClick = useCallback(() => {
       useTimelineSelection.getState().setAnchor(itemKey);
       if (noteLocked) {
         void revealLockedNote(sessionId).then((ok) => {
-          if (ok) openCurrent({ id: sessionId, type: "sessions" });
+          if (ok) void openSession();
         });
         return;
       }
-      openCurrent({ id: sessionId, type: "sessions" });
-    }, [noteLocked, sessionId, openCurrent, itemKey]);
+      void openSession();
+    }, [noteLocked, sessionId, openSession, itemKey]);
 
     const handleCmdClick = useCallback(() => {
       useTimelineSelection.getState().toggleSelect(itemKey);
@@ -720,6 +747,7 @@ const SessionItem = memo(
         timelineSessionId={sessionId}
         isUpcoming={isUpcoming}
         upcomingProgress={upcomingProgress}
+        onPreload={handlePreload}
         draggable
       />
     );


### PR DESCRIPTION
Preload selected session content before mounting the editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when notes switch and can briefly serve cached session body before the live query. Navigation still proceeds if preload fails.
> 
> **Overview**
> Reduces delay when opening past notes from the sidebar by prefetching session content before the editor mounts.
> 
> `preloadSession` runs the same SQLite session query as `useSession`, caches one result for 5s, and dedupes in-flight loads. While the live subscription is still starting, `useSession` returns that prefetched record.
> 
> Timeline session rows start preload on pointer-down/focus and **wait for it before switching tabs**, showing a spinner on the current row until then. Locked notes skip the hover preload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5e7ad127883f61aed9a4df4a908f3471366a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->