### PR TITLE
Harden mobile capture and sync readiness

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,9 +1,13 @@
 import * as Sentry from "@sentry/react-native";
 import { type ErrorBoundaryProps, Stack, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 
+import {
+  getMobileCaptureActive,
+  subscribeMobileCapture,
+} from "@/audio/capture-lifecycle";
 import { recoverInterruptedRecordings } from "@/audio/recover-recordings";
 import { AuthProvider, useAuth } from "@/auth/context";
 import { PaywallScreen, SignInScreen } from "@/auth/screens";
@@ -16,7 +20,10 @@ import {
   initializeErrorReporting,
 } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
+import { canUseMobileCapture } from "@/sync/capture-access";
+import { getMobileSyncSnapshot, subscribeMobileSync } from "@/sync/mobile-sync";
 import { MobileSyncLifecycle } from "@/sync/mobile-sync-lifecycle";
+import { SyncEnrollmentScreen } from "@/sync/sync-enrollment-screen";
 import { initializeWatchConnectivity } from "@/watch-connectivity";
 
 initializeErrorReporting();
@@ -77,6 +84,16 @@ function Screens({ accountUserId }: { accountUserId: string | null }) {
 
 function Gate() {
   const auth = useAuth();
+  const captureActive = useSyncExternalStore(
+    subscribeMobileCapture,
+    getMobileCaptureActive,
+    getMobileCaptureActive,
+  );
+  const sync = useSyncExternalStore(
+    subscribeMobileSync,
+    getMobileSyncSnapshot,
+    getMobileSyncSnapshot,
+  );
   const [signingIn, setSigningIn] = useState(false);
 
   const handleSignIn = async () => {
@@ -91,6 +108,22 @@ function Gate() {
   };
 
   if (auth.bypass) return <Screens accountUserId={null} />;
+
+  if (captureActive) {
+    const activeSession = auth.session;
+    return (
+      <>
+        {activeSession && (
+          <MobileSyncLifecycle
+            key={`${activeSession.user.id}:${activeSession.access_token}`}
+            accessToken={activeSession.access_token}
+            accountUserId={activeSession.user.id}
+          />
+        )}
+        <Screens accountUserId={activeSession?.user.id ?? null} />
+      </>
+    );
+  }
 
   if (
     auth.status === "loading" ||
@@ -130,7 +163,11 @@ function Gate() {
         accessToken={session.access_token}
         accountUserId={session.user.id}
       />
-      <Screens accountUserId={session.user.id} />
+      {canUseMobileCapture(sync) ? (
+        <Screens accountUserId={session.user.id} />
+      ) : (
+        <SyncEnrollmentScreen />
+      )}
     </>
   );
 }

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -163,7 +163,7 @@ function Gate() {
         accessToken={session.access_token}
         accountUserId={session.user.id}
       />
-      {canUseMobileCapture(sync) ? (
+      {canUseMobileCapture(sync, session.user.id) ? (
         <Screens accountUserId={session.user.id} />
       ) : (
         <SyncEnrollmentScreen />

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,29 +1,15 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useRef, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useAuth } from "@/auth/context";
-import { ProfileSheet } from "@/components/profile-sheet";
 import { SessionCard } from "@/components/session-card";
+import { StartListeningButton } from "@/components/start-listening-button";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
-import {
-  Colors,
-  CornerCurve,
-  LISTENING_CONTROL_HEIGHT,
-  LISTENING_CONTROL_RADIUS,
-  Spacing,
-  Typography,
-} from "@/constants/theme";
+import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
 import { importVoiceMemos } from "@/data/import-voice-memo";
 import { useSessionSearch } from "@/data/search";
 import { createSession, deleteSession } from "@/data/session";
@@ -48,7 +34,6 @@ export default function HomeScreen() {
   const router = useRouter();
   const auth = useAuth();
   const { items, isLoading } = useTimelineSessions();
-  const [profileOpen, setProfileOpen] = useState(false);
   const [importing, setImporting] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const [settledSearchQuery, setSettledSearchQuery] = useState("");
@@ -172,9 +157,9 @@ export default function HomeScreen() {
         ) : (
           <>
             <IconButton
-              accessibilityLabel="Open profile"
+              accessibilityLabel="Open settings"
               icon="person-outline"
-              onPress={() => setProfileOpen(true)}
+              onPress={() => router.push("/settings")}
               variant="surface"
             />
             <IconButton
@@ -261,48 +246,41 @@ export default function HomeScreen() {
         )}
       </ScrollView>
 
-      <View style={styles.actions}>
-        <Button
-          label="New meeting"
-          onPress={() => void createAndOpen()}
-          leading={
-            <Ionicons name="create-outline" size={17} color={Colors.ink} />
-          }
-          style={styles.secondaryButton}
-          variant="outline"
-        />
-        <Button
-          label={importing ? "Importing…" : "Import recording"}
-          onPress={handleImport}
-          disabled={importing}
-          leading={
-            <Ionicons
-              name="cloud-upload-outline"
-              size={17}
-              color={Colors.ink}
+      {!searching && (
+        <>
+          <View style={styles.actions}>
+            <Button
+              label="New meeting"
+              onPress={() => void createAndOpen()}
+              leading={
+                <Ionicons name="create-outline" size={17} color={Colors.ink} />
+              }
+              style={styles.secondaryButton}
+              variant="outline"
             />
-          }
-          loading={importing}
-          style={styles.secondaryButton}
-          variant="outline"
-        />
-      </View>
+            <Button
+              label={importing ? "Importing…" : "Import recording"}
+              onPress={handleImport}
+              disabled={importing}
+              leading={
+                <Ionicons
+                  name="cloud-upload-outline"
+                  size={17}
+                  color={Colors.ink}
+                />
+              }
+              loading={importing}
+              style={styles.secondaryButton}
+              variant="outline"
+            />
+          </View>
 
-      <Pressable
-        onPress={() => void createAndOpen("?listen=1")}
-        style={({ pressed }) => [
-          styles.listenButton,
-          pressed && styles.pressed,
-        ]}
-      >
-        <View style={styles.listenDot} />
-        <Text style={styles.listenLabel}>Start listening</Text>
-      </Pressable>
-
-      <ProfileSheet
-        visible={profileOpen}
-        onClose={() => setProfileOpen(false)}
-      />
+          <StartListeningButton
+            bottomSpacing={Spacing.xs}
+            onPress={() => void createAndOpen("?listen=1")}
+          />
+        </>
+      )}
     </SafeAreaView>
   );
 }
@@ -317,14 +295,17 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.md,
   },
   searchInput: {
     flex: 1,
+    height: ControlSize.compact,
     marginRight: Spacing.sm,
+    paddingVertical: Spacing.sm,
     ...Typography.body,
     color: Colors.ink,
-    paddingVertical: 0,
+    textAlignVertical: "center",
   },
   list: {
     flex: 1,
@@ -367,31 +348,5 @@ const styles = StyleSheet.create({
   },
   secondaryButton: {
     flex: 1,
-  },
-  pressed: {
-    opacity: 0.6,
-  },
-  listenButton: {
-    height: LISTENING_CONTROL_HEIGHT,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: Spacing.sm,
-    marginHorizontal: Spacing.lg,
-    marginBottom: Spacing.md,
-    borderRadius: LISTENING_CONTROL_RADIUS,
-    borderCurve: CornerCurve.squircle,
-    backgroundColor: Colors.primary,
-  },
-  listenDot: {
-    width: 12,
-    height: 12,
-    borderRadius: 6,
-    borderCurve: CornerCurve.squircle,
-    backgroundColor: Colors.accent,
-  },
-  listenLabel: {
-    ...Typography.section,
-    color: Colors.primaryForeground,
   },
 });

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -10,6 +10,7 @@ import {
   Platform,
   Pressable,
   ScrollView,
+  Share,
   StyleSheet,
   Text,
   TextInput,
@@ -21,10 +22,12 @@ import { useSessionRecorder } from "@/audio/use-session-recorder";
 import { useAuth } from "@/auth/context";
 import { AudioChip } from "@/components/audio-chip";
 import { EditorAccessory } from "@/components/editor-accessory";
-import { HandoffCard } from "@/components/handoff-card";
 import { ListeningSheet } from "@/components/listening-sheet";
+import { NoteActionsSheet } from "@/components/note-actions-sheet";
 import { NoteAttachmentCard } from "@/components/note-attachment-card";
+import { RecordingSyncCard } from "@/components/recording-sync-card";
 import { RemoteAudioCard } from "@/components/remote-audio-card";
+import { StartListeningButton } from "@/components/start-listening-button";
 import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
@@ -66,6 +69,7 @@ function BodyEditor({
   onAttach,
   onChangeText,
   onCommit,
+  onFocusChange,
 }: {
   accessoryId: string;
   defaultBodyFormat: "prosemirror_json" | "markdown";
@@ -77,6 +81,7 @@ function BodyEditor({
     bodyFormat: "prosemirror_json" | "markdown",
   ) => void;
   onCommit: () => void;
+  onFocusChange: (focused: boolean) => void;
 }) {
   const inputRef = useRef<TextInput>(null);
   const textRef = useRef(defaultValue);
@@ -199,6 +204,8 @@ function BodyEditor({
         placeholderTextColor={Colors.muted}
         textAlignVertical="top"
         onChangeText={handleChangeText}
+        onBlur={() => onFocusChange(false)}
+        onFocus={() => onFocusChange(true)}
         onSelectionChange={(event) => {
           selectionRef.current = event.nativeEvent.selection;
         }}
@@ -243,6 +250,8 @@ export default function NoteScreen() {
   const transcripts = useSessionTranscripts(id);
   const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
+  const [editorFocused, setEditorFocused] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
   const recorder = useSessionRecorder(id, listening);
   const [audioRestoreError, setAudioRestoreError] = useState<string | null>(
     null,
@@ -283,6 +292,12 @@ export default function NoteScreen() {
     bodyFormat?: "prosemirror_json" | "markdown";
   }>({});
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showEmptyNoteCta =
+    !listening &&
+    !editorFocused &&
+    data !== null &&
+    data.title.trim() === "" &&
+    data.noteText.trim() === "";
 
   // The live query lags our own writes, so a body-only flush would otherwise
   // resend the pre-edit title and undo the title we just persisted.
@@ -585,6 +600,55 @@ export default function NoteScreen() {
     }
   };
 
+  const handleExport = async () => {
+    const current = dataRef.current;
+    if (!current) return;
+    const draft = { ...draftRef.current };
+    flush();
+
+    const title = (draft.title ?? current.title).trim() || "Untitled";
+    const note = (draft.body ?? current.noteText).trim();
+    const transcript = transcripts
+      .map((segment) => segment.text)
+      .join("\n\n")
+      .trim();
+    const sections = [`# ${title}`];
+    if (current.summary) {
+      sections.push(
+        `## ${current.summary.title}\n\n${current.summary.text}`.trim(),
+      );
+    }
+    if (note) sections.push(`## Notes\n\n${note}`);
+    if (transcript) sections.push(`## Transcript\n\n${transcript}`);
+
+    try {
+      await Share.share({
+        title,
+        message: sections.join("\n\n"),
+      });
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "session_export",
+        tags: { entry_point: "mobile_note" },
+      });
+    }
+  };
+
+  const handleListeningAction = () => {
+    if (listening) void handleStop();
+    else {
+      setListening(true);
+      void recorder.start();
+    }
+  };
+
+  const handleMoreActions = () => {
+    if (!data) return;
+    Keyboard.dismiss();
+    setEditorFocused(false);
+    setActionsOpen(true);
+  };
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.header}>
@@ -595,9 +659,11 @@ export default function NoteScreen() {
           onPress={() => void handleBack()}
         />
         <IconButton
-          accessibilityLabel="Delete note"
-          icon="trash-outline"
-          onPress={() => void handleDelete()}
+          accessibilityLabel="More actions"
+          disabled={!data}
+          icon="ellipsis-horizontal"
+          iconSize={22}
+          onPress={handleMoreActions}
           tone="muted"
         />
       </View>
@@ -609,7 +675,9 @@ export default function NoteScreen() {
             defaultValue={data.title}
             placeholder="Untitled"
             placeholderTextColor={Colors.muted}
+            onBlur={() => setEditorFocused(false)}
             onChangeText={(title) => onEdit({ title })}
+            onFocus={() => setEditorFocused(true)}
           />
           {data.summary && (
             <Card style={styles.summary} tone="muted">
@@ -631,10 +699,7 @@ export default function NoteScreen() {
                 filename={audio.data.filename}
                 sizeBytes={audio.data.sizeBytes}
               />
-              <HandoffCard
-                uri={localAudioFile.uri}
-                filename={audio.data.filename}
-              />
+              <RecordingSyncCard audio={audio.data} />
             </View>
           )}
           {audio.data && !localAudioAvailable && (
@@ -710,7 +775,6 @@ export default function NoteScreen() {
               ))}
             </View>
           )}
-          <Text style={styles.noteLabel}>Notes</Text>
           {!data.plainEditable && (
             <View style={styles.readOnlyChip}>
               <Ionicons
@@ -731,9 +795,24 @@ export default function NoteScreen() {
             onAttach={handleAttachFile}
             onChangeText={(body, bodyFormat) => onEdit({ body, bodyFormat })}
             onCommit={flush}
+            onFocusChange={setEditorFocused}
           />
         </View>
       )}
+
+      {showEmptyNoteCta && (
+        <StartListeningButton onPress={handleListeningAction} />
+      )}
+
+      <NoteActionsSheet
+        hasRecordingHistory={Boolean(audio.data || transcripts.length > 0)}
+        listening={listening}
+        onClose={() => setActionsOpen(false)}
+        onDelete={() => void handleDelete()}
+        onExport={() => void handleExport()}
+        onToggleListening={handleListeningAction}
+        visible={actionsOpen}
+      />
 
       {listening && (
         <ListeningSheet
@@ -761,7 +840,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.md,
     paddingVertical: Spacing.md,
   },
   editor: {
@@ -835,12 +914,6 @@ const styles = StyleSheet.create({
     marginTop: Spacing.md,
   },
   attachmentLabel: {
-    ...Typography.captionStrong,
-    color: Colors.muted,
-  },
-  noteLabel: {
-    marginHorizontal: Spacing.lg,
-    marginTop: Spacing.md,
     ...Typography.captionStrong,
     color: Colors.muted,
   },

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -274,6 +274,7 @@ export default function NoteScreen() {
     : null;
   const localAudioAvailable =
     audio.data?.availableLocally === true && localAudioFile?.exists === true;
+  const hasRecordingHistory = audio.data !== null || transcripts.length > 0;
   const localNoteAttachments = noteAttachments.map((attachment) => {
     const file = attachment.localRelativePath
       ? new File(Paths.document, "sessions", id, attachment.localRelativePath)
@@ -295,9 +296,13 @@ export default function NoteScreen() {
   const showEmptyNoteCta =
     !listening &&
     !editorFocused &&
+    !audio.isLoading &&
     data !== null &&
     data.title.trim() === "" &&
-    data.noteText.trim() === "";
+    data.noteText.trim() === "" &&
+    !data.summary &&
+    !hasRecordingHistory &&
+    noteAttachments.length === 0;
 
   // The live query lags our own writes, so a body-only flush would otherwise
   // resend the pre-edit title and undo the title we just persisted.
@@ -636,7 +641,7 @@ export default function NoteScreen() {
 
   const handleListeningAction = () => {
     if (listening) void handleStop();
-    else {
+    else if (!audio.isLoading && !hasRecordingHistory) {
       setListening(true);
       void recorder.start();
     }
@@ -805,7 +810,7 @@ export default function NoteScreen() {
       )}
 
       <NoteActionsSheet
-        hasRecordingHistory={Boolean(audio.data || transcripts.length > 0)}
+        hasRecordingHistory={hasRecordingHistory}
         listening={listening}
         onClose={() => setActionsOpen(false)}
         onDelete={() => void handleDelete()}

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,0 +1,54 @@
+import { useRouter } from "expo-router";
+import { StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { SettingsContent } from "@/components/profile-sheet";
+import { IconButton } from "@/components/ui/icon-button";
+import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
+
+export default function SettingsScreen() {
+  const router = useRouter();
+
+  const handleBack = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace("/");
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.header}>
+        <IconButton
+          accessibilityLabel="Back"
+          icon="arrow-back"
+          iconSize={22}
+          onPress={handleBack}
+        />
+        <Text style={styles.title}>Settings</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+      <SettingsContent />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+  },
+  title: {
+    ...Typography.section,
+    color: Colors.ink,
+  },
+  headerSpacer: {
+    width: ControlSize.compact,
+    height: ControlSize.compact,
+  },
+});

--- a/apps/mobile/src/attachment-sync/upload-store.ts
+++ b/apps/mobile/src/attachment-sync/upload-store.ts
@@ -330,6 +330,33 @@ export async function failMobileAttachmentUpload(
   ]);
 }
 
+export async function requeueMobileAttachmentUpload(
+  attachmentId: string,
+): Promise<number> {
+  const now = nowIso();
+  const [count = 0] = await executeTransaction([
+    {
+      sql: `
+        UPDATE attachment_transfer_jobs
+        SET phase = 'retry_wait', next_attempt_at = ?, last_error = '', updated_at = ?
+        WHERE attachment_id = ?
+          AND direction = 'upload'
+          AND phase IN ('failed', 'retry_wait')
+          AND EXISTS (
+            SELECT 1 FROM session_attachments AS attachment
+            WHERE attachment.id = attachment_transfer_jobs.attachment_id
+              AND attachment.sha256 = attachment_transfer_jobs.expected_sha256
+              AND attachment.size_bytes = attachment_transfer_jobs.expected_size_bytes
+              AND attachment.deleted_at IS NULL
+              AND attachment.cloud_sync_enabled = 1
+          )
+      `,
+      params: [now, now, attachmentId],
+    },
+  ]);
+  return count;
+}
+
 async function updateJob(
   job: MobileAttachmentUploadJob,
   phase: "preparing" | "transferring" | "finalizing",
@@ -391,5 +418,6 @@ export const mobileAttachmentUploadStore = {
   complete: completeMobileAttachmentUpload,
   completeWithoutTransfer: completeMobileAttachmentUploadWithoutTransfer,
   retry: retryMobileAttachmentUpload,
+  requeue: requeueMobileAttachmentUpload,
   fail: failMobileAttachmentUpload,
 };

--- a/apps/mobile/src/audio/capture-lifecycle.test.mjs
+++ b/apps/mobile/src/audio/capture-lifecycle.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  beginMobileCapture,
+  endMobileCapture,
+  getMobileCaptureActive,
+} from "./capture-lifecycle.ts";
+
+test("keeps the mobile gate open until every active capture is settled", () => {
+  beginMobileCapture("session-1");
+  beginMobileCapture("session-2");
+  assert.equal(getMobileCaptureActive(), true);
+
+  endMobileCapture("session-1");
+  assert.equal(getMobileCaptureActive(), true);
+
+  endMobileCapture("session-2");
+  assert.equal(getMobileCaptureActive(), false);
+});

--- a/apps/mobile/src/audio/capture-lifecycle.ts
+++ b/apps/mobile/src/audio/capture-lifecycle.ts
@@ -1,0 +1,27 @@
+const activeSessions = new Set<string>();
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+export function beginMobileCapture(sessionId: string): void {
+  const wasActive = activeSessions.size > 0;
+  activeSessions.add(sessionId);
+  if (!wasActive) notify();
+}
+
+export function endMobileCapture(sessionId: string): void {
+  const wasActive = activeSessions.size > 0;
+  activeSessions.delete(sessionId);
+  if (wasActive && activeSessions.size === 0) notify();
+}
+
+export function subscribeMobileCapture(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getMobileCaptureActive(): boolean {
+  return activeSessions.size > 0;
+}

--- a/apps/mobile/src/audio/session-wav-writer.ts
+++ b/apps/mobile/src/audio/session-wav-writer.ts
@@ -23,7 +23,7 @@ export class SessionWavWriter {
     const directory = new Directory(Paths.document, "sessions", sessionId);
     directory.create({ intermediates: true, idempotent: true });
     this.file = new File(directory, "audio.wav");
-    this.file.create({ overwrite: true });
+    this.file.create();
     this.handle = this.file.open(FileMode.ReadWrite);
   }
 
@@ -68,6 +68,11 @@ export class SessionWavWriter {
     if (this.handle && this.initialized) this.writeHeader();
     this.handle?.close();
     this.handle = null;
+  }
+
+  closeAndDiscardEmpty() {
+    this.close();
+    if (this.dataBytes === 0 && this.file.exists) this.file.delete();
   }
 
   private writeHeader() {

--- a/apps/mobile/src/audio/session-wav-writer.ts
+++ b/apps/mobile/src/audio/session-wav-writer.ts
@@ -6,7 +6,7 @@ import {
   type FileHandle,
 } from "expo-file-system";
 
-import { wavHeader } from "@/audio/pcm-wav";
+import { WAV_HEADER_BYTES, wavHeader } from "@/audio/pcm-wav";
 
 export class SessionWavWriter {
   readonly file: File;
@@ -23,6 +23,9 @@ export class SessionWavWriter {
     const directory = new Directory(Paths.document, "sessions", sessionId);
     directory.create({ intermediates: true, idempotent: true });
     this.file = new File(directory, "audio.wav");
+    if (this.file.exists && this.file.size <= WAV_HEADER_BYTES) {
+      this.file.delete();
+    }
     this.file.create();
     this.handle = this.file.open(FileMode.ReadWrite);
   }

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -8,6 +8,10 @@ import {
 import { useCallback, useRef, useState } from "react";
 import { AppState } from "react-native";
 
+import {
+  beginMobileCapture,
+  endMobileCapture,
+} from "@/audio/capture-lifecycle";
 import { pcmAmplitude } from "@/audio/pcm-wav";
 import { type RecorderPhase } from "@/audio/recorder-status";
 import { SessionWavWriter } from "@/audio/session-wav-writer";
@@ -46,6 +50,7 @@ export function useSessionRecorder(
   durationMs: number;
   liveStatus: LiveTranscriptionStatus;
   liveTranscript: string;
+  start: () => Promise<void>;
   stop: () => Promise<StopResult>;
   retry: () => Promise<StopResult>;
 } {
@@ -66,6 +71,19 @@ export function useSessionRecorder(
   const completionTrackedRef = useRef(false);
   const reportedFailureRef = useRef<string | null>(null);
   const durationRef = useRef(0);
+  const captureRegisteredRef = useRef(false);
+
+  const registerCapture = useCallback(() => {
+    if (captureRegisteredRef.current) return;
+    captureRegisteredRef.current = true;
+    beginMobileCapture(sessionId);
+  }, [sessionId]);
+
+  const unregisterCapture = useCallback(() => {
+    if (!captureRegisteredRef.current) return;
+    captureRegisteredRef.current = false;
+    endMobileCapture(sessionId);
+  }, [sessionId]);
 
   const setPhase = useCallback((next: RecorderPhase) => {
     phaseRef.current = next;
@@ -198,6 +216,7 @@ export function useSessionRecorder(
       });
       if (!isCurrent()) return;
       writerRef.current = new SessionWavWriter(sessionId);
+      registerCapture();
       await stream.start();
       if (!isCurrent()) {
         phaseRef.current = "recording";
@@ -226,13 +245,21 @@ export function useSessionRecorder(
       writerRef.current = null;
       void liveRef.current?.stop();
       liveRef.current = null;
+      unregisterCapture();
       reportFailure("start_failed", error, "recording_start");
       captureAnalytics("session_start_failed", {
         failure_stage: "capture_start",
       });
       setPhase("error");
     }
-  }, [reportFailure, sessionId, setPhase, stream]);
+  }, [
+    registerCapture,
+    reportFailure,
+    sessionId,
+    setPhase,
+    stream,
+    unregisterCapture,
+  ]);
 
   useMountEffect(() => {
     activeRef.current = true;
@@ -301,6 +328,7 @@ export function useSessionRecorder(
       }
       writerRef.current = null;
       liveRef.current = null;
+      unregisterCapture();
       setFailure(null);
       setPhase("saved");
       return "saved";
@@ -354,6 +382,7 @@ export function useSessionRecorder(
     durationMs,
     liveStatus,
     liveTranscript,
+    start,
     stop,
     retry,
   };

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -166,7 +166,7 @@ export function useSessionRecorder(
   const streamRef = useRef(stream);
   streamRef.current = stream;
 
-  const start = useCallback(async () => {
+  const performStart = useCallback(async () => {
     const generation = ++startGenerationRef.current;
     const isCurrent = () =>
       activeRef.current && generation === startGenerationRef.current;
@@ -236,7 +236,7 @@ export function useSessionRecorder(
         stream.stop();
       } catch {}
       try {
-        writerRef.current?.close();
+        writerRef.current?.closeAndDiscardEmpty();
       } catch (cleanupError) {
         captureOperationalError(cleanupError, {
           operation: "recording_start_cleanup",
@@ -261,10 +261,29 @@ export function useSessionRecorder(
     unregisterCapture,
   ]);
 
+  const start = useCallback((): Promise<void> => {
+    const currentOperation = startRef.current;
+    if (currentOperation) return currentOperation;
+    if (
+      !["idle", "unavailable", "interrupted", "error"].includes(
+        phaseRef.current,
+      )
+    ) {
+      return Promise.resolve();
+    }
+    const operation = performStart();
+    startRef.current = operation;
+    const clearOperation = () => {
+      if (startRef.current === operation) startRef.current = null;
+    };
+    void operation.then(clearOperation, clearOperation);
+    return operation;
+  }, [performStart]);
+
   useMountEffect(() => {
     activeRef.current = true;
     if (!enabled) return;
-    startRef.current = start();
+    void start();
   });
 
   useMountEffect(() => {
@@ -275,7 +294,7 @@ export function useSessionRecorder(
         nextState === "active" &&
         phaseRef.current === "unavailable";
       previousState = nextState;
-      if (returnedFromSettings) startRef.current = start();
+      if (returnedFromSettings) void start();
     });
     return () => subscription.remove();
   });
@@ -361,8 +380,7 @@ export function useSessionRecorder(
       return stop();
     }
     if (["unavailable", "interrupted", "error"].includes(phaseRef.current)) {
-      startRef.current = start();
-      await startRef.current;
+      await start();
     }
     return "noop";
   };
@@ -372,7 +390,7 @@ export function useSessionRecorder(
   useMountEffect(() => () => {
     activeRef.current = false;
     startGenerationRef.current += 1;
-    void stopRef.current();
+    void stopRef.current().then(unregisterCapture, unregisterCapture);
   });
 
   return {

--- a/apps/mobile/src/components/note-actions-sheet.tsx
+++ b/apps/mobile/src/components/note-actions-sheet.tsx
@@ -28,11 +28,7 @@ export function NoteActionsSheet({
   visible: boolean;
 }) {
   const insets = useSafeAreaInsets();
-  const listeningLabel = listening
-    ? "Stop listening"
-    : hasRecordingHistory
-      ? "Resume listening"
-      : "Start listening";
+  const listeningLabel = listening ? "Stop listening" : "Start listening";
 
   const select = (action: () => void) => {
     onClose();
@@ -81,21 +77,23 @@ export function NoteActionsSheet({
             <Ionicons name="download-outline" size={20} color={Colors.ink} />
             <Text style={styles.actionLabel}>Export</Text>
           </Pressable>
-          <Pressable
-            accessibilityRole="button"
-            onPress={() => select(onToggleListening)}
-            style={({ pressed }) => [
-              styles.action,
-              pressed && styles.actionPressed,
-            ]}
-          >
-            <Ionicons
-              name={listening ? "mic-off-outline" : "mic-outline"}
-              size={20}
-              color={Colors.ink}
-            />
-            <Text style={styles.actionLabel}>{listeningLabel}</Text>
-          </Pressable>
+          {(listening || !hasRecordingHistory) && (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => select(onToggleListening)}
+              style={({ pressed }) => [
+                styles.action,
+                pressed && styles.actionPressed,
+              ]}
+            >
+              <Ionicons
+                name={listening ? "mic-off-outline" : "mic-outline"}
+                size={20}
+                color={Colors.ink}
+              />
+              <Text style={styles.actionLabel}>{listeningLabel}</Text>
+            </Pressable>
+          )}
           <View style={styles.separator} />
           <Pressable
             accessibilityRole="button"

--- a/apps/mobile/src/components/note-actions-sheet.tsx
+++ b/apps/mobile/src/components/note-actions-sheet.tsx
@@ -1,0 +1,184 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  Colors,
+  CornerCurve,
+  Radius,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
+
+export function NoteActionsSheet({
+  hasRecordingHistory,
+  listening,
+  onClose,
+  onDelete,
+  onExport,
+  onToggleListening,
+  visible,
+}: {
+  hasRecordingHistory: boolean;
+  listening: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  onExport: () => void;
+  onToggleListening: () => void;
+  visible: boolean;
+}) {
+  const insets = useSafeAreaInsets();
+  const listeningLabel = listening
+    ? "Stop listening"
+    : hasRecordingHistory
+      ? "Resume listening"
+      : "Start listening";
+
+  const select = (action: () => void) => {
+    onClose();
+    requestAnimationFrame(action);
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="overFullScreen"
+      statusBarTranslucent
+      transparent
+      visible={visible}
+    >
+      <View accessibilityViewIsModal style={styles.container}>
+        <Pressable
+          accessibilityLabel="Dismiss note actions"
+          accessibilityRole="button"
+          onPress={onClose}
+          style={styles.scrim}
+        />
+        <View
+          style={[
+            styles.sheet,
+            { paddingBottom: Math.max(insets.bottom, Spacing.md) },
+          ]}
+        >
+          <Pressable
+            accessibilityLabel="Close note actions"
+            accessibilityRole="button"
+            hitSlop={8}
+            onPress={onClose}
+            style={styles.handleTarget}
+          >
+            <View style={styles.handle} />
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => select(onExport)}
+            style={({ pressed }) => [
+              styles.action,
+              pressed && styles.actionPressed,
+            ]}
+          >
+            <Ionicons name="download-outline" size={20} color={Colors.ink} />
+            <Text style={styles.actionLabel}>Export</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => select(onToggleListening)}
+            style={({ pressed }) => [
+              styles.action,
+              pressed && styles.actionPressed,
+            ]}
+          >
+            <Ionicons
+              name={listening ? "mic-off-outline" : "mic-outline"}
+              size={20}
+              color={Colors.ink}
+            />
+            <Text style={styles.actionLabel}>{listeningLabel}</Text>
+          </Pressable>
+          <View style={styles.separator} />
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => select(onDelete)}
+            style={({ pressed }) => [
+              styles.action,
+              pressed && styles.destructivePressed,
+            ]}
+          >
+            <Ionicons
+              name="trash-outline"
+              size={20}
+              color={Colors.destructive}
+            />
+            <Text style={styles.destructiveLabel}>Delete</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  scrim: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.scrim,
+  },
+  sheet: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: 0,
+    borderColor: Colors.border,
+    borderTopLeftRadius: Radius.sheet,
+    borderTopRightRadius: Radius.sheet,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.background,
+    paddingHorizontal: Spacing.md,
+    shadowColor: Colors.ink,
+    shadowOffset: { width: 0, height: -4 },
+    shadowOpacity: 0.12,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.border,
+  },
+  handleTarget: {
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  action: {
+    minHeight: 52,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.md,
+    borderRadius: Radius.control,
+    borderCurve: CornerCurve.squircle,
+    paddingHorizontal: Spacing.md,
+  },
+  actionPressed: {
+    backgroundColor: Colors.accentSurface,
+  },
+  actionLabel: {
+    ...Typography.bodyStrong,
+    color: Colors.ink,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginVertical: Spacing.xs,
+    backgroundColor: Colors.border,
+  },
+  destructivePressed: {
+    backgroundColor: Colors.alert,
+  },
+  destructiveLabel: {
+    ...Typography.bodyStrong,
+    color: Colors.destructive,
+  },
+});

--- a/apps/mobile/src/components/note-actions-sheet.tsx
+++ b/apps/mobile/src/components/note-actions-sheet.tsx
@@ -124,7 +124,11 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   scrim: {
-    ...StyleSheet.absoluteFillObject,
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
     backgroundColor: Colors.scrim,
   },
   sheet: {

--- a/apps/mobile/src/components/profile-sheet.tsx
+++ b/apps/mobile/src/components/profile-sheet.tsx
@@ -1,9 +1,8 @@
+import { Ionicons } from "@expo/vector-icons";
 import { useState, useSyncExternalStore } from "react";
 import {
   KeyboardAvoidingView,
-  Modal,
   Platform,
-  Pressable,
   ScrollView,
   Share,
   StyleSheet,
@@ -32,14 +31,12 @@ import {
 } from "@/sync/mobile-sync";
 import { syncStatusPresentation } from "@/sync/status-presentation";
 
-type SheetMode = "status" | "choose" | "import" | "generated";
+export type SettingsMode = "status" | "choose" | "import" | "generated";
 
-export function ProfileSheet({
-  visible,
-  onClose,
+export function SettingsContent({
+  initialMode = "status",
 }: {
-  visible: boolean;
-  onClose: () => void;
+  initialMode?: SettingsMode;
 }) {
   const auth = useAuth();
   const sync = useSyncExternalStore(
@@ -47,7 +44,7 @@ export function ProfileSheet({
     getMobileSyncSnapshot,
     getMobileSyncSnapshot,
   );
-  const [mode, setMode] = useState<SheetMode>("status");
+  const [mode, setMode] = useState<SettingsMode>(initialMode);
   const [recoveryKey, setRecoveryKey] = useState("");
   const [generatedKey, setGeneratedKey] = useState("");
   const [busy, setBusy] = useState(false);
@@ -61,14 +58,6 @@ export function ProfileSheet({
         ? "Pro"
         : "Free";
   const presentation = syncStatusPresentation(sync);
-
-  const close = () => {
-    if (mode === "generated" || busy) return;
-    setMode("status");
-    setRecoveryKey("");
-    setActionError(null);
-    onClose();
-  };
 
   const createRecoveryKey = async () => {
     setBusy(true);
@@ -196,10 +185,7 @@ export function ProfileSheet({
         <View style={styles.actions}>
           <Button
             label="Sign out"
-            onPress={() => {
-              close();
-              void auth.signOut();
-            }}
+            onPress={() => void auth.signOut()}
             size="small"
             variant="outline"
           />
@@ -222,227 +208,214 @@ export function ProfileSheet({
   };
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={close}
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      style={styles.container}
     >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        style={styles.backdrop}
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
       >
-        <Pressable style={styles.backdropPressable} onPress={close}>
-          <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
-            <View style={styles.handle} />
-            <ScrollView
-              contentContainerStyle={styles.content}
-              keyboardShouldPersistTaps="handled"
-              showsVerticalScrollIndicator={false}
-            >
-              <View style={styles.row}>
-                <Text style={styles.email} numberOfLines={1}>
-                  {auth.bypass
-                    ? "Not signed in"
-                    : (auth.session?.user.email ?? "")}
-                </Text>
-                <View style={styles.planChip}>
-                  <Text style={styles.planLabel}>{planLabel}</Text>
-                </View>
-              </View>
+        <View style={styles.accountCard}>
+          <View style={styles.accountIcon}>
+            <Ionicons name="person-outline" size={22} color={Colors.ink} />
+          </View>
+          <View style={styles.accountIdentity}>
+            <Text style={styles.accountLabel}>Account</Text>
+            <Text style={styles.email} numberOfLines={1}>
+              {auth.bypass ? "Not signed in" : (auth.session?.user.email ?? "")}
+            </Text>
+          </View>
+          <View style={styles.planChip}>
+            <Text style={styles.planLabel}>{planLabel}</Text>
+          </View>
+        </View>
 
-              {mode === "status" && (
-                <View style={styles.syncCard}>
-                  <View style={styles.statusHeading}>
-                    <View
-                      style={[
-                        styles.statusDot,
-                        presentation.healthy
-                          ? styles.statusDotReady
-                          : presentation.retrying || presentation.pending
-                            ? styles.statusDotRetrying
-                            : styles.statusDotQuiet,
-                      ]}
-                    />
-                    <Text style={styles.eyebrow}>Cloud sync</Text>
-                  </View>
-                  <Text style={styles.syncTitle}>{presentation.title}</Text>
-                  <Text style={styles.syncDescription}>
-                    {presentation.description}
-                  </Text>
-                  {presentation.detail && (
-                    <Text style={styles.syncDetail}>{presentation.detail}</Text>
-                  )}
-                  {renderStatusActions()}
-                </View>
-              )}
+        {mode === "status" && (
+          <View style={styles.syncCard}>
+            <View style={styles.statusHeading}>
+              <View
+                style={[
+                  styles.statusDot,
+                  presentation.healthy
+                    ? styles.statusDotReady
+                    : presentation.retrying || presentation.pending
+                      ? styles.statusDotRetrying
+                      : styles.statusDotQuiet,
+                ]}
+              />
+              <Text style={styles.eyebrow}>Cloud sync</Text>
+            </View>
+            <Text style={styles.syncTitle}>{presentation.title}</Text>
+            <Text style={styles.syncDescription}>
+              {presentation.description}
+            </Text>
+            {presentation.detail && (
+              <Text style={styles.syncDetail}>{presentation.detail}</Text>
+            )}
+            {renderStatusActions()}
+          </View>
+        )}
 
-              {mode === "choose" && (
-                <View style={styles.setup}>
-                  <Text style={styles.setupTitle}>Set up encrypted sync</Text>
-                  <Text style={styles.setupDescription}>
-                    Your recovery key protects every synced note. Anarlog cannot
-                    recover it for you.
-                  </Text>
-                  <Button
-                    label="Create a recovery key"
-                    loading={busy}
-                    onPress={() => void createRecoveryKey()}
-                  />
-                  <Button
-                    label="Use an existing key"
-                    disabled={busy}
-                    onPress={() => {
-                      setActionError(null);
-                      setMode("import");
-                    }}
-                    variant="outline"
-                  />
-                  <Button
-                    label="Back"
-                    disabled={busy}
-                    onPress={() => setMode("status")}
-                    size="small"
-                    variant="ghost"
-                  />
-                </View>
-              )}
+        {mode === "choose" && (
+          <View style={styles.setup}>
+            <Text style={styles.setupTitle}>Set up encrypted sync</Text>
+            <Text style={styles.setupDescription}>
+              Your recovery key protects every synced note. Anarlog cannot
+              recover it for you.
+            </Text>
+            <Button
+              label="Create a recovery key"
+              loading={busy}
+              onPress={() => void createRecoveryKey()}
+            />
+            <Button
+              label="Use an existing key"
+              disabled={busy}
+              onPress={() => {
+                setActionError(null);
+                setMode("import");
+              }}
+              variant="outline"
+            />
+            <Button
+              label="Back"
+              disabled={busy}
+              onPress={() => setMode("status")}
+              size="small"
+              variant="ghost"
+            />
+          </View>
+        )}
 
-              {mode === "import" && (
-                <View style={styles.setup}>
-                  <Text style={styles.setupTitle}>Use a recovery key</Text>
-                  <Text style={styles.setupDescription}>
-                    Enter the key saved from Anarlog on another device.
-                  </Text>
-                  <TextInput
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    editable={!busy}
-                    multiline
-                    onChangeText={setRecoveryKey}
-                    placeholder="Paste recovery key"
-                    placeholderTextColor={Colors.muted}
-                    style={styles.keyInput}
-                    value={recoveryKey}
-                  />
-                  <Button
-                    label="Use this key"
-                    loading={busy}
-                    onPress={() => void importRecoveryKey()}
-                  />
-                  <Button
-                    label="Back"
-                    disabled={busy}
-                    onPress={() => {
-                      setActionError(null);
-                      setMode(
-                        sync.phase === "identity_mismatch"
-                          ? "status"
-                          : "choose",
-                      );
-                    }}
-                    size="small"
-                    variant="ghost"
-                  />
-                </View>
-              )}
+        {mode === "import" && (
+          <View style={styles.setup}>
+            <Text style={styles.setupTitle}>Use a recovery key</Text>
+            <Text style={styles.setupDescription}>
+              Enter the key saved from Anarlog on another device.
+            </Text>
+            <TextInput
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!busy}
+              multiline
+              onChangeText={setRecoveryKey}
+              placeholder="Paste recovery key"
+              placeholderTextColor={Colors.muted}
+              style={styles.keyInput}
+              value={recoveryKey}
+            />
+            <Button
+              label="Use this key"
+              loading={busy}
+              onPress={() => void importRecoveryKey()}
+            />
+            <Button
+              label="Back"
+              disabled={busy}
+              onPress={() => {
+                setActionError(null);
+                setMode(
+                  sync.phase === "identity_mismatch" ? "status" : "choose",
+                );
+              }}
+              size="small"
+              variant="ghost"
+            />
+          </View>
+        )}
 
-              {mode === "generated" && (
-                <View style={styles.setup}>
-                  <Text style={styles.setupTitle}>Save your recovery key</Text>
-                  <Text style={styles.setupDescription}>
-                    Keep this in a password manager. You will need it to add
-                    another device or recover your synced notes.
-                  </Text>
-                  <View style={styles.generatedKeyBox}>
-                    <Text selectable style={styles.generatedKey}>
-                      {generatedKey}
-                    </Text>
-                  </View>
-                  <Button
-                    label="Save recovery key"
-                    onPress={() => void shareRecoveryKey()}
-                    variant="outline"
-                  />
-                  <Button
-                    label="I saved it"
-                    loading={busy}
-                    onPress={() => void finishRecoveryKey()}
-                  />
-                  <Button
-                    label="Cancel"
-                    disabled={busy}
-                    onPress={discardGeneratedKey}
-                    size="small"
-                    variant="ghost"
-                  />
-                </View>
-              )}
+        {mode === "generated" && (
+          <View style={styles.setup}>
+            <Text style={styles.setupTitle}>Save your recovery key</Text>
+            <Text style={styles.setupDescription}>
+              Keep this in a password manager. You will need it to add another
+              device or recover your synced notes.
+            </Text>
+            <View style={styles.generatedKeyBox}>
+              <Text selectable style={styles.generatedKey}>
+                {generatedKey}
+              </Text>
+            </View>
+            <Button
+              label="Save recovery key"
+              onPress={() => void shareRecoveryKey()}
+              variant="outline"
+            />
+            <Button
+              label="I saved it"
+              loading={busy}
+              onPress={() => void finishRecoveryKey()}
+            />
+            <Button
+              label="Cancel"
+              disabled={busy}
+              onPress={discardGeneratedKey}
+              size="small"
+              variant="ghost"
+            />
+          </View>
+        )}
 
-              {actionError && (
-                <Text accessibilityLiveRegion="polite" style={styles.error}>
-                  {actionError}
-                </Text>
-              )}
+        {actionError && (
+          <Text accessibilityLiveRegion="polite" style={styles.error}>
+            {actionError}
+          </Text>
+        )}
 
-              {!auth.bypass && mode === "status" && (
-                <Button
-                  label="Sign out"
-                  onPress={() => {
-                    close();
-                    void auth.signOut();
-                  }}
-                  size="small"
-                  style={styles.signOut}
-                  variant="ghost"
-                />
-              )}
-            </ScrollView>
-          </Pressable>
-        </Pressable>
-      </KeyboardAvoidingView>
-    </Modal>
+        {!auth.bypass && mode === "status" && (
+          <Button
+            label="Sign out"
+            onPress={() => void auth.signOut()}
+            size="small"
+            style={styles.signOut}
+            variant="ghost"
+          />
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  backdrop: {
+  container: {
     flex: 1,
-  },
-  backdropPressable: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: Colors.scrim,
-  },
-  sheet: {
-    maxHeight: "88%",
-    backgroundColor: Colors.surface,
-    borderTopLeftRadius: Radius.sheet,
-    borderTopRightRadius: Radius.sheet,
-    paddingHorizontal: Spacing.lg,
-    paddingBottom: Spacing.xl,
-    paddingTop: Spacing.sm,
+    backgroundColor: Colors.background,
   },
   content: {
-    paddingBottom: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.roomy,
   },
-  handle: {
-    alignSelf: "center",
-    width: 40,
-    height: 4,
-    borderRadius: 2,
-    borderCurve: CornerCurve.squircle,
-    backgroundColor: Colors.border,
-    marginBottom: Spacing.md,
-  },
-  row: {
+  accountCard: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
     gap: Spacing.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderRadius: Radius.card,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.surface,
+    padding: Spacing.md,
+  },
+  accountIcon: {
+    width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.accentSurface,
+  },
+  accountIdentity: {
+    flex: 1,
+  },
+  accountLabel: {
+    ...Typography.captionStrong,
+    color: Colors.muted,
   },
   email: {
-    flex: 1,
+    marginTop: Spacing.xs,
     ...Typography.section,
     color: Colors.ink,
   },
@@ -465,7 +438,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.border,
     borderRadius: Radius.card,
     borderCurve: CornerCurve.squircle,
-    backgroundColor: Colors.background,
+    backgroundColor: Colors.surface,
     padding: Spacing.md,
   },
   statusHeading: {

--- a/apps/mobile/src/components/recording-sync-card.tsx
+++ b/apps/mobile/src/components/recording-sync-card.tsx
@@ -1,0 +1,105 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Colors, Spacing, Typography } from "@/constants/theme";
+import {
+  retrySessionAudioUpload,
+  type SessionAudio,
+} from "@/data/audio-catalog";
+import { captureOperationalError } from "@/lib/error-reporting";
+
+const presentation = {
+  queued: {
+    icon: "time-outline" as const,
+    text: "Saved locally · waiting to back up",
+  },
+  uploading: {
+    icon: "cloud-upload-outline" as const,
+    text: "Backing up encrypted recording…",
+  },
+  synced: {
+    icon: "cloud-done-outline" as const,
+    text: "Encrypted recording backed up",
+  },
+  failed: {
+    icon: "alert-circle-outline" as const,
+    text: "Saved locally · backup needs attention",
+  },
+};
+
+export function RecordingSyncCard({ audio }: { audio: SessionAudio }) {
+  const [retrying, setRetrying] = useState(false);
+  const [retryError, setRetryError] = useState(false);
+  const status = presentation[audio.deliveryState];
+  const waitingToRetry = audio.uploadPhase === "retry_wait";
+  const canRetry = audio.deliveryState === "failed" || waitingToRetry;
+
+  const handleRetry = async () => {
+    if (retrying) return;
+    setRetrying(true);
+    setRetryError(false);
+    try {
+      await retrySessionAudioUpload(audio.attachmentId);
+    } catch (error) {
+      setRetryError(true);
+      captureOperationalError(error, {
+        operation: "session_audio_upload_retry",
+      });
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  return (
+    <Card
+      style={styles.card}
+      tone={audio.deliveryState === "failed" ? "alert" : "muted"}
+    >
+      <View style={styles.statusRow}>
+        <Ionicons name={status.icon} size={17} color={Colors.muted} />
+        <Text accessibilityLiveRegion="polite" style={styles.status}>
+          {retryError
+            ? "Could not restart the backup. Try again."
+            : waitingToRetry
+              ? "Saved locally · retrying when online"
+              : status.text}
+        </Text>
+      </View>
+      {canRetry && (
+        <Button
+          label="Retry now"
+          loading={retrying}
+          onPress={() => void handleRetry()}
+          size="small"
+          style={styles.button}
+          variant="outline"
+        />
+      )}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: Spacing.sm,
+    marginHorizontal: Spacing.lg,
+    marginTop: Spacing.sm,
+    padding: Spacing.md,
+  },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.sm,
+  },
+  status: {
+    flex: 1,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  button: {
+    alignSelf: "flex-start",
+  },
+});

--- a/apps/mobile/src/components/session-card.tsx
+++ b/apps/mobile/src/components/session-card.tsx
@@ -19,68 +19,68 @@ export function SessionCard({
   onPress: () => void;
   onDelete?: () => void;
 }) {
+  const title = session.title || "Untitled";
+
   return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
-    >
-      <View style={styles.row}>
+    <View style={styles.card}>
+      <Pressable
+        accessibilityLabel={`${title}, ${relativeLabel(session.startedAt)}`}
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({ pressed }) => [
+          styles.cardContent,
+          pressed && styles.cardPressed,
+        ]}
+      >
         <Text
           style={[styles.title, !session.title && styles.titleEmpty]}
           numberOfLines={1}
         >
-          {session.title || "Untitled"}
+          {title}
         </Text>
-        {onDelete && (
-          <Pressable
-            accessibilityLabel={`Delete ${session.title || "Untitled"}`}
-            accessibilityRole="button"
-            hitSlop={4}
-            onPress={(event) => {
-              event.stopPropagation();
-              onDelete();
-            }}
-            style={({ pressed }) => [
-              styles.moreButton,
-              pressed && styles.moreButtonPressed,
-            ]}
-          >
-            <Ionicons
-              name="ellipsis-horizontal"
-              size={17}
-              color={Colors.muted}
-            />
-          </Pressable>
-        )}
-      </View>
-      <Text style={styles.subtitle}>{relativeLabel(session.startedAt)}</Text>
-    </Pressable>
+        <Text style={styles.subtitle}>{relativeLabel(session.startedAt)}</Text>
+      </Pressable>
+      {onDelete && (
+        <Pressable
+          accessibilityLabel={`Delete ${title}`}
+          accessibilityRole="button"
+          hitSlop={4}
+          onPress={onDelete}
+          style={({ pressed }) => [
+            styles.moreButton,
+            pressed && styles.moreButtonPressed,
+          ]}
+        >
+          <Ionicons name="ellipsis-horizontal" size={17} color={Colors.muted} />
+        </Pressable>
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
     minHeight: 64,
-    justifyContent: "center",
+    flexDirection: "row",
+    alignItems: "stretch",
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: Colors.border,
     borderRadius: Radius.card,
     borderCurve: CornerCurve.squircle,
-    paddingHorizontal: Spacing.compact,
-    paddingVertical: Spacing.sm,
     marginBottom: Spacing.sm,
     backgroundColor: Colors.surface,
+    overflow: "hidden",
+  },
+  cardContent: {
+    flex: 1,
+    justifyContent: "center",
+    paddingLeft: Spacing.compact,
+    paddingVertical: Spacing.sm,
   },
   cardPressed: {
     backgroundColor: Colors.accentSurface,
   },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
   title: {
-    flex: 1,
     ...Typography.bodyStrong,
     color: Colors.ink,
   },
@@ -89,11 +89,12 @@ const styles = StyleSheet.create({
   },
   moreButton: {
     width: 32,
-    height: 32,
+    alignSelf: "stretch",
     alignItems: "center",
     justifyContent: "center",
+    marginHorizontal: Spacing.compact,
+    marginVertical: Spacing.sm,
     borderRadius: Radius.pill,
-    marginLeft: Spacing.sm,
   },
   moreButtonPressed: {
     backgroundColor: Colors.accentSurface,

--- a/apps/mobile/src/components/start-listening-button.tsx
+++ b/apps/mobile/src/components/start-listening-button.tsx
@@ -1,0 +1,61 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  Colors,
+  CornerCurve,
+  LISTENING_CONTROL_HEIGHT,
+  LISTENING_CONTROL_RADIUS,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
+
+export function StartListeningButton({
+  bottomSpacing = Spacing.md,
+  onPress,
+}: {
+  bottomSpacing?: number;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.button,
+        { marginBottom: bottomSpacing },
+        pressed && styles.buttonPressed,
+      ]}
+    >
+      <View style={styles.dot} />
+      <Text style={styles.label}>Start listening</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    height: LISTENING_CONTROL_HEIGHT,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.sm,
+    marginHorizontal: Spacing.lg,
+    borderRadius: LISTENING_CONTROL_RADIUS,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.primary,
+  },
+  buttonPressed: {
+    opacity: 0.6,
+  },
+  dot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.accent,
+  },
+  label: {
+    ...Typography.section,
+    color: Colors.primaryForeground,
+  },
+});

--- a/apps/mobile/src/data/audio-catalog-model.ts
+++ b/apps/mobile/src/data/audio-catalog-model.ts
@@ -9,7 +9,15 @@ export type SessionAudioRow = {
   available_locally: number;
   local_relative_path: string;
   cloud_object_key: string;
+  upload_phase: string | null;
+  upload_error: string;
 };
+
+export type SessionAudioDeliveryState =
+  | "queued"
+  | "uploading"
+  | "synced"
+  | "failed";
 
 export type SessionAudio = {
   attachmentId: string;
@@ -22,6 +30,9 @@ export type SessionAudio = {
   availableLocally: boolean;
   localRelativePath: string | null;
   cloudObjectKey: string | null;
+  deliveryState: SessionAudioDeliveryState;
+  uploadPhase: string | null;
+  uploadError: string | null;
 };
 
 export function mapSessionAudioRows(
@@ -31,6 +42,16 @@ export function mapSessionAudioRows(
   if (!row) return null;
   const availableLocally =
     row.available_locally === 1 && row.local_relative_path !== "";
+  const cloudObjectKey = row.cloud_object_key || null;
+  const deliveryState: SessionAudioDeliveryState = cloudObjectKey
+    ? "synced"
+    : row.upload_phase === "failed"
+      ? "failed"
+      : ["preparing", "ready", "transferring", "finalizing"].includes(
+            row.upload_phase ?? "",
+          )
+        ? "uploading"
+        : "queued";
   return {
     attachmentId: row.id,
     filename: row.filename,
@@ -41,6 +62,9 @@ export function mapSessionAudioRows(
     createdAt: row.created_at,
     availableLocally,
     localRelativePath: availableLocally ? row.local_relative_path : null,
-    cloudObjectKey: row.cloud_object_key || null,
+    cloudObjectKey,
+    deliveryState,
+    uploadPhase: row.upload_phase,
+    uploadError: row.upload_error || null,
   };
 }

--- a/apps/mobile/src/data/audio-catalog.test.mjs
+++ b/apps/mobile/src/data/audio-catalog.test.mjs
@@ -15,6 +15,8 @@ const row = {
   local_relative_path: "audio.wav",
   cloud_object_key:
     "e8d8149f-af6a-4c14-8b91-066fa196187c/02425e17-c452-41c9-869c-196d09f75c91.anb1",
+  upload_phase: "completed",
+  upload_error: "",
 };
 
 test("maps a device-local audio attachment to a playable file", () => {
@@ -30,6 +32,9 @@ test("maps a device-local audio attachment to a playable file", () => {
     localRelativePath: "audio.wav",
     cloudObjectKey:
       "e8d8149f-af6a-4c14-8b91-066fa196187c/02425e17-c452-41c9-869c-196d09f75c91.anb1",
+    deliveryState: "synced",
+    uploadPhase: "completed",
+    uploadError: null,
   });
 });
 
@@ -50,7 +55,29 @@ test("does not treat synced metadata as a local audio file", () => {
       localRelativePath: null,
       cloudObjectKey:
         "e8d8149f-af6a-4c14-8b91-066fa196187c/02425e17-c452-41c9-869c-196d09f75c91.anb1",
+      deliveryState: "synced",
+      uploadPhase: "completed",
+      uploadError: null,
     },
+  );
+});
+
+test("maps the durable upload job to a per-record delivery state", () => {
+  assert.equal(
+    mapSessionAudioRows([
+      {
+        ...row,
+        cloud_object_key: "",
+        upload_phase: "transferring",
+      },
+    ])?.deliveryState,
+    "uploading",
+  );
+  assert.equal(
+    mapSessionAudioRows([
+      { ...row, cloud_object_key: "", upload_phase: "failed" },
+    ])?.deliveryState,
+    "failed",
   );
 });
 

--- a/apps/mobile/src/data/audio-catalog.ts
+++ b/apps/mobile/src/data/audio-catalog.ts
@@ -1,6 +1,7 @@
 import { File, FileMode, Paths } from "expo-file-system";
 
 import { requestMobileAttachmentUploads } from "@/attachment-sync/upload-runner";
+import { requeueMobileAttachmentUpload } from "@/attachment-sync/upload-store";
 import { executeTransaction, useLiveQuery } from "@/db";
 import { id, nowIso } from "@/lib/ids";
 
@@ -128,10 +129,23 @@ SELECT
   attachment.created_at,
   CASE WHEN local_state.availability = 'present' THEN 1 ELSE 0 END AS available_locally,
   COALESCE(local_state.relative_path, '') AS local_relative_path,
-  attachment.cloud_object_key
+  attachment.cloud_object_key,
+  upload.phase AS upload_phase,
+  COALESCE(upload.last_error, '') AS upload_error
 FROM session_attachments AS attachment
 LEFT JOIN attachment_local_state AS local_state
   ON local_state.attachment_id = attachment.id
+LEFT JOIN attachment_transfer_jobs AS upload
+  ON upload.id = (
+    SELECT candidate.id
+    FROM attachment_transfer_jobs AS candidate
+    WHERE candidate.attachment_id = attachment.id
+      AND candidate.direction = 'upload'
+      AND candidate.expected_sha256 = attachment.sha256
+      AND candidate.expected_size_bytes = attachment.size_bytes
+    ORDER BY candidate.updated_at DESC, candidate.id DESC
+    LIMIT 1
+  )
 WHERE attachment.session_id = ?
   AND attachment.source_type = 'session_audio'
   AND attachment.deleted_at IS NULL
@@ -151,4 +165,11 @@ export function useSessionAudio(sessionId: string): {
     mapRows: mapSessionAudioRows,
   });
   return { data: data ?? null, isLoading };
+}
+
+export async function retrySessionAudioUpload(
+  attachmentId: string,
+): Promise<void> {
+  await requeueMobileAttachmentUpload(attachmentId);
+  requestMobileAttachmentUploads();
 }

--- a/apps/mobile/src/data/timeline-model.test.mjs
+++ b/apps/mobile/src/data/timeline-model.test.mjs
@@ -3,9 +3,43 @@ import test from "node:test";
 
 import {
   buildSessionList,
+  dayLabel,
   mapTimelineRows,
   nextTimelineRefreshAt,
+  relativeLabel,
 } from "./timeline-model.ts";
+
+test("uses calendar labels around the current day", () => {
+  const now = new Date(2026, 7, 17, 12).getTime();
+
+  assert.equal(dayLabel(new Date(2026, 7, 17, 23).toISOString(), now), "Today");
+  assert.equal(
+    dayLabel(new Date(2026, 7, 18, 0).toISOString(), now),
+    "Tomorrow",
+  );
+  assert.equal(
+    dayLabel(new Date(2026, 7, 16, 23).toISOString(), now),
+    "Yesterday",
+  );
+});
+
+test("uses readable relative units instead of unbounded hours", () => {
+  const now = new Date("2026-08-17T12:00:00.000Z").getTime();
+
+  assert.equal(relativeLabel(new Date(now - 29_000).toISOString(), now), "now");
+  assert.equal(
+    relativeLabel(new Date(now - 90 * 60_000).toISOString(), now),
+    "2 hours ago",
+  );
+  assert.equal(
+    relativeLabel(new Date(now - 205 * 60 * 60_000).toISOString(), now),
+    "9 days ago",
+  );
+  assert.equal(
+    relativeLabel(new Date(now + 2 * 24 * 60 * 60_000).toISOString(), now),
+    "in 2 days",
+  );
+});
 
 test("groups upcoming meetings nearest-first and past meetings newest-first", () => {
   const now = new Date(2026, 7, 17, 12).getTime();

--- a/apps/mobile/src/data/timeline-model.ts
+++ b/apps/mobile/src/data/timeline-model.ts
@@ -28,31 +28,42 @@ function startOfDay(timestamp: number): number {
 export function dayLabel(iso: string, now = Date.now()): string {
   const timestamp = new Date(iso).getTime();
   if (!Number.isFinite(timestamp)) return "Date unavailable";
-  const today = startOfDay(now);
-  const day = startOfDay(timestamp);
-  if (day === today) return "Today";
-  if (day === today + DAY) return "Tomorrow";
-  if (day === today - DAY) return "Yesterday";
-  const date = new Date(day);
-  const sameYear = date.getFullYear() === new Date(today).getFullYear();
-  return date.toLocaleDateString(undefined, {
+  const today = new Date(startOfDay(now));
+  const day = new Date(startOfDay(timestamp));
+  const dayOffset = Math.round(
+    (Date.UTC(day.getFullYear(), day.getMonth(), day.getDate()) -
+      Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())) /
+      DAY,
+  );
+  if (dayOffset === 0) return "Today";
+  if (dayOffset === 1) return "Tomorrow";
+  if (dayOffset === -1) return "Yesterday";
+  const sameYear = day.getFullYear() === today.getFullYear();
+  return day.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
     ...(sameYear ? {} : { year: "numeric" }),
   });
 }
 
-export function relativeLabel(iso: string): string {
+export function relativeLabel(iso: string, now = Date.now()): string {
   const timestamp = new Date(iso).getTime();
   if (!Number.isFinite(timestamp)) return "date unavailable";
-  const diff = timestamp - Date.now();
+  const diff = timestamp - now;
   const minutes = Math.round(Math.abs(diff) / 60000);
   if (minutes < 1) return "now";
-  const unit =
+  const [value, label] =
     minutes < 60
-      ? `${minutes} min${minutes === 1 ? "" : "s"}`
-      : `${Math.round(minutes / 60)} hour${Math.round(minutes / 60) === 1 ? "" : "s"}`;
-  return diff > 0 ? `${unit} later` : `${unit} ago`;
+      ? [minutes, "min"]
+      : minutes < 24 * 60
+        ? [Math.round(minutes / 60), "hour"]
+        : minutes < 30 * 24 * 60
+          ? [Math.round(minutes / (24 * 60)), "day"]
+          : minutes < 365 * 24 * 60
+            ? [Math.round(minutes / (30 * 24 * 60)), "month"]
+            : [Math.round(minutes / (365 * 24 * 60)), "year"];
+  const unit = `${value} ${label}${value === 1 ? "" : "s"}`;
+  return diff > 0 ? `in ${unit}` : `${unit} ago`;
 }
 
 export function buildSessionList(

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -27,6 +27,7 @@ export type TranscriptionState = "idle" | "running" | "failed";
 
 const states = new Map<string, TranscriptionState>();
 const inflight = new Map<string, Promise<void>>();
+const automaticRetryBlocked = new Set<string>();
 const listeners = new Set<() => void>();
 const MAX_RETAINED_FAILED_STATES = 100;
 const transcriptionAdmission = new TranscriptionAdmission(2, 32);
@@ -84,6 +85,21 @@ WHERE attachment.session_id = ?
   AND attachment.deleted_at IS NULL
   AND COALESCE(json_extract(attachment.metadata_json, '$.transcript_status'), '') <> 'complete'
 LIMIT 1
+`;
+
+const PENDING_TRANSCRIPTION_RETRY_SQL = `
+SELECT attachment.session_id
+FROM session_attachments AS attachment
+JOIN attachment_local_state AS local_state
+  ON local_state.attachment_id = attachment.id
+ AND local_state.availability = 'present'
+WHERE attachment.source_type = 'session_audio'
+  AND attachment.deleted_at IS NULL
+  AND attachment.size_bytes > 0
+  AND attachment.size_bytes <= ?
+  AND COALESCE(json_extract(attachment.metadata_json, '$.transcript_status'), '') <> 'complete'
+ORDER BY attachment.updated_at, attachment.id
+LIMIT 8
 `;
 
 const TRANSCRIPT_TOMBSTONE_SQL = `
@@ -290,6 +306,16 @@ function transcriptionStage(error: unknown): TranscriptionStage | "unknown" {
     : "unknown";
 }
 
+function isPermanentTranscriptionFailure(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  return [
+    "audio_missing",
+    "audio_too_large",
+    "stt_response_too_large",
+  ].includes(String(code));
+}
+
 function requestTimeoutMs(sizeBytes: number): number {
   // The abort covers the whole /stt/listen round trip, not just the upload, so
   // budgeting for transfer alone aborts long recordings the provider is still
@@ -469,6 +495,7 @@ export function transcribeSession(sessionId: string): Promise<void> {
           mode: "batch",
           entry_point: "mobile_audio",
         });
+        automaticRetryBlocked.delete(sessionId);
         clearStateSilently(sessionId);
       })
       .catch((error: unknown) => {
@@ -484,6 +511,9 @@ export function transcribeSession(sessionId: string): Promise<void> {
           entry_point: "mobile_audio",
           failure_stage: "transcription",
         });
+        if (isPermanentTranscriptionFailure(error)) {
+          automaticRetryBlocked.add(sessionId);
+        }
         setState(sessionId, "failed");
       }),
   );
@@ -507,4 +537,37 @@ export function transcribeSession(sessionId: string): Promise<void> {
   });
   inflight.set(sessionId, task);
   return task;
+}
+
+let pendingRetryPass: Promise<void> | null = null;
+
+export function retryPendingTranscriptions(): Promise<void> {
+  if (pendingRetryPass) return pendingRetryPass;
+
+  const pass = execute<{ session_id: string }>(
+    PENDING_TRANSCRIPTION_RETRY_SQL,
+    [MAX_TRANSCRIPTION_AUDIO_BYTES],
+  )
+    .then((rows) =>
+      Promise.all(
+        rows
+          .map((row) => row.session_id)
+          .filter(
+            (sessionId) =>
+              !automaticRetryBlocked.has(sessionId) && !inflight.has(sessionId),
+          )
+          .map((sessionId) => transcribeSession(sessionId)),
+      ),
+    )
+    .then(() => {})
+    .catch((error) => {
+      captureOperationalError(error, {
+        operation: "transcription_retry_pending",
+        level: "warning",
+      });
+    });
+  pendingRetryPass = pass.finally(() => {
+    pendingRetryPass = null;
+  });
+  return pendingRetryPass;
 }

--- a/apps/mobile/src/sync/capture-access.test.mjs
+++ b/apps/mobile/src/sync/capture-access.test.mjs
@@ -5,27 +5,63 @@ import { canUseMobileCapture } from "./capture-access.ts";
 
 test("blocks capture until encrypted sync has been enrolled", () => {
   assert.equal(
-    canUseMobileCapture({ phase: "setup_required", hasRecoveryKey: false }),
+    canUseMobileCapture(
+      {
+        phase: "setup_required",
+        accountUserId: "user-123",
+        hasRecoveryKey: false,
+      },
+      "user-123",
+    ),
     false,
   );
   assert.equal(
-    canUseMobileCapture({ phase: "starting", hasRecoveryKey: false }),
+    canUseMobileCapture(
+      {
+        phase: "starting",
+        accountUserId: "user-123",
+        hasRecoveryKey: false,
+      },
+      "user-123",
+    ),
     false,
   );
   assert.equal(
-    canUseMobileCapture({ phase: "ready", hasRecoveryKey: false }),
+    canUseMobileCapture(
+      {
+        phase: "ready",
+        accountUserId: "user-123",
+        hasRecoveryKey: false,
+      },
+      "user-123",
+    ),
     false,
   );
 });
 
 test("keeps capture available through an ordinary outage after enrollment", () => {
+  for (const phase of ["inactive", "starting", "ready", "error"]) {
+    assert.equal(
+      canUseMobileCapture(
+        { phase, accountUserId: "user-123", hasRecoveryKey: true },
+        "user-123",
+      ),
+      true,
+    );
+  }
+});
+
+test("does not carry enrollment across accounts", () => {
   assert.equal(
-    canUseMobileCapture({ phase: "error", hasRecoveryKey: true }),
-    true,
-  );
-  assert.equal(
-    canUseMobileCapture({ phase: "starting", hasRecoveryKey: true }),
-    true,
+    canUseMobileCapture(
+      {
+        phase: "inactive",
+        accountUserId: "user-123",
+        hasRecoveryKey: true,
+      },
+      "user-456",
+    ),
+    false,
   );
 });
 
@@ -37,6 +73,12 @@ test("blocks explicit account and entitlement failures", () => {
     "not_entitled",
     "reauth_required",
   ]) {
-    assert.equal(canUseMobileCapture({ phase, hasRecoveryKey: true }), false);
+    assert.equal(
+      canUseMobileCapture(
+        { phase, accountUserId: "user-123", hasRecoveryKey: true },
+        "user-123",
+      ),
+      false,
+    );
   }
 });

--- a/apps/mobile/src/sync/capture-access.test.mjs
+++ b/apps/mobile/src/sync/capture-access.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { canUseMobileCapture } from "./capture-access.ts";
+
+test("blocks capture until encrypted sync has been enrolled", () => {
+  assert.equal(
+    canUseMobileCapture({ phase: "setup_required", hasRecoveryKey: false }),
+    false,
+  );
+  assert.equal(
+    canUseMobileCapture({ phase: "starting", hasRecoveryKey: false }),
+    false,
+  );
+  assert.equal(
+    canUseMobileCapture({ phase: "ready", hasRecoveryKey: false }),
+    false,
+  );
+});
+
+test("keeps capture available through an ordinary outage after enrollment", () => {
+  assert.equal(
+    canUseMobileCapture({ phase: "error", hasRecoveryKey: true }),
+    true,
+  );
+  assert.equal(
+    canUseMobileCapture({ phase: "starting", hasRecoveryKey: true }),
+    true,
+  );
+});
+
+test("blocks explicit account and entitlement failures", () => {
+  for (const phase of [
+    "account_mismatch",
+    "device_limit",
+    "identity_mismatch",
+    "not_entitled",
+    "reauth_required",
+  ]) {
+    assert.equal(canUseMobileCapture({ phase, hasRecoveryKey: true }), false);
+  }
+});

--- a/apps/mobile/src/sync/capture-access.ts
+++ b/apps/mobile/src/sync/capture-access.ts
@@ -1,10 +1,16 @@
 import type { MobileSyncSnapshot } from "./controller";
 
 export function canUseMobileCapture(
-  sync: Pick<MobileSyncSnapshot, "phase" | "hasRecoveryKey">,
+  sync: Pick<MobileSyncSnapshot, "phase" | "accountUserId" | "hasRecoveryKey">,
+  accountUserId: string,
 ): boolean {
-  if (sync.phase === "ready") return sync.hasRecoveryKey;
+  if (!sync.hasRecoveryKey || sync.accountUserId !== accountUserId) {
+    return false;
+  }
   return (
-    sync.hasRecoveryKey && (sync.phase === "starting" || sync.phase === "error")
+    sync.phase === "inactive" ||
+    sync.phase === "starting" ||
+    sync.phase === "ready" ||
+    sync.phase === "error"
   );
 }

--- a/apps/mobile/src/sync/capture-access.ts
+++ b/apps/mobile/src/sync/capture-access.ts
@@ -1,0 +1,10 @@
+import type { MobileSyncSnapshot } from "./controller";
+
+export function canUseMobileCapture(
+  sync: Pick<MobileSyncSnapshot, "phase" | "hasRecoveryKey">,
+): boolean {
+  if (sync.phase === "ready") return sync.hasRecoveryKey;
+  return (
+    sync.hasRecoveryKey && (sync.phase === "starting" || sync.phase === "error")
+  );
+}

--- a/apps/mobile/src/sync/controller.test.mjs
+++ b/apps/mobile/src/sync/controller.test.mjs
@@ -81,6 +81,7 @@ test("boots the native replica with the stored account key", async () => {
   ]);
   assert.deepEqual(controller.getSnapshot(), {
     phase: "ready",
+    hasRecoveryKey: true,
     running: true,
     syncingNow: false,
     hasUnsentChanges: false,

--- a/apps/mobile/src/sync/controller.test.mjs
+++ b/apps/mobile/src/sync/controller.test.mjs
@@ -81,6 +81,7 @@ test("boots the native replica with the stored account key", async () => {
   ]);
   assert.deepEqual(controller.getSnapshot(), {
     phase: "ready",
+    accountUserId: "user-123",
     hasRecoveryKey: true,
     running: true,
     syncingNow: false,
@@ -295,6 +296,35 @@ test("stops native sync when the account lifecycle ends", async () => {
   controller.suspend();
   await waitFor(() => stopCount === 2);
   assert.equal(controller.getSnapshot().phase, "inactive");
+  assert.equal(controller.getSnapshot().accountUserId, session.accountUserId);
+  assert.equal(controller.getSnapshot().hasRecoveryKey, true);
+});
+
+test("preserves enrollment only for same-account restarts", async () => {
+  const controller = new MobileSyncController(dependencies(), 0, 0);
+  controller.activate(session);
+  await waitFor(() => controller.getSnapshot().phase === "ready");
+
+  controller.suspend();
+  assert.deepEqual(
+    {
+      phase: controller.getSnapshot().phase,
+      accountUserId: controller.getSnapshot().accountUserId,
+      hasRecoveryKey: controller.getSnapshot().hasRecoveryKey,
+    },
+    {
+      phase: "inactive",
+      accountUserId: "user-123",
+      hasRecoveryKey: true,
+    },
+  );
+
+  controller.activate({ ...session, accessToken: "refreshed-token" });
+  assert.equal(controller.getSnapshot().hasRecoveryKey, true);
+
+  controller.activate({ ...session, accountUserId: "user-456" });
+  assert.equal(controller.getSnapshot().accountUserId, "user-456");
+  assert.equal(controller.getSnapshot().hasRecoveryKey, false);
 });
 
 test("coalesces foreground and manual sync requests while one is active", async () => {

--- a/apps/mobile/src/sync/controller.ts
+++ b/apps/mobile/src/sync/controller.ts
@@ -12,6 +12,7 @@ export type MobileSyncPhase =
 
 export type MobileSyncSnapshot = {
   phase: MobileSyncPhase;
+  hasRecoveryKey: boolean;
   running: boolean;
   syncingNow: boolean;
   hasUnsentChanges: boolean | null;
@@ -71,6 +72,7 @@ type ControllerTimers = {
 
 const initialSnapshot: MobileSyncSnapshot = {
   phase: "inactive",
+  hasRecoveryKey: false,
   running: false,
   syncingNow: false,
   hasUnsentChanges: null,
@@ -225,6 +227,7 @@ export class MobileSyncController {
     await this.stopSafely();
     if (generation !== this.generation) return;
 
+    let hasRecoveryKey = false;
     try {
       const recoveryKey = await this.dependencies.readRecoveryKey(
         session.accountUserId,
@@ -234,6 +237,12 @@ export class MobileSyncController {
         this.update({ ...initialSnapshot, phase: "setup_required" });
         return;
       }
+      hasRecoveryKey = true;
+      this.update({
+        ...initialSnapshot,
+        phase: "starting",
+        hasRecoveryKey: true,
+      });
 
       const device = await this.dependencies.getDevice();
       if (generation !== this.generation) return;
@@ -244,11 +253,20 @@ export class MobileSyncController {
       );
       if (generation !== this.generation) return;
       if (result === "account_mismatch") {
-        this.update({ ...initialSnapshot, phase: "account_mismatch" });
+        this.update({
+          ...initialSnapshot,
+          phase: "account_mismatch",
+          hasRecoveryKey: true,
+        });
         return;
       }
 
-      this.update({ ...initialSnapshot, phase: "ready", running: true });
+      this.update({
+        ...initialSnapshot,
+        phase: "ready",
+        hasRecoveryKey: true,
+        running: true,
+      });
       await this.refreshStatus(generation);
       if (generation !== this.generation) return;
       this.startPolling(generation);
@@ -259,6 +277,7 @@ export class MobileSyncController {
       this.update({
         ...initialSnapshot,
         phase,
+        hasRecoveryKey,
         errorMessage: errorMessage(error),
       });
       if (phase === "error") {

--- a/apps/mobile/src/sync/controller.ts
+++ b/apps/mobile/src/sync/controller.ts
@@ -12,6 +12,7 @@ export type MobileSyncPhase =
 
 export type MobileSyncSnapshot = {
   phase: MobileSyncPhase;
+  accountUserId: string | null;
   hasRecoveryKey: boolean;
   running: boolean;
   syncingNow: boolean;
@@ -72,6 +73,7 @@ type ControllerTimers = {
 
 const initialSnapshot: MobileSyncSnapshot = {
   phase: "inactive",
+  accountUserId: null,
   hasRecoveryKey: false,
   running: false,
   syncingNow: false,
@@ -144,9 +146,17 @@ export class MobileSyncController {
   activate(session: MobileSyncSession): () => void {
     this.generation += 1;
     const generation = this.generation;
+    const hasRecoveryKey =
+      this.snapshot.accountUserId === session.accountUserId &&
+      this.snapshot.hasRecoveryKey;
     this.session = session;
     this.clearTimers();
-    this.update({ ...initialSnapshot, phase: "starting" });
+    this.update({
+      ...initialSnapshot,
+      phase: "starting",
+      accountUserId: session.accountUserId,
+      hasRecoveryKey,
+    });
     this.enqueue(async () => this.start(generation, session));
     return () => {
       if (this.generation === generation) {
@@ -159,7 +169,11 @@ export class MobileSyncController {
     this.generation += 1;
     this.session = null;
     this.clearTimers();
-    this.update(initialSnapshot);
+    this.update({
+      ...initialSnapshot,
+      accountUserId: this.snapshot.accountUserId,
+      hasRecoveryKey: this.snapshot.hasRecoveryKey,
+    });
     this.enqueue(async () => {
       await this.stopSafely();
     });
@@ -227,20 +241,27 @@ export class MobileSyncController {
     await this.stopSafely();
     if (generation !== this.generation) return;
 
-    let hasRecoveryKey = false;
+    let hasRecoveryKey =
+      this.snapshot.accountUserId === session.accountUserId &&
+      this.snapshot.hasRecoveryKey;
     try {
       const recoveryKey = await this.dependencies.readRecoveryKey(
         session.accountUserId,
       );
       if (generation !== this.generation) return;
       if (!recoveryKey) {
-        this.update({ ...initialSnapshot, phase: "setup_required" });
+        this.update({
+          ...initialSnapshot,
+          phase: "setup_required",
+          accountUserId: session.accountUserId,
+        });
         return;
       }
       hasRecoveryKey = true;
       this.update({
         ...initialSnapshot,
         phase: "starting",
+        accountUserId: session.accountUserId,
         hasRecoveryKey: true,
       });
 
@@ -256,6 +277,7 @@ export class MobileSyncController {
         this.update({
           ...initialSnapshot,
           phase: "account_mismatch",
+          accountUserId: session.accountUserId,
           hasRecoveryKey: true,
         });
         return;
@@ -264,6 +286,7 @@ export class MobileSyncController {
       this.update({
         ...initialSnapshot,
         phase: "ready",
+        accountUserId: session.accountUserId,
         hasRecoveryKey: true,
         running: true,
       });
@@ -277,6 +300,7 @@ export class MobileSyncController {
       this.update({
         ...initialSnapshot,
         phase,
+        accountUserId: session.accountUserId,
         hasRecoveryKey,
         errorMessage: errorMessage(error),
       });

--- a/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
+++ b/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
@@ -1,6 +1,7 @@
 import { AppState } from "react-native";
 
 import { activateMobileAttachmentUploads } from "@/attachment-sync/upload-runner";
+import { retryPendingTranscriptions } from "@/data/transcribe";
 import { useMountEffect } from "@/lib/use-mount-effect";
 import { shouldSyncAfterAppStateChange } from "@/sync/app-state";
 import {
@@ -20,30 +21,42 @@ export function MobileSyncLifecycle({
   useMountEffect(() => {
     const deactivate = activateMobileSync({ accessToken, accountUserId });
     const uploads = activateMobileAttachmentUploads({ accessToken });
-    const updateUploads = () => {
-      const sync = getMobileSyncSnapshot();
+    let transcriptionRetryTimer: ReturnType<typeof setInterval> | undefined;
+    let syncWasReady = false;
+    const retryPending = () => {
       if (
         AppState.currentState === "active" &&
-        sync.phase === "ready" &&
-        sync.running
+        getMobileSyncSnapshot().hasRecoveryKey
       ) {
+        void retryPendingTranscriptions();
+      }
+    };
+    const updateUploads = () => {
+      const sync = getMobileSyncSnapshot();
+      const syncReady = sync.phase === "ready" && sync.running;
+      if (syncReady) {
         uploads.resume();
       } else {
         uploads.pause();
       }
+      if (syncReady && !syncWasReady) retryPending();
+      syncWasReady = syncReady;
     };
     const unsubscribeSync = subscribeMobileSync(updateUploads);
     let previousState = AppState.currentState;
     const subscription = AppState.addEventListener("change", (nextState) => {
       if (shouldSyncAfterAppStateChange(previousState, nextState)) {
         void syncMobileNow();
+        retryPending();
       }
       previousState = nextState;
-      updateUploads();
     });
     updateUploads();
+    retryPending();
+    transcriptionRetryTimer = setInterval(retryPending, 60_000);
 
     return () => {
+      if (transcriptionRetryTimer) clearInterval(transcriptionRetryTimer);
       subscription.remove();
       unsubscribeSync();
       uploads.stop();

--- a/apps/mobile/src/sync/sync-enrollment-screen.tsx
+++ b/apps/mobile/src/sync/sync-enrollment-screen.tsx
@@ -1,0 +1,74 @@
+import { useSyncExternalStore } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { SettingsContent } from "@/components/profile-sheet";
+import { Colors, Spacing, Typography } from "@/constants/theme";
+import { getMobileSyncSnapshot, subscribeMobileSync } from "@/sync/mobile-sync";
+
+export function SyncEnrollmentScreen() {
+  const sync = useSyncExternalStore(
+    subscribeMobileSync,
+    getMobileSyncSnapshot,
+    getMobileSyncSnapshot,
+  );
+  const loading =
+    sync.phase === "inactive" ||
+    (sync.phase === "starting" && !sync.hasRecoveryKey);
+
+  if (loading) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator color={Colors.ink} />
+        <Text style={styles.loadingText}>Checking encrypted sync…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.intro}>
+        <Text style={styles.title}>Connect encrypted sync</Text>
+        <Text style={styles.description}>
+          Mobile capture is a Pro sync companion. Set up your recovery key once,
+          then you can keep recording when this phone is offline.
+        </Text>
+      </View>
+      <SettingsContent
+        initialMode={sync.phase === "setup_required" ? "choose" : "status"}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  loading: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: Spacing.sm,
+    backgroundColor: Colors.background,
+  },
+  loadingText: {
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  intro: {
+    gap: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.lg,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.ink,
+  },
+  description: {
+    ...Typography.body,
+    color: Colors.muted,
+  },
+});


### PR DESCRIPTION
Summary:
- tighten mobile timeline, search, note actions, settings, spacing, and safe-area behavior
- require encrypted sync enrollment for first capture while preserving offline capture after enrollment
- add durable per-record backup status, upload retry, transcription retry, and active-recording entitlement protection

Validation:
- pnpm exec dprint fmt
- pnpm fmt:check
- pnpm -F @anlg/mobile typecheck
- pnpm -F @anlg/mobile test
- pnpm exec oxlint --quiet --format=github apps/mobile/src/
- git diff --check
- iOS Simulator background-capture QA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth-adjacent gating, recording lifecycle, and sync/upload/transcription retry paths; mis-gating could block capture or allow recording without enrollment, but behavior is covered by new unit tests.
> 
> **Overview**
> This PR **gates the main app on encrypted sync enrollment** while keeping capture usable offline after a recovery key exists. Signed-in users who are not enrolled see `SyncEnrollmentScreen` instead of the timeline; **`canUseMobileCapture`** blocks first use until `hasRecoveryKey` matches the account, but still allows capture through ordinary sync outages (`inactive`, `starting`, `ready`, `error`).
> 
> **Active recording is protected from that gate:** a new **`capture-lifecycle`** store (ref-counted per session) keeps `Gate` on the main stack for the whole recording, including optional `MobileSyncLifecycle`, so entitlement checks do not interrupt an in-progress session.
> 
> **Note and home UX** move profile/sync into a **`/settings`** route (`SettingsContent`), extract **`StartListeningButton`**, and add **`NoteActionsSheet`** (export via Share, listen toggle, delete). Empty notes can start listening from a bottom CTA; local audio shows **`RecordingSyncCard`** with per-record backup state and manual retry instead of **`HandoffCard`**.
> 
> **Recorder and durability:** `useSessionRecorder` exposes **`start`**, registers capture lifecycle, and discards empty WAV files on failed starts; **`SessionWavWriter`** avoids clobbering non-empty files and adds **`closeAndDiscardEmpty`**. Audio catalog joins upload jobs for **`deliveryState`**; **`requeueMobileAttachmentUpload`** powers **`retrySessionAudioUpload`**. **`retryPendingTranscriptions`** runs on sync readiness, foreground, and a 60s interval, skipping permanent failures.
> 
> Smaller polish: timeline **relative/day labels**, session card delete hit target, and sync snapshot fields **`accountUserId`** / **`hasRecoveryKey`** preserved across suspend and same-account re-activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac87fb44c52982c2ccfaacec69809ea553746e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->