### PR TITLE
Verify tagged candidate certificates locally

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -228,7 +228,6 @@ jobs:
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLICATION_CERT_ID: ${{ steps.apple-store-cert.outputs.application-cert-id }}
-          APPLICATION_CERT_SHA1: ${{ steps.apple-store-cert.outputs.application-cert-sha1 }}
           INSTALLER_CERT_ID: ${{ steps.apple-store-cert.outputs.installer-cert-id }}
           PROVISIONING_PROFILE: ${{ secrets.MAC_APP_STORE_PROVISIONING_PROFILE }}
         run: |
@@ -267,6 +266,16 @@ jobs:
               print(hashlib.sha1(certificate).hexdigest().upper())
           PY
           )
+          application_cert_sha1=$(
+            security find-identity -v "$RUNNER_TEMP/mac-app-store.keychain-db" |
+              awk -v identity="\"$APPLICATION_CERT_ID\"" \
+                'index($0, identity) { print $2; exit }'
+          )
+          if [[ ! "$application_cert_sha1" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+            echo "::error::Could not read the imported Mac App Distribution certificate fingerprint"
+            exit 1
+          fi
+          application_cert_sha1="${application_cert_sha1^^}"
 
           profile_app_prefix="${profile_app_id%.com.hyprnote.desktop}"
           if [[ -z "$profile_app_prefix" || "$profile_app_prefix" == "$profile_app_id" ]]; then
@@ -281,7 +290,7 @@ jobs:
             echo "::error::Mac App Distribution certificate is not for Apple team $APPLE_TEAM_ID"
             exit 1
           fi
-          if ! grep -Fxq "$APPLICATION_CERT_SHA1" <<< "$profile_certificate_sha1s"; then
+          if ! grep -Fxq "$application_cert_sha1" <<< "$profile_certificate_sha1s"; then
             echo "::error::Provisioning profile does not contain the imported Mac App Distribution certificate"
             exit 1
           fi

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -360,6 +360,14 @@ test("Mac App Store builds include a compiled app icon catalog", async () => {
   assert.match(storeWorkflow, /Contents\/Resources\/Assets\.car/);
   assert.match(
     storeWorkflow,
+    /security find-identity -v "\$RUNNER_TEMP\/mac-app-store\.keychain-db"/,
+  );
+  assert.doesNotMatch(
+    storeWorkflow,
+    /APPLICATION_CERT_SHA1:.*application-cert-sha1/,
+  );
+  assert.match(
+    storeWorkflow,
     /\.bundle\.macOS\.files\["Resources\/Assets\.car"\]/,
   );
   assert.equal(


### PR DESCRIPTION
Read the imported application certificate fingerprint directly from the temporary keychain so the current store workflow can validate provisioning profiles for older release tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how the Mac App Store certificate fingerprint is sourced; signing and secret handling are unchanged.
> 
> **Overview**
> **Mac App Store provisioning verification** no longer depends on the `apple_store_cert` action’s `application-cert-sha1` output. During **Install and verify provisioning profile**, the workflow reads the application certificate fingerprint from `$RUNNER_TEMP/mac-app-store.keychain-db` via `security find-identity`, validates it, and uses that value when checking the profile’s embedded certificates.
> 
> **Release provenance tests** now require that keychain lookup in `desktop_store_publish.yaml` and assert the workflow does **not** wire `APPLICATION_CERT_SHA1` from `application-cert-sha1`.
> 
> This keeps profile-vs-certificate checks working when store jobs run against **older tagged candidates** whose checked-out `apple_store_cert` action may not expose the SHA1 output, while still using the cert that was just imported into the temp keychain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6f2ff525173b2fe050e24c3f532e01f0930aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->