### PR TITLE
Fix CloudSync witness recovery starvation

### DIFF
--- a/crates/db-sync/src/e2ee_sync.rs
+++ b/crates/db-sync/src/e2ee_sync.rs
@@ -83,6 +83,7 @@ pub struct E2eeSyncHook {
     pub replica_sync_requested: tokio::sync::Notify,
     replica_status: std::sync::Mutex<ReplicaSyncStatus>,
     activities: std::sync::RwLock<HashSet<CloudsyncActivity>>,
+    activity_epoch: std::sync::atomic::AtomicU64,
     pub activity_changed: tokio::sync::Notify,
     reconciliation_requested_epoch: std::sync::atomic::AtomicU64,
     reconciliation_completed_epoch: std::sync::atomic::AtomicU64,
@@ -278,10 +279,15 @@ impl E2eeSyncHook {
     }
 
     pub fn begin_activity(&self, activity: String, key: String) {
-        self.activities
+        let inserted = self
+            .activities
             .write()
             .unwrap()
             .insert(CloudsyncActivity { activity, key });
+        if inserted {
+            self.activity_epoch
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        }
         self.activity_changed.notify_waiters();
     }
 
@@ -296,6 +302,11 @@ impl E2eeSyncHook {
 
     pub fn activity_paused(&self) -> bool {
         !self.activities.read().unwrap().is_empty()
+    }
+
+    pub fn activity_epoch(&self) -> u64 {
+        self.activity_epoch
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     pub fn has_activity_lease(&self, activity: &str, key: &str) -> bool {

--- a/plugins/db/src/runtime/recovery.rs
+++ b/plugins/db/src/runtime/recovery.rs
@@ -153,7 +153,7 @@ impl PluginDbRuntime {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let join_handle = tokio::spawn(async move {
             let mut clean_receive_attempt_started = false;
-            let mut witness_repair_refreshed = false;
+            let mut witness_repair_refresh_epoch = None;
             let mut witness_repair_batches = 0_u64;
             let mut witness_repaired_records = 0_u64;
             loop {
@@ -213,7 +213,7 @@ impl PluginDbRuntime {
                         state.phase,
                         anlg_db_app::CloudsyncRecoveryPhase::NeedWitnessRepair
                     ) {
-                        witness_repair_refreshed = false;
+                        witness_repair_refresh_epoch = None;
                         witness_repair_batches = 0;
                         witness_repaired_records = 0;
                     }
@@ -420,7 +420,8 @@ impl PluginDbRuntime {
                                 return Ok(CloudsyncRecoveryStep::Deferred);
                             }
 
-                            if !witness_repair_refreshed {
+                            let activity_epoch = e2ee_sync_hook.activity_epoch();
+                            if witness_repair_refresh_epoch != Some(activity_epoch) {
                                 let received_before_publish = witness
                                     .refresh_cancellable(db.pool(), &key, &witness_cancellation)
                                     .await?;
@@ -437,7 +438,10 @@ impl PluginDbRuntime {
                                 if cloudsync_recovery_cancelled(&recovery_cancelled) {
                                     return Ok(CloudsyncRecoveryStep::Deferred);
                                 }
-                                witness_repair_refreshed = true;
+                                if e2ee_sync_hook.activity_epoch() != activity_epoch {
+                                    return Ok(CloudsyncRecoveryStep::Deferred);
+                                }
+                                witness_repair_refresh_epoch = Some(activity_epoch);
                                 tracing::info!(
                                     phase = "witness_repair",
                                     received_events = received_before_publish
@@ -602,7 +606,7 @@ impl PluginDbRuntime {
                                 repaired_records = witness_repaired_records,
                                 "CloudSync recovery finished encrypted witness repair"
                             );
-                            witness_repair_refreshed = false;
+                            witness_repair_refresh_epoch = None;
                             Ok(CloudsyncRecoveryStep::Progressed)
                         }
                         anlg_db_app::CloudsyncRecoveryPhase::NeedBarrierCleanup => {
@@ -729,7 +733,7 @@ impl PluginDbRuntime {
                         }
                         match cancellation {
                             CloudsyncRecoveryCancellation::Activity => {
-                                witness_repair_refreshed = false;
+                                witness_repair_refresh_epoch = None;
                                 if matches!(drained_step, Ok(CloudsyncRecoveryStep::Complete)) {
                                     drained_step
                                 } else {

--- a/plugins/db/src/runtime/recovery.rs
+++ b/plugins/db/src/runtime/recovery.rs
@@ -153,6 +153,9 @@ impl PluginDbRuntime {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let join_handle = tokio::spawn(async move {
             let mut clean_receive_attempt_started = false;
+            let mut witness_repair_refreshed = false;
+            let mut witness_repair_batches = 0_u64;
+            let mut witness_repaired_records = 0_u64;
             loop {
                 if cloudsync_auth_generation.load(std::sync::atomic::Ordering::Acquire)
                     != auth_generation
@@ -205,6 +208,14 @@ impl PluginDbRuntime {
                             "CloudSync recovery generation changed while running",
                         )
                         .into());
+                    }
+                    if !matches!(
+                        state.phase,
+                        anlg_db_app::CloudsyncRecoveryPhase::NeedWitnessRepair
+                    ) {
+                        witness_repair_refreshed = false;
+                        witness_repair_batches = 0;
+                        witness_repaired_records = 0;
                     }
                     let key = e2ee_sync_hook
                         .workspace_key(&state.workspace_id)
@@ -409,21 +420,30 @@ impl PluginDbRuntime {
                                 return Ok(CloudsyncRecoveryStep::Deferred);
                             }
 
-                            witness
-                                .refresh_cancellable(db.pool(), &key, &witness_cancellation)
-                                .await?;
-                            if cloudsync_recovery_cancelled(&recovery_cancelled) {
-                                return Ok(CloudsyncRecoveryStep::Deferred);
-                            }
-                            witness
-                                .publish_and_refresh_cancellable(
-                                    db.pool(),
-                                    &key,
-                                    &witness_cancellation,
-                                )
-                                .await?;
-                            if cloudsync_recovery_cancelled(&recovery_cancelled) {
-                                return Ok(CloudsyncRecoveryStep::Deferred);
+                            if !witness_repair_refreshed {
+                                let received_before_publish = witness
+                                    .refresh_cancellable(db.pool(), &key, &witness_cancellation)
+                                    .await?;
+                                if cloudsync_recovery_cancelled(&recovery_cancelled) {
+                                    return Ok(CloudsyncRecoveryStep::Deferred);
+                                }
+                                let received_after_publish = witness
+                                    .publish_and_refresh_cancellable(
+                                        db.pool(),
+                                        &key,
+                                        &witness_cancellation,
+                                    )
+                                    .await?;
+                                if cloudsync_recovery_cancelled(&recovery_cancelled) {
+                                    return Ok(CloudsyncRecoveryStep::Deferred);
+                                }
+                                witness_repair_refreshed = true;
+                                tracing::info!(
+                                    phase = "witness_repair",
+                                    received_events = received_before_publish
+                                        .saturating_add(received_after_publish),
+                                    "CloudSync recovery refreshed encrypted witness"
+                                );
                             }
                             let keys = e2ee_sync_hook.snapshot();
                             let apply = anlg_db_app::apply_received_e2ee_replica_changes_with_witness_cancellable(
@@ -455,6 +475,21 @@ impl PluginDbRuntime {
                                 return Ok(CloudsyncRecoveryStep::Deferred);
                             }
                             if repair.repaired_records > 0 {
+                                witness_repair_batches = witness_repair_batches.saturating_add(1);
+                                witness_repaired_records = witness_repaired_records
+                                    .saturating_add(repair.repaired_records);
+                                if witness_repair_batches == 1
+                                    || witness_repair_batches.is_multiple_of(16)
+                                    || !repair.remaining
+                                {
+                                    tracing::info!(
+                                        phase = "witness_repair",
+                                        batch = witness_repair_batches,
+                                        repaired_records = witness_repaired_records,
+                                        remaining = repair.remaining,
+                                        "CloudSync recovery repaired encrypted records"
+                                    );
+                                }
                                 return Ok(CloudsyncRecoveryStep::Progressed);
                             }
                             if repair.remaining || apply.remaining_replica_changes {
@@ -561,6 +596,13 @@ impl PluginDbRuntime {
                                     anlg_db_app::CloudsyncWorkspaceError::RecoveryConflict.into()
                                 );
                             }
+                            tracing::info!(
+                                phase = "witness_repair",
+                                batches = witness_repair_batches,
+                                repaired_records = witness_repaired_records,
+                                "CloudSync recovery finished encrypted witness repair"
+                            );
+                            witness_repair_refreshed = false;
                             Ok(CloudsyncRecoveryStep::Progressed)
                         }
                         anlg_db_app::CloudsyncRecoveryPhase::NeedBarrierCleanup => {
@@ -687,6 +729,7 @@ impl PluginDbRuntime {
                         }
                         match cancellation {
                             CloudsyncRecoveryCancellation::Activity => {
+                                witness_repair_refreshed = false;
                                 if matches!(drained_step, Ok(CloudsyncRecoveryStep::Complete)) {
                                     drained_step
                                 } else {

--- a/plugins/db/src/runtime/tests/recovery_schedule.rs
+++ b/plugins/db/src/runtime/tests/recovery_schedule.rs
@@ -171,6 +171,235 @@ fn full_resync_schedule_tracks_generation_until_cancelled() {
     assert!(!schedule.is_active("generation-1"));
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+#[tokio::test]
+async fn witness_repair_reuses_one_refresh_while_draining_bounded_batches() {
+    use std::io::{Read, Write};
+
+    let db = std::sync::Arc::new(Db::connect_memory().await.unwrap());
+    anlg_db_app::prepare_schema(db.as_ref()).await.unwrap();
+    anlg_db_app::claim_cloudsync_workspace(db.pool(), "workspace-1")
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE sync_probe (
+            id TEXT PRIMARY KEY NOT NULL,
+            value TEXT NOT NULL DEFAULT ''
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    db.cloudsync_init("sync_probe", None, None).await.unwrap();
+    let runtime = std::sync::Arc::new(PluginDbRuntime::new(std::sync::Arc::clone(&db)));
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    runtime
+        .set_e2ee_recovery_key("workspace-1", &recovery_key)
+        .unwrap();
+    let workspace_key = runtime.workspace_key("workspace-1").unwrap();
+    let witness_server = MockServer::start().await;
+    Mock::given(path("/sync/e2ee/witness/workspace-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "initialized": true,
+            "initializedAt": "2026-08-26T00:00:00Z",
+            "headSequence": 130,
+            "throughSequence": 130,
+            "nextAfterSequence": 130,
+            "events": [],
+        })))
+        .mount(&witness_server)
+        .await;
+    runtime.e2ee_sync_hook.set_witness(
+        crate::e2ee_witness::E2eeWitnessClient::new(
+            crate::CloudsyncE2eeWitness {
+                endpoint: format!("{}/sync/e2ee/witness/workspace-1", witness_server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            "workspace-1",
+        )
+        .unwrap(),
+    );
+
+    let cloudsync_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    cloudsync_listener.set_nonblocking(true).unwrap();
+    let cloudsync_endpoint = format!("http://{}", cloudsync_listener.local_addr().unwrap());
+    let (cloudsync_shutdown_tx, cloudsync_shutdown_rx) = std::sync::mpsc::sync_channel(1);
+    let cloudsync_server = std::thread::spawn(move || {
+        loop {
+            if cloudsync_shutdown_rx.try_recv().is_ok() {
+                return;
+            }
+            let (mut stream, _) = match cloudsync_listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    continue;
+                }
+                Err(error) => panic!("failed to accept CloudSync status request: {error}"),
+            };
+            let mut request = [0_u8; 4096];
+            let size = stream.read(&mut request).unwrap();
+            assert!(
+                String::from_utf8_lossy(&request[..size]).contains("/status"),
+                "recovery made an unexpected CloudSync request"
+            );
+            let body =
+                r#"{"lastOptimisticVersion":9999999,"lastConfirmedVersion":9999999,"gaps":[]}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+            stream.flush().unwrap();
+        }
+    });
+    let config = anlg_db_core::CloudsyncRuntimeConfig {
+        connection_string: "test-database".to_string(),
+        auth: anlg_db_core::CloudsyncAuth::None,
+        tables: vec![],
+        sync_interval_ms: DEFAULT_CLOUDSYNC_INTERVAL_MS,
+        wait_ms: Some(5_000),
+        max_retries: Some(3),
+    };
+    db.cloudsync_prepare_manual_transport(config.clone())
+        .await
+        .unwrap();
+    sqlx::query("SELECT cloudsync_network_init_custom(?, ?)")
+        .bind(cloudsync_endpoint)
+        .bind("witness-repair-refresh-test")
+        .fetch_optional(db.pool())
+        .await
+        .unwrap();
+
+    let generation =
+        anlg_db_app::stage_cloudsync_poison_recovery(db.pool(), "workspace-1", "workspace-1")
+            .await
+            .unwrap();
+    anlg_db_app::ensure_cloudsync_recovery_state(
+        db.pool(),
+        &generation,
+        "workspace-1",
+        "workspace-1",
+        &workspace_key,
+    )
+    .await
+    .unwrap();
+    for (from, to) in [
+        (
+            anlg_db_app::CloudsyncRecoveryPhase::NeedFirstLogout,
+            anlg_db_app::CloudsyncRecoveryPhase::NeedBarrierInsert,
+        ),
+        (
+            anlg_db_app::CloudsyncRecoveryPhase::NeedBarrierInsert,
+            anlg_db_app::CloudsyncRecoveryPhase::NeedBarrierConfirm,
+        ),
+        (
+            anlg_db_app::CloudsyncRecoveryPhase::NeedBarrierConfirm,
+            anlg_db_app::CloudsyncRecoveryPhase::NeedCleanReceive,
+        ),
+        (
+            anlg_db_app::CloudsyncRecoveryPhase::NeedCleanReceive,
+            anlg_db_app::CloudsyncRecoveryPhase::NeedWitnessRepair,
+        ),
+    ] {
+        assert!(
+            anlg_db_app::advance_cloudsync_recovery_phase(db.pool(), &generation, from, to)
+                .await
+                .unwrap()
+        );
+    }
+
+    let events = (0..130)
+        .map(|index| {
+            let sealed = workspace_key
+                .seal_field(
+                    "workspace-1",
+                    "sessions",
+                    &format!("session-{index:03}"),
+                    "$row",
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    1,
+                    false,
+                    serde_json::json!(true),
+                )
+                .unwrap();
+            anlg_db_app::E2eeWitnessEvent {
+                sequence: u64::try_from(index + 1).unwrap(),
+                record_id: sealed.record_id,
+                workspace_id: "workspace-1".to_string(),
+                payload_hash: anlg_e2ee::payload_hash(&sealed.payload),
+                payload: sealed.payload,
+            }
+        })
+        .collect::<Vec<_>>();
+    anlg_db_app::merge_e2ee_witness_events(db.pool(), &workspace_key, "workspace-1", &events)
+        .await
+        .unwrap();
+    anlg_db_app::advance_e2ee_witness_cursor(db.pool(), "workspace-1", 130)
+        .await
+        .unwrap();
+
+    let auth_generation = runtime.cloudsync_auth_generation();
+    runtime
+        .schedule_cloudsync_full_resync(generation, config, auth_generation)
+        .await;
+    let drain = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            let repaired: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_records")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+            if repaired == 130 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    let failure = if drain.is_err() {
+        let repaired: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_records")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let pending: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_witness_repair_pending")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let phase = anlg_db_app::cloudsync_recovery_state(db.pool())
+            .await
+            .unwrap()
+            .map(|state| state.phase);
+        let witness_requests = witness_server.received_requests().await.unwrap().len();
+        Some(format!(
+            "witness repair did not drain all bounded batches: repaired={repaired}, pending={pending}, phase={phase:?}, witness_requests={witness_requests}"
+        ))
+    } else {
+        None
+    };
+    runtime.cancel_cloudsync_full_resync().await;
+    cloudsync_shutdown_tx.send(()).unwrap();
+    cloudsync_server.join().unwrap();
+    if let Some(failure) = failure {
+        panic!("{failure}");
+    }
+
+    let requests = witness_server.received_requests().await.unwrap();
+    let refreshes = requests
+        .iter()
+        .filter(|request| request.method == wiremock::http::Method::GET)
+        .count();
+    assert!(refreshes >= 2, "witness freshness was not established");
+    assert!(
+        refreshes <= 3,
+        "witness was refreshed {refreshes} times while draining three repair batches"
+    );
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn activity_drains_stalled_full_resync_before_immediate_local_write() {

--- a/plugins/db/src/runtime/tests/recovery_schedule.rs
+++ b/plugins/db/src/runtime/tests/recovery_schedule.rs
@@ -173,7 +173,7 @@ fn full_resync_schedule_tracks_generation_until_cancelled() {
 
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 #[tokio::test]
-async fn witness_repair_reuses_one_refresh_while_draining_bounded_batches() {
+async fn witness_repair_refresh_is_reused_until_activity_invalidates_it() {
     use std::io::{Read, Write};
 
     let db = std::sync::Arc::new(Db::connect_memory().await.unwrap());
@@ -240,6 +240,7 @@ async fn witness_repair_reuses_one_refresh_while_draining_bounded_batches() {
                 }
                 Err(error) => panic!("failed to accept CloudSync status request: {error}"),
             };
+            stream.set_nonblocking(false).unwrap();
             let mut request = [0_u8; 4096];
             let size = stream.read(&mut request).unwrap();
             assert!(
@@ -348,6 +349,28 @@ async fn witness_repair_reuses_one_refresh_while_draining_bounded_batches() {
     runtime
         .schedule_cloudsync_full_resync(generation, config, auth_generation)
         .await;
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let repaired: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_records")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+            if repaired >= 64 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("witness repair did not finish its first bounded batch");
+    runtime
+        .begin_cloudsync_activity("capture".to_string(), "session-1".to_string())
+        .await
+        .unwrap();
+    runtime
+        .end_cloudsync_activity("capture".to_string(), "session-1".to_string())
+        .await
+        .unwrap();
     let drain = tokio::time::timeout(std::time::Duration::from_secs(15), async {
         loop {
             let repaired: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_records")
@@ -393,10 +416,13 @@ async fn witness_repair_reuses_one_refresh_while_draining_bounded_batches() {
         .iter()
         .filter(|request| request.method == wiremock::http::Method::GET)
         .count();
-    assert!(refreshes >= 2, "witness freshness was not established");
     assert!(
-        refreshes <= 3,
-        "witness was refreshed {refreshes} times while draining three repair batches"
+        refreshes >= 4,
+        "witness freshness was not re-established after activity"
+    );
+    assert!(
+        refreshes <= 5,
+        "witness was refreshed {refreshes} times while draining three batches around one activity"
     );
 }
 


### PR DESCRIPTION
Reuse a fresh witness snapshot while bounded repair batches drain, and add privacy-safe progress logging with regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes encrypted CloudSync poison-recovery witness repair timing and freshness guarantees; incorrect epoch handling could stall repair or apply stale witness state, though bounded batches and defer-on-activity mitigate that.
> 
> **Overview**
> Fixes CloudSync **witness repair starvation** by not re-running witness **refresh + publish** on every bounded repair loop iteration.
> 
> **E2eeSyncHook** now tracks an **`activity_epoch`** that bumps when a new CloudSync activity lease starts, so recovery can tell when pause/resume invalidated prior work.
> 
> In **`NeedWitnessRepair`**, recovery caches a witness snapshot for the current activity epoch and only re-establishes freshness when the epoch changes (including after activity pause). If the epoch changes mid-refresh, the step defers. Counters and **privacy-safe** `tracing::info` logs record refresh and batch repair progress without leaking sensitive data.
> 
> Adds regression test **`witness_repair_refresh_is_reused_until_activity_invalidates_it`** to ensure multiple repair batches reuse one refresh until activity forces a re-refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 351a814e8c1a7cbff47e18b195ee747b1f7bfc51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->