### PR TITLE
Show restored data during device sync

### DIFF
--- a/crates/db-sync/src/witness.rs
+++ b/crates/db-sync/src/witness.rs
@@ -214,6 +214,26 @@ impl E2eeWitnessClient {
         keyring: &anlg_e2ee::WorkspaceKeyring,
         cancellation: &E2eeWitnessCancellation,
     ) -> io::Result<()> {
+        self.initialize_keyring_with_page_handler_cancellable(
+            pool,
+            keyring,
+            || std::future::ready(Ok(())),
+            cancellation,
+        )
+        .await
+    }
+
+    pub async fn initialize_keyring_with_page_handler_cancellable<F, Fut>(
+        &self,
+        pool: &sqlx::SqlitePool,
+        keyring: &anlg_e2ee::WorkspaceKeyring,
+        mut on_merged_page: F,
+        cancellation: &E2eeWitnessCancellation,
+    ) -> io::Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = io::Result<()>>,
+    {
         let cursor = witness_cursor_cancellable(pool, &self.workspace_id, cancellation).await?;
         let status = self
             .read_page_cancellable(cursor, None, cancellation)
@@ -224,8 +244,13 @@ impl E2eeWitnessClient {
         }
 
         if status.initialized {
-            self.refresh_keyring_cancellable(pool, keyring, cancellation)
-                .await?;
+            self.refresh_keyring_with_page_handler_cancellable(
+                pool,
+                keyring,
+                &mut on_merged_page,
+                cancellation,
+            )
+            .await?;
             self.publish_pending(pool, keyring.active(), false, cancellation)
                 .await?;
         } else {
@@ -243,9 +268,14 @@ impl E2eeWitnessClient {
                 .await?;
         }
 
-        self.refresh_keyring_cancellable(pool, keyring, cancellation)
-            .await
-            .map(|_| ())
+        self.refresh_keyring_with_page_handler_cancellable(
+            pool,
+            keyring,
+            &mut on_merged_page,
+            cancellation,
+        )
+        .await?;
+        Ok(())
     }
 
     #[cfg(test)]
@@ -386,11 +416,55 @@ impl E2eeWitnessClient {
         &self,
         pool: &sqlx::SqlitePool,
         keyring: &anlg_e2ee::WorkspaceKeyring,
-        mut on_events: F,
+        on_events: F,
         cancellation: &E2eeWitnessCancellation,
     ) -> io::Result<usize>
     where
         F: FnMut(),
+    {
+        self.refresh_keyring_with_handlers_cancellable(
+            pool,
+            keyring,
+            on_events,
+            || std::future::ready(Ok(())),
+            cancellation,
+        )
+        .await
+    }
+
+    pub async fn refresh_keyring_with_page_handler_cancellable<F, Fut>(
+        &self,
+        pool: &sqlx::SqlitePool,
+        keyring: &anlg_e2ee::WorkspaceKeyring,
+        on_merged_page: F,
+        cancellation: &E2eeWitnessCancellation,
+    ) -> io::Result<usize>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = io::Result<()>>,
+    {
+        self.refresh_keyring_with_handlers_cancellable(
+            pool,
+            keyring,
+            || {},
+            on_merged_page,
+            cancellation,
+        )
+        .await
+    }
+
+    async fn refresh_keyring_with_handlers_cancellable<F, G, Fut>(
+        &self,
+        pool: &sqlx::SqlitePool,
+        keyring: &anlg_e2ee::WorkspaceKeyring,
+        mut on_events: F,
+        mut on_merged_page: G,
+        cancellation: &E2eeWitnessCancellation,
+    ) -> io::Result<usize>
+    where
+        F: FnMut(),
+        G: FnMut() -> Fut,
+        Fut: Future<Output = io::Result<()>>,
     {
         let mut cursor = witness_cursor_cancellable(pool, &self.workspace_id, cancellation).await?;
         let mut page = self
@@ -409,8 +483,9 @@ impl E2eeWitnessClient {
         let through = page.through_sequence;
         let mut received_events = 0_usize;
         loop {
+            let page_has_events = !page.events.is_empty();
             received_events = received_events.saturating_add(page.events.len());
-            if !page.events.is_empty() {
+            if page_has_events {
                 on_events();
             }
             let events = page
@@ -436,6 +511,10 @@ impl E2eeWitnessClient {
             .map_err(replica_error)?;
             cancellation.check()?;
             let after = page.next_after_sequence;
+            if page_has_events {
+                on_merged_page().await?;
+                cancellation.check()?;
+            }
             if after != cursor {
                 cancellation.check()?;
                 anlg_db_app::advance_e2ee_witness_cursor(pool, &self.workspace_id, after)

--- a/crates/db-sync/src/witness/tests.rs
+++ b/crates/db-sync/src/witness/tests.rs
@@ -97,6 +97,29 @@ impl Respond for InterruptedPage {
     }
 }
 
+#[derive(Clone)]
+struct PagedWitness {
+    events: Vec<serde_json::Value>,
+    page_size: usize,
+}
+
+impl Respond for PagedWitness {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let after = request
+            .url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "afterSequence").then(|| value.parse().unwrap()))
+            .unwrap_or(0);
+        let start = usize::try_from(after).unwrap();
+        let end = start.saturating_add(self.page_size).min(self.events.len());
+        witness_page(
+            &self.events[start..end],
+            self.events.len() as u64,
+            self.events.len() as u64,
+        )
+    }
+}
+
 fn witness_page(
     events: &[serde_json::Value],
     head_sequence: u64,
@@ -368,6 +391,106 @@ async fn empty_refresh_does_not_write_an_unchanged_cursor() {
             .unwrap(),
         0
     );
+}
+
+#[tokio::test]
+async fn merged_witness_pages_can_materialize_rows_before_refresh_completes() {
+    let db = anlg_db_core::Db::connect_memory_plain().await.unwrap();
+    anlg_db_app::prepare_schema(&db).await.unwrap();
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    let key = recovery_key.workspace_key("user-a").unwrap();
+    let writer_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let manifest = key
+        .seal_field(
+            "user-a",
+            "sessions",
+            "session-1",
+            "$row",
+            writer_id,
+            1,
+            false,
+            json!(true),
+        )
+        .unwrap();
+    let title = key
+        .seal_field(
+            "user-a",
+            "sessions",
+            "session-1",
+            "title",
+            writer_id,
+            1,
+            false,
+            json!("Remote"),
+        )
+        .unwrap();
+    let events = [manifest, title]
+        .into_iter()
+        .enumerate()
+        .map(|(index, sealed)| {
+            json!({
+                "sequence": index + 1,
+                "recordId": sealed.record_id,
+                "payloadHash": anlg_e2ee::payload_hash(&sealed.payload),
+                "payload": sealed.payload,
+            })
+        })
+        .collect::<Vec<_>>();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/sync/e2ee/witness/user-a"))
+        .respond_with(PagedWitness {
+            events,
+            page_size: 1,
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+    let client = E2eeWitnessClient::new(
+        E2eeWitnessConfig {
+            endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+            access_token: "access-token".to_string(),
+        },
+        "user-a",
+    )
+    .unwrap();
+    let keys = HashMap::from([("user-a".to_string(), key.clone().into())]);
+    let observed_titles = Arc::new(Mutex::new(Vec::new()));
+    let observed_titles_for_handler = Arc::clone(&observed_titles);
+
+    client
+        .refresh_keyring_with_page_handler_cancellable(
+            db.pool(),
+            &keys["user-a"],
+            || {
+                let observed_titles = Arc::clone(&observed_titles_for_handler);
+                let pool = db.pool().clone();
+                let keys = keys.clone();
+                async move {
+                    anlg_db_app::apply_received_e2ee_replica_changes_with_witness(
+                        &pool, &keys, true,
+                    )
+                    .await
+                    .map_err(replica_error)?;
+                    let title = sqlx::query_scalar::<_, String>(
+                        "SELECT title FROM sessions WHERE id = 'session-1'",
+                    )
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(|error| io::Error::other(error.to_string()))?;
+                    observed_titles.lock().unwrap().push(title);
+                    Ok(())
+                }
+            },
+            &E2eeWitnessCancellation::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*observed_titles.lock().unwrap(), ["", "Remote"]);
 }
 
 #[tokio::test]

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -1314,11 +1314,45 @@ impl PluginDbRuntime {
         for workspace_id in workspace_ids {
             let witness = &witnesses[workspace_id];
             witness
-                .initialize_keyring_cancellable(self.db.pool(), &keys[workspace_id], cancellation)
+                .initialize_keyring_with_page_handler_cancellable(
+                    self.db.pool(),
+                    &keys[workspace_id],
+                    || self.materialize_authenticated_e2ee_changes(keys, cancellation),
+                    cancellation,
+                )
                 .await?;
             cancellation.check()?;
         }
         Ok(())
+    }
+
+    async fn materialize_authenticated_e2ee_changes(
+        &self,
+        keys: &HashMap<String, anlg_e2ee::WorkspaceKeyring>,
+        cancellation: &crate::e2ee_witness::E2eeWitnessCancellation,
+    ) -> std::io::Result<()> {
+        loop {
+            cancellation.check()?;
+            let stats = anlg_db_app::apply_received_e2ee_replica_changes_with_witness_cancellable(
+                self.db.pool(),
+                keys,
+                true,
+                || cancellation.is_cancelled(),
+            )
+            .await
+            .map_err(|error| {
+                std::io::Error::other(format!("E2EE witness hydration failed: {error}"))
+            })?;
+            cancellation.check()?;
+            tracing::debug!(
+                applied_fields = stats.applied_fields,
+                remaining = stats.remaining_replica_changes,
+                "materialized authenticated E2EE changes"
+            );
+            if !stats.remaining_replica_changes {
+                return Ok(());
+            }
+        }
     }
 
     async fn legacy_e2ee_cutover_required(&self) -> Result<bool> {

--- a/plugins/db/src/runtime/tests/recovery_protocol.rs
+++ b/plugins/db/src/runtime/tests/recovery_protocol.rs
@@ -277,6 +277,72 @@ async fn legacy_cutover_snapshots_local_state_before_initializing_the_witness() 
 }
 
 #[tokio::test]
+async fn witness_hydration_drains_more_than_one_replica_apply_batch() {
+    let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
+    anlg_db_app::prepare_schema(db.as_ref()).await.unwrap();
+    let runtime = PluginDbRuntime::new(std::sync::Arc::clone(&db));
+    let workspace_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap()
+    .workspace_key("workspace-1")
+    .unwrap();
+    let events = (0..20)
+        .map(|index| {
+            let sealed = workspace_key
+                .seal_field(
+                    "workspace-1",
+                    "sessions",
+                    &format!("session-{index:02}"),
+                    "$row",
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    1,
+                    false,
+                    serde_json::json!(true),
+                )
+                .unwrap();
+            anlg_db_app::E2eeWitnessEvent {
+                sequence: u64::try_from(index + 1).unwrap(),
+                record_id: sealed.record_id,
+                workspace_id: "workspace-1".to_string(),
+                payload_hash: anlg_e2ee::payload_hash(&sealed.payload),
+                payload: sealed.payload,
+            }
+        })
+        .collect::<Vec<_>>();
+    anlg_db_app::merge_e2ee_witness_events(db.pool(), &workspace_key, "workspace-1", &events)
+        .await
+        .unwrap();
+    let keys = HashMap::from([(
+        "workspace-1".to_string(),
+        anlg_e2ee::WorkspaceKeyring::new(workspace_key),
+    )]);
+
+    runtime
+        .materialize_authenticated_e2ee_changes(
+            &keys,
+            &crate::e2ee_witness::E2eeWitnessCancellation::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM sessions WHERE id LIKE 'session-%'",)
+            .fetch_one(db.pool())
+            .await
+            .unwrap(),
+        20
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM e2ee_replica_pending")
+            .fetch_one(db.pool())
+            .await
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
 async fn reconciliation_barrier_blocks_renderer_writes() {
     let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
     let runtime = std::sync::Arc::new(PluginDbRuntime::new(db));


### PR DESCRIPTION
Materialize authenticated witness pages incrementally so live queries reveal restored notes before initial sync completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches E2EE witness initialization and replica hydration during CloudSync cutover; incorrect ordering could leave partial state visible, but behavior is covered by new integration tests.
> 
> **Overview**
> **Restored notes can appear in the UI while initial E2EE witness sync is still running**, instead of waiting until the full refresh finishes.
> 
> The witness client gains an **`on_merged_page` async hook** on keyring initialize/refresh: after each authenticated page is merged into local witness state, callers can run work before the cursor advances. Existing APIs delegate to this with a no-op handler. The DB plugin wires witness initialization to **`materialize_authenticated_e2ee_changes`**, which loops **`apply_received_e2ee_replica_changes_with_witness_cancellable`** until pending replica work is drained.
> 
> Tests add a paged witness mock and cover per-page materialization (e.g. session title updates after each page) and multi-batch hydration of many sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e49ae8415ff907369e9ef82b77d573dfb154ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->