### PR TITLE
Avoid AppKit abort when Launch Services is unreachable

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -163,6 +163,11 @@ pub fn main() {
         run_crash_reporter_process();
     }
 
+    // AppKit abort()s in _RegisterApplication when launchservicesd is unreachable
+    // (inherited sandbox from a parent like a browser agent). Check before the
+    // event loop is created so we can relaunch via `open` or exit cleanly.
+    startup::ensure_macos_appkit_launch_context();
+
     // Keep a process-wide Tokio runtime for Tauri plugins, but leave it before
     // Builder::build(). tauri-plugin-single-instance's Linux setup uses zbus's
     // blocking Connection::build, which starts a nested runtime and panics if

--- a/apps/desktop/src-tauri/src/startup.rs
+++ b/apps/desktop/src-tauri/src/startup.rs
@@ -1,5 +1,5 @@
 use std::fs::TryLockError;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 const LAUNCH_LOCK_FILENAME: &str = "launch.lock";
@@ -27,6 +27,175 @@ pub(crate) fn apply_linux_webkit_workarounds() {
 
 fn linux_webkit_dmabuf_override(existing: Option<&std::ffi::OsStr>) -> Option<&'static str> {
     existing.is_none().then_some("1")
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const LAUNCHD_PID: u32 = 1;
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const LAUNCH_SERVICES_MACH_SERVICE: &str = "com.apple.coreservices.launchservicesd";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppkitLaunchPlan {
+    Continue,
+    Relaunch,
+    Exit,
+}
+
+fn appkit_launch_plan(
+    parent_is_launchd: bool,
+    launch_services_reachable: bool,
+    has_app_bundle: bool,
+) -> AppkitLaunchPlan {
+    if parent_is_launchd || launch_services_reachable {
+        return AppkitLaunchPlan::Continue;
+    }
+    if has_app_bundle {
+        AppkitLaunchPlan::Relaunch
+    } else {
+        AppkitLaunchPlan::Exit
+    }
+}
+
+fn app_bundle_path_from_executable(executable: &Path) -> Option<PathBuf> {
+    let bundle = executable.parent()?.parent()?.parent()?;
+    (bundle.extension().and_then(|ext| ext.to_str()) == Some("app")).then(|| bundle.to_path_buf())
+}
+
+// macOS AppKit abort()s in _RegisterApplication when this process cannot obtain
+// an ASN from launchservicesd (typically an inherited sandbox from a parent
+// such as a browser agent). Probe before EventLoop/NSApplication is created.
+pub(crate) fn ensure_macos_appkit_launch_context() {
+    #[cfg(target_os = "macos")]
+    ensure_macos_appkit_launch_context_macos();
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_macos_appkit_launch_context_macos() {
+    let bundle = std::env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(app_bundle_path_from_executable);
+    match appkit_launch_plan(
+        process_parent_id() == LAUNCHD_PID,
+        launch_services_reachable(),
+        bundle.is_some(),
+    ) {
+        AppkitLaunchPlan::Continue => {}
+        AppkitLaunchPlan::Relaunch => {
+            if let Some(bundle) = bundle.as_deref()
+                && relaunch_via_launch_services(bundle)
+            {
+                std::process::exit(0);
+            }
+            exit_for_unreachable_launch_services();
+        }
+        AppkitLaunchPlan::Exit => exit_for_unreachable_launch_services(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn process_parent_id() -> u32 {
+    // SAFETY: getppid is a POSIX query of this process's parent.
+    (unsafe { libc_getppid() }) as u32
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    #[link_name = "getppid"]
+    fn libc_getppid() -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn launch_services_reachable() -> bool {
+    !sandbox_denies_launch_services_lookup() && launch_services_mach_service_reachable()
+}
+
+#[cfg(target_os = "macos")]
+fn sandbox_denies_launch_services_lookup() -> bool {
+    let Ok(operation) = std::ffi::CString::new("mach-lookup") else {
+        return false;
+    };
+    let Ok(name) = std::ffi::CString::new(LAUNCH_SERVICES_MACH_SERVICE) else {
+        return false;
+    };
+    const SANDBOX_FILTER_GLOBAL_NAME: i32 = 2;
+    const SANDBOX_CHECK_NO_REPORT: i32 = 1 << 16;
+
+    // SAFETY: CStrings outlive the call; sandbox_check only reads the pointers.
+    let result = unsafe {
+        sandbox_check(
+            std::process::id() as i32,
+            operation.as_ptr(),
+            SANDBOX_FILTER_GLOBAL_NAME | SANDBOX_CHECK_NO_REPORT,
+            name.as_ptr(),
+        )
+    };
+    result != 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::PermissionDenied
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn sandbox_check(
+        pid: i32,
+        operation: *const std::ffi::c_char,
+        filter_type: i32,
+        name: *const std::ffi::c_char,
+    ) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn launch_services_mach_service_reachable() -> bool {
+    let Ok(name) = std::ffi::CString::new(LAUNCH_SERVICES_MACH_SERVICE) else {
+        return false;
+    };
+    let mut port = 0u32;
+    // SAFETY: bootstrap_port is the process bootstrap port; name is a valid
+    // C string; we deallocate any returned send right.
+    let kr = unsafe { bootstrap_look_up(bootstrap_port, name.as_ptr(), &mut port) };
+    if kr == 0 && port != 0 {
+        unsafe {
+            let _ = mach_port_deallocate(mach_task_self_, port);
+        }
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    static bootstrap_port: u32;
+    static mach_task_self_: u32;
+    fn bootstrap_look_up(bp: u32, service_name: *const std::ffi::c_char, sp: *mut u32) -> i32;
+    fn mach_port_deallocate(task: u32, name: u32) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn relaunch_via_launch_services(bundle: &Path) -> bool {
+    let mut command = std::process::Command::new("/usr/bin/open");
+    command.arg(bundle);
+    let extra_args: Vec<_> = std::env::args_os().skip(1).collect();
+    if !extra_args.is_empty() {
+        command.arg("--args").args(extra_args);
+    }
+    command
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn exit_for_unreachable_launch_services() -> ! {
+    eprintln!(
+        "Anarlog could not start because this environment cannot register a Mac app with Launch Services. Open Anarlog from the Dock, Spotlight, or Finder."
+    );
+
+    let alert = "display alert \"Anarlog could not start\" message \"This environment cannot open Anarlog as a graphical app. Please open Anarlog from the Dock, Spotlight, or Finder.\" as critical buttons {\"OK\"} default button \"OK\"";
+    let _ = std::process::Command::new("/usr/bin/osascript")
+        .args(["-e", alert])
+        .spawn();
+
+    std::process::exit(1);
 }
 
 // Startup migrations can hold the database for minutes before any window or
@@ -223,5 +392,59 @@ mod tests {
         let state = indicator.state.lock().unwrap();
         assert!(state.dismissed);
         assert!(state.child.is_none());
+    }
+
+    #[test]
+    fn appkit_launch_plan_continues_when_parent_is_launchd() {
+        assert_eq!(
+            appkit_launch_plan(true, false, true),
+            AppkitLaunchPlan::Continue
+        );
+    }
+
+    #[test]
+    fn appkit_launch_plan_continues_when_launch_services_is_reachable() {
+        assert_eq!(
+            appkit_launch_plan(false, true, false),
+            AppkitLaunchPlan::Continue
+        );
+    }
+
+    #[test]
+    fn appkit_launch_plan_relaunches_a_bundle_when_launch_services_is_blocked() {
+        assert_eq!(
+            appkit_launch_plan(false, false, true),
+            AppkitLaunchPlan::Relaunch
+        );
+    }
+
+    #[test]
+    fn appkit_launch_plan_exits_unpackaged_binaries_when_launch_services_is_blocked() {
+        assert_eq!(
+            appkit_launch_plan(false, false, false),
+            AppkitLaunchPlan::Exit
+        );
+    }
+
+    #[test]
+    fn app_bundle_path_from_macos_executable() {
+        assert_eq!(
+            app_bundle_path_from_executable(Path::new(
+                "/Applications/Anarlog.app/Contents/MacOS/anarlog"
+            )),
+            Some(PathBuf::from("/Applications/Anarlog.app"))
+        );
+    }
+
+    #[test]
+    fn app_bundle_path_ignores_unpackaged_executables() {
+        assert_eq!(
+            app_bundle_path_from_executable(Path::new("/tmp/target/debug/desktop")),
+            None
+        );
+        assert_eq!(
+            app_bundle_path_from_executable(Path::new("/Applications/Anarlog.app/Contents/MacOS")),
+            None
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Stable 1.4.13 aborted on macOS 26 during `NSApplication` init:

```
abort()
___RegisterApplication_block_invoke
_RegisterApplication
+[NSApplication sharedApplication]
tao::EventLoop::new
tauri::Builder::build
```

The process was spawned from bash under Aside (`procRole: Unspecified`, coalition `at.studio.AsideBrowser`). In that launch context, `launchservicesd` is unreachable (inherited sandbox / bootstrap), so HIServices `abort()`s instead of returning an error. This is the same AppKit path as Electron/Codex reports for macOS 26.

Normal Dock / Spotlight / `open` launches are unaffected.

## Fix

Before creating the Tauri event loop, probe whether this process can talk to Launch Services. If not:

1. Relaunch the `.app` bundle with `/usr/bin/open` so launchd starts a properly registered GUI process (when the parent sandbox allows it).
2. Otherwise print a clear error, show the existing osascript alert, and `exit(1)` instead of crashing.

Dock-launched processes (parent `launchd`) skip the probe.

## Testing

- `cargo test -p desktop --lib startup` (Linux): 12 passed
- Could not reproduce the macOS 26 / Aside launch path in this environment

Open Anarlog from the Dock, Spotlight, or Finder. Running `/Applications/Anarlog.app/Contents/MacOS/anarlog` from a sandboxed agent/terminal should no longer produce a crash report.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa565faa-0327-42aa-bcfe-cf74773a5d89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa565faa-0327-42aa-bcfe-cf74773a5d89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

