### PR TITLE
Stop rodio ALSA errors from panicking on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,7 @@ name = "audio-mock"
 version = "0.1.0"
 dependencies = [
  "audio",
+ "audio-utils",
  "data",
  "futures-util",
  "rodio",
@@ -14303,6 +14304,7 @@ dependencies = [
  "rtrb",
  "symphonia",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -18283,6 +18285,7 @@ dependencies = [
 name = "tauri-plugin-sfx"
 version = "0.1.0"
 dependencies = [
+ "audio-utils",
  "rodio",
  "serde",
  "specta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,7 +380,7 @@ mp3lame-encoder = "0.2.2"
 ratatui = "0.30"
 realfft = "3.5.0"
 ringbuf = "0.4.8"
-rodio = "0.22"
+rodio = { version = "0.22", features = ["tracing"] }
 tachyonfx = "0.25"
 vorbis_rs = "0.5.5"
 

--- a/crates/audio-actual/src/lib.rs
+++ b/crates/audio-actual/src/lib.rs
@@ -21,11 +21,11 @@ pub struct AudioOutput {}
 
 impl AudioOutput {
     pub fn to_speaker(bytes: &'static [u8]) -> std::sync::mpsc::Sender<()> {
-        use rodio::{Decoder, Player, stream::DeviceSinkBuilder};
+        use rodio::{Decoder, Player};
         let (tx, rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            if let Ok(stream) = DeviceSinkBuilder::open_default_sink() {
+            if let Ok(stream) = anlg_audio_utils::open_default_playback_sink() {
                 let file = std::io::Cursor::new(bytes);
                 if let Ok(source) = Decoder::try_from(file) {
                     let player = Player::connect_new(stream.mixer());
@@ -44,13 +44,12 @@ impl AudioOutput {
         use rodio::{
             Player, nz,
             source::{Source, Zero},
-            stream::DeviceSinkBuilder,
         };
 
         let (tx, rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
-            if let Ok(stream) = DeviceSinkBuilder::open_default_sink() {
+            if let Ok(stream) = anlg_audio_utils::open_default_playback_sink() {
                 let silence = Zero::new(nz!(2u16), nz!(48_000u32))
                     .take_duration(std::time::Duration::from_secs(1))
                     .repeat_infinite();
@@ -286,7 +285,6 @@ pub(crate) fn play_sine_for_sec(seconds: u64) -> std::thread::JoinHandle<()> {
     use rodio::{
         Player, nz,
         source::{Function::Sine, SignalGenerator, Source},
-        stream::DeviceSinkBuilder,
     };
     use std::{
         thread::{sleep, spawn},
@@ -294,7 +292,7 @@ pub(crate) fn play_sine_for_sec(seconds: u64) -> std::thread::JoinHandle<()> {
     };
 
     spawn(move || {
-        let stream = DeviceSinkBuilder::open_default_sink().unwrap();
+        let stream = anlg_audio_utils::open_default_playback_sink().unwrap();
         let source = SignalGenerator::new(nz!(44100u32), 440.0, Sine);
 
         let source = source

--- a/crates/audio-mock/Cargo.toml
+++ b/crates/audio-mock/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 anlg-audio = { workspace = true }
+anlg-audio-utils = { workspace = true }
 anlg-data = { workspace = true }
 
 futures-util = { workspace = true }

--- a/crates/audio-mock/src/lib.rs
+++ b/crates/audio-mock/src/lib.rs
@@ -231,9 +231,8 @@ fn start_stereo_playback(mic: &MockAudioData, spk: &MockAudioData, stop: Arc<Ato
 
     std::thread::spawn(move || {
         use rodio::Player;
-        use rodio::stream::DeviceSinkBuilder;
 
-        match DeviceSinkBuilder::open_default_sink() {
+        match anlg_audio_utils::open_default_playback_sink() {
             Ok(stream) => {
                 let player = Player::connect_new(stream.mixer());
                 player.append(MonoPlaybackSource {

--- a/crates/audio-utils/src/lib.rs
+++ b/crates/audio-utils/src/lib.rs
@@ -6,10 +6,12 @@ use futures_util::{Stream, StreamExt};
 
 mod error;
 mod pcm;
+mod playback;
 mod vorbis;
 
 pub use error::*;
 pub use pcm::*;
+pub use playback::open_default_playback_sink;
 pub use vorbis::*;
 
 pub use rodio::Source;

--- a/crates/audio-utils/src/playback.rs
+++ b/crates/audio-utils/src/playback.rs
@@ -1,0 +1,25 @@
+use rodio::stream::{DeviceSinkBuilder, DeviceSinkError, MixerDeviceSink};
+
+pub fn open_default_playback_sink() -> Result<MixerDeviceSink, DeviceSinkError> {
+    // rodio's default callback uses eprintln!, which panics if writing to stderr fails.
+    let mut sink = DeviceSinkBuilder::from_default_device()?
+        .with_error_callback(|err| log_audio_stream_error(&err))
+        .open_stream()?;
+    sink.log_on_drop(false);
+    Ok(sink)
+}
+
+fn log_audio_stream_error(err: &dyn std::fmt::Display) {
+    tracing::warn!(error = %err, "audio output stream error");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::log_audio_stream_error;
+
+    #[test]
+    fn audio_stream_error_log_does_not_panic() {
+        log_audio_stream_error(&"alsa::poll() returned POLLERR");
+        log_audio_stream_error(&"device not available");
+    }
+}

--- a/crates/audio-utils/src/playback.rs
+++ b/crates/audio-utils/src/playback.rs
@@ -38,17 +38,33 @@ fn disable_drop_log(mut sink: MixerDeviceSink) -> MixerDeviceSink {
 }
 
 fn is_usable_output_device(device: &impl DeviceTrait) -> bool {
-    is_usable_output_driver(
-        device
-            .description()
-            .ok()
-            .as_ref()
-            .and_then(|description| description.driver()),
-    )
+    if device
+        .id()
+        .ok()
+        .is_some_and(|id| is_silent_output_pcm(&id.1))
+    {
+        return false;
+    }
+
+    let Some(description) = device.description().ok() else {
+        return false;
+    };
+    if is_silent_output_pcm(description.name())
+        || description.driver().is_some_and(is_silent_output_pcm)
+    {
+        return false;
+    }
+
+    description.driver().is_some()
 }
 
-fn is_usable_output_driver(driver: Option<&str>) -> bool {
-    driver.is_some_and(|driver| driver != "null")
+fn is_silent_output_pcm(id: &str) -> bool {
+    matches!(
+        id.trim()
+            .split_once([':', ','])
+            .map_or(id.trim(), |(plugin, _)| plugin),
+        "null" | "dummy"
+    )
 }
 
 fn log_audio_stream_error(err: cpal::StreamError) {
@@ -57,7 +73,7 @@ fn log_audio_stream_error(err: cpal::StreamError) {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_usable_output_driver, log_audio_stream_error};
+    use super::{is_silent_output_pcm, log_audio_stream_error};
     use rodio::cpal::StreamError;
 
     #[test]
@@ -66,9 +82,13 @@ mod tests {
     }
 
     #[test]
-    fn skips_null_and_unknown_output_drivers() {
-        assert!(!is_usable_output_driver(None));
-        assert!(!is_usable_output_driver(Some("null")));
-        assert!(is_usable_output_driver(Some("alsa")));
+    fn skips_alsa_discard_pcms() {
+        assert!(is_silent_output_pcm("null"));
+        assert!(is_silent_output_pcm("dummy"));
+        assert!(is_silent_output_pcm("null:CARD=Dummy"));
+        assert!(!is_silent_output_pcm("alsa"));
+        assert!(!is_silent_output_pcm("default"));
+        assert!(!is_silent_output_pcm("pipewire"));
+        assert!(!is_silent_output_pcm("hw:0,0"));
     }
 }

--- a/crates/audio-utils/src/playback.rs
+++ b/crates/audio-utils/src/playback.rs
@@ -1,25 +1,74 @@
+use rodio::cpal::traits::HostTrait;
 use rodio::stream::{DeviceSinkBuilder, DeviceSinkError, MixerDeviceSink};
+use rodio::{DeviceTrait, cpal};
 
 pub fn open_default_playback_sink() -> Result<MixerDeviceSink, DeviceSinkError> {
-    // rodio's default callback uses eprintln!, which panics if writing to stderr fails.
-    let mut sink = DeviceSinkBuilder::from_default_device()?
-        .with_error_callback(|err| log_audio_stream_error(&err))
-        .open_stream()?;
-    sink.log_on_drop(false);
-    Ok(sink)
+    DeviceSinkBuilder::from_default_device()
+        .and_then(open_builder)
+        .or_else(|original_err| {
+            let devices = match cpal::default_host().output_devices() {
+                Ok(devices) => devices,
+                Err(err) => {
+                    tracing::warn!(error = %err, "error getting list of output devices");
+                    return Err(original_err);
+                }
+            };
+            devices
+                .filter(is_usable_output_device)
+                .find_map(|device| {
+                    DeviceSinkBuilder::from_device(device)
+                        .and_then(open_builder)
+                        .ok()
+                })
+                .ok_or(original_err)
+        })
 }
 
-fn log_audio_stream_error(err: &dyn std::fmt::Display) {
+fn open_builder(builder: DeviceSinkBuilder) -> Result<MixerDeviceSink, DeviceSinkError> {
+    // rodio's default callback uses eprintln!, which panics if writing to stderr fails.
+    builder
+        .with_error_callback(log_audio_stream_error)
+        .open_sink_or_fallback()
+        .map(disable_drop_log)
+}
+
+fn disable_drop_log(mut sink: MixerDeviceSink) -> MixerDeviceSink {
+    sink.log_on_drop(false);
+    sink
+}
+
+fn is_usable_output_device(device: &impl DeviceTrait) -> bool {
+    is_usable_output_driver(
+        device
+            .description()
+            .ok()
+            .as_ref()
+            .and_then(|description| description.driver()),
+    )
+}
+
+fn is_usable_output_driver(driver: Option<&str>) -> bool {
+    driver.is_some_and(|driver| driver != "null")
+}
+
+fn log_audio_stream_error(err: cpal::StreamError) {
     tracing::warn!(error = %err, "audio output stream error");
 }
 
 #[cfg(test)]
 mod tests {
-    use super::log_audio_stream_error;
+    use super::{is_usable_output_driver, log_audio_stream_error};
+    use rodio::cpal::StreamError;
 
     #[test]
     fn audio_stream_error_log_does_not_panic() {
-        log_audio_stream_error(&"alsa::poll() returned POLLERR");
-        log_audio_stream_error(&"device not available");
+        log_audio_stream_error(StreamError::DeviceNotAvailable);
+    }
+
+    #[test]
+    fn skips_null_and_unknown_output_drivers() {
+        assert!(!is_usable_output_driver(None));
+        assert!(!is_usable_output_driver(Some("null")));
+        assert!(is_usable_output_driver(Some("alsa")));
     }
 }

--- a/plugins/sfx/Cargo.toml
+++ b/plugins/sfx/Cargo.toml
@@ -14,6 +14,8 @@ tauri-plugin = { workspace = true, features = ["build"] }
 specta-typescript = { workspace = true }
 
 [dependencies]
+anlg-audio-utils = { workspace = true }
+
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 

--- a/plugins/sfx/src/ext.rs
+++ b/plugins/sfx/src/ext.rs
@@ -33,15 +33,15 @@ pub(crate) fn to_speaker(
     looping: bool,
     volume: f32,
 ) -> std::sync::mpsc::Sender<SoundControl> {
+    use anlg_audio_utils::open_default_playback_sink;
     use rodio::source::Source;
-    use rodio::{Decoder, Player, stream::DeviceSinkBuilder};
+    use rodio::{Decoder, Player};
     let (tx, rx) = std::sync::mpsc::channel();
 
     std::thread::spawn(move || {
-        let Ok(mut stream) = DeviceSinkBuilder::open_default_sink() else {
+        let Ok(stream) = open_default_playback_sink() else {
             return;
         };
-        stream.log_on_drop(false);
 
         let file = std::io::Cursor::new(bytes);
         let Ok(source) = Decoder::try_from(file) else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [ANARLOG-2N88](https://fastrepl.sentry.io/issues/ANARLOG-2N88).

**What happened:** On Linux, cpal/ALSA can report a stream error (device glitch, PipeWire restart, `POLLERR`). rodio’s default callback then calls `eprintln!`. That macro panics if writing to stderr fails, which is common in GUI apps. Sentry captured it as a fatal panic in `rodio::stream::default_error_callback` on Fedora (`anarlog-desktop@1.4.13`).

**Fix:** Open playback sinks through a shared helper that:
- installs a `tracing::warn` error callback instead of rodio’s `eprintln!` default
- retries other supported formats and output devices, matching `open_default_sink`
- skips silent ALSA PCMs (`null`, `dummy`) so fallback cannot open a sink that discards audio
- disables rodio’s drop-time stderr log
- enables rodio’s `tracing` feature so remaining rodio logs don’t go through `eprintln!`

Call sites: SFX playback, real audio output (including silence), and mock playback.

The underlying ALSA error can still stop that output stream; we just no longer crash the process. Transient stream errors are breadcrumbs (`warn`), not Sentry error events.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64989526-9fa5-42f0-8cbc-bd2e1ea85f65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64989526-9fa5-42f0-8cbc-bd2e1ea85f65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

