### PR TITLE
Submit Mac releases for App Review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,21 @@
 on:
   pull_request:
+permissions:
+  contents: read
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - run: |
           python3 .github/scripts/test_check_license_boundary.py
           python3 .github/scripts/check_license_boundary.py
       - run: >-
           node --test
           .agents/skills/qa-critical-ux/scripts/launch-native-dev-qa.test.mjs
+          scripts/app-store-connect-submit.test.mjs
           scripts/desktop-release-provenance.test.mjs
           scripts/publish-anarlog-skill.test.mjs
           scripts/repack-linux-appimage.test.mjs

--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -424,12 +424,21 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - if: ${{ inputs.submit_to_stores }}
-        name: Validate and upload to App Store Connect
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-source
+          persist-credentials: false
+          sparse-checkout: scripts/app-store-connect-submit.mjs
+          sparse-checkout-cone-mode: false
+      - if: ${{ inputs.submit_to_stores }}
+        name: Upload and submit to App Review
         env:
           APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           PKG_PATH: ${{ steps.package.outputs.path }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -457,18 +466,13 @@ jobs:
           fi
           chmod 600 "$key_path"
 
-          xcrun altool \
-            --validate-app \
-            --type macos \
-            --file "$PKG_PATH" \
-            --apiKey "$APPSTORE_API_KEY_ID" \
-            --apiIssuer "$APPSTORE_ISSUER_ID"
-          xcrun altool \
-            --upload-app \
-            --type macos \
-            --file "$PKG_PATH" \
-            --apiKey "$APPSTORE_API_KEY_ID" \
-            --apiIssuer "$APPSTORE_ISSUER_ID"
+          node workflow-source/scripts/app-store-connect-submit.mjs \
+            --bundle-id com.hyprnote.desktop \
+            --issuer-id "$APPSTORE_ISSUER_ID" \
+            --key-id "$APPSTORE_API_KEY_ID" \
+            --package "$PKG_PATH" \
+            --private-key "$key_path" \
+            --version "$VERSION"
       - name: Summarize Mac App Store release
         env:
           SUBMITTED: ${{ inputs.submit_to_stores }}
@@ -478,7 +482,7 @@ jobs:
             echo "## Mac App Store"
             echo "- Version: \`$VERSION\`"
             echo "- Architecture: Apple Silicon"
-            echo "- Uploaded to App Store Connect: \`$SUBMITTED\`"
+            echo "- Submitted to App Review: \`$SUBMITTED\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   microsoft-store:

--- a/scripts/app-store-connect-submit.mjs
+++ b/scripts/app-store-connect-submit.mjs
@@ -1,0 +1,483 @@
+import { spawn } from "node:child_process";
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const apiOrigin = "https://api.appstoreconnect.apple.com";
+const editableVersionStates = new Set([
+  "DEVELOPER_REJECTED",
+  "METADATA_REJECTED",
+  "PREPARE_FOR_SUBMISSION",
+  "REJECTED",
+]);
+const submittedVersionStates = new Set([
+  "ACCEPTED",
+  "IN_REVIEW",
+  "PENDING_APPLE_RELEASE",
+  "PENDING_DEVELOPER_RELEASE",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+  "WAITING_FOR_REVIEW",
+]);
+
+export class AppStoreConnectError extends Error {
+  constructor(message, { status } = {}) {
+    super(message);
+    this.name = "AppStoreConnectError";
+    this.status = status;
+  }
+}
+
+function base64Url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+export function createAppStoreConnectToken({
+  issuerId,
+  keyId,
+  privateKey,
+  now = Date.now,
+}) {
+  const issuedAt = Math.floor(now() / 1000);
+  const header = base64Url(
+    JSON.stringify({ alg: "ES256", kid: keyId, typ: "JWT" }),
+  );
+  const payload = base64Url(
+    JSON.stringify({
+      aud: "appstoreconnect-v1",
+      exp: issuedAt + 19 * 60,
+      iat: issuedAt,
+      iss: issuerId,
+    }),
+  );
+  const unsignedToken = `${header}.${payload}`;
+  const signer = createSign("SHA256");
+  signer.update(unsignedToken);
+  signer.end();
+  const signature = signer.sign({
+    dsaEncoding: "ieee-p1363",
+    key: privateKey,
+  });
+
+  return `${unsignedToken}.${base64Url(signature)}`;
+}
+
+function formatApiErrors(payload) {
+  if (!Array.isArray(payload?.errors)) {
+    return "App Store Connect returned an unexpected response";
+  }
+
+  return payload.errors
+    .map((error) =>
+      [error.status, error.code, error.title, error.detail]
+        .filter(Boolean)
+        .join(" "),
+    )
+    .join("; ");
+}
+
+export function createAppStoreConnectClient({
+  fetchImpl = globalThis.fetch,
+  issuerId,
+  keyId,
+  now,
+  privateKey,
+}) {
+  return {
+    async request(method, pathname, { body, query } = {}) {
+      const url = new URL(pathname, apiOrigin);
+      for (const [name, value] of Object.entries(query ?? {})) {
+        if (value !== undefined) {
+          url.searchParams.set(name, String(value));
+        }
+      }
+
+      const response = await fetchImpl(url, {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${createAppStoreConnectToken({ issuerId, keyId, privateKey, now })}`,
+          ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+        },
+        method,
+      });
+      const responseText = await response.text();
+      const payload = responseText === "" ? null : JSON.parse(responseText);
+
+      if (!response.ok) {
+        throw new AppStoreConnectError(formatApiErrors(payload), {
+          status: response.status,
+        });
+      }
+
+      return payload;
+    },
+  };
+}
+
+async function resolveApp(client, bundleId) {
+  const response = await client.request("GET", "/v1/apps", {
+    query: { "filter[bundleId]": bundleId, limit: 2 },
+  });
+  if (response.data.length !== 1) {
+    throw new Error(
+      `Expected one App Store Connect app for ${bundleId}, found ${response.data.length}`,
+    );
+  }
+  return response.data[0];
+}
+
+async function listMacVersions(client, appId) {
+  const response = await client.request(
+    "GET",
+    `/v1/apps/${appId}/appStoreVersions`,
+    {
+      query: {
+        "fields[appStoreVersions]":
+          "appStoreState,platform,releaseType,versionString",
+        "filter[platform]": "MAC_OS",
+        limit: 200,
+      },
+    },
+  );
+  return response.data;
+}
+
+async function updateVersion(client, appStoreVersion, attributes) {
+  const response = await client.request(
+    "PATCH",
+    `/v1/appStoreVersions/${appStoreVersion.id}`,
+    {
+      body: {
+        data: {
+          attributes,
+          id: appStoreVersion.id,
+          type: "appStoreVersions",
+        },
+      },
+    },
+  );
+  return response.data;
+}
+
+async function ensureMacVersion(client, app, version) {
+  const versions = await listMacVersions(client, app.id);
+  const exactVersion = versions.find(
+    (candidate) => candidate.attributes.versionString === version,
+  );
+  if (exactVersion) {
+    if (submittedVersionStates.has(exactVersion.attributes.appStoreState)) {
+      return { appStoreVersion: exactVersion, alreadySubmitted: true };
+    }
+    if (!editableVersionStates.has(exactVersion.attributes.appStoreState)) {
+      throw new Error(
+        `App Store version ${version} is in unsupported state ${exactVersion.attributes.appStoreState}`,
+      );
+    }
+    if (exactVersion.attributes.releaseType !== "AFTER_APPROVAL") {
+      return {
+        appStoreVersion: await updateVersion(client, exactVersion, {
+          releaseType: "AFTER_APPROVAL",
+        }),
+        alreadySubmitted: false,
+      };
+    }
+    return { appStoreVersion: exactVersion, alreadySubmitted: false };
+  }
+
+  const placeholders = versions.filter(
+    (candidate) =>
+      candidate.attributes.appStoreState === "PREPARE_FOR_SUBMISSION",
+  );
+  if (placeholders.length > 1) {
+    throw new Error(
+      `Found ${placeholders.length} editable macOS App Store versions; cannot choose one safely`,
+    );
+  }
+  if (placeholders.length === 1) {
+    return {
+      appStoreVersion: await updateVersion(client, placeholders[0], {
+        releaseType: "AFTER_APPROVAL",
+        versionString: version,
+      }),
+      alreadySubmitted: false,
+    };
+  }
+
+  const response = await client.request("POST", "/v1/appStoreVersions", {
+    body: {
+      data: {
+        attributes: {
+          platform: "MAC_OS",
+          releaseType: "AFTER_APPROVAL",
+          versionString: version,
+        },
+        relationships: {
+          app: { data: { id: app.id, type: "apps" } },
+        },
+        type: "appStoreVersions",
+      },
+    },
+  });
+  return { appStoreVersion: response.data, alreadySubmitted: false };
+}
+
+async function listBuilds(client, appId, version) {
+  const response = await client.request("GET", "/v1/builds", {
+    query: {
+      "fields[builds]": "processingState,uploadedDate,version",
+      "filter[app]": appId,
+      "filter[preReleaseVersion.platform]": "MAC_OS",
+      "filter[preReleaseVersion.version]": version,
+      limit: 10,
+      sort: "-uploadedDate",
+    },
+  });
+  return response.data;
+}
+
+async function waitForBuild({
+  appId,
+  client,
+  pollIntervalMs,
+  sleep,
+  timeoutMs,
+  version,
+}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const builds = await listBuilds(client, appId, version);
+    const validBuild = builds.find(
+      (build) => build.attributes.processingState === "VALID",
+    );
+    if (validBuild) {
+      return validBuild;
+    }
+
+    const failedBuild = builds.find((build) =>
+      ["FAILED", "INVALID"].includes(build.attributes.processingState),
+    );
+    if (failedBuild) {
+      throw new Error(
+        `App Store Connect rejected build ${failedBuild.attributes.version} with state ${failedBuild.attributes.processingState}`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for App Store Connect to process macOS ${version}`,
+  );
+}
+
+async function attachBuild(client, appStoreVersionId, buildId) {
+  await client.request(
+    "PATCH",
+    `/v1/appStoreVersions/${appStoreVersionId}/relationships/build`,
+    { body: { data: { id: buildId, type: "builds" } } },
+  );
+}
+
+function submissionContainsVersion(items, appStoreVersionId) {
+  return items.some(
+    (item) =>
+      item.relationships?.appStoreVersion?.data?.id === appStoreVersionId,
+  );
+}
+
+async function ensureReviewSubmission(client, appId, appStoreVersionId) {
+  const submissionsResponse = await client.request(
+    "GET",
+    `/v1/apps/${appId}/reviewSubmissions`,
+    {
+      query: {
+        "fields[reviewSubmissions]": "platform,state",
+        "filter[platform]": "MAC_OS",
+        "filter[state]": "READY_FOR_REVIEW",
+        limit: 10,
+      },
+    },
+  );
+  let submission = submissionsResponse.data[0];
+  if (!submission) {
+    const response = await client.request("POST", "/v1/reviewSubmissions", {
+      body: {
+        data: {
+          attributes: { platform: "MAC_OS" },
+          relationships: {
+            app: { data: { id: appId, type: "apps" } },
+          },
+          type: "reviewSubmissions",
+        },
+      },
+    });
+    submission = response.data;
+  }
+
+  const itemsResponse = await client.request(
+    "GET",
+    `/v1/reviewSubmissions/${submission.id}/items`,
+    { query: { limit: 50 } },
+  );
+  if (!submissionContainsVersion(itemsResponse.data, appStoreVersionId)) {
+    await client.request("POST", "/v1/reviewSubmissionItems", {
+      body: {
+        data: {
+          relationships: {
+            appStoreVersion: {
+              data: { id: appStoreVersionId, type: "appStoreVersions" },
+            },
+            reviewSubmission: {
+              data: { id: submission.id, type: "reviewSubmissions" },
+            },
+          },
+          type: "reviewSubmissionItems",
+        },
+      },
+    });
+  }
+
+  await client.request("PATCH", `/v1/reviewSubmissions/${submission.id}`, {
+    body: {
+      data: {
+        attributes: { submitted: true },
+        id: submission.id,
+        type: "reviewSubmissions",
+      },
+    },
+  });
+  return submission;
+}
+
+function runAltoolCommand(action, packagePath, keyId, issuerId) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "xcrun",
+      [
+        "altool",
+        action,
+        "--type",
+        "macos",
+        "--file",
+        packagePath,
+        "--apiKey",
+        keyId,
+        "--apiIssuer",
+        issuerId,
+      ],
+      { stdio: "inherit" },
+    );
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`xcrun altool exited with status ${code}`));
+    });
+  });
+}
+
+async function runAltool(packagePath, keyId, issuerId) {
+  await runAltoolCommand("--validate-app", packagePath, keyId, issuerId);
+  await runAltoolCommand("--upload-app", packagePath, keyId, issuerId);
+}
+
+export async function publishMacApp({
+  bundleId,
+  client,
+  packagePath,
+  pollIntervalMs = 30_000,
+  sleep = (duration) => new Promise((resolve) => setTimeout(resolve, duration)),
+  timeoutMs = 45 * 60_000,
+  upload,
+  version,
+}) {
+  const app = await resolveApp(client, bundleId);
+  const versionResult = await ensureMacVersion(client, app, version);
+  if (versionResult.alreadySubmitted) {
+    return {
+      appStoreVersionId: versionResult.appStoreVersion.id,
+      alreadySubmitted: true,
+    };
+  }
+
+  let builds = await listBuilds(client, app.id, version);
+  if (builds.length === 0) {
+    await upload(packagePath);
+  }
+  const build = await waitForBuild({
+    appId: app.id,
+    client,
+    pollIntervalMs,
+    sleep,
+    timeoutMs,
+    version,
+  });
+  await attachBuild(client, versionResult.appStoreVersion.id, build.id);
+  const submission = await ensureReviewSubmission(
+    client,
+    app.id,
+    versionResult.appStoreVersion.id,
+  );
+
+  return {
+    alreadySubmitted: false,
+    appStoreVersionId: versionResult.appStoreVersion.id,
+    buildId: build.id,
+    reviewSubmissionId: submission.id,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${name ?? ""}`.trim());
+    }
+    args[name.slice(2)] = value;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const required = [
+    "bundle-id",
+    "issuer-id",
+    "key-id",
+    "package",
+    "private-key",
+    "version",
+  ];
+  const missing = required.filter((name) => !args[name]);
+  if (missing.length > 0) {
+    throw new Error(`Missing arguments: ${missing.join(", ")}`);
+  }
+
+  const privateKey = await readFile(args["private-key"], "utf8");
+  const client = createAppStoreConnectClient({
+    issuerId: args["issuer-id"],
+    keyId: args["key-id"],
+    privateKey,
+  });
+  const result = await publishMacApp({
+    bundleId: args["bundle-id"],
+    client,
+    packagePath: args.package,
+    upload: (packagePath) =>
+      runAltool(packagePath, args["key-id"], args["issuer-id"]),
+    version: args.version,
+  });
+  console.log(JSON.stringify(result));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/app-store-connect-submit.test.mjs
+++ b/scripts/app-store-connect-submit.test.mjs
@@ -1,0 +1,338 @@
+import assert from "node:assert/strict";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+
+import {
+  AppStoreConnectError,
+  createAppStoreConnectClient,
+  createAppStoreConnectToken,
+  publishMacApp,
+} from "./app-store-connect-submit.mjs";
+
+function resource(type, id, attributes = {}, relationships) {
+  return { attributes, id, relationships, type };
+}
+
+test("creates an App Store Connect ES256 token", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const now = 1_800_000_000_000;
+  const token = createAppStoreConnectToken({
+    issuerId: "issuer-id",
+    keyId: "key-id",
+    now: () => now,
+    privateKey,
+  });
+  const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+  const header = JSON.parse(Buffer.from(encodedHeader, "base64url"));
+  const payload = JSON.parse(Buffer.from(encodedPayload, "base64url"));
+
+  assert.deepEqual(header, { alg: "ES256", kid: "key-id", typ: "JWT" });
+  assert.deepEqual(payload, {
+    aud: "appstoreconnect-v1",
+    exp: Math.floor(now / 1000) + 19 * 60,
+    iat: Math.floor(now / 1000),
+    iss: "issuer-id",
+  });
+  const verifier = createVerify("SHA256");
+  verifier.update(`${encodedHeader}.${encodedPayload}`);
+  verifier.end();
+  assert.equal(
+    verifier.verify(
+      { dsaEncoding: "ieee-p1363", key: publicKey },
+      Buffer.from(encodedSignature, "base64url"),
+    ),
+    true,
+  );
+});
+
+test("surfaces App Store Connect API errors", async () => {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const client = createAppStoreConnectClient({
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          errors: [
+            {
+              code: "ENTITY_ERROR",
+              detail: "The build is not ready",
+              status: "409",
+              title: "Conflict",
+            },
+          ],
+        }),
+        { status: 409 },
+      ),
+    issuerId: "issuer-id",
+    keyId: "key-id",
+    privateKey,
+  });
+
+  await assert.rejects(
+    client.request("GET", "/v1/apps"),
+    (error) =>
+      error instanceof AppStoreConnectError &&
+      error.status === 409 &&
+      /The build is not ready/.test(error.message),
+  );
+});
+
+test("reuses the editable first version and submits a processed build", async () => {
+  const requests = [];
+  let uploaded = false;
+  const client = {
+    async request(method, pathname, options = {}) {
+      requests.push({ method, pathname, ...options });
+      if (pathname === "/v1/apps") {
+        return { data: [resource("apps", "app-id")] };
+      }
+      if (pathname === "/v1/apps/app-id/appStoreVersions") {
+        return {
+          data: [
+            resource("appStoreVersions", "placeholder-id", {
+              appStoreState: "PREPARE_FOR_SUBMISSION",
+              platform: "MAC_OS",
+              releaseType: "MANUAL",
+              versionString: "1.0",
+            }),
+          ],
+        };
+      }
+      if (
+        method === "PATCH" &&
+        pathname === "/v1/appStoreVersions/placeholder-id"
+      ) {
+        return {
+          data: resource("appStoreVersions", "placeholder-id", {
+            appStoreState: "PREPARE_FOR_SUBMISSION",
+            platform: "MAC_OS",
+            releaseType: "AFTER_APPROVAL",
+            versionString: "1.4.13",
+          }),
+        };
+      }
+      if (pathname === "/v1/builds") {
+        return uploaded
+          ? {
+              data: [
+                resource("builds", "build-id", {
+                  processingState: "VALID",
+                  uploadedDate: "2026-08-25T00:00:00Z",
+                  version: "1.4.13",
+                }),
+              ],
+            }
+          : { data: [] };
+      }
+      if (
+        pathname === "/v1/appStoreVersions/placeholder-id/relationships/build"
+      ) {
+        return null;
+      }
+      if (pathname === "/v1/apps/app-id/reviewSubmissions") {
+        return { data: [] };
+      }
+      if (method === "POST" && pathname === "/v1/reviewSubmissions") {
+        return { data: resource("reviewSubmissions", "submission-id") };
+      }
+      if (pathname === "/v1/reviewSubmissions/submission-id/items") {
+        return { data: [] };
+      }
+      if (method === "POST" && pathname === "/v1/reviewSubmissionItems") {
+        return { data: resource("reviewSubmissionItems", "item-id") };
+      }
+      if (
+        method === "PATCH" &&
+        pathname === "/v1/reviewSubmissions/submission-id"
+      ) {
+        return { data: resource("reviewSubmissions", "submission-id") };
+      }
+      throw new Error(`Unexpected request ${method} ${pathname}`);
+    },
+  };
+
+  const result = await publishMacApp({
+    bundleId: "com.hyprnote.desktop",
+    client,
+    packagePath: "/tmp/Anarlog.pkg",
+    pollIntervalMs: 0,
+    sleep: async () => {},
+    upload: async () => {
+      uploaded = true;
+    },
+    version: "1.4.13",
+  });
+
+  assert.deepEqual(result, {
+    alreadySubmitted: false,
+    appStoreVersionId: "placeholder-id",
+    buildId: "build-id",
+    reviewSubmissionId: "submission-id",
+  });
+  assert.equal(uploaded, true);
+  assert.deepEqual(
+    requests.find(
+      (request) =>
+        request.method === "PATCH" &&
+        request.pathname === "/v1/appStoreVersions/placeholder-id",
+    ).body.data.attributes,
+    { releaseType: "AFTER_APPROVAL", versionString: "1.4.13" },
+  );
+  assert.deepEqual(requests.at(-1).body.data.attributes, { submitted: true });
+});
+
+test("reuses an existing processing build instead of uploading it again", async () => {
+  let buildRequestCount = 0;
+  let uploadCount = 0;
+  const client = {
+    async request(method, pathname) {
+      if (pathname === "/v1/apps") {
+        return { data: [resource("apps", "app-id")] };
+      }
+      if (pathname === "/v1/apps/app-id/appStoreVersions") {
+        return {
+          data: [
+            resource("appStoreVersions", "version-id", {
+              appStoreState: "PREPARE_FOR_SUBMISSION",
+              platform: "MAC_OS",
+              releaseType: "AFTER_APPROVAL",
+              versionString: "1.4.13",
+            }),
+          ],
+        };
+      }
+      if (pathname === "/v1/builds") {
+        buildRequestCount += 1;
+        return {
+          data: [
+            resource("builds", "build-id", {
+              processingState: buildRequestCount === 1 ? "PROCESSING" : "VALID",
+              version: "1.4.13",
+            }),
+          ],
+        };
+      }
+      if (pathname === "/v1/appStoreVersions/version-id/relationships/build") {
+        return null;
+      }
+      if (pathname === "/v1/apps/app-id/reviewSubmissions") {
+        return {
+          data: [resource("reviewSubmissions", "submission-id")],
+        };
+      }
+      if (pathname === "/v1/reviewSubmissions/submission-id/items") {
+        return {
+          data: [
+            resource(
+              "reviewSubmissionItems",
+              "item-id",
+              {},
+              {
+                appStoreVersion: {
+                  data: { id: "version-id", type: "appStoreVersions" },
+                },
+              },
+            ),
+          ],
+        };
+      }
+      if (
+        method === "PATCH" &&
+        pathname === "/v1/reviewSubmissions/submission-id"
+      ) {
+        return { data: resource("reviewSubmissions", "submission-id") };
+      }
+      throw new Error(`Unexpected request ${method} ${pathname}`);
+    },
+  };
+
+  const result = await publishMacApp({
+    bundleId: "com.hyprnote.desktop",
+    client,
+    packagePath: "/tmp/Anarlog.pkg",
+    pollIntervalMs: 0,
+    sleep: async () => {},
+    upload: async () => {
+      uploadCount += 1;
+    },
+    version: "1.4.13",
+  });
+
+  assert.equal(result.buildId, "build-id");
+  assert.equal(uploadCount, 0);
+  assert.equal(buildRequestCount, 2);
+});
+
+test("treats an already submitted version as an idempotent success", async () => {
+  const requests = [];
+  const client = {
+    async request(method, pathname) {
+      requests.push({ method, pathname });
+      if (pathname === "/v1/apps") {
+        return { data: [resource("apps", "app-id")] };
+      }
+      if (pathname === "/v1/apps/app-id/appStoreVersions") {
+        return {
+          data: [
+            resource("appStoreVersions", "version-id", {
+              appStoreState: "WAITING_FOR_REVIEW",
+              platform: "MAC_OS",
+              releaseType: "AFTER_APPROVAL",
+              versionString: "1.4.13",
+            }),
+          ],
+        };
+      }
+      throw new Error(`Unexpected request ${method} ${pathname}`);
+    },
+  };
+
+  const result = await publishMacApp({
+    bundleId: "com.hyprnote.desktop",
+    client,
+    packagePath: "/tmp/Anarlog.pkg",
+    upload: async () => assert.fail("upload should not run"),
+    version: "1.4.13",
+  });
+
+  assert.deepEqual(result, {
+    alreadySubmitted: true,
+    appStoreVersionId: "version-id",
+  });
+  assert.equal(requests.length, 2);
+});
+
+test("refuses to choose between multiple editable placeholder versions", async () => {
+  const client = {
+    async request(_method, pathname) {
+      if (pathname === "/v1/apps") {
+        return { data: [resource("apps", "app-id")] };
+      }
+      if (pathname === "/v1/apps/app-id/appStoreVersions") {
+        return {
+          data: ["one", "two"].map((id) =>
+            resource("appStoreVersions", id, {
+              appStoreState: "PREPARE_FOR_SUBMISSION",
+              platform: "MAC_OS",
+              releaseType: "MANUAL",
+              versionString: id,
+            }),
+          ),
+        };
+      }
+      throw new Error(`Unexpected request ${pathname}`);
+    },
+  };
+
+  await assert.rejects(
+    publishMacApp({
+      bundleId: "com.hyprnote.desktop",
+      client,
+      packagePath: "/tmp/Anarlog.pkg",
+      upload: async () => {},
+      version: "1.4.13",
+    }),
+    /cannot choose one safely/,
+  );
+});

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -298,6 +298,11 @@ test("stable desktop releases submit both store packages", async () => {
   assert.match(storePublishJob, /include_windows: true/);
   assert.match(storePublishJob, /submit_to_stores: true/);
   assert.doesNotMatch(storePublishJob, /secrets: inherit/);
+  assert.match(
+    storeWorkflow,
+    /node workflow-source\/scripts\/app-store-connect-submit\.mjs/,
+  );
+  assert.match(storeWorkflow, /Submitted to App Review/);
 
   const expectedSecrets = [
     "APPLE_TEAM_ID",


### PR DESCRIPTION
Automate App Store Connect build reuse, version attachment, review submission, and release after approval. Add focused API orchestration tests and harden the touched CI checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production Mac App Store release automation: it now submits builds for Apple review using API keys and can affect live store listings if misconfigured or run with wrong version/state.
> 
> **Overview**
> Mac store publish no longer stops at **validate/upload via `xcrun altool`**. When `submit_to_stores` is enabled, the workflow sparse-checkouts `scripts/app-store-connect-submit.mjs` and runs it to upload the `.pkg` (if needed), wait for a **VALID** build, attach it to the macOS App Store version, and **submit for App Review** with release type **AFTER_APPROVAL**. The job summary now reports **Submitted to App Review** instead of only “uploaded to App Store Connect.”
> 
> The new script adds an App Store Connect API client (ES256 JWT), version/build/review-submission orchestration, idempotent handling when a version is already in review, and reuse of in-flight builds to avoid duplicate uploads. **Unit tests** cover token signing, API errors, and the main publish paths; **CI** pins `actions/checkout` to v4.4.0 with `persist-credentials: false`, sets `contents: read`, and runs the new test file in `node --test`. **Release provenance tests** assert the store workflow invokes the script and updated summary wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4a1257566f16d351c68c5f31335eb4270c6b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->