### PR TITLE
Verify the App Store profile signing certificate

### DIFF
--- a/.github/actions/apple_store_cert/action.yaml
+++ b/.github/actions/apple_store_cert/action.yaml
@@ -20,6 +20,9 @@ outputs:
   application-cert-id:
     description: "Application certificate identity used by codesign"
     value: ${{ steps.verify.outputs.application-cert-id }}
+  application-cert-sha1:
+    description: "SHA-1 fingerprint of the application certificate"
+    value: ${{ steps.verify.outputs.application-cert-sha1 }}
   installer-cert-id:
     description: "Installer certificate identity used by productbuild"
     value: ${{ steps.verify.outputs.installer-cert-id }}
@@ -72,6 +75,8 @@ runs:
         identities=$(security find-identity -v "$RUNNER_TEMP/mac-app-store.keychain-db")
         application_cert_id=$(printf '%s\n' "$identities" | awk -F'"' \
           '/"(3rd Party Mac Developer Application|Mac App Distribution|Apple Distribution):/ { print $2; exit }')
+        application_cert_sha1=$(printf '%s\n' "$identities" | awk \
+          '/"(3rd Party Mac Developer Application|Mac App Distribution|Apple Distribution):/ { print $2; exit }')
         installer_cert_id=$(printf '%s\n' "$identities" | awk -F'"' \
           '/"(3rd Party Mac Developer Installer|Mac Installer Distribution):/ { print $2; exit }')
 
@@ -85,5 +90,6 @@ runs:
         fi
 
         echo "application-cert-id=$application_cert_id" >> "$GITHUB_OUTPUT"
+        echo "application-cert-sha1=$application_cert_sha1" >> "$GITHUB_OUTPUT"
         echo "installer-cert-id=$installer_cert_id" >> "$GITHUB_OUTPUT"
         echo "Mac App Store certificates imported."

--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -228,6 +228,7 @@ jobs:
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLICATION_CERT_ID: ${{ steps.apple-store-cert.outputs.application-cert-id }}
+          APPLICATION_CERT_SHA1: ${{ steps.apple-store-cert.outputs.application-cert-sha1 }}
           INSTALLER_CERT_ID: ${{ steps.apple-store-cert.outputs.installer-cert-id }}
           PROVISIONING_PROFILE: ${{ secrets.MAC_APP_STORE_PROVISIONING_PROFILE }}
         run: |
@@ -254,6 +255,18 @@ jobs:
               -c 'Print :TeamIdentifier:0' \
               "$profile_plist"
           )
+          profile_certificate_sha1s=$(
+            python3 - "$profile_plist" <<'PY'
+          import hashlib
+          import plistlib
+          import sys
+
+          with open(sys.argv[1], "rb") as profile_file:
+              profile = plistlib.load(profile_file)
+          for certificate in profile.get("DeveloperCertificates", []):
+              print(hashlib.sha1(certificate).hexdigest().upper())
+          PY
+          )
 
           profile_app_prefix="${profile_app_id%.com.hyprnote.desktop}"
           if [[ -z "$profile_app_prefix" || "$profile_app_prefix" == "$profile_app_id" ]]; then
@@ -266,6 +279,10 @@ jobs:
           fi
           if [[ "$APPLICATION_CERT_ID" != *"($APPLE_TEAM_ID)"* ]]; then
             echo "::error::Mac App Distribution certificate is not for Apple team $APPLE_TEAM_ID"
+            exit 1
+          fi
+          if ! grep -Fxq "$APPLICATION_CERT_SHA1" <<< "$profile_certificate_sha1s"; then
+            echo "::error::Provisioning profile does not contain the imported Mac App Distribution certificate"
             exit 1
           fi
           if [[ "$INSTALLER_CERT_ID" != *"($APPLE_TEAM_ID)"* ]]; then


### PR DESCRIPTION
Fails before the desktop build when the provisioning profile does not contain the imported Mac App Distribution certificate, preventing server-side 90284 rejections after certificate rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions release validation; no runtime app or signing logic in the product itself.
> 
> **Overview**
> Adds **early CI validation** so Mac App Store releases fail fast when the imported distribution certificate is not listed in the embedded provisioning profile—common after certificate rotation and a cause of App Store **90284** rejections post-upload.
> 
> The **`apple_store_cert`** composite action now exposes **`application-cert-sha1`**, parsed from `security find-identity` alongside the existing signing identity. The **desktop store publish** workflow passes that fingerprint into the provisioning-profile step, computes SHA-1 digests for every cert in the profile’s **`DeveloperCertificates`** (via a small Python plist helper), and **aborts the job** if the imported app cert’s SHA-1 is missing from that set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4e369776f5e233819b09f90cc4c4d54a57ba9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->