### PR TITLE
Fix cardless trial conversion tracking

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr "Restoring cloud sync..."
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr "Resume"
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr "Your Pro trial ends in 1 day"
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr "Your Pro trial has ended"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -3608,6 +3608,7 @@ msgid "Restoring cloud sync..."
 msgstr ""
 
 #: src/session/components/outer-header/index.tsx
+#: src/settings/general/account.tsx
 msgid "Resume"
 msgstr ""
 
@@ -5172,6 +5173,7 @@ msgid "Your Pro trial ends in 1 day"
 msgstr ""
 
 #: src/billing/trial-ended-dialog.tsx
+#: src/settings/general/account.tsx
 msgid "Your Pro trial has ended"
 msgstr ""
 

--- a/apps/desktop/src/settings/general/account.test.tsx
+++ b/apps/desktop/src/settings/general/account.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
     hasPaymentMethod: false,
     isPaid: false,
     isTrialing: false,
+    isPaused: false,
     plan: "free",
     trialDaysRemaining: null as number | null,
   },
@@ -89,6 +90,7 @@ describe("SettingsAccount", () => {
       hasPaymentMethod: false,
       isPaid: false,
       isTrialing: false,
+      isPaused: false,
       plan: "free",
       trialDaysRemaining: null,
     };
@@ -147,6 +149,7 @@ describe("SettingsAccount", () => {
       hasPaymentMethod: false,
       isPaid: true,
       isTrialing: true,
+      isPaused: false,
       plan: "trial",
       trialDaysRemaining: 3,
     };
@@ -169,12 +172,34 @@ describe("SettingsAccount", () => {
     });
   });
 
