### PR TITLE
Unify share panel and header icon sizes

### DIFF
--- a/apps/desktop/src/session-sharing/access-management.tsx
+++ b/apps/desktop/src/session-sharing/access-management.tsx
@@ -332,7 +332,7 @@ export function AccessEntryRow({
       </div>
       {pending ? (
         <CircleNotch
-          className="text-muted-foreground size-3.5 animate-spin"
+          className="text-muted-foreground size-4 animate-spin"
           aria-label={t`Updating access`}
         />
       ) : entry.entryType === "request" ? (

--- a/apps/desktop/src/session-sharing/attachment-controls.tsx
+++ b/apps/desktop/src/session-sharing/attachment-controls.tsx
@@ -40,7 +40,7 @@ export function SessionAttachmentControls({
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <div className="bg-muted flex size-7 shrink-0 items-center justify-center rounded-lg">
-            <Waveform className="size-3.5" aria-hidden="true" />
+            <Waveform className="size-4" aria-hidden="true" />
           </div>
           <div className="min-w-0">
             <label

--- a/apps/desktop/src/session-sharing/delivery-panel.tsx
+++ b/apps/desktop/src/session-sharing/delivery-panel.tsx
@@ -115,7 +115,7 @@ function ShareRecapFormHeading({
           aria-label={t`Back`}
           className="text-muted-foreground hover:text-foreground flex size-6 shrink-0 items-center justify-center rounded-md"
         >
-          <CaretLeft className="size-3.5" aria-hidden="true" />
+          <CaretLeft className="size-4" aria-hidden="true" />
         </button>
       ) : null}
       <h3 id={id} className="text-xs font-medium">
@@ -239,9 +239,9 @@ export function SlackRecapForm({
           className="h-8"
         >
           {openingAction ? (
-            <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
+            <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
           ) : (
-            <SlackBrandIcon size={14} />
+            <SlackBrandIcon size={16} />
           )}
           {reconnect ? (
             <Trans>Reconnect Slack</Trans>
@@ -301,7 +301,7 @@ export function SlackRecapForm({
           className="h-8 shrink-0"
         >
           {pending ? (
-            <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
+            <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
           ) : null}
           <Trans>Send</Trans>
         </Button>

--- a/apps/desktop/src/session-sharing/draft-panel.tsx
+++ b/apps/desktop/src/session-sharing/draft-panel.tsx
@@ -180,12 +180,9 @@ export function SessionShareDraftContent({
             className="h-7 rounded-md px-2.5 text-xs"
           >
             {pendingAction?.type === "copy-link" ? (
-              <CircleNotch
-                className="size-3.5 animate-spin"
-                aria-hidden="true"
-              />
+              <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
             ) : (
-              <Copy className="size-3.5" aria-hidden="true" />
+              <Copy className="size-4" aria-hidden="true" />
             )}
             <Trans>Copy link</Trans>
           </Button>

--- a/apps/desktop/src/session-sharing/general-access.tsx
+++ b/apps/desktop/src/session-sharing/general-access.tsx
@@ -44,9 +44,9 @@ export function GeneralAccessSelector({
     <div className="flex items-center gap-2 rounded-lg px-1.5 py-1">
       <span className="bg-muted flex size-7 shrink-0 items-center justify-center rounded-md">
         {pending ? (
-          <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
+          <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
         ) : (
-          <AccessIcon className="size-3.5" aria-hidden="true" />
+          <AccessIcon className="size-4" aria-hidden="true" />
         )}
       </span>
       <Select

--- a/apps/desktop/src/session-sharing/invite-recipients.tsx
+++ b/apps/desktop/src/session-sharing/invite-recipients.tsx
@@ -189,7 +189,7 @@ export function ShareInviteForm({
           className="h-8 shrink-0 rounded-full px-3"
         >
           {pending ? (
-            <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
+            <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
           ) : null}
           {actionLabel ?? <Trans>Invite</Trans>}
           {invite.emails.length ? (
@@ -286,7 +286,7 @@ export function ShareInviteRecipientRows({
           onClick={() => invite.remove(recipient.email)}
           className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-7 shrink-0 items-center justify-center rounded-md disabled:cursor-not-allowed"
         >
-          <X className="size-3.5" aria-hidden="true" />
+          <X className="size-4" aria-hidden="true" />
         </button>
       </div>
     );

--- a/apps/desktop/src/session-sharing/management-panel.tsx
+++ b/apps/desktop/src/session-sharing/management-panel.tsx
@@ -375,7 +375,7 @@ export function SessionSharePopoverContent({
                     <Trans>Access settings could not be loaded.</Trans>
                   </p>
                   <Button size="sm" variant="outline" onClick={onRetry}>
-                    <ArrowsClockwise className="size-3.5" aria-hidden="true" />
+                    <ArrowsClockwise className="size-4" aria-hidden="true" />
                     <Trans>Try again</Trans>
                   </Button>
                 </div>
@@ -413,12 +413,12 @@ export function SessionSharePopoverContent({
                         >
                           {openWebCopyMutation.isPending ? (
                             <CircleNotch
-                              className="size-3.5 animate-spin"
+                              className="size-4 animate-spin"
                               aria-hidden="true"
                             />
                           ) : (
                             <ArrowSquareOut
-                              className="size-3.5"
+                              className="size-4"
                               aria-hidden="true"
                             />
                           )}
@@ -432,7 +432,7 @@ export function SessionSharePopoverContent({
                         >
                           {keepDesktopMutation.isPending ? (
                             <CircleNotch
-                              className="size-3.5 animate-spin"
+                              className="size-4 animate-spin"
                               aria-hidden="true"
                             />
                           ) : null}
@@ -617,11 +617,11 @@ export function SessionSharePopoverContent({
             >
               {generalCopyMutation.isPending || scopeMutation.isPending ? (
                 <CircleNotch
-                  className="size-3.5 animate-spin"
+                  className="size-4 animate-spin"
                   aria-hidden="true"
                 />
               ) : (
-                <Copy className="size-3.5" aria-hidden="true" />
+                <Copy className="size-4" aria-hidden="true" />
               )}
               <Trans>Copy link</Trans>
             </Button>

--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -32,7 +32,7 @@ describe("FolderPicker", () => {
     cleanup();
   });
 
-  it("optically sizes the folder icon when no folder is selected", () => {
+  it("sizes the folder icon with the other header actions", () => {
     render(<FolderPicker sessionId="session-1" />);
 
     const trigger = screen.getByRole("combobox", { name: "Select folder" });
@@ -41,7 +41,7 @@ describe("FolderPicker", () => {
     expect(trigger.textContent).toBe("");
     expect(trigger.className).toContain("w-7");
     expect(icons).toHaveLength(1);
-    expect(icons[0]?.getAttribute("class")).toContain("size-[18px]");
+    expect(icons[0]?.getAttribute("class")).toContain("size-4");
   });
 
   it("shows the selected folder name without a chevron", () => {

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -107,7 +107,7 @@ export function FolderPicker({
             open && "bg-accent text-foreground",
           ])}
         >
-          <FolderSimple className="size-[18px] shrink-0" aria-hidden="true" />
+          <FolderSimple className="size-4 shrink-0" aria-hidden="true" />
           {currentPath ? (
             <span className="min-w-0 truncate text-xs text-neutral-600 dark:text-neutral-300">
               {currentPath}

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -60,7 +60,7 @@ const TriggerInner = forwardRef<
         open && "bg-muted text-foreground",
       ])}
     >
-      <CalendarBlank size={16} />
+      <CalendarBlank className="size-4" />
     </Button>
   );
 });

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -125,7 +125,7 @@ export function OverflowButton({
             data-tauri-drag-region="false"
             className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full"
           >
-            <DotsThree size={16} />
+            <DotsThree className="size-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent variant="app" align="end" className="w-56">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Phosphor Regular uses a fixed viewBox stroke, so on-screen weight follows display size. The share popover mixed 14px icons with 16px chevrons/overflow, and the header folder was optically sized at 18px next to 16px calendar/share/overflow actions.

This puts those sibling icons on `size-4` (16px) so stroke weight matches wherever the nearby text is the same compact scale (`text-xs` / `text-[10px]` / `text-[11px]`).

**Changed**
- Header: folder, calendar, overflow dots all `size-4` (share was already)
- Share panel: remove, globe, copy, back, waveform, and matching spinners now `size-4`

Left comments-drawer icons and Slack channel lock prefixes alone — different text scale / glyph role.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b92044b-cd1f-43c7-83f1-bcd47208df71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b92044b-cd1f-43c7-83f1-bcd47208df71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

