### PR TITLE
Create a contact when enhance finds no existing one

### DIFF
--- a/apps/desktop/src/contacts/queries.test.tsx
+++ b/apps/desktop/src/contacts/queries.test.tsx
@@ -621,4 +621,36 @@ describe("contact SQLite queries", () => {
     expect(statements[1]?.sql).toContain("organization_id = CASE");
     expect(statements[1]?.params).toContain("human-1");
   });
+
+  it("inserts a missing human before applying enhancement changes", async () => {
+    mocks.executeTransaction.mockResolvedValueOnce([1, 1]);
+
+    await applyContactEnhancement({
+      humanId: "human-1",
+      ownerUserId: "user-1",
+      createIfMissing: true,
+      changes: {
+        name: "Marco Bambini",
+        email: "marco.bambini@gmail.com",
+      },
+    });
+
+    const statements = mocks.executeTransaction.mock.calls[0][0];
+    expect(statements).toHaveLength(2);
+    expect(statements[0]?.sql).toContain("INSERT INTO humans");
+    expect(statements[0]?.sql).toContain("ON CONFLICT(id) DO UPDATE");
+    expect(statements[0]?.params).toEqual([
+      "human-1",
+      "user-1",
+      "Marco Bambini",
+      "marco.bambini@gmail.com",
+      expect.any(String),
+      expect.any(String),
+    ]);
+    expect(statements[1]?.sql).toContain("UPDATE humans");
+    expect(mocks.trackAnalyticsEvent).toHaveBeenCalledWith("contact_created", {
+      entry_point: "session_participants",
+      has_email: true,
+    });
+  });
 });

