### PR TITLE
Support the macOS runner shell

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -275,7 +275,7 @@ jobs:
             echo "::error::Could not read the imported Mac App Distribution certificate fingerprint"
             exit 1
           fi
-          application_cert_sha1="${application_cert_sha1^^}"
+          application_cert_sha1=$(printf '%s' "$application_cert_sha1" | tr '[:lower:]' '[:upper:]')
 
           profile_app_prefix="${profile_app_id%.com.hyprnote.desktop}"
           if [[ -z "$profile_app_prefix" || "$profile_app_prefix" == "$profile_app_id" ]]; then

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -366,6 +366,7 @@ test("Mac App Store builds include a compiled app icon catalog", async () => {
     storeWorkflow,
     /APPLICATION_CERT_SHA1:.*application-cert-sha1/,
   );
+  assert.doesNotMatch(storeWorkflow, /application_cert_sha1\^\^/);
   assert.match(
     storeWorkflow,
     /\.bundle\.macOS\.files\["Resources\/Assets\.car"\]/,


### PR DESCRIPTION
Use portable fingerprint normalization so the strict App Store certificate/profile guard runs on Apple’s Bash 3.2 environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell portability change; behavior of the certificate fingerprint guard is unchanged aside from running successfully on Bash 3.2.
> 
> **Overview**
> Replaces Bash 4 **`${var^^}`** uppercase normalization of the Mac App Distribution certificate fingerprint with **`tr '[:lower:]' '[:upper:]'`**, so the provisioning-profile certificate check runs on **macOS GitHub runners (Bash 3.2)** instead of failing at shell parse time.
> 
> Adds a **desktop release provenance** test that the store publish workflow must **not** contain **`application_cert_sha1^^`**, locking in the portable approach alongside existing checks for in-workflow cert SHA1 handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf1be499da82e5adbbaa473a492fe9f4ce59e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->