### PR TITLE
Complete Anarlog 1.4.13 changelog

### DIFF
--- a/packages/changelog/content/1.4.13.md
+++ b/packages/changelog/content/1.4.13.md
@@ -39,6 +39,8 @@ summary: "Anarlog 1.4.13 adds custom automations, clickable chat context, stable
 
 ## Recording and reliability
 
+- See and edit a note's title before recording starts
+- Open past notes with less delay while their session content loads
 - On Linux, fall back to another usable microphone when the default input
   cannot open instead of crashing or ending recording setup
 - Avoid PulseAudio and PipeWire monitor sources when choosing a Linux


### PR DESCRIPTION
Add the final note-title and past-note loading improvements that landed before release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no code or security impact.
> 
> **Overview**
> Adds two missing 1.4.13 changelog bullets under **Recording and reliability**: edit a note title before recording starts, and open past notes with less delay while session content loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34faae3c1053479f7a5b5d719e7d160fa7af0c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->