--- a/apps/desktop/src/contacts/queries.ts
+++ b/apps/desktop/src/contacts/queries.ts
@@ -780,14 +780,58 @@ export function applyContactEnhancement({
   humanId,
   ownerUserId,
   changes,
+  createIfMissing = false,
 }: {
   humanId: string;
   ownerUserId: string;
   changes: { name?: string; email?: string; companyName?: string };
+  createIfMissing?: boolean;
 }): Promise<void> {
   return enqueueDatabaseWrite(`human:${humanId}`, async () => {
     const now = new Date().toISOString();
     const statements: Array<{ sql: string; params: unknown[] }> = [];
+
+    if (createIfMissing) {
+      statements.push({
+        sql: `
+          INSERT INTO humans (
+            id, workspace_id, owner_user_id, organization_id, name, email,
+            phone, job_title, linkedin_username, memo, pinned, pin_order,
+            metadata_json, created_at, updated_at, deleted_at
+          ) VALUES (
+            ?, NULLIF((
+              SELECT json_extract(value_json, '$.workspace_id')
+              FROM app_settings
+              WHERE id = 'cloudsync_workspace_binding'
+            ), ''), COALESCE(
+              NULLIF(NULLIF(?, ''), '${DEFAULT_USER_ID}'),
+              NULLIF((
+                SELECT json_extract(value_json, '$.workspace_id')
+                FROM app_settings
+                WHERE id = 'cloudsync_workspace_binding'
+              ), ''),
+              '${DEFAULT_USER_ID}'
+            ), '', ?, ?, '', '', '', '', 0, NULL, '{}', ?, ?, NULL
+          )
+          ON CONFLICT(id) DO UPDATE SET
+            deleted_at = NULL,
+            updated_at = excluded.updated_at
+          WHERE humans.deleted_at IS NOT NULL
+        `,
+        params: [
+          humanId,
+          ownerUserId,
+          changes.name ?? "",
+          changes.email ?? "",
+          now,
+          now,
+        ],
+      });
+      trackAnalyticsEvent("contact_created", {
+        entry_point: "session_participants",
+        has_email: Boolean(changes.email),
+      });
+    }
 
     if (changes.companyName) {
       const organizationId = id();

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -155,6 +155,7 @@ describe("event contact extraction", () => {
         {
           name: "Alice Kim",
           email: "alice@example.com",
+          companyName: "Example",
         },
       ],
     });
@@ -202,6 +203,22 @@ describe("event contact extraction", () => {
   });
 
   test("infers a company from a work email when creating a contact", () => {
+    const extraction = extractEventContacts({
+      context: {
+        title: "Check-in",
+        candidates: [
+          {
+            name: "John Jeong",
+            email: "john@example.com",
+            isCurrentUser: true,
+          },
+          {
+            name: "tom@kestroll.com",
+            email: "tom@kestroll.com",
+          },
+        ],
+      },
+    });
     const { result, changes } = planExtractedContactToHuman({
       humanId: "human-1",
       userId: "user-1",
@@ -212,7 +229,7 @@ describe("event contact extraction", () => {
         name: "tom@kestroll.com",
         email: "tom@kestroll.com",
       },
-      contacts: [],
+      contacts: extraction.contacts,
     });
 
     expect(result).toMatchObject({ matched: true, created: 1 });
@@ -220,6 +237,51 @@ describe("event contact extraction", () => {
       name: "Tom",
       email: "tom@kestroll.com",
       companyName: "Kestroll",
+    });
+  });
+
+  test("does not treat a shared first name with a different email as the current user", () => {
+    const extraction = extractEventContacts({
+      context: {
+        title: "Intro",
+        candidates: [
+          {
+            name: "John Jeong",
+            email: "john@example.com",
+            isCurrentUser: true,
+          },
+          {
+            name: "john@other.com",
+            email: "john@other.com",
+          },
+        ],
+      },
+    });
+    const { result, changes } = planExtractedContactToHuman({
+      humanId: "human-1",
+      userId: "user-1",
+      human: undefined,
+      currentUser: { name: "John Jeong", email: "john@example.com" },
+      mappingSource: "auto",
+      participant: {
+        name: "john@other.com",
+        email: "john@other.com",
+      },
+      contacts: extraction.contacts,
+    });
+
+    expect(extraction.contacts).toEqual([
+      {
+        name: "John",
+        email: "john@other.com",
+        companyName: "Other",
+      },
+    ]);
+    expect(result).toMatchObject({ matched: true, created: 1, skipped: 0 });
+    expect(changes).toEqual({
+      name: "John",
+      email: "john@other.com",
+      companyName: "Other",
     });
   });
 

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.test.ts
@@ -159,4 +159,98 @@ describe("event contact extraction", () => {
       ],
     });
   });
+
+  test("creates a contact from the participant when the human is missing", () => {
+    const { result, changes } = planExtractedContactToHuman({
+      humanId: "human-1",
+      userId: "user-1",
+      human: undefined,
+      currentUser: { name: "John Jeong", email: "john@example.com" },
+      mappingSource: "auto",
+      participant: {
+        name: "marco.bambini@gmail.com",
+        email: "marco.bambini@gmail.com",
+      },
+      contacts: [],
+    });
+
+    expect(result).toMatchObject({ matched: true, created: 1, updated: 0 });
+    expect(changes).toEqual({
+      name: "Marco Bambini",
+      email: "marco.bambini@gmail.com",
+    });
+  });
+
+  test("derives a name from an email-only human when extraction is empty", () => {
+    const { result, changes } = planExtractedContactToHuman({
+      humanId: "human-1",
+      userId: "user-1",
+      human: {
+        name: "marco.bambini@gmail.com",
+        email: "marco.bambini@gmail.com",
+        organizationId: "",
+      },
+      currentUser: { name: "John Jeong", email: "john@example.com" },
+      mappingSource: "auto",
+      contacts: [],
+    });
+
+    expect(result).toMatchObject({ matched: true, created: 0, updated: 1 });
+    expect(changes).toEqual({
+      name: "Marco Bambini",
+    });
+  });
+
+  test("infers a company from a work email when creating a contact", () => {
+    const { result, changes } = planExtractedContactToHuman({
+      humanId: "human-1",
+      userId: "user-1",
+      human: undefined,
+      currentUser: { name: "John Jeong", email: "john@example.com" },
+      mappingSource: "auto",
+      participant: {
+        name: "tom@kestroll.com",
+        email: "tom@kestroll.com",
+      },
+      contacts: [],
+    });
+
+    expect(result).toMatchObject({ matched: true, created: 1 });
+    expect(changes).toEqual({
+      name: "Tom",
+      email: "tom@kestroll.com",
+      companyName: "Kestroll",
+    });
+  });
+
+  test("extracts organizer contacts that only have an email", () => {
+    const result = extractEventContacts({
+      context: {
+        title: "SQLite AI",
+        description:
+          "<p>Marco Bambini is inviting you to a scheduled Zoom meeting.</p>",
+        candidates: [
+          {
+            humanId: "user-1",
+            name: "John Jeong",
+            email: "john@example.com",
+            isCurrentUser: true,
+          },
+          {
+            humanId: "human-1",
+            name: "marco.bambini@gmail.com",
+            email: "marco.bambini@gmail.com",
+            isOrganizer: true,
+          },
+        ],
+      },
+    });
+
+    expect(result.contacts).toEqual([
+      {
+        name: "Marco Bambini",
+        email: "marco.bambini@gmail.com",
+      },
+    ]);
+  });
 });

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -90,6 +90,7 @@ export function planExtractedContactToHuman({
   human,
   currentUser,
   mappingSource,
+  participant,
   contacts,
 }: {
   humanId: string;
@@ -97,6 +98,7 @@ export function planExtractedContactToHuman({
   human: { name: string; email: string; organizationId: string } | undefined;
   currentUser: { name: string; email: string } | undefined;
   mappingSource: string | undefined;
+  participant?: { name: string; email: string };
   contacts: ExtractedEventContact[];
 }): {
   result: ApplyContactEnhancementResult;
@@ -113,21 +115,24 @@ export function planExtractedContactToHuman({
   };
   const changes: ContactEnhancementChanges = {};
 
-  if (
-    normalizedContacts.length === 0 ||
-    !human ||
-    !mappingSource ||
-    mappingSource === "excluded"
-  ) {
+  if (!mappingSource || mappingSource === "excluded") {
     if (normalizedContacts.length > 0) result.skipped += 1;
     return { result, changes };
   }
 
-  const contact = findContactForHuman(human, normalizedContacts);
+  const identity = {
+    name: human?.name || participant?.name || "",
+    email: human?.email || participant?.email || "",
+    organizationId: human?.organizationId || "",
+  };
+  const contact =
+    findContactForHuman(identity, normalizedContacts) ??
+    contactFromIdentity(identity);
+
   if (!contact) {
-    if (humanId === userId) {
+    if (humanId === userId && normalizedContacts[0]) {
       result.matched = true;
-      result.contacts.push(normalizedContacts[0]!);
+      result.contacts.push(normalizedContacts[0]);
       result.skipped += 1;
     }
     return { result, changes };
@@ -137,6 +142,14 @@ export function planExtractedContactToHuman({
   result.contacts.push(contact);
   if (humanId === userId || isCurrentUserContact(contact, currentUser)) {
     result.skipped += 1;
+    return { result, changes };
+  }
+
+  if (!human) {
+    changes.name = contact.name;
+    if (contact.email) changes.email = contact.email;
+    if (contact.companyName) changes.companyName = contact.companyName;
+    result.created = 1;
     return { result, changes };
   }
 
@@ -163,7 +176,7 @@ export function extractEventContacts({
     [
       ...inferContactsFromEventText(context),
       ...context.candidates.flatMap((candidate) =>
-        candidate.isCurrentUser || candidate.isOrganizer
+        candidate.isCurrentUser
           ? []
           : [{ name: candidate.name, email: candidate.email }],
       ),
@@ -292,8 +305,12 @@ function normalizeExtractedContacts(
   const keysByName = new Map<string, string>();
 
   for (const contact of contacts) {
-    const name = cleanNameHint(contact.name ?? "");
-    const email = normalizeEmail(contact.email ?? undefined);
+    let name = cleanNameHint(contact.name ?? "");
+    const email =
+      normalizeEmail(contact.email ?? undefined) ?? normalizeEmail(name);
+    if (!isLikelyPersonName(name) && email) {
+      name = nameFromEmailLocalPart(email);
+    }
     if (!isLikelyPersonName(name) || isSelfReference(name, candidates)) {
       continue;
     }
@@ -586,6 +603,91 @@ function getStrongCandidateAliases(
   }
 
   return aliases;
+}
+
+const PERSONAL_EMAIL_DOMAINS = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "yahoo.com",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "msn.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "aol.com",
+  "proton.me",
+  "protonmail.com",
+  "pm.me",
+  "hey.com",
+  "fastmail.com",
+]);
+
+function contactFromIdentity(identity: {
+  name?: string;
+  email?: string;
+}): ExtractedEventContact | undefined {
+  const rawName = cleanNameHint(identity.name ?? "");
+  const email = normalizeEmail(identity.email) ?? normalizeEmail(rawName);
+  const name = isLikelyPersonName(rawName)
+    ? rawName
+    : email
+      ? nameFromEmailLocalPart(email)
+      : "";
+  if (!isLikelyPersonName(name)) {
+    return undefined;
+  }
+
+  const contact: ExtractedEventContact = { name };
+  if (email) {
+    contact.email = email;
+  }
+  const companyName = inferCompanyNameFromEmail(email);
+  if (companyName) {
+    contact.companyName = companyName;
+  }
+  return contact;
+}
+
+function nameFromEmailLocalPart(email: string): string {
+  const local = email.split("@")[0]?.split("+")[0] ?? "";
+  return local
+    .replace(/[._-]+/g, " ")
+    .split(" ")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0 && !/^\d+$/.test(part))
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function inferCompanyNameFromEmail(
+  email: string | undefined,
+): string | undefined {
+  const domain = email?.split("@")[1]?.toLowerCase();
+  if (!domain || PERSONAL_EMAIL_DOMAINS.has(domain)) {
+    return undefined;
+  }
+
+  const labels = domain.split(".").filter(Boolean);
+  if (labels.length < 2) {
+    return undefined;
+  }
+
+  const secondLast = labels[labels.length - 2];
+  const companyLabel =
+    labels.length >= 3 &&
+    secondLast &&
+    ["co", "com", "org", "net", "ac"].includes(secondLast)
+      ? labels[labels.length - 3]
+      : secondLast;
+  if (!companyLabel || companyLabel.length < 2) {
+    return undefined;
+  }
+
+  return normalizeCompanyName(
+    companyLabel.charAt(0).toUpperCase() + companyLabel.slice(1),
+  );
 }
 
 function shouldUpdateHumanName(

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/event-contact-extraction.ts
@@ -311,12 +311,17 @@ function normalizeExtractedContacts(
     if (!isLikelyPersonName(name) && email) {
       name = nameFromEmailLocalPart(email);
     }
-    if (!isLikelyPersonName(name) || isSelfReference(name, candidates)) {
+    if (
+      !isLikelyPersonName(name) ||
+      (!email && isSelfReference(name, candidates))
+    ) {
       continue;
     }
 
     const matchedEmail = email || matchCandidateEmail(name, candidates);
-    const companyName = normalizeCompanyName(contact.companyName);
+    const companyName =
+      normalizeCompanyName(contact.companyName) ??
+      inferCompanyNameFromEmail(matchedEmail);
     const normalizedContact: ExtractedEventContact = {
       name,
     };
@@ -495,8 +500,9 @@ function isSelfContactFromCandidates(
       return false;
     }
 
-    if (email && email === normalizeEmail(candidate.email)) {
-      return true;
+    const candidateEmail = normalizeEmail(candidate.email);
+    if (email) {
+      return Boolean(candidateEmail && email === candidateEmail);
     }
 
     return getCandidateAliases(candidate).has(name);
@@ -512,8 +518,9 @@ function isCurrentUserContact(
   }
 
   const email = normalizeEmail(contact.email);
-  if (email && email === normalizeEmail(stringCell(currentUser.email))) {
-    return true;
+  const currentEmail = normalizeEmail(stringCell(currentUser.email));
+  if (email && currentEmail) {
+    return email === currentEmail;
   }
 
   const currentUserCandidate: EventContactCandidate = {

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -438,21 +438,30 @@ function useEventContactEnhancement(sessionId: string) {
         human,
         currentUser,
         mappingSource: participant?.source,
+        participant: participant
+          ? { name: participant.name, email: participant.email }
+          : undefined,
         contacts: extraction.contacts,
       });
       await applyContactEnhancement({
         humanId,
         ownerUserId: userId,
         changes,
+        createIfMissing: applied.created > 0,
       });
 
-      return { extraction, applied, humanId };
+      return { applied, humanId };
     },
-    onSuccess: ({ extraction, applied, humanId }) => {
+    onSuccess: ({ applied, humanId }) => {
       const changed = applied.created + applied.updated + applied.linked;
       const toastId = `event-contact-enhancement-${humanId}`;
 
-      if (extraction.contacts.length === 0 || !applied.matched) {
+      if (applied.created > 0) {
+        sonnerToast.success("Contact created", { id: toastId });
+        return;
+      }
+
+      if (!applied.matched) {
         sonnerToast.info("No contact detail found", { id: toastId });
         return;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Clicking **Enhance contact** on a meeting participant no longer shows the blue "No contact detail found" toast when the person isn't already a full contact.

## What changed

Enhance now treats the participant themselves as the contact source:

- If the human row is missing, it **creates** the contact (and undeletes a soft-deleted row with the same id).
- If the participant is email-only (`marco.bambini@gmail.com`), it derives a display name and updates the contact.
- Organizer attendees are included in local extraction, not skipped.
- Work-email domains infer a company name during normalization, so the Enhance UI path (which matches extracted attendees first) still gets an organization. Personal inboxes like Gmail do not.
- A shared first name with a **different email** is not treated as the current user, so `john@other.com` still creates a contact for someone named John Jeong.

Success toasts are **Contact created** or **Contact enhanced**. The info toast only remains for the rare case where there is no name or email to save.

## Tests

- `event-contact-extraction.test.ts`: missing human, email-only name, work-email company through the Enhance extract+plan path, organizer email, shared first name with a different email
- `queries.test.tsx`: `createIfMissing` inserts the human before applying updates
- `pnpm -F desktop typecheck` and `pnpm -F desktop test` (3453 tests) passed locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92caa0a2-00ae-4399-9ea7-ff3dcefe82e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92caa0a2-00ae-4399-9ea7-ff3dcefe82e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

