### PR TITLE
Apply App Store assets to tagged candidates

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -324,6 +324,7 @@ jobs:
           asset_output="$RUNNER_TEMP/mac-app-store-assets"
           asset_source="$RUNNER_TEMP/AppIcon.icon"
           asset_catalog="apps/desktop/src-tauri/resources/app-store/Assets.car"
+          app_store_config="apps/desktop/src-tauri/tauri.conf.app-store.json"
           mkdir -p "$asset_output" "$(dirname "$asset_catalog")"
           cp -R apps/desktop/src-tauri/icons/src/stable.icon "$asset_source"
           xcrun actool \
@@ -345,6 +346,10 @@ jobs:
             exit 1
           fi
           cp "$asset_output/Assets.car" "$asset_catalog"
+          jq \
+            '.bundle.macOS.files["Resources/Assets.car"] = "./resources/app-store/Assets.car"' \
+            "$app_store_config" > "$RUNNER_TEMP/tauri.conf.app-store.json"
+          mv "$RUNNER_TEMP/tauri.conf.app-store.json" "$app_store_config"
       - name: Build signed Mac App Store application
         env:
           APPLE_SIGNING_IDENTITY: ${{ steps.apple-store-cert.outputs.application-cert-id }}

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -358,6 +358,10 @@ test("Mac App Store builds include a compiled app icon catalog", async () => {
   assert.match(storeWorkflow, /icons\/src\/stable\.icon/);
   assert.match(storeWorkflow, /AppIcon\.icon/);
   assert.match(storeWorkflow, /Contents\/Resources\/Assets\.car/);
+  assert.match(
+    storeWorkflow,
+    /\.bundle\.macOS\.files\["Resources\/Assets\.car"\]/,
+  );
   assert.equal(
     appStoreConfig.bundle.macOS.files["Resources/Assets.car"],
     "./resources/app-store/Assets.car",


### PR DESCRIPTION
Inject the Assets.car mapping into the checked-out release candidate so existing stable tags can use the repaired store packaging workflow without moving published tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Mac App Store workflow config injection and test coverage; no runtime app logic.
> 
> **Overview**
> **Mac App Store store-publish** now patches `tauri.conf.app-store.json` during the asset-catalog step, after `actool` produces `Assets.car`, so `Resources/Assets.car` points at `./resources/app-store/Assets.car` even when the workflow checks out an older **tagged** release candidate that never committed that mapping.
> 
> That lets repaired store packaging run against existing stable tags without moving published tags. **Provenance tests** assert the workflow contains the `jq` injection for `.bundle.macOS.files["Resources/Assets.car"]`, alongside the existing checks that the app-store config defines the mapping and the stable config does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a638cbe923bae82c614cbd16986b42d69692a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->