+  it("offers to resume a paused cardless trial", async () => {
+    mocks.billing = {
+      canStartTrial: { data: false, isPending: false },
+      hasPaymentMethod: false,
+      isPaid: false,
+      isTrialing: false,
+      isPaused: true,
+      plan: "free",
+      trialDaysRemaining: 0,
+    };
+
+    renderAccount();
+
+    expect(screen.getByText("Your Pro trial has ended")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+
+    await waitFor(() =>
+      expect(mocks.buildWebAppUrl).toHaveBeenCalledWith("/app/portal"),
+    );
+  });
+
   it("starts a cardless trial from the behavioral action variant", async () => {
     mocks.billing = {
       canStartTrial: { data: true, isPending: false },
       hasPaymentMethod: false,
       isPaid: false,
       isTrialing: false,
+      isPaused: false,
       plan: "free",
       trialDaysRemaining: null,
     };
@@ -241,6 +266,7 @@ describe("SettingsAccount", () => {
       hasPaymentMethod: true,
       isPaid: true,
       isTrialing: true,
+      isPaused: false,
       plan: "trial",
       trialDaysRemaining: 3,
     };

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -43,7 +43,8 @@ function tierActionLabel(action: NonNullable<TierAction>): string {
 export function SettingsAccount() {
   const { t } = useLingui();
   const auth = useAuth();
-  const { plan, isPaid, isTrialing, trialDaysRemaining } = useBillingAccess();
+  const { plan, isPaid, isTrialing, isPaused, trialDaysRemaining } =
+    useBillingAccess();
 
   const isAuthenticated = !!auth?.session;
   const [isPending, setIsPending] = useState(false);
@@ -198,6 +199,7 @@ export function SettingsAccount() {
       <PlanBillingSection
         currentTier={currentTier}
         isTrialing={isTrialing}
+        isPaused={isPaused}
         trialDaysRemaining={trialDaysRemaining}
         isPaid={isPaid}
       />
@@ -208,11 +210,13 @@ export function SettingsAccount() {
 function PlanBillingSection({
   currentTier,
   isTrialing,
+  isPaused,
   trialDaysRemaining,
   isPaid,
 }: {
   currentTier: PlanTier;
   isTrialing: boolean;
+  isPaused: boolean;
   trialDaysRemaining: number | null;
   isPaid: boolean;
 }) {
@@ -222,7 +226,7 @@ function PlanBillingSection({
 
   const [actionPending, setActionPending] = useState(false);
 
-  // A cardless trial cancels at the end unless a card is added, so replace the
+  // A cardless trial pauses at the end unless a card is added, so replace the
   // static current-plan status with an explicit payment-method action.
   const needsPaymentMethod = isTrialing && !hasPaymentMethod;
 
@@ -253,6 +257,8 @@ function PlanBillingSection({
       <Trans>Pro trial</Trans>
       {trialDaysText != null && ` - ${trialDaysText}`}
     </>
+  ) : isPaused ? (
+    <Trans>Your Pro trial has ended</Trans>
   ) : (
     <Trans>
       You're on the <span className="font-semibold">{planLabel}</span> plan
@@ -341,6 +347,11 @@ function PlanBillingSection({
         return;
       }
 
+      if (isPaused) {
+        await openBillingUrl(() => buildWebAppUrl("/app/portal"));
+        return;
+      }
+
       void analyticsCommands.event({
         event: "upgrade_clicked",
         plan: action.plan,
@@ -358,7 +369,7 @@ function PlanBillingSection({
     };
 
     const isBusy = actionPending;
-    const label = tierActionLabel(action);
+    const label = isPaused ? t`Resume` : tierActionLabel(action);
 
     if (compact) {
       return (

--- a/apps/mobile/src/auth/billing.test.mjs
+++ b/apps/mobile/src/auth/billing.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deriveBillingInfo } from "./billing.ts";
+
+test("paused subscriptions fail closed when a Pro entitlement lingers", () => {
+  const billing = deriveBillingInfo({
+    entitlements: ["hyprnote_pro"],
+    subscription_status: "paused",
+  });
+
+  assert.equal(billing.isPaused, true);
+  assert.equal(billing.isPro, false);
+  assert.equal(billing.isPaid, false);
+  assert.equal(billing.plan, "free");
+});
+
+test("paused Pro does not suppress an independent Lite entitlement", () => {
+  const billing = deriveBillingInfo({
+    entitlements: ["hyprnote_pro", "hyprnote_lite"],
+    subscription_status: "paused",
+  });
+
+  assert.equal(billing.isPaused, true);
+  assert.equal(billing.isPro, false);
+  assert.equal(billing.isLite, true);
+  assert.equal(billing.isPaid, true);
+});

--- a/apps/mobile/src/auth/billing.ts
+++ b/apps/mobile/src/auth/billing.ts
@@ -31,6 +31,7 @@ export type BillingInfo = {
   isLite: boolean;
   isPaid: boolean;
   isTrialing: boolean;
+  isPaused: boolean;
   trialEnd: Date | null;
   trialDaysRemaining: number | null;
   cancelAtPeriodEnd: boolean;
@@ -96,10 +97,15 @@ export function deriveBillingInfo(
 
   const hasProEntitlement = entitlements.includes("hyprnote_pro");
   const hasLiteEntitlement = entitlements.includes("hyprnote_lite");
-  // While status is "trialing", the entitlement alone does not count;
-  // Pro requires the trial clock to still be running (fails closed on expiry).
+  const isPaused = subscriptionStatus === "paused";
+  // Trial clocks and paused subscriptions override stale entitlements so every
+  // client fails closed consistently.
   const hasEffectiveProEntitlement =
-    subscriptionStatus === "trialing" ? isTrialing : hasProEntitlement;
+    subscriptionStatus === "trialing"
+      ? isTrialing
+      : isPaused
+        ? false
+        : hasProEntitlement;
   const hasPaidEntitlement = hasEffectiveProEntitlement || hasLiteEntitlement;
 
   const plan: Plan = isTrialing ? "trial" : hasPaidEntitlement ? "pro" : "free";
@@ -114,6 +120,7 @@ export function deriveBillingInfo(
     isLite: hasLiteEntitlement,
     isPaid: hasPaidEntitlement,
     isTrialing,
+    isPaused,
     trialEnd,
     trialDaysRemaining,
     cancelAtPeriodEnd: payload?.cancel_at_period_end === true,

--- a/apps/stripe/src/scripts/stripe-migrate-cardless-trials-to-pause.ts
+++ b/apps/stripe/src/scripts/stripe-migrate-cardless-trials-to-pause.ts
@@ -1,0 +1,126 @@
+// Preserve existing cardless trial subscriptions after their trial ends.
+//
+// Native Anarlog trials historically used missing_payment_method=cancel. A
+// customer who paid after the trial therefore received a second subscription,
+// so Stripe could not attribute the payment to the original trial. Pausing the
+// original subscription keeps it resumable without requiring a card at signup.
+//
+// https://docs.stripe.com/billing/subscriptions/trials/free-trials
+import Stripe from "stripe";
+import { parseArgs } from "util";
+
+const STRIPE_API_VERSION = "2026-02-25.clover";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    apply: { type: "boolean", default: false },
+    limit: { type: "string" },
+    price: { type: "string", multiple: true },
+    subscription: { type: "string" },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+const apply = values.apply ?? false;
+const limit = values.limit ? parsePositiveInteger(values.limit, "limit") : null;
+const priceIds = new Set(values.price ?? []);
+const subscriptionId = values.subscription ?? null;
+const { STRIPE_SECRET_KEY } = Bun.env;
+
+if (!STRIPE_SECRET_KEY) {
+  throw new Error("Missing required STRIPE_SECRET_KEY environment variable");
+}
+if (!subscriptionId && priceIds.size === 0) {
+  throw new Error(
+    "Pass at least one --price price_... or restrict the run with --subscription sub_...",
+  );
+}
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: STRIPE_API_VERSION,
+});
+
+const matchesPrice = (subscription: Stripe.Subscription) =>
+  priceIds.size === 0 ||
+  subscription.items.data.some((item) => priceIds.has(item.price.id));
+
+const needsPauseEndBehavior = (subscription: Stripe.Subscription) =>
+  subscription.status === "trialing" &&
+  subscription.trial_settings?.end_behavior.missing_payment_method ===
+    "cancel" &&
+  matchesPrice(subscription);
+
+const collectCandidates = async () => {
+  if (subscriptionId) {
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    return needsPauseEndBehavior(subscription) ? [subscription] : [];
+  }
+
+  const candidates: Stripe.Subscription[] = [];
+  for await (const subscription of stripe.subscriptions.list({
+    status: "trialing",
+    limit: 100,
+  })) {
+    if (needsPauseEndBehavior(subscription)) {
+      candidates.push(subscription);
+      if (limit !== null && candidates.length >= limit) {
+        break;
+      }
+    }
+  }
+  return candidates;
+};
+
+const candidates = await collectCandidates();
+console.log(
+  `${apply ? "Applying" : "Dry run"}: ${candidates.length} cardless trial subscription(s) will pause instead of cancel`,
+);
+
+let updated = 0;
+let errors = 0;
+
+for (let offset = 0; offset < candidates.length; offset += 10) {
+  await Promise.all(
+    candidates.slice(offset, offset + 10).map(async (subscription) => {
+      console.log(`  ${subscription.id}`);
+      if (!apply) {
+        return;
+      }
+
+      try {
+        await stripe.subscriptions.update(subscription.id, {
+          trial_settings: {
+            end_behavior: { missing_payment_method: "pause" },
+          },
+        });
+        updated++;
+      } catch (error) {
+        errors++;
+        console.error(`  ${subscription.id}: ${String(error)}`);
+      }
+    }),
+  );
+}
+
+console.log(
+  JSON.stringify({
+    mode: apply ? "apply" : "dry-run",
+    matched: candidates.length,
+    updated,
+    errors,
+  }),
+);
+
+if (errors > 0) {
+  process.exitCode = 1;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -36,6 +36,10 @@ import {
   getStripeCustomerIdentityMetadata,
   getStripeCustomerOwnership,
 } from "@/lib/stripe-customer";
+import {
+  getPlanSwitchRoute,
+  selectCurrentSubscription,
+} from "@/lib/subscription-selection";
 import { WEB_TRIAL_CHECKOUT_FIELDS } from "@/lib/trial-policy";
 import {
   startWorkspaceCheckout,
@@ -145,7 +149,7 @@ const getBillingReturnUrl = (scheme?: z.infer<typeof desktopSchemeSchema>) => {
 
 export const portalIntentSchema = z.enum(["manage", "payment_method_update"]);
 
-// Cardless trials cancel unless a card is added, so add-card CTAs must land on
+// Cardless trials pause unless a card is added, so add-card CTAs must land on
 // the card form. The portal home page leads with "Cancel subscription".
 const paymentMethodUpdateFlow = (
   returnUrl: string,
@@ -177,11 +181,7 @@ async function getCurrentSubscription(
     ...(options?.expandDiscounts ? { expand: ["data.discounts"] } : {}),
   });
 
-  return (
-    subscriptions.data.find((sub) => sub.status === "active") ||
-    subscriptions.data.find((sub) => sub.status === "trialing") ||
-    null
-  );
+  return selectCurrentSubscription(subscriptions.data);
 }
 
 async function ensureStripeCustomerId(
@@ -493,15 +493,19 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
       );
 
       if (stripeCustomerId) {
-        const activeSubscription = await getCurrentSubscription(
+        const currentSubscription = await getCurrentSubscription(
           stripe,
           stripeCustomerId,
         );
 
-        if (activeSubscription) {
+        if (currentSubscription) {
           if (reservationId) {
             await releaseTrialReservation(user.id, reservationId);
           }
+
+          // Resuming reuses the subscription's existing price. Checkout entry
+          // points often default to monthly, which must not silently rewrite a
+          // paused yearly trial.
 
           if (ycPromotion) {
             const result = await applyYcPromotionToCustomer({
@@ -516,16 +520,27 @@ export const createCheckoutSession = createServerFn({ method: "POST" })
               result.status === "applied" ||
               result.status === "already_applied"
             ) {
-              return { url: getAccountYcPerkUrl(data.scheme, "applied") };
+              const perkUrl = getAccountYcPerkUrl(data.scheme, "applied");
+              if (currentSubscription.status === "paused") {
+                const portalSession =
+                  await stripe.billingPortal.sessions.create({
+                    customer: stripeCustomerId,
+                    return_url: perkUrl,
+                  });
+                return { url: portalSession.url };
+              }
+              return { url: perkUrl };
             }
           } else {
             const returnUrl = data.scheme
               ? `${getBillingReturnUrl(data.scheme)}&source=${data.source}`
               : toAbsoluteInternalReturnUrl(getRequestAppOrigin(), returnTo);
+            // Stripe's portal can reactivate a trial that ended in `paused`.
+            // Trialing subscriptions only need the focused add-card form.
             const portalSession = await stripe.billingPortal.sessions.create({
               customer: stripeCustomerId,
               return_url: returnUrl,
-              ...(activeSubscription.status === "trialing"
+              ...(currentSubscription.status === "trialing"
                 ? { flow_data: paymentMethodUpdateFlow(returnUrl) }
                 : {}),
             });
@@ -780,7 +795,11 @@ export const createPlanSwitchSession = createServerFn({ method: "POST" })
       });
     }
 
-    if (!activeSubscription.items.data[0]) {
+    const targetPriceId = getProPriceId(data.targetPeriod);
+    const returnUrl = getBillingReturnUrl(data.scheme);
+    const route = getPlanSwitchRoute(activeSubscription, targetPriceId);
+
+    if (route === "checkout") {
       return createCheckoutUrl({
         supabase,
         user,
@@ -789,20 +808,20 @@ export const createPlanSwitchSession = createServerFn({ method: "POST" })
       });
     }
 
-    const subscriptionItem = activeSubscription.items.data[0];
-    const targetPriceId = getProPriceId(data.targetPeriod);
-    const returnUrl = getBillingReturnUrl(data.scheme);
-
-    // Stripe rejects a subscription_update_confirm flow that changes nothing.
-    // Legacy desktop builds link here with the default monthly period, so a
-    // monthly subscriber lands on a no-op switch.
-    if (subscriptionItem.price.id === targetPriceId) {
+    // Stripe rejects a no-op subscription_update_confirm flow, and paused
+    // subscriptions must use the portal's Start subscription flow to resume.
+    if (route === "portal") {
       const portalSession = await stripe.billingPortal.sessions.create({
         customer: stripeCustomerId,
         return_url: returnUrl,
       });
 
       return { url: portalSession.url };
+    }
+
+    const subscriptionItem = activeSubscription.items.data[0];
+    if (!subscriptionItem) {
+      throw new Error("Subscription item is unavailable");
     }
 
     const portalSession = await stripe.billingPortal.sessions.create({

--- a/apps/web/src/lib/account-plan.test.ts
+++ b/apps/web/src/lib/account-plan.test.ts
@@ -29,6 +29,24 @@ test("prefers cancel_at, then item period end, then subscription period end", ()
   assert.equal(getSubscriptionAccessEnd({}), null);
 });
 
+test("paused cardless trial copy explains that Pro can be resumed", () => {
+  assert.deepEqual(
+    getAccountPlanCopy({
+      isTrialing: false,
+      isPaused: true,
+      isPaid: false,
+      trialDaysRemaining: 0,
+      trialEnd: new Date("2026-08-24T00:00:00.000Z"),
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
+    }),
+    {
+      planLabel: "Free",
+      planDetail: "Your Pro trial ended. Resume it to reactivate Pro.",
+    },
+  );
+});
+
 test("paid copy acknowledges a scheduled cancellation", () => {
   const currentPeriodEnd = new Date("2026-09-17T00:00:00.000Z");
 

--- a/apps/web/src/lib/account-plan.ts
+++ b/apps/web/src/lib/account-plan.ts
@@ -30,6 +30,7 @@ export function formatAccountPlanDate(date: Date) {
 
 export function getAccountPlanCopy({
   isTrialing,
+  isPaused = false,
   isPaid,
   isLite,
   isPro,
@@ -40,6 +41,7 @@ export function getAccountPlanCopy({
   hasYcPerk = false,
 }: {
   isTrialing: boolean;
+  isPaused?: boolean;
   isPaid: boolean;
   isLite?: boolean;
   isPro?: boolean;
@@ -68,6 +70,13 @@ export function getAccountPlanCopy({
             day: "numeric",
           })}.`
         : "Your trial is running.",
+    };
+  }
+
+  if (isPaused) {
+    return {
+      planLabel,
+      planDetail: "Your Pro trial ended. Resume it to reactivate Pro.",
     };
   }
 

--- a/apps/web/src/lib/subscription-selection.test.ts
+++ b/apps/web/src/lib/subscription-selection.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type Stripe from "stripe";
+
+import {
+  getPlanSwitchRoute,
+  selectCurrentSubscription,
+} from "./subscription-selection.ts";
+
+const subscription = (id: string, status: Stripe.Subscription.Status) => ({
+  id,
+  status,
+});
+
+test("selects an active subscription before trialing or paused subscriptions", () => {
+  assert.equal(
+    selectCurrentSubscription([
+      subscription("sub_paused", "paused"),
+      subscription("sub_trial", "trialing"),
+      subscription("sub_active", "active"),
+    ])?.id,
+    "sub_active",
+  );
+});
+
+test("keeps a paused cardless trial reusable", () => {
+  assert.equal(
+    selectCurrentSubscription([
+      subscription("sub_canceled", "canceled"),
+      subscription("sub_paused", "paused"),
+    ])?.id,
+    "sub_paused",
+  );
+});
+
+test("preserves the selected paused subscription and its billing period", () => {
+  const paused = {
+    id: "sub_paused",
+    status: "paused",
+    items: {
+      data: [{ id: "si_pro", price: { id: "price_yearly" } }],
+    },
+  } as Stripe.Subscription;
+
+  const selected = selectCurrentSubscription([paused]);
+
+  assert.equal(selected, paused);
+  assert.equal(selected?.items.data[0]?.price.id, "price_yearly");
+});
+
+test("routes paused plan switches to the resume portal", () => {
+  const paused = {
+    id: "sub_paused",
+    status: "paused",
+    items: {
+      data: [{ id: "si_pro", price: { id: "price_yearly" } }],
+    },
+  } as Stripe.Subscription;
+
+  assert.equal(getPlanSwitchRoute(paused, "price_monthly"), "portal");
+});
+
+test("routes active plan switches by their available item and price", () => {
+  const active = {
+    id: "sub_active",
+    status: "active",
+    items: {
+      data: [{ id: "si_pro", price: { id: "price_monthly" } }],
+    },
+  } as Stripe.Subscription;
+
+  assert.equal(getPlanSwitchRoute(active, "price_monthly"), "portal");
+  assert.equal(getPlanSwitchRoute(active, "price_yearly"), "update");
+  const withoutItem = {
+    ...active,
+    items: { ...active.items, data: [] },
+  } as Stripe.Subscription;
+  assert.equal(getPlanSwitchRoute(withoutItem, "price_yearly"), "checkout");
+});
+
+test("ignores subscriptions that cannot be reused", () => {
+  assert.equal(
+    selectCurrentSubscription([
+      subscription("sub_canceled", "canceled"),
+      subscription("sub_expired", "incomplete_expired"),
+    ]),
+    null,
+  );
+});

--- a/apps/web/src/lib/subscription-selection.ts
+++ b/apps/web/src/lib/subscription-selection.ts
@@ -1,0 +1,38 @@
+import type Stripe from "stripe";
+
+const CURRENT_SUBSCRIPTION_STATUS_PRIORITY = [
+  "active",
+  "trialing",
+  "paused",
+] satisfies Stripe.Subscription.Status[];
+
+export function selectCurrentSubscription<T extends { status: string }>(
+  subscriptions: readonly T[],
+): T | null {
+  for (const status of CURRENT_SUBSCRIPTION_STATUS_PRIORITY) {
+    const subscription = subscriptions.find(
+      (candidate) => candidate.status === status,
+    );
+    if (subscription) {
+      return subscription;
+    }
+  }
+
+  return null;
+}
+
+export function getPlanSwitchRoute(
+  subscription: Pick<Stripe.Subscription, "status" | "items">,
+  targetPriceId: string,
+): "portal" | "checkout" | "update" {
+  if (subscription.status === "paused") {
+    return "portal";
+  }
+
+  const item = subscription.items.data[0];
+  if (!item) {
+    return "checkout";
+  }
+
+  return item.price.id === targetPriceId ? "portal" : "update";
+}

--- a/apps/web/src/lib/yc-perk-apply.test.ts
+++ b/apps/web/src/lib/yc-perk-apply.test.ts
@@ -71,7 +71,7 @@ test("treats a fully redeemed promotion as unavailable", () => {
   );
 });
 
-test("prefers an active subscription over a trial", () => {
+test("prefers active and trialing subscriptions but preserves paused trials", () => {
   assert.equal(
     pickCurrentSubscription([
       { status: "canceled" },
@@ -83,6 +83,11 @@ test("prefers an active subscription over a trial", () => {
   assert.equal(
     pickCurrentSubscription([{ status: "trialing" }])?.status,
     "trialing",
+  );
+  assert.equal(
+    pickCurrentSubscription([{ status: "canceled" }, { status: "paused" }])
+      ?.status,
+    "paused",
   );
   assert.equal(pickCurrentSubscription([{ status: "canceled" }]), null);
 });
@@ -123,6 +128,43 @@ test("applies the promotion to an existing subscription and clears a scheduled c
         discounts: [{ promotion_code: "promo_yc" }],
         cancel_at_period_end: false,
       },
+    },
+  ]);
+});
+
+test("applies the promotion to a paused cardless trial", async () => {
+  const updates: unknown[] = [];
+  const stripe = {
+    subscriptions: {
+      list: async () => ({
+        data: [
+          {
+            id: "sub_paused",
+            status: "paused",
+            cancel_at_period_end: false,
+            discounts: [],
+          },
+        ],
+      }),
+      update: async (id: string, params: unknown) => {
+        updates.push({ id, params });
+        return { id };
+      },
+    },
+  } as unknown as Stripe;
+
+  assert.deepEqual(
+    await applyYcPromotionToCustomer({
+      stripe,
+      customerId: "cus_trial",
+      promotion,
+    }),
+    { status: "applied", subscriptionId: "sub_paused" },
+  );
+  assert.deepEqual(updates, [
+    {
+      id: "sub_paused",
+      params: { discounts: [{ promotion_code: "promo_yc" }] },
     },
   ]);
 });

--- a/apps/web/src/lib/yc-perk-apply.ts
+++ b/apps/web/src/lib/yc-perk-apply.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 
+import { selectCurrentSubscription } from "./subscription-selection.ts";
 import { YC_FOUNDER_COUPON_ID } from "./yc-perk-promotion.ts";
 
 function couponId(
@@ -48,11 +49,7 @@ export function isYcPromotionAvailable(promotion: {
 export function pickCurrentSubscription<T extends { status: string }>(
   subscriptions: T[],
 ): T | null {
-  return (
-    subscriptions.find((subscription) => subscription.status === "active") ||
-    subscriptions.find((subscription) => subscription.status === "trialing") ||
-    null
-  );
+  return selectCurrentSubscription(subscriptions);
 }
 
 export async function findPromotionCodeByCustomerCode(

--- a/apps/web/src/routes/_view/app/-account-plan.tsx
+++ b/apps/web/src/routes/_view/app/-account-plan.tsx
@@ -37,7 +37,9 @@ export function PlanSection({
     queryKey: accountSubscriptionQueryKey,
     enabled:
       typeof window !== "undefined" &&
-      (billing?.isPaid === true || billing?.isTrialing === true),
+      (billing?.isPaid === true ||
+        billing?.isTrialing === true ||
+        billing?.isPaused === true),
     queryFn: () => getAccountSubscription(),
   });
 
@@ -54,6 +56,7 @@ export function PlanSection({
 
   const { planLabel, planDetail } = getAccountPlanCopy({
     isTrialing: billing?.isTrialing === true,
+    isPaused: billing?.isPaused === true,
     isPaid: billing?.isPaid === true,
     isLite: billing?.isLite,
     isPro: billing?.isPro,
@@ -104,7 +107,7 @@ export function PlanSection({
                 }}
                 className={accountPillPrimaryClassName}
               >
-                Upgrade to Pro
+                {billing?.isPaused ? "Resume Pro" : "Upgrade to Pro"}
               </Link>
             )}
           </>

--- a/crates/api-subscription/src/stripe.rs
+++ b/crates/api-subscription/src/stripe.rs
@@ -310,7 +310,7 @@ fn build_trial_subscription(
         .trial_period_days(trial_days)
         .trial_settings(CreateSubscriptionTrialSettings::new(
             CreateSubscriptionTrialSettingsEndBehavior::new(
-                CreateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod::Cancel,
+                CreateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod::Pause,
             ),
         ))
 }
@@ -419,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn native_trials_are_cardless_and_cancel_if_no_card_is_added() {
+    fn native_trials_are_cardless_and_pause_if_no_card_is_added() {
         let request = serde_json::to_value(build_trial_subscription(
             "cus_test",
             "price_test",
@@ -432,7 +432,7 @@ mod tests {
         assert_eq!(request["trial_period_days"], json!(pro_trial_days()));
         assert_eq!(
             request["trial_settings"]["end_behavior"]["missing_payment_method"],
-            json!("cancel")
+            json!("pause")
         );
         assert!(request.get("default_payment_method").is_none());
     }

--- a/crates/supabase-auth/src/claims/mod.rs
+++ b/crates/supabase-auth/src/claims/mod.rs
@@ -45,10 +45,12 @@ impl Claims {
     }
 
     pub fn has_entitlement(&self, entitlement: &str) -> bool {
-        if entitlement == "hyprnote_pro"
-            && matches!(self.subscription_status, Some(SubscriptionStatus::Trialing))
-        {
-            return self.has_active_trial();
+        if entitlement == "hyprnote_pro" {
+            match self.subscription_status {
+                Some(SubscriptionStatus::Trialing) => return self.has_active_trial(),
+                Some(SubscriptionStatus::Paused) => return false,
+                _ => {}
+            }
         }
 
         self.entitlements.iter().any(|value| value == entitlement)
@@ -222,6 +224,23 @@ mod tests {
 
         assert!(!claims.has_active_trial());
         assert!(!claims.is_pro());
+    }
+
+    #[test]
+    fn test_paused_subscription_fails_closed_for_pro() {
+        let claims = Claims {
+            sub: "paused-user".to_string(),
+            email: None,
+            entitlements: vec!["hyprnote_pro".to_string(), "hyprnote_lite".to_string()],
+            subscription_status: Some(SubscriptionStatus::Paused),
+            trial_end: None,
+            has_payment_method: Some(false),
+        };
+
+        assert!(!claims.has_entitlement("hyprnote_pro"));
+        assert!(!claims.is_pro());
+        assert!(claims.is_lite());
+        assert!(claims.is_paid());
     }
 
     #[test]

--- a/packages/supabase/src/billing.test.ts
+++ b/packages/supabase/src/billing.test.ts
@@ -30,6 +30,20 @@ test("an expired trial no longer grants Pro access", () => {
   expect(billing.plan).toBe("free");
 });
 
+test("a paused cardless trial loses access but remains resumable", () => {
+  const billing = deriveBillingInfo({
+    entitlements: ["hyprnote_pro"],
+    subscription_status: "paused",
+    trial_end: secondsFromNow(-60),
+  });
+
+  expect(billing.isPaused).toBe(true);
+  expect(billing.isTrialing).toBe(false);
+  expect(billing.isPro).toBe(false);
+  expect(billing.isPaid).toBe(false);
+  expect(billing.plan).toBe("free");
+});
+
 test("a trial without an end date fails closed", () => {
   const billing = deriveBillingInfo({
     entitlements: ["hyprnote_pro"],

--- a/packages/supabase/src/billing.ts
+++ b/packages/supabase/src/billing.ts
@@ -9,6 +9,7 @@ export type BillingInfo = {
   isLite: boolean;
   isPaid: boolean;
   isTrialing: boolean;
+  isPaused: boolean;
   hasPaymentMethod: boolean;
   trialEnd: Date | null;
   trialDaysRemaining: number | null;
@@ -39,10 +40,15 @@ export function deriveBillingInfo(
     trialDaysRemaining !== null &&
     trialDaysRemaining > 0;
 
+  const isPaused = subscriptionStatus === "paused";
   const hasProEntitlement = entitlements.includes("hyprnote_pro");
   const hasLiteEntitlement = entitlements.includes("hyprnote_lite");
   const hasEffectiveProEntitlement =
-    subscriptionStatus === "trialing" ? isTrialing : hasProEntitlement;
+    subscriptionStatus === "trialing"
+      ? isTrialing
+      : isPaused
+        ? false
+        : hasProEntitlement;
   const hasPaidEntitlement = hasEffectiveProEntitlement || hasLiteEntitlement;
 
   const isPro = hasEffectiveProEntitlement;
@@ -61,6 +67,7 @@ export function deriveBillingInfo(
     isLite,
     isPaid,
     isTrialing,
+    isPaused,
     hasPaymentMethod: payload?.has_payment_method === true,
     trialEnd,
     trialDaysRemaining,

--- a/supabase/migrations/20260825113500_auth_hook_paused_subscription_claim.sql
+++ b/supabase/migrations/20260825113500_auth_hook_paused_subscription_claim.sql
@@ -1,0 +1,175 @@
+GRANT SELECT (subscription, current_period_end)
+ON TABLE stripe.subscription_items
+TO supabase_auth_admin;
+
+-- search_path is pinned here rather than left to the ALTER in
+-- 20260714134923: CREATE OR REPLACE resets attributes it does not restate.
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+DECLARE
+  claims jsonb;
+  entitlements jsonb := '[]'::jsonb;
+  v_user_id uuid := (event->>'user_id')::uuid;
+  v_customer_id text;
+  v_subscription_status text;
+  v_trial_end bigint;
+  v_has_payment_method boolean;
+  v_cancel_at_period_end boolean;
+  v_current_period_end bigint;
+BEGIN
+  SELECT p.stripe_customer_id INTO v_customer_id
+  FROM public.profiles p
+  WHERE p.id = v_user_id;
+
+  SELECT
+    COALESCE(
+      jsonb_agg(DISTINCT granted.lookup_key ORDER BY granted.lookup_key)
+        FILTER (WHERE granted.lookup_key IS NOT NULL),
+      '[]'::jsonb
+    )
+  INTO entitlements
+  FROM (
+    SELECT ae.lookup_key
+    FROM public.profiles p
+    JOIN stripe.active_entitlements ae
+      ON ae.customer = p.stripe_customer_id
+    WHERE p.id = v_user_id
+
+    UNION
+
+    SELECT ae.lookup_key
+    FROM public.workspace_memberships m
+    JOIN public.workspaces w
+      ON w.id = m.workspace_id
+    JOIN stripe.active_entitlements ae
+      ON ae.customer = w.stripe_customer_id
+    WHERE m.user_id = v_user_id
+      AND m.deleted_at IS NULL
+      AND w.deleted_at IS NULL
+      AND w.stripe_customer_id IS NOT NULL
+  ) AS granted;
+
+  IF v_customer_id IS NOT NULL THEN
+    SELECT
+      s.status::text,
+      (s.trial_end #>> '{}')::bigint,
+      s.default_payment_method IS NOT NULL
+        OR c.invoice_settings->>'default_payment_method' IS NOT NULL
+        OR c.default_source IS NOT NULL,
+      COALESCE(s.cancel_at_period_end, false),
+      -- cancel_at is the scheduled end; newer Stripe APIs keep the period on items.
+      COALESCE(
+        s.cancel_at,
+        s.current_period_end,
+        (
+          SELECT MAX(si.current_period_end)
+          FROM stripe.subscription_items si
+          WHERE si.subscription = s.id
+        )
+      )
+    INTO
+      v_subscription_status,
+      v_trial_end,
+      v_has_payment_method,
+      v_cancel_at_period_end,
+      v_current_period_end
+    FROM stripe.subscriptions s
+    JOIN stripe.customers c ON c.id = s.customer
+    WHERE s.customer = v_customer_id
+      AND s.status IN ('trialing', 'active')
+    ORDER BY
+      CASE s.status WHEN 'active' THEN 1 WHEN 'trialing' THEN 2 END,
+      s.created DESC
+    LIMIT 1;
+  END IF;
+
+  -- A member with no subscription of their own still reads as subscribed while
+  -- a workspace covers them; personal billing state wins when both exist.
+  IF v_subscription_status IS NULL THEN
+    SELECT s.status::text
+    INTO v_subscription_status
+    FROM public.workspace_memberships m
+    JOIN public.workspaces w
+      ON w.id = m.workspace_id
+    JOIN stripe.subscriptions s
+      ON s.customer = w.stripe_customer_id
+    WHERE m.user_id = v_user_id
+      AND m.deleted_at IS NULL
+      AND w.deleted_at IS NULL
+      AND w.stripe_customer_id IS NOT NULL
+      AND s.status IN ('trialing', 'active')
+    ORDER BY
+      CASE s.status WHEN 'active' THEN 1 WHEN 'trialing' THEN 2 END,
+      s.created DESC
+    LIMIT 1;
+  END IF;
+
+  -- A paused personal subscription is resumable, but it must not override an
+  -- effective personal or workspace subscription selected above.
+  IF v_subscription_status IS NULL AND v_customer_id IS NOT NULL THEN
+    SELECT
+      s.status::text,
+      (s.trial_end #>> '{}')::bigint,
+      s.default_payment_method IS NOT NULL
+        OR c.invoice_settings->>'default_payment_method' IS NOT NULL
+        OR c.default_source IS NOT NULL,
+      COALESCE(s.cancel_at_period_end, false),
+      COALESCE(
+        s.cancel_at,
+        s.current_period_end,
+        (
+          SELECT MAX(si.current_period_end)
+          FROM stripe.subscription_items si
+          WHERE si.subscription = s.id
+        )
+      )
+    INTO
+      v_subscription_status,
+      v_trial_end,
+      v_has_payment_method,
+      v_cancel_at_period_end,
+      v_current_period_end
+    FROM stripe.subscriptions s
+    JOIN stripe.customers c ON c.id = s.customer
+    WHERE s.customer = v_customer_id
+      AND s.status = 'paused'
+    ORDER BY s.created DESC
+    LIMIT 1;
+  END IF;
+
+  claims := event->'claims';
+  claims := jsonb_set(claims, '{entitlements}', entitlements);
+
+  IF v_subscription_status IS NOT NULL THEN
+    claims := jsonb_set(claims, '{subscription_status}', to_jsonb(v_subscription_status));
+  END IF;
+
+  IF v_trial_end IS NOT NULL THEN
+    claims := jsonb_set(claims, '{trial_end}', to_jsonb(v_trial_end));
+  END IF;
+
+  IF v_has_payment_method IS NOT NULL THEN
+    claims := jsonb_set(claims, '{has_payment_method}', to_jsonb(v_has_payment_method));
+  END IF;
+
+  IF v_cancel_at_period_end IS NOT NULL THEN
+    claims := jsonb_set(
+      claims,
+      '{cancel_at_period_end}',
+      to_jsonb(v_cancel_at_period_end)
+    );
+  END IF;
+
+  IF v_current_period_end IS NOT NULL THEN
+    claims := jsonb_set(claims, '{current_period_end}', to_jsonb(v_current_period_end));
+  END IF;
+
+  event := jsonb_set(event, '{claims}', claims);
+
+  RETURN event;
+END;
+$$;

--- a/supabase/migrations/20260825140000_gate_paused_pro_entitlements.sql
+++ b/supabase/migrations/20260825140000_gate_paused_pro_entitlements.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION private.require_hyprnote_pro_entitlement()
+RETURNS void
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+DECLARE
+  v_claims jsonb := COALESCE(auth.jwt(), '{}'::jsonb);
+  v_trial_end text;
+BEGIN
+  v_trial_end := v_claims ->> 'trial_end';
+
+  IF v_claims ->> 'subscription_status' = 'paused' THEN
+    RAISE EXCEPTION 'hyprnote pro entitlement required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_claims ->> 'subscription_status' = 'trialing' THEN
+    IF COALESCE(v_trial_end, '') ~ '^[0-9]+$'
+      AND v_trial_end::bigint > EXTRACT(epoch FROM now())::bigint
+    THEN
+      RETURN;
+    END IF;
+
+    RAISE EXCEPTION 'hyprnote pro entitlement required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_claims -> 'entitlements' @> '["hyprnote_pro"]'::jsonb THEN
+    RETURN;
+  END IF;
+
+  RAISE EXCEPTION 'hyprnote pro entitlement required'
+    USING ERRCODE = '42501';
+END;
+$$;
+
+COMMENT ON FUNCTION private.require_hyprnote_pro_entitlement()
+  IS 'Requires a paid Pro entitlement or an unexpired server-issued Pro trial claim, and rejects paused subscriptions.';

--- a/supabase/tests/003-auth-custom-access-token-hook.sql
+++ b/supabase/tests/003-auth-custom-access-token-hook.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(19);
+select plan(20);
 
 select tests.create_supabase_user('pro', 'pro@example.com');
 select tests.create_supabase_user('free', 'free@example.com');
@@ -194,6 +194,35 @@ select results_eq(
   $$,
   array['"active"'],
   'custom_access_token_hook sets subscription_status for active user'
+);
+
+select tests.create_supabase_user('paused', 'paused@example.com');
+
+update public.profiles
+set stripe_customer_id = 'cus_paused'
+where id = tests.get_supabase_uid('paused');
+
+insert into stripe.customers (id)
+values ('cus_paused')
+on conflict (id) do nothing;
+
+insert into stripe.subscriptions (id, customer, status, created)
+values ('sub_paused', 'cus_paused', 'paused', 2500)
+on conflict (id) do nothing;
+
+select results_eq(
+  $$
+  select (
+    public.custom_access_token_hook(
+      jsonb_build_object(
+        'user_id', tests.get_supabase_uid('paused')::text,
+        'claims', '{}'::jsonb
+      )
+    ) -> 'claims' -> 'subscription_status'
+  )::text
+  $$,
+  array['"paused"'],
+  'custom_access_token_hook sets subscription_status for paused user'
 );
 
 select is(

--- a/supabase/tests/013-session-sharing-pro-entitlement.sql
+++ b/supabase/tests/013-session-sharing-pro-entitlement.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(62);
+select plan(63);
 
 select tests.create_supabase_user('pro_share_owner', 'pro-share-owner@example.com');
 select tests.create_supabase_user('pro_share_recipient', 'pro-share-recipient@example.com');
@@ -255,6 +255,34 @@ select throws_ok(
   '42501',
   'hyprnote pro entitlement required',
   'An expired trial no longer receives Pro sharing access even before entitlement propagation catches up'
+);
+
+select tests.authenticate_as('pro_share_owner');
+
+select set_config(
+  'request.jwt.claims',
+  jsonb_set(
+    jsonb_set(
+      (select auth.jwt()),
+      '{entitlements}',
+      '["hyprnote_pro"]'::jsonb,
+      true
+    ),
+    '{subscription_status}',
+    '"paused"'::jsonb,
+    true
+  )::text,
+  true
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share(auth.uid(), 'paused-trial-share')
+  $$,
+  '42501',
+  'hyprnote pro entitlement required',
+  'A paused trial cannot use SQL-gated Pro features when its entitlement lingers'
 );
 
 select tests.authenticate_as_hyprnote_pro('pro_share_owner');

--- a/supabase/tests/033-workspace-billing-and-seats.sql
+++ b/supabase/tests/033-workspace-billing-and-seats.sql
@@ -154,6 +154,19 @@ select results_eq(
 select tests.clear_authentication();
 reset role;
 
+-- A resumable personal trial must not hide an effective workspace plan.
+update public.profiles
+set stripe_customer_id = 'cus_seat_member_paused'
+where id = tests.get_supabase_uid('seat_member');
+
+insert into stripe.customers (id)
+values ('cus_seat_member_paused')
+on conflict (id) do nothing;
+
+insert into stripe.subscriptions (id, customer, status)
+values ('sub_seat_member_paused', 'cus_seat_member_paused', 'paused'::stripe.subscription_status)
+on conflict (id) do nothing;
+
 select results_eq(
   $$
     select public.custom_access_token_hook(


### PR DESCRIPTION
## Summary
- pause native cardless trials instead of canceling them when no payment method is present
- reuse and reactivate the original paused Stripe subscription so native trial conversion is attributable
- preserve the selected billing period and YC promotions during reactivation
- show a clear Resume Pro state while keeping paused users off Pro entitlements
- add a dry-run migration for currently trialing subscriptions

## Why
Anarlog intentionally uses no-card signup. Canceling the original trial forced late payers into a second subscription, so Stripe could not connect the payment to the trial. Stripe supports pausing cardless trials indefinitely and resuming the same subscription later.

## Validation
- 18 focused web billing tests passed
- 17 shared billing tests passed
- 8 desktop account tests passed
- web, desktop, and Stripe TypeScript checks passed
- Rust service compiled and the test target built

## Rollout
After deployment, run the migration in dry-run mode and review the matched live trials before applying it. Historical trials that already canceled cannot be retroactively linked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription lifecycle, JWT claims, and entitlement gating across clients; incorrect paused handling could block paying users or grant Pro after trial end.
> 
> **Overview**
> Cardless Pro trials now **pause** at the end of the trial when no payment method is on file, instead of canceling the Stripe subscription. New trials use Stripe’s `missing_payment_method: pause` behavior (API subscription creation and web checkout comments updated accordingly), and a **dry-run/apply migration script** can flip existing trialing subscriptions still set to cancel.
> 
> Billing and auth layers add **`isPaused`** and **fail closed on Pro** when `subscription_status` is paused (stale `hyprnote_pro` entitlements no longer grant Pro; Lite can still apply). The Supabase access-token hook surfaces paused status without letting a personal paused trial override an active workspace plan; RLS and SQL tests cover paused Pro gating.
> 
> **Resume** flows route users to the billing portal instead of creating a duplicate subscription: shared `selectCurrentSubscription` / `getPlanSwitchRoute` treat paused subs as the current subscription; web checkout and plan-switch logic send paused users to the portal (including YC perk apply). Desktop and web account UI show ended-trial copy and a **Resume** action; i18n catalogs pick up the new account strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65313eef99bfda6a0d9bb846b3db290eb0b53cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->