### PR TITLE
Normalize App Store API key secrets

### DIFF
--- a/scripts/app-store-connect-submit.mjs
+++ b/scripts/app-store-connect-submit.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createSign } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 const apiOrigin = "https://api.appstoreconnect.apple.com";
@@ -31,6 +31,17 @@ export class AppStoreConnectError extends Error {
 
 function base64Url(value) {
   return Buffer.from(value).toString("base64url");
+}
+
+export function normalizePrivateKey(value) {
+  let normalized = value.trim();
+  if (normalized.startsWith('"') && normalized.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(normalized);
+      if (typeof parsed === "string") normalized = parsed.trim();
+    } catch {}
+  }
+  return `${normalized.replaceAll("\\r\\n", "\n").replaceAll("\\n", "\n")}\n`;
 }
 
 export function createAppStoreConnectToken({
@@ -455,7 +466,10 @@ async function main() {
     throw new Error(`Missing arguments: ${missing.join(", ")}`);
   }
 
-  const privateKey = await readFile(args["private-key"], "utf8");
+  const privateKey = normalizePrivateKey(
+    await readFile(args["private-key"], "utf8"),
+  );
+  await writeFile(args["private-key"], privateKey, { mode: 0o600 });
   const client = createAppStoreConnectClient({
     issuerId: args["issuer-id"],
     keyId: args["key-id"],

--- a/scripts/app-store-connect-submit.test.mjs
+++ b/scripts/app-store-connect-submit.test.mjs
@@ -6,6 +6,7 @@ import {
   AppStoreConnectError,
   createAppStoreConnectClient,
   createAppStoreConnectToken,
+  normalizePrivateKey,
   publishMacApp,
 } from "./app-store-connect-submit.mjs";
 
@@ -44,6 +45,23 @@ test("creates an App Store Connect ES256 token", () => {
       Buffer.from(encodedSignature, "base64url"),
     ),
     true,
+  );
+});
+
+test("normalizes a JSON-escaped App Store Connect private key", () => {
+  const { privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const pem = privateKey.export({ format: "pem", type: "pkcs8" });
+  const normalized = normalizePrivateKey(JSON.stringify(pem));
+
+  assert.equal(normalized, pem);
+  assert.doesNotThrow(() =>
+    createAppStoreConnectToken({
+      issuerId: "issuer-id",
+      keyId: "key-id",
+      privateKey: normalized,
+    }),
   );
 });
 


### PR DESCRIPTION
Normalizes JSON-escaped PEM secrets before JWT signing and altool upload. Adds a regression test for the GitHub secret representation that failed the first live App Store submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to submit-script key handling and tests; no changes to app runtime or auth beyond fixing PEM parsing for CI secrets.
> 
> **Overview**
> Fixes **live App Store submission** when the API private key file contains **JSON-escaped PEM** (e.g. a GitHub secret written as a quoted string with `\n` instead of real line breaks), which broke **ES256 JWT signing** and **`xcrun altool`**.
> 
> Adds exported **`normalizePrivateKey`**: trim, optional `JSON.parse` for quoted strings, convert escaped `\n` / `\r\n` to real newlines, and ensure a trailing newline. The CLI **normalizes the key after read** and **rewrites the same path** with mode `0o600` so both the App Store Connect client and altool see valid PEM.
> 
> Adds a **regression test** that feeds `JSON.stringify(pem)` through normalization and confirms token creation succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907b1402dd2aaa12ed4af3493d9d0518a37c74c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->