### PR TITLE
Fix Mac App Store asset catalog packaging

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -317,6 +317,34 @@ jobs:
             "$cloudsync_dylib"
           codesign --verify --strict --verbose=2 "$cloudsync_dylib"
         working-directory: ./apps/desktop
+      - name: Compile Mac App Store asset catalog
+        run: |
+          set -euo pipefail
+
+          asset_output="$RUNNER_TEMP/mac-app-store-assets"
+          asset_source="$RUNNER_TEMP/AppIcon.icon"
+          asset_catalog="apps/desktop/src-tauri/resources/app-store/Assets.car"
+          mkdir -p "$asset_output" "$(dirname "$asset_catalog")"
+          cp -R apps/desktop/src-tauri/icons/src/stable.icon "$asset_source"
+          xcrun actool \
+            "$asset_source" \
+            --compile "$asset_output" \
+            --output-format human-readable-text \
+            --notices \
+            --warnings \
+            --errors \
+            --output-partial-info-plist "$asset_output/assetcatalog_generated_info.plist" \
+            --app-icon AppIcon \
+            --include-all-app-icons \
+            --enable-on-demand-resources NO \
+            --target-device mac \
+            --minimum-deployment-target 10.13 \
+            --platform macosx
+          if [[ ! -s "$asset_output/Assets.car" ]]; then
+            echo "::error::actool did not produce the Mac App Store asset catalog"
+            exit 1
+          fi
+          cp "$asset_output/Assets.car" "$asset_catalog"
       - name: Build signed Mac App Store application
         env:
           APPLE_SIGNING_IDENTITY: ${{ steps.apple-store-cert.outputs.application-cert-id }}
@@ -374,6 +402,17 @@ jobs:
           fi
           if [[ ! -f "$app/Contents/embedded.provisionprofile" ]]; then
             echo "::error::Mac App Store application is missing its embedded provisioning profile"
+            exit 1
+          fi
+          if [[ ! -s "$app/Contents/Resources/Assets.car" ]]; then
+            echo "::error::Mac App Store application is missing its compiled asset catalog"
+            exit 1
+          fi
+          app_icon_name=$(
+            /usr/libexec/PlistBuddy -c 'Print :CFBundleIconName' "$app/Contents/Info.plist"
+          )
+          if [[ "$app_icon_name" != "AppIcon" ]]; then
+            echo "::error::Mac App Store application has icon catalog name $app_icon_name"
             exit 1
           fi
 

--- a/apps/desktop/src-tauri/tauri.conf.app-store.json
+++ b/apps/desktop/src-tauri/tauri.conf.app-store.json
@@ -13,7 +13,10 @@
     "externalBin": [],
     "targets": ["app"],
     "macOS": {
-      "entitlements": "./Entitlements.app-store.plist"
+      "entitlements": "./Entitlements.app-store.plist",
+      "files": {
+        "Resources/Assets.car": "./resources/app-store/Assets.car"
+      }
     }
   },
   "plugins": {

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -342,6 +342,32 @@ test("stable desktop releases submit both store packages", async () => {
   assert.deepEqual(forwardedSecrets, expectedSecrets);
 });
 
+test("Mac App Store builds include a compiled app icon catalog", async () => {
+  const [storeWorkflow, appStoreConfig, stableConfig] = await Promise.all([
+    readFile(".github/workflows/desktop_store_publish.yaml", "utf8"),
+    readFile("apps/desktop/src-tauri/tauri.conf.app-store.json", "utf8").then(
+      JSON.parse,
+    ),
+    readFile("apps/desktop/src-tauri/tauri.conf.stable.json", "utf8").then(
+      JSON.parse,
+    ),
+  ]);
+
+  assert.match(storeWorkflow, /name: Compile Mac App Store asset catalog/);
+  assert.match(storeWorkflow, /xcrun actool/);
+  assert.match(storeWorkflow, /icons\/src\/stable\.icon/);
+  assert.match(storeWorkflow, /AppIcon\.icon/);
+  assert.match(storeWorkflow, /Contents\/Resources\/Assets\.car/);
+  assert.equal(
+    appStoreConfig.bundle.macOS.files["Resources/Assets.car"],
+    "./resources/app-store/Assets.car",
+  );
+  assert.equal(
+    stableConfig.bundle.macOS.files["Resources/Assets.car"],
+    undefined,
+  );
+});
+
 test("binds every release asset to a candidate run and detects replacement", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "anarlog-release-provenance-"),


### PR DESCRIPTION
Compile the stable AppIcon catalog for the store-only bundle, package Assets.car through the App Store Tauri config, and fail before upload when the catalog metadata is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release CI and store-only bundle packaging only; no runtime auth, data, or direct-download artifact changes.
> 
> **Overview**
> **Mac App Store builds now compile and ship a proper app icon asset catalog** so the store bundle is not missing `Assets.car` or misaligned icon metadata.
> 
> The store publish workflow gains a **Compile Mac App Store asset catalog** step that copies `stable.icon`, runs `xcrun actool` with `AppIcon`, writes `resources/app-store/Assets.car`, and fails if actool produces nothing. **Verify and package** now errors out when the signed `.app` lacks a non-empty `Contents/Resources/Assets.car` or when `CFBundleIconName` is not `AppIcon`.
> 
> **App Store–only Tauri config** maps `Resources/Assets.car` into the bundle from that compiled file (stable direct-distribution config unchanged). A **desktop-release-provenance** test locks in the workflow strings, actool usage, and the app-store vs stable file mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287cf4601f795a8db0f87a471a7aae795dd5df28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->