### PR TITLE
Refresh free transcription software guide

### DIFF
--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -81,7 +81,16 @@
   "fathom-ai-alternatives": [],
   "fireflies-ai-alternatives": [],
   "free-ai-notetakers": [],
-  "free-transcription-software": [],
+  "free-transcription-software": [
+    {
+      "filename": "free-transcription-paths.png",
+      "content": "Title: Four Free Transcription Paths\nLive meetings with local control: desktop meeting notetaker\nPrivate audio and video files: on-device file transcription\nOne-off browser upload: no-signup web transcriber\nAutomatic calendar meetings: cloud meeting assistant",
+      "context": "Four-branch decision map for an Anarlog blog post showing that free transcription software falls into four practical workflows. Each need maps to one tool category, not a specific brand. Neutral reference diagram. Do not add rankings, scores, pros, cons, or invented features.",
+      "visualQuery": "mapping diagram",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "google-gemini-data-retention-policy": [
     {
       "filename": "gemini-retention-by-tier.png",

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -1,265 +1,205 @@
 ---
-meta_title: "Top 6 Truly Free Transcription Software in 2026"
+meta_title: "Best Free Transcription Software in 2026: 6 Useful Options"
 display_title: "Best Free Transcription Software in 2026"
-meta_description: "Find truly free transcription solutions in 2026 that offer real usability, privacy, and accuracy for all your speech-to-text needs. No surprises or limits."
+meta_description: "Compare six genuinely free transcription tools by usage limits, local or cloud processing, meeting capture, exports, and the point where you need to pay."
 author:
   - "John Jeong"
 featured: false
 category: "Comparisons"
-date: "2025-10-08"
+date: "2026-08-25"
 ---
 
-If you're looking for free transcription tools to automatically transcribe your meetings, video, or audio files, we've researched the options for you.
+Free transcription software is not one category.
 
-Most "free" tools cap you at 30 minutes total, force upgrades after a trial period, or lock basic features behind paywalls.
+A local desktop app can transcribe without a monthly quota. A browser tool is faster for one audio file. A meeting assistant can join scheduled calls automatically, but usually stores the result in a cloud workspace. Those are different workflows, even when every product calls itself free.
 
-This guide reviews genuinely free transcription software that works without constant payment prompts.
+The short version:
 
-## Best free transcription software: quick comparison
+- **Choose Anarlog** for live, bot-free meeting transcription with local data ownership and no transcription-minute cap.
+- **Choose MacWhisper** for private audio or video file transcription on a Mac.
+- **Choose Riverside** for an occasional browser upload without creating an account.
+- **Choose Transcript LOL** when the source is a URL or cloud file and two short transcripts per day are enough.
+- **Choose Otter** for automatic calendar meetings and a searchable cloud meeting workspace.
+- **Choose Notta** for multilingual cloud transcription, while treating its three-minute free-session limit as an evaluation tier.
 
+## Free transcription software compared
 
-| Tool           | Best For                   | Transcription Type                       | Real-Time | Monthly Limit               | Export Formats           |
-| -------------- | -------------------------- | ---------------------------------------- | --------- | --------------------------- | ------------------------ |
-| Anarlog           | Privacy & unlimited use    | Meeting + live video/audio transcription | ✅ Yes     | Unlimited                   | MD, PDF, RTF             |
-| Transcript LOL | Multi-source imports       | Files + URL imports                      | ❌ No      | 2 files daily (20 min each) | TXT, DOCX, PDF, SRT, VTT |
-| Riverside      | Unlimited no-signup tool   | Files only                               | ❌ No      | Unlimited                   | TXT, SRT                 |
-| Otter AI       | Meeting bot automation     | Meeting bot + files                      | ✅ Yes     | 300 min (30 min/recording)  | MP3, TXT (PDF/DOCX paid) |
-| Notta          | Multi-language translation | Meeting bot + files                      | ✅ Yes     | 120 min (3 min/recording)   | TXT (others paid)        |
-| MacWhisper     | Simple Mac transcription   | Files only                               | ❌ No      | Unlimited                   | TXT, SRT, VTT            |
+| Tool | What is actually free | Best fit | Processing model | Main free limit |
+| --- | --- | --- | --- | --- |
+| Anarlog | Unlimited local transcription and BYOK or local AI | Live meetings with local ownership | Local-first desktop app | You provide an AI key or local model for free AI summaries |
+| MacWhisper | Unlimited on-device file transcription with smaller local models | Private files on a Mac | Local desktop app | Larger models and meeting recording require Pro |
+| Riverside | Unlimited standalone audio and video uploads | One-off browser transcription | Cloud web tool | Free output treats multi-speaker audio as one speaker |
+| Transcript LOL | Two transcripts per day, up to 20 minutes each | Short files, cloud drives, and media URLs | Cloud web tool | No summaries or chat on free; one upload at a time |
+| Otter | 300 minutes per month | Automatic meeting capture and follow-up | Cloud workspace with bot and bot-free capture options | 30 minutes per conversation and three lifetime file imports |
+| Notta | 120 or 200 minutes per month, depending on region | Multilingual cloud transcription | Cloud workspace with bot and desktop capture | Three minutes per conversation |
 
+![Four practical paths through free transcription software](/api/assets/blog/articles/free-transcription-software/free-transcription-paths.png)
 
-## How we chose these tools
+Start with what you need to capture, where you are willing to process it, and whether the free limit survives normal use.
 
-We evaluated dozens of transcription tools using these criteria:
+## How we evaluated these tools
 
-- **Automatic transcription only**: Manual transcription assistants help you type faster while listening to audio, but don't transcribe automatically. This guide focuses on software that actually transcribes for you.
-- **Genuine free access**: We prioritized tools with permanent free plans, not trials disguised as "free" offerings.
-- **Usable limitations**: Many "free" tools impose restrictions that make them unusable—10-minute one-time trials or 3-minute recording limits. We focused on tools where the free tier actually works for real-world use.
-- **Transcription quality**: All selected tools use modern AI models (primarily OpenAI's Whisper) that deliver genuine accuracy.
-- **Privacy and data handling**: We noted whether tools process locally or in the cloud, and whether your data gets used for AI training.
-- **No hidden costs**: We clearly documented where free plans end and paid features begin.
+We used five practical filters:
 
-## Popular transcription tools we didn't include (and why)
+1. **The free access is ongoing.** A permanent free plan, open-source app, or unlimited free utility qualifies. A short trial does not.
+2. **The limit is explicit.** Minutes, file imports, meeting duration, and export restrictions matter more than a large "Free" label.
+3. **The capture method fits the job.** Live meetings, uploaded recordings, browser URLs, and manual transcription are different jobs.
+4. **The data path is understandable.** Local tools keep processing on your computer by default. Cloud tools require you to evaluate the vendor's current privacy and retention terms.
+5. **The upgrade trigger is honest.** We call out the point where a free plan stops being useful instead of hiding it below a feature list.
 
-### 1. oTranscribe
+We checked each vendor's current product, pricing, and privacy pages for this update. Plans still change often, so follow the source links before committing a workflow.
 
-[oTranscribe](https://otranscribe.com) is a manual transcription assistant. You still type everything yourself; they just provide keyboard shortcuts and audio playback controls.
+## 1. Anarlog: best for free live meeting transcription with local control
 
-**Consider for**: Academic research or journalism, where you need complete control over every word transcribed.
+[Anarlog](/) is an open-source AI meeting notetaker for macOS, Windows, and Linux. It captures microphone and system audio from your computer, so no meeting bot needs to join Zoom, Microsoft Teams, Google Meet, or an in-person conversation.
 
-### 2. Rev
+The canonical meeting record lives in local SQLite. Notes, transcripts, and meeting metadata are not dependent on a vendor-hosted workspace, and Markdown is available when you want a portable export.
 
-[Rev](https://www.rev.com) only offers 45 minutes of AI transcription per month on the free plan, which most regular users exhaust within days.
+### What the free plan includes
 
-**Consider for**: The hybrid model offering both AI transcription and the option to upgrade to 99% accurate human transcription for critical documents.
+- Unlimited local transcription with no monthly minute quota
+- Bot-free capture of microphone and system audio
+- Local storage for meetings, notes, and transcripts
+- Bring-your-own-key support for AI providers
+- Local AI through tools such as Ollama or LM Studio
+- Search, templates, imports, and portable exports
+- An MIT-licensed codebase that can be audited or forked
 
-### 3. Sonix
+The free path is most useful when you already have an API key or are comfortable running a local model for summaries. Local transcription itself does not require a paid Anarlog subscription.
 
-[Sonix](https://sonix.ai) only offers a 30-minute one-time trial with no ongoing free plan. After that, you must pay $10/hour for transcription.
+### When you would pay
 
-**Consider for**: Multi-language support across 53+ languages and team collaboration features with shared folders.
+[Anarlog Pro is $15 per month or $150 per year](/pricing) when you want hosted transcription and AI, encrypted CloudSync, sharing, and calendar-connected services without configuring your own providers.
 
-### 4. Trint
 
-[Trint](https://trint.com) provides a 7-day free trial (up to 3 files) with no ongoing free tier. Plans start at $80/month.
+## 2. MacWhisper: best for private audio and video files on Mac
 
-**Consider for**: Newsrooms and media professionals who need fast turnaround times and collaborative editing workflows.
+[MacWhisper](https://macwhisper.com/) is a native Mac app built around local speech-to-text models. Drop in a recording, record from the microphone, or use its basic dictation mode, and the transcription runs on your Mac by default.
 
-### 5. Happy Scribe
+Its free version includes smaller Whisper models, more than 100 languages, and TXT, SRT, and VTT export. Because the audio stays on the device when you use local models, it is a strong fit for interviews, lectures, and recordings you do not want to upload to a browser service. MacWhisper's [privacy documentation](https://docs.macwhisper.com/article/52-keeping-transcriptions-private) explains the exceptions: cloud transcription, translation, or AI providers receive data when you explicitly use those services.
 
-[Happy Scribe](https://www.happyscribe.com) offers only 10 minutes of transcription total (one-time, not monthly) and doesn't allow file exports on the free tier.
+### What the free version includes
 
-**Consider for**: Subtitle creation with support for 120+ languages and automated translation capabilities.
+- Unlimited local file transcription
+- Tiny, Base, and Small Whisper models
+- Microphone recording and basic dictation
+- TXT, SRT, and VTT export
+- Local processing on macOS
 
-You can check detailed reviews of these tools in our guide to [best transcription software for Mac](/blog/transcription-software-mac).
+### When you would pay
 
-## Best free transcription software: detailed reviews
+MacWhisper Pro is a one-time purchase through the official site. It adds larger and faster models, batch transcription, advanced exports, automatic speaker recognition, meeting recording, real-time captions, and more AI-provider integrations. The Gumroad and Mac App Store editions have different licenses and pricing, so buy through [MacWhisper's official site](https://macwhisper.com/) rather than a lookalike domain.
 
-### 1. Anarlog: best for local processing and unlimited transcription
 
-![Anarlog](/api/assets/blog/free-transcription-software/transcription-1.webp)
+## 3. Riverside: best for a one-off transcript without signup
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Meeting data is stored locally in SQLite instead of a vendor-hosted workspace. Markdown is available when you want to export it. You choose your AI: managed cloud, BYOK, or run local models.
+[Riverside's standalone transcriber](https://riverside.com/transcription) accepts audio or video in a browser and does not require an account. Riverside says the utility is free to use without a transcription quota, supports more than 100 languages, and exports TXT or SRT.
 
-Zero lock-in means you can switch AI providers anytime and your files work with any tool (Obsidian, Notion, VS Code).
+That makes it the lowest-friction option in this list for a single non-sensitive file. Upload, wait for the transcript, download it, and leave.
 
-#### What's free forever
+The trade-off is context. This is a cloud upload, not an on-device workflow. The free standalone tool also assigns all text in a multi-speaker file to one speaker. Riverside's paid recording platform adds speaker detection, editing, captions, and the rest of its creator workflow.
 
-- Unlimited transcription with no monthly caps or per-minute charges
-- Real-time transcription using Whisper models (Tiny, Base, V3 Large Turbo)
-- Conversational search across all transcription history
-- Custom vocabulary support for industry-specific terminology
-- Universal platform compatibility without bots
-- Works completely offline for maximum privacy
-- Export as Markdown, PDF, or Rich Text
-- Open-source transparency with full code access
-- Connect your own AI models (OpenAI, Gemini, Ollama via LM Studio)
+Riverside's [privacy policy](https://riverside.com/privacy-policy) treats recordings and transcripts as Content Data and describes how that data may be used to provide and improve the service. Read the current policy before uploading confidential interviews or meetings.
 
-#### When will you need to pay?
 
-![Anarlog pricing](/api/assets/blog/articles/free-transcription-software/screenshot-2026-03-04-at-9-01-49-pm.png)
+## 4. Transcript LOL: best for short files and media URLs
 
-Free forever for local transcription, BYOK, and all core features. The managed cloud service ($15/month or $150/year) adds the easiest setup without managing API keys.
+[Transcript LOL](https://transcript.lol/) is a cloud transcription tool designed around flexible input. It accepts files, cloud drives, and links from media platforms. Its free tier allows two transcripts per day, each up to 20 minutes, with TXT, DOCX, PDF, SRT, and VTT exports.
 
-For teams with procurement requirements, evaluate the exact desktop configuration and any enabled AI, CloudSync, or sharing services before adoption.
+That daily reset can be more useful than a one-time trial. It works well for short clips, voice notes, and individual podcast or video segments. It is less useful for full-length interviews because the 20-minute limit applies to every free upload.
 
-&nbsp;
+### What the free plan includes
 
-### 2. Transcript.LOL: best for multi-source imports
+- Two transcripts per day
+- Up to 20 minutes per transcript
+- One upload processed at a time
+- File, cloud-drive, and supported URL inputs
+- Speaker detection
+- TXT, DOCX, PDF, SRT, and VTT export
 
-![is transcript lol free](/api/assets/blog/free-transcription-software/transcription-3.webp)
+Summaries, custom prompts, chat, longer files, and priority processing require the paid plan. Transcript LOL says in its [privacy policy](https://transcript.lol/legal/privacy) that it does not use customer content to train AI models, but the files are still processed through a cloud service.
 
-Transcript.LOL is a cloud-based transcription platform powered by OpenAI's Whisper that converts audio and video files into text across 100+ languages.
 
-The platform handles imports directly from Google Drive, Dropbox, YouTube, and Zoom, so you can transcribe content without downloading files first. You can also transcribe audio from WhatsApp or Telegram messages directly through integrations.
+## 5. Otter: best for automatic meeting capture on a free plan
 
-The daily allocation model provides 2 transcripts per day (up to 20 minutes each) rather than a monthly bucket that disappears quickly. For podcasters processing a few episodes weekly or professionals with regular but moderate transcription needs, this daily reset provides consistent access.
+[Otter](https://otter.ai/) is no longer positioned as a simple transcriber. It describes itself as a conversational knowledge engine that turns meetings into a searchable workspace and pushes the output into other tools.
 
-#### What's free forever
+Its Basic plan includes 300 transcription minutes per month, with a 30-minute cap per conversation. Otter Notetaker can join Zoom, Google Meet, and Microsoft Teams as a participant. Otter also offers bot-free recording through desktop, mobile, and browser capture paths, so the bot is an option rather than the only workflow.
 
-- 2 transcripts daily (up to 20 minutes each)
-- 99.8% accuracy with OpenAI Whisper
-- Speaker detection and recognition
-- Import from Google Drive, Dropbox, YouTube, Zoom, URLs
-- Basic editing tools (find & replace, speaker assignment, highlighting)
-- Export as TXT, DOCX, PDF, SRT, VTT
-- Chrome extension, WhatsApp, and Telegram integrations
-- Low priority processing (slower turnaround)
+### What the free plan includes
 
-#### When will you need to pay?
+- 300 transcription minutes per month
+- Unlimited meetings, up to 30 minutes per conversation
+- Three audio or video file imports for the lifetime of the account
+- The 25 most recent conversations in history
+- Speaker identification, editable text, playback, and basic AI Chat
+- TXT and MP3 export
 
-![transcript lol pricing](/api/assets/blog/free-transcription-software/transcription-4.webp)
+The free plan is generous for short recurring calls but poor for a backlog of recordings because file imports are limited to three for the life of the account. PDF, DOCX, SRT, longer meetings, more imports, and deeper workflow features require a paid plan. Verify the current numbers on [Otter's pricing page](https://otter.ai/pricing).
 
-The $20/month Unlimited plan is necessary when you exceed 2 daily transcripts, need files longer than 20 minutes, want AI summaries and custom prompts, require chatbot features for querying transcripts, or need high-priority faster processing.
+Otter is a cloud workspace. Its [privacy policy](https://otter.ai/privacy-policy) describes using de-identified audio recordings and transcriptions to improve and train its proprietary AI technology. If that boundary does not fit your meeting, use a local workflow instead.
 
-The $40/month Team plan adds shared workspaces for collaboration, multiple user accounts under one subscription, and team access management.
 
-### 3. Riverside: best for no-signup transcription
+## 6. Notta: best for testing multilingual cloud transcription
 
-![riverside free transcription](/api/assets/blog/free-transcription-software/transcription-5.webp)
+[Notta](https://www.notta.ai/en/) combines real-time transcription, meeting bots, a desktop app, mobile capture, file uploads, translation, and post-meeting AI deliverables. Its clearest advantage is language breadth: Notta currently advertises transcription in 58 languages and supports several bilingual and translation workflows on paid plans.
 
-While Riverside is primarily known as a podcast and video recording platform, their [standalone transcription tool](https://riverside.com/transcription) works as a simple web utility that converts any audio or video file to text.
+The free tier looks larger in minutes than it feels in use. Notta's public pages show different monthly allowances by region, including 120 and 200 minutes, but each free conversation stops at three minutes. That is enough to test quality on your own accent and audio setup. It is not enough for a normal meeting or interview.
 
-The tool uses OpenAI's Whisper model and handles files up to 5GB across 100+ languages. Upload your file, wait a few minutes (a 50-minute file processes in roughly 5 minutes), and download your transcript as plain text or SRT format for video captions.
+### What the free plan includes
 
-#### What's free forever
+- A monthly transcription allowance, with regional variation
+- Three minutes per conversation
+- Up to 50 file uploads per month
+- A limited number of AI summaries
+- Real-time transcription, mobile apps, and speaker identification
 
-- Unlimited transcriptions with no signup required
-- 99% accuracy using OpenAI Whisper
-- Supports 100+ languages and accents
-- Files up to 5GB (approximately 50+ minutes)
-- Real-time processing (transcribes while you wait)
-- Download as TXT or SRT (caption format)
-- Timestamps included in transcript
-- Works with MP3, WAV, MP4, MOV formats
+Paid plans raise the recording duration, add transcript export and translation capabilities, and expand collaboration and integrations. Check [Notta's pricing page](https://www.notta.ai/en/pricing) because the regional free allowance and paid pricing can differ.
 
-#### When will you need to pay?
 
-![riverside pricing](/api/assets/blog/free-transcription-software/transcription-6.webp)
+## Tools we did not count as genuinely free automatic transcription
 
-Riverside's paid platform ($19/month Standard or $29/month Pro) adds speaker detection and labeling, in-tool transcript editing with audio playback sync, AI-powered Magic Clips for social media, automated show notes generation, text-based video editing, and professional recording features with 4K video and separate audio tracks.
+Some useful products do not fit this list:
 
-The free transcription tool handles basic text conversion. Serious content creators will outgrow its limitations and upgrade for editing workflow integration.
+- **oTranscribe** is free and open source, but it is a manual transcription workspace. It helps you type while controlling playback; it does not automatically convert speech to text.
+- **Rev, Sonix, Trint, and Happy Scribe** offer trials or small introductory allowances, but the automatic transcription workflow becomes paid after the trial or starter credit.
+- **OpenAI Whisper** is open source and free to run, but it is a model rather than a ready-made end-user workflow. If you are comfortable with a command line, it remains a strong building block. MacWhisper and other desktop apps package that kind of local model into a usable interface.
 
-### 4. Otter.ai: best for meeting bot integration
+A free trial can still be the right answer for one critical file. It simply should not be confused with software you can keep using every week without paying.
 
-![otter ai transcription review](/api/assets/blog/free-transcription-software/transcription-7.webp)
+## Which free transcription tool should you choose?
 
-Otter.ai is a meeting assistant similar to Anarlog. It transcribes conversations, generates summaries, and helps you search through meeting history. The key difference is that Anarlog processes everything locally on your device, while Otter sends all your audio to the cloud for processing.
+Use the input and privacy boundary to decide:
 
-The cloud approach enables Otter's signature feature: the meeting bot that automatically joins your Zoom, Microsoft Teams, and Google Meet calls based on your calendar, records everything, and shares notes with participants afterward.
+- **Live meetings, local record:** Anarlog
+- **Private files on Mac:** MacWhisper
+- **One quick browser upload:** Riverside
+- **Short online media or cloud files:** Transcript LOL
+- **Automatic scheduled meetings:** Otter
+- **Multilingual cloud evaluation:** Notta
 
-**Also read**: [Otter AI Review](/blog/otter-ai-review)
+For sensitive material, do not stop at a product's marketing page. Confirm consent requirements, the exact capture path, enabled AI providers, retention settings, and the current privacy agreement for every service that receives the audio.
 
-#### What's free forever
+## Frequently asked questions
 
-- 300 transcription minutes per month (resets monthly)
-- 30-minute max per conversation
-- Live transcription in English, Spanish, or French
-- Automatic meeting bot joins Zoom, Teams, Google Meet
-- Speaker identification and AI summaries
-- 20 AI Chat queries per month (3 per conversation)
-- iOS and Android apps
-- Search by keywords and basic playback
-- Export as MP3 or TXT only (no PDF, DOCX, or SRT on free)
-- 25 most recent conversations stored (older ones deleted)
+### Is there completely free transcription software?
 
-#### When will you need to pay?
+Yes. Anarlog provides unlimited local meeting transcription, MacWhisper provides unlimited local file transcription on Mac, and Riverside offers a free standalone browser transcriber. The catch differs: local apps need your computer to run the model, while a browser tool requires uploading the file to a cloud service.
 
-![otter ai pricing](/api/assets/blog/free-transcription-software/transcription-8.webp)
+### What is the best free transcribing software for Mac?
 
-The $16.99/month Pro plan becomes necessary when you exceed 300 minutes, need 90-minute conversations instead of 30, want 1,200 monthly minutes, require PDF/DOCX/SRT exports, need unlimited conversation history, or want advanced search and custom vocabulary features.
+Use MacWhisper for existing audio and video files. Use Anarlog for live meetings, system audio, notes, and a searchable local meeting history. Both offer ongoing local transcription without a monthly minute bucket, but they solve different jobs.
 
-The $30/month Business plan adds 6,000 minutes per user, 4-hour meeting support, unlimited file imports, concurrent meeting joining, usage analytics, and prioritized support.
+### Can I transcribe audio for free without uploading it?
 
-Enterprise is relevant for organizations requiring SSO, HIPAA compliance, domain capture, custom CRM integrations, video replay features, or dedicated customer success management.
+Yes. Use an on-device tool such as MacWhisper, or use Anarlog for live meetings and imported recordings. Keep the speech-to-text model and any summary model local if the audio must not leave your computer.
 
-### 5. Notta: best for multi-language transcription
+### Which free transcription software works for meetings?
 
-![Notta transcription review](/api/assets/blog/free-transcription-software/transcription-9.webp)
+Anarlog captures meetings from your desktop without a bot. Otter can automatically join scheduled meetings or record through its desktop and browser tools. Notta also supports meeting bots and desktop capture, but its free three-minute conversation limit makes it better for testing than routine meetings.
 
-[Notta](https://www.notta.ai/en) is a cloud-based transcription platform that handles 58 languages with claimed 98% accuracy.
+### Are free transcription tools accurate?
 
-Similar to Otter.ai, Notta automatically joins your Zoom, Google Meet, Microsoft Teams, and Webex meetings to transcribe conversations in real-time. The platform also accepts file uploads from YouTube, Google Drive, and Dropbox.
-
-#### What's free forever
-
-- 120 transcription minutes per month (resets monthly)
-- 3-minute maximum per recording (severely limiting)
-- 50 file uploads per month
-- 10 AI summaries per month
-- Live transcription for Zoom, Google Meet, Teams, Webex
-- Speaker identification
-- Chrome extension, web app, iOS and Android apps
-- Basic editing and playback features
-- Export as TXT only (no PDF, DOCX, or SRT on free)
-- Cross-device sync
-
-#### When will you need to pay?
-
-![notta pricing](/api/assets/blog/free-transcription-software/transcription-10.webp)
-
-The 3-minute recording limit makes the free plan nearly useless for actual meeting transcription. The $13.49/month Pro plan is necessary immediately, providing 1,800 minutes monthly, up to 5 hours per recording, 100 file uploads, 100 AI summaries, transcript translation, custom vocabulary, and exports in multiple formats (TXT, PDF, DOCX, SRT, XLSX).
-
-The $27.99/month Business plan adds unlimited transcription, video recording for web meetings, CRM integrations with Salesforce and HubSpot, Zapier automation, usage analytics, and collaborative workspace features.
-
-Enterprise becomes relevant for organizations requiring SAML SSO, audit logs, no AI training on your data, flexible payment options, priority support, and customized transcription quotas.
-
-### 6. MacWhisper: best for simple Mac transcription
-
-![mac whisper review](/api/assets/blog/free-transcription-software/transcription-11.webp)
-
-[MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) is a Mac app that wraps OpenAI's Whisper technology in a simple drag-and-drop interface.
-
-While tools like Anarlog use Whisper as part of a complete meeting assistant, MacWhisper focuses purely on transcription. You drop in an audio file, it gives you text. The interface is minimal: drag your file, select a model size based on how much accuracy versus speed you want, and get your transcript with synced audio playback.
-
-Performance depends heavily on your hardware. Apple Silicon Macs (M1/M2/M3) handle transcription smoothly, processing files at roughly 15x real-time speed. Older Intel Macs work but run significantly slower, especially with larger models that require more than 8GB of RAM.
-
-#### What's free forever
-
-- Unlimited transcriptions with no usage caps
-- Three Whisper models: Tiny (fastest), Base (balanced), Small (more accurate)
-- Local transcription on your Mac
-- Drag-and-drop interface for audio files
-- Supports 100+ languages with automatic detection
-- Audio playback synced to transcript
-- Search and highlight keywords in transcripts
-- Export as SRT, VTT, TXT, or copy to clipboard
-- Supports MP3, WAV, M4A, MP4, MOV, OGG, OPUS formats
-- Works completely offline once installed
-
-#### When will you need to pay?
-
-![Mac whisper pricing](/api/assets/blog/free-transcription-software/transcription-12.webp)
-
-MacWhisper Pro ($29-35 one-time payment, no subscription) unlocks better accuracy with Medium, Large, Large-V2, or Large-V3 models, batch transcription to process multiple files simultaneously, speaker identification for multi-person conversations, system audio recording to transcribe Zoom or Teams meetings directly, and advanced exports including Word, PDF, and HTML formats.
-
-## Our top recommendation for free transcription
-
-If data privacy matters and you need truly unlimited transcription without hidden costs, Anarlog is the clear choice.
-
-Unlike tools built around a cloud workspace, Anarlog stores meeting data locally in SQLite and lets you choose your AI stack. Markdown export is available when you need a portable copy.
-
-Ready to take control of your transcription workflow? **[Download Anarlog for macOS](/download)** and try on-device transcription with your own API keys.
+Accuracy depends more on the recording than the price label. Clear audio, separate microphones, limited crosstalk, and the right language model matter. Treat vendor percentage claims as marketing unless they publish a reproducible benchmark. Test the tool with your own speakers, accents, terminology, and worst normal audio before building a workflow around it.
 
 <CtaCard/>


### PR DESCRIPTION
## SEO target

- Primary keyword: `free transcribing software`
- Semrush US volume: 210/month
- KD: 41
- Current Anarlog position: 8
- Target URL: `https://anarlog.so/blog/free-transcription-software`
- Supporting near-wins: `transcribe software free` (90 volume, position 12, KD 45), `transcription programs free` (90, position 15, KD 50), `best transcription software free` (90, position 20, KD 26), and `what is the best free transcription software` (30, position 10, KD 25)
- Semrush database date: August 23, 2026

## What changed

- Rewrote the stale 2025 guide around six genuinely ongoing free options and the workflow each one fits.
- Rechecked current official product, pricing, privacy, capture, export, and content positioning for Otter, Notta, MacWhisper, Riverside, and Transcript LOL.
- Corrected Anarlog positioning to local SQLite, bot-free system-audio capture, BYOK/local AI, and the current $15/$150 Pro plan.
- Removed eleven broken legacy images returning 502 plus one reachable but obsolete Anarlog pricing screenshot.
- Added and visually reviewed `free-transcription-paths.png` through the figures manifest pipeline.
- Added decision guidance and FAQs for supporting query intent without padding the article.

## Validation

- `pnpm exec dprint check --config dprint.json apps/web/content/articles/free-transcription-software.mdx apps/web/content/articles/figures.json`
- `pnpm -F @anlg/web typecheck`
- `pnpm -F @anlg/web media:figures:check` (25 figures across 65 articles)
- New figure asset returns 200 through the production proxy.
- Every official source URL referenced in the article returns 200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to marketing blog content and figure metadata; no application runtime, auth, or data-handling code is modified.
> 
> **Overview**
> **Refreshes the `free-transcription-software` comparison article** for SEO and accuracy: updated title, meta description, and publication date, and reframed the piece around **workflow fit** (local meetings, Mac files, browser uploads, cloud meeting assistants) instead of a generic “top free tools” list.
> 
> The comparison table and six tool sections were **rewritten** with explicit free limits, processing model (local vs cloud), privacy/upgrade triggers, and rechecked vendor positioning—including **Anarlog** (local SQLite, bot-free capture, BYOK/local AI, Pro pricing). Legacy embedded screenshots were removed; a single new **four-path decision diagram** (`free-transcription-paths.png`) is registered in `figures.json` and linked in the article.
> 
> Adds **decision guidance**, a tightened “not genuinely free” exclusions list, and **FAQs** for supporting query intent without padding length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a7db9d6091a58f91dfddd5f721e33ea7af2312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->