### PR TITLE
Refresh Zoom AI notetaker guide for 2026

### DIFF
--- a/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
@@ -1,420 +1,284 @@
 ---
-meta_title: "Best AI Notetaker for Zoom: Top 10 Options"
-meta_description: "Find the best AI notetaker for Zoom with our 2026 guide. Compare real-time transcription, privacy options, CRM integrations, and pricing plans."
-author: "John Jeong"
+meta_title: "7 Best AI Notetakers for Zoom in 2026"
+display_title: "Best AI Notetakers for Zoom in 2026"
+meta_description: "Compare seven Zoom AI notetakers by bot visibility, live transcription, data model, workflow automation, and current pricing."
+author:
+  - "John Jeong"
+featured: false
 category: "Comparisons"
-date: "2025-09-06"
+date: "2026-08-26"
 ---
 
-Zoom is where a lot of AI notetakers look better in a demo than they do in real use.
+The best AI notetaker for Zoom depends on how you want the meeting captured.
 
-The real test is not whether a tool can join a call. It is whether it still feels useful when the meeting is messy: bad audio, client sensitivity, technical jargon, IT restrictions, or a team that does not want another bot in the room.
+Some tools are native to Zoom. Some send a visible participant into the call. Others capture system audio from your computer, so nothing new appears in the participant list. That choice affects consent, reliability, automation, and where the transcript lives after the meeting.
 
-These are the tools that held up best when we evaluated them through that lens.
+The short version:
 
-- **Anarlog** → Zero lock-in, complete control over data and AI stack
-- **Zoom AI Companion** → Teams already invested in Zoom's ecosystem
-- **Fathom** → Sales teams wanting instant CRM integration
-- **Otter AI** → Teams comfortable with established cloud automation
-- **tl;dv** → Sales teams needing detailed video analysis
-- **Fireflies AI** → International teams requiring multilingual support
-- **MeetGeek** → Teams wanting automated workflow integrations
-- **Avoma** → Customer-facing teams extracting revenue insights
-- **Tactiq** → Chrome users wanting real-time browser transcription
-- **Krisp** → Noisy environments needing AI notes bonus
+- **Choose Anarlog** for bot-free Zoom notes with local SQLite storage, open-source code, and your choice of AI provider.
+- **Choose Zoom My Notes** when your team already pays for Zoom Workplace and wants the most native workflow.
+- **Choose Granola** for polished, collaborative notes built around the notes you jot during the call.
+- **Choose Tactiq** for a live transcript inside Chrome without a meeting bot.
+- **Choose Fathom** for a generous individual plan and sales follow-up workflows.
+- **Choose Otter** for real-time collaboration and a searchable cloud meeting workspace.
+- **Choose Fireflies** for broad integrations, multilingual workflows, and conversation intelligence.
 
-**Also check:** [How to Transcribe Zoom Calls Automatically?](/blog/how-to-transcribe-zoom-calls)
+## Zoom AI notetakers compared
 
-## How We Chose These AI Notetakers
+| Tool | Zoom capture path | Bot in participant list | Live transcript | Where the meeting record lives | Free or entry plan |
+| --- | --- | --- | --- | --- | --- |
+| Anarlog | Desktop system audio and microphone | No | Yes | Local SQLite by default | Free; Pro $15/month or $150/year |
+| Zoom My Notes | Native Zoom client and desktop audio capture | No | Yes | Zoom Hub and Zoom Canvas | Limited Basic access; standalone from $8.33/month billed annually |
+| Granola | Desktop system audio and microphone | No | Transcript runs in the background | Granola cloud workspace | Basic free; Business $14/user/month |
+| Tactiq | Chrome extension or supported desktop capture | No | Yes | Tactiq cloud workspace; no audio recording | 10 transcripts/month free; Pro $8/user/month billed annually |
+| Fathom | Visible assistant or bot-free beta on Mac | Optional | Yes | Fathom cloud workspace | Free for individuals; Premium $16/month billed annually |
+| Otter | Visible Notetaker, desktop app, or browser capture | Optional | Yes | Otter cloud workspace | 300 minutes/month free |
+| Fireflies | Visible assistant, Chrome extension, or desktop app | Optional | Yes | Fireflies cloud workspace | Free; Pro $10/seat/month billed annually |
 
-We were not looking for the longest feature list. We were looking for tools that still worked once the easy cases were gone.
+![Four ways to capture a Zoom meeting](/api/assets/blog/articles/best-ai-notetaker-for-zoom/zoom-capture-paths.png)
 
-We prioritized:
+The capture method is the first filter. A visible meeting assistant is useful when you want automatic attendance and cloud workflow automation. Desktop capture is better when you want the call to remain visually unchanged or need the same tool across Zoom, Teams, phone calls, and in-person conversations.
 
-- **Transcription accuracy** - How well does it handle multiple speakers, technical terms, and varying audio quality?
-- **Summary quality** - Can it identify key decisions, action items, and important discussion points?
-- **Integration capabilities** - Does it connect with workflow tools like Slack, CRMs, or project management platforms?
-- **Privacy and security** - Where is data processed and stored? What compliance standards does it meet?
-- **Ease of use** - How quickly can teams start using it without complex setup or training?
-- **Pricing value** - Does it offer good functionality relative to cost, including free tier options?
+## How we evaluated the tools
 
-> **Note:** Zoom's native AI Companion requires a paid plan and has limited customization options. Third-party AI notetakers often provide more sophisticated features, better accuracy, and flexible deployment options worth considering even for Zoom-centric organizations.
+We checked each vendor's current product, pricing, security, and help pages for this update. We did not rank tools by vendor accuracy percentages because those numbers rarely use the same audio, speakers, or scoring method.
 
-## What Are the Best AI Notetakers for Zoom?
+Instead, we used five practical criteria:
 
-### 1. Anarlog
+1. **Capture behavior:** native Zoom feature, visible participant, browser extension, or desktop system audio.
+2. **Meeting output:** live transcript, summary, action items, search, clips, and follow-up automation.
+3. **Data model:** local record or vendor-hosted workspace, plus the AI and sharing paths available.
+4. **Workflow fit:** personal notes, team memory, sales automation, multilingual meetings, or regulated work.
+5. **Current limits:** free-plan caps, paid entry point, platform restrictions, and admin controls.
 
-**Best for:** High-agency professionals who demand complete control over their data, AI stack, and workflow.
+No capture method removes your responsibility to tell people that transcription is active. Bot-free does not mean consent-free. Follow the law, company policy, and client expectations that apply to the meeting.
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-1.webp" alt="Best ai notetaker for zoom" />
+## 1. Anarlog: best for local ownership and AI-provider choice
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control. Meeting data is stored locally in SQLite on your device. Markdown is available when you want to export it. You choose your AI stack: managed cloud, bring your own keys, or run local models.
+[Anarlog](/) is an open-source AI meeting notetaker for macOS, Windows, and Linux. It records microphone and system audio from your computer, so it can capture Zoom without joining the call or requesting calendar access.
 
-The interface works like Apple Notes with AI superpowers. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+The canonical meeting record lives in local SQLite. Notes, transcripts, and meeting metadata are not dependent on a vendor-hosted workspace, and Markdown is available as an export when you need a portable copy.
 
-The AI can work completely hands-off, generating organized notes without any input from you. Or you can collaborate by jotting down key points, and the AI will expand your rough notes with context you might have missed while actively participating.
+### What stands out
 
-#### Key features
+- Live transcription without a Zoom participant bot
+- Local SQLite storage for the canonical meeting record
+- On-device transcription, bring-your-own-key providers, or managed cloud AI
+- Local models through Ollama or LM Studio
+- Templates, transcript chat, search, imports, and portable exports
+- MIT-licensed code that an IT team can inspect
 
-- Local SQLite storage with Markdown export when it fits your workflow
-- Your choice of AI stack: managed cloud, bring your own keys, or run local models
-- Open source—zero lock-in, full transparency
-- Customizable templates for different meeting types (therapy, legal, interviews)
-- Smart Consent Management Package for enterprise compliance
-- AI Chat with MCP server connections for enhanced functionality
-- Calendar integration with notification system
-- Conversational search across all meeting history
-- Flexible AI model options (local, self-host, or connect to custom AI endpoints)
+### What to consider
 
-#### Strengths
+Windows and Linux builds are newer than the macOS app. Anarlog also does not try to be a sales-intelligence platform: it does not lead with call scoring, deal risk, or automatic CRM field updates.
 
-- Zero lock-in—local SQLite storage, portable exports, and open-source code
-- [Free forever](/blog/free-ai-notetakers) for local transcription, BYOK, and all core features
-- Your choice of AI stack—managed cloud ($15/mo), bring your own keys, or run local
-- Works without internet—great for secure environments
-- True file ownership—works with Obsidian, Notion, VS Code, anything
-- IT teams can audit the code and approve the AI provider
+The local-first model is not the same as claiming that data can never leave your computer. If you enable managed AI, CloudSync, sharing, or another provider, review that service path for the meeting you are recording.
 
-#### Considerations
+### Pricing
 
-- Currently available for macOS; check the download page for the latest platform availability
-- No video recording by design for maximum privacy
+The Free plan supports local transcription, bring-your-own-key workflows, and the core meeting experience. [Anarlog Pro is $15 per month or $150 per year](/pricing) and adds hosted transcription and AI, encrypted CloudSync, sharing, and calendar-connected services.
 
-#### Pricing
+**Choose Anarlog if:** you want a Zoom notetaker that remains useful even if you change conferencing platforms, AI providers, or cloud vendors.
 
-Anarlog is free forever for local transcription, BYOK, and all core features. Managed cloud service is $15/month or $150/year for the easiest setup.
+## 2. Zoom My Notes: best native option for Zoom Workplace teams
 
-For teams with compliance or procurement requirements, evaluate the exact desktop configuration and any enabled AI, CloudSync, or sharing services before adoption.
+[Zoom My Notes](https://www.zoom.com/en/products/ai-assistant/features/ai-note-taking/) is now a broader product than the old Meeting Summary feature. It can transcribe in real time, combine the transcript with notes you type, generate a summary and action items, and trigger follow-up workflows.
 
-### 2. Zoom AI Companion
+For Zoom meetings, the main advantage is that it is native. There is no separate meeting assistant in the participant list, and hosts or participants can work from the Zoom client they already use. My Notes can also capture third-party meetings and in-person conversations from the desktop or mobile app.
 
-**Best for:** Teams already invested in Zoom's ecosystem who want built-in AI features.
+### What stands out
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-2.webp" alt="zoom ai companion review" />
+- Native Zoom experience with a visible transcription indicator
+- Real-time transcription, manual notes, summaries, and action items
+- Notes linked to the Zoom account, calendar, Hub, and Canvas
+- Workflows for recap emails, team updates, and to-dos
+- More than 30 languages for Meeting Summary and a smaller supported set for My Notes
+- Zoom says customer communications content is not used to train Zoom or third-party AI models
 
-[Zoom AI Companion](https://www.zoom.com/en/products/ai-assistant/?cms_guid=false&lang=en-US) is built directly into Zoom Workplace, working across Meetings, Team Chat, Phone, Email, and Whiteboard.
+### What to consider
 
-Compared to specialized tools, it's fairly basic. You need a paid Zoom plan to access it. All features are disabled by default, and the core functionality is limited to meeting summaries, smart recording, in-meeting questions, and whiteboard assistance.
+The result remains inside Zoom's cloud ecosystem. That is convenient if Zoom is already your system of record, but less attractive if you want a local archive or expect to change meeting platforms.
 
-Unlike tools like Anarlog that work offline and provide real-time transcription, Zoom AI Companion requires cloud processing and doesn't offer live transcription during meetings.
+The old claim that Zoom AI Companion has no live transcription is no longer accurate. The current My Notes workflow can transcribe while the meeting is running. It also requires a current Zoom client for the full feature set.
 
-Any meaningful customization—like custom dictionaries, meeting templates, or third-party integrations—costs an extra $12/user/month.
+### Pricing
 
-#### Key features
+Zoom lists My Notes as included with paid Zoom Workplace plans and available as a standalone plan starting at $8.33 per user per month when billed annually. Zoom Basic has limited My Notes capacity. Check the [current My Notes pricing](https://zoom.us/pricing/my-notes) because Workplace packaging can change.
 
-- Meeting summaries with next steps (no real-time transcription)
-- Smart recording with highlights and chapters
-- In-meeting questions to catch up without interrupting
-- AI-powered whiteboard content generation
-- Custom templates and third-party integrations (paid add-on)
+**Choose Zoom My Notes if:** your team wants the fewest moving parts and is comfortable keeping its meeting memory in Zoom.
 
-#### Strengths
+## 3. Granola: best for note-first collaboration
 
-- Built directly into Zoom with no separate installation (disabled by default—admins must enable)
-- Clear notifications when AI features are active
-- Uses multiple AI models for optimal results
+[Granola](https://www.granola.ai/) is a desktop and mobile notepad that captures computer audio without inviting a bot. Its distinctive workflow starts with the notes you type. Granola uses the transcript to expand those notes into a cleaner record rather than treating the raw transcript as the main interface.
 
-#### Considerations
+### What stands out
 
-- Requires paid Zoom subscription—not available on free plans
-- No real-time transcription or live collaboration like other tools
-- Basic customization costs $12/user/month extra—more expensive than most standalone alternatives
-- Not available for [HIPAA-compliant instances](https://zoom.oit.uci.edu/useful-zoom-features/ai-companion/)
-- Limited accuracy and features compared to specialized AI notetakers
+- Bot-free capture across Zoom, Meet, Teams, and other meeting apps
+- Notes shaped by what you marked as important during the call
+- AI chat within and across meetings
+- Shared folders and custom templates
+- Business integrations with Slack, Notion, HubSpot, Attio, Affinity, Zapier, and MCP-compatible tools
+- No audio or video recording retained in the standard transcription workflow
 
-#### Pricing
+### What to consider
 
-Included with paid Zoom accounts. The custom AI Companion add-on costs $12/user/month.
+Granola is still a hosted workspace. Its privacy policy allows some de-identified, aggregated product data to support model improvement, while users can opt out and Enterprise workspaces are opted out by default. The product is also not presented as a local or self-hosted meeting archive.
 
-Also, check out our detailed [Zoom AI Companion review](/blog/zoom-ai-companion-review).
+### Pricing
 
-### 3. Fathom
+[Granola Basic](https://www.granola.ai/pricing) is free with limited meeting history. Business is $14 per user per month for unlimited notes and history, advanced models, integrations, API access, and centralized billing. Enterprise is $35 per user per month.
 
-**Best for:** Sales teams and customer-facing professionals who want instant summaries with CRM integration.
+**Choose Granola if:** you already take concise notes during Zoom calls and want AI to turn them into polished team memory.
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-3.webp" alt="Fathom for zoom" />
+## 4. Tactiq: best live Zoom transcript in Chrome
 
-[Fathom](https://www.fathom.ai) joins your Zoom calls as a bot and emphasizes speed—you get meeting summaries within 30 seconds of hanging up. Its main strength is handling the post-meeting workflow, automatically pushing notes and action items into your CRM without manual work.
+[Tactiq](https://tactiq.io/) is a Chrome extension for Zoom, Google Meet, and Microsoft Teams. It shows a live transcript without adding a participant to the meeting and then turns that transcript into summaries, action items, follow-up emails, and reusable AI workflows.
 
-During calls, you can click buttons to highlight important moments or mark action items. After the meeting, everything gets organized into a summary you can immediately forward to colleagues or sync with Salesforce.
+Tactiq does not record or store meeting audio. That makes it a lighter option than a video recorder, although the transcript and AI output still live in Tactiq's cloud service.
 
-#### Key features
+### What stands out
 
-- Direct integrations with major CRMs like Salesforce and HubSpot
-- Works with 28 languages for international teams
-- Custom summary templates you can modify for different meeting types
-- Can create shareable video clips from longer recordings
-- Search feature that works across your entire meeting history
-- Takes screenshots automatically when people share screens
+- Live transcript during supported browser meetings
+- No meeting bot and no stored audio recording
+- More than 60 supported languages across its meeting platforms
+- Reusable AI questions and Workflow Builder
+- Integrations with tools such as Slack, Notion, Salesforce, HubSpot, Jira, and Linear
+- Export and sharing without a separate desktop meeting workspace
 
-#### Strengths
+### What to consider
 
-- Actually free forever for core features (unlimited recordings and storage)
-- CRM integrations work smoothly and save manual data entry
-- Easy to create and share video highlights with teammates
-- Handles multiple speakers and accents reasonably well
+The browser workflow is the constraint. If your company standardizes on the Zoom desktop client, confirm the current Tactiq desktop support for your operating system before adopting it. Language availability also differs by meeting platform, and a user may need to switch the active language manually.
 
-#### Considerations
+### Pricing
 
-- Bot appears in your meeting participant list (might feel awkward for sensitive calls)
-- AI-powered features limited on free plan after first 5 summaries per month
-- Works best with Zoom, other platforms feel secondary
+[Tactiq Free](https://tactiq.io/pricing) includes 10 transcripts and five AI credits per month. Pro is $8 per user per month billed annually for unlimited transcripts and 10 AI credits. Team is $16.67 per user per month billed annually with unlimited transcripts and AI credits.
 
-#### Pricing
+**Choose Tactiq if:** you want to read the transcript during a browser-based Zoom call and do not need an audio or video archive.
 
-Free plan includes unlimited recordings and basic summaries. Premium costs $19/month for unlimited AI features. Team plans start at $29/month with collaboration tools.
+## 5. Fathom: best individual plan for sales follow-up
 
-### 4. Otter AI
+[Fathom](https://www.fathom.ai/) combines recording, transcription, clips, summaries, search, and CRM-oriented follow-up. Its traditional workflow uses a visible assistant, but Fathom now lists a bot-free capture option in beta for Mac. Availability and recording behavior vary by capture mode, so test the exact Zoom setup you plan to use.
 
-**Best for:** Teams already comfortable with cloud-based tools who want established meeting automation.
+### What stands out
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-4.webp" alt="Otter ai for zoom" />
+- Unlimited recordings and transcriptions on the individual Free plan
+- Instant summaries, searchable calls, and shareable clips
+- Five advanced AI summaries per month on Free
+- Paid action items, follow-up emails, and cross-call assistant
+- HubSpot and Salesforce workflows on higher team plans
+- Choice of bot or bot-free capture where the beta is available
 
-[Otter AI](https://otter.ai) is probably the most well-known AI meeting assistant—though not always for the right reasons, which we'll address.
+### What to consider
 
-Otter pioneered many features that are now standard in the industry. It joins your Zoom, Google Meet, and Teams calls as a visible bot and delivers solid real-time transcription with speaker identification. You can assign action items directly in the transcript, and everyone gets access to searchable meeting notes immediately after calls end.
+Fathom is strongest when the meeting output should feed a sales or customer workflow. It is less compelling if your priority is a local archive, a fully browser-based live transcript, or a mature bot-free path across every desktop platform.
 
-However, Otter has developed a reputation for privacy issues that have made headlines. Users have reported the bot joining meetings without proper consent and spamming all participants with meeting notes. An [ongoing class-action lawsuit](/blog/is-otter-ai-safe) addresses these privacy practices.
+### Pricing
 
-#### Key features
+[Fathom Free](https://fathom.video/pricing) includes unlimited recordings and transcription for individuals. Premium is $16 per month billed annually. Team starts at $15 per user per month billed annually, and Business is $25 per user per month billed annually for deeper CRM and coaching features.
 
-- Real-time transcription with live team collaboration features
-- AI Chat for querying meeting history and generating follow-ups
-- Mobile app that syncs seamlessly across devices
-- Custom vocabulary that learns technical terms and company language
-- Integration with CRMs and productivity tools
+**Choose Fathom if:** you want a generous personal plan now and may add sales automation later.
 
-#### Strengths
+## 6. Otter: best for real-time cloud collaboration
 
-- Excellent real-time collaboration with commenting and highlighting
-- Strong speaker identification that improves with usage
-- Reliable platform with consistent performance and updates
-- Mobile app handles both virtual and [in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings) effectively
+[Otter](https://otter.ai/) remains one of the most established meeting workspaces. Its visible Notetaker can join scheduled Zoom meetings automatically, but Otter is no longer bot-only. Its Mac and Windows desktop apps can capture device audio without adding a participant, and browser and mobile recording cover other workflows.
 
-#### Considerations
+### What stands out
 
-- Free plan limited to 300 monthly minutes (gets consumed quickly)
-- Language support restricted to English, Spanish, and French
-- Bot presence visible in meetings can feel intrusive for sensitive calls
-- Serious privacy considerations
+- Live transcript with speaker identification and collaborative editing
+- Automatic calendar attendance through the visible Notetaker
+- Bot-free desktop capture for Mac and Windows
+- Search, AI Chat, action items, playback, and slide capture
+- Salesforce, HubSpot, Slack, Asana, Google, and automation connections
+- A mature cloud workspace for teams that want shared meeting history
 
-#### Pricing
+### What to consider
 
-Free plan with 300 monthly minutes. Paid plans start at $16.99/user/month.
+Otter stores the meeting record in its cloud workspace. Its [privacy policy](https://otter.ai/privacy-policy) describes training proprietary AI on de-identified audio recordings and transcriptions. That may be acceptable for some organizations and disqualifying for others, so review the current policy instead of treating every cloud notetaker as equivalent.
 
-<CtaCard/>
+### Pricing
 
-### 5. tl;dv
+[Otter Basic](https://otter.ai/pricing) includes 300 transcription minutes per month, a 30-minute limit per conversation, three lifetime file imports, and the 25 most recent conversations in history. Paid plans raise those limits and add deeper export, integration, and administration features.
 
-**Best for:** Sales teams and customer-facing roles who need detailed video analysis and CRM automation.
+**Choose Otter if:** live collaboration and a searchable shared workspace matter more than local ownership.
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-5.webp" alt="tl;dv for zoom" />
+## 7. Fireflies: best for integrations and multilingual workflows
 
-[tl;dv](https://tldv.io) is a video-focused meeting assistant that records your Zoom, Google Meet, and Teams meetings and creates shareable video clips from longer recordings.
+[Fireflies](https://fireflies.ai/) is a broad meeting automation platform. Its assistant can join Zoom as a visible participant, while its Chrome extension and desktop app provide bot-free capture paths for supported setups.
 
-What makes tl;dv different is its emphasis on post-meeting workflow automation. It can automatically update your CRM with call details, draft follow-up emails based on conversation content, and generate aggregated insights across multiple meetings. For sales teams, it tracks playbook adherence and objection handling to improve performance.
+The product goes beyond notes into conversation intelligence, CRM updates, AI skills, assistants, and team analytics. That breadth is useful for a sales or recruiting operation and unnecessary for someone who only wants a clean personal summary.
 
-#### Key features
+### What stands out
 
-- Automatic CRM updates and follow-up email drafting
-- Video clip creation and sharing from longer recordings
-- AI-powered sales coaching with playbook tracking
-- Cross-meeting insights and trend analysis
-- Support for 30+ languages with translation capabilities
+- Visible assistant, browser extension, and desktop capture options
+- Unlimited transcription and AI summaries on the current Free plan
+- More than 100 languages, with multi-language mode on higher tiers
+- CRM, project-management, messaging, API, and automation integrations
+- Topic, question, sentiment, and speaker analytics
+- Fireflies states that customer meeting content is not used to train AI models
 
-#### Strengths
+### What to consider
 
-- Excellent video handling with easy clip creation and sharing
-- Strong CRM automation that actually saves manual work
-- Good privacy practices with explicit no-training policy
-- Sales-focused features like objection tracking and coaching insights
+Free storage is a cumulative team allowance rather than an unlimited archive. Advanced conversation intelligence, multi-language mode, admin controls, and private storage require higher plans. The product surface is also much larger than a focused note-taking app.
 
-#### Considerations
+### Pricing
 
-- Heavily sales-focused (may feel overkill for general meeting needs)
-- Bot joins meetings visibly which can interrupt flow
-- No mobile app yet (web version works on mobile)
-- Interface can feel complex for users wanting simple note-taking
+[Fireflies Free](https://fireflies.ai/pricing) includes unlimited transcription and summaries, 400 minutes of storage per team, and 20 AI credits. Pro is $10 per seat per month billed annually. Business is $19 per seat per month billed annually.
 
-#### Pricing
+**Choose Fireflies if:** meeting data needs to trigger many downstream workflows and language breadth matters.
 
-Free forever plan with unlimited recordings. Pro plans start at $29/month for advanced analytics and coaching features.
+## Which capture method should you choose?
 
-### 6. Fireflies AI
+### Use native Zoom notes when convenience wins
 
-**Best for:** International teams needing multilingual support with comprehensive conversation analytics.
+Choose Zoom My Notes when Zoom is already the approved workspace and the notes should stay connected to Zoom calendars, chats, and workflows.
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-6.webp" alt="fireflies ai for zoom" />
+### Use desktop capture when participant visibility and ownership matter
 
-[Fireflies.ai](https://fireflies.ai) works similarly to Otter AI—its AI assistant "Fred" automatically joins your meetings and creates detailed transcripts. When meetings end, it generates structured summaries with clear action items, decisions, and next steps automatically extracted.
+Choose Anarlog when you want a local canonical record and AI-provider choice. Choose Granola when you want a hosted, collaborative note-first experience. Both avoid adding a participant to Zoom, but their storage models are fundamentally different.
 
-Fireflies stands out for multilingual support across 100+ languages and conversation analytics. It tracks speaker talk time, monitors sentiment, identifies key topics, and provides team performance insights to optimize meeting effectiveness.
+### Use a browser extension when you need the transcript now
 
-#### Key features
+Choose Tactiq when the Zoom call runs in Chrome and a live text transcript is more useful than a recording.
 
-- Support for 100+ languages with automatic language detection
-- AskFred AI assistant for querying past meeting content
-- Comprehensive conversation analytics including sentiment analysis
-- 200+ AI apps for extracting specific insights (sales scoring, candidate evaluation)
-- Strong integrations with CRMs, project management, and productivity tools
+### Use a cloud assistant when automation matters most
 
-#### Strengths
+Choose Fathom, Otter, or Fireflies when automatic attendance, shared cloud history, clips, CRM updates, and team analytics outweigh the friction of another meeting service.
 
-- Good transcription accuracy with clear speaker identification
-- Comprehensive integration ecosystem with popular business tools
-- Mobile app works well for capturing meetings on the go
+## Questions to ask before buying a Zoom notetaker
 
-#### Considerations
+1. Will a visible assistant join the meeting, and can an admin control that behavior?
+2. Can participants see that transcription is active?
+3. Is audio or video retained, or only the transcript?
+4. Where are transcripts, summaries, and embeddings stored?
+5. Does the vendor use customer or de-identified data for model improvement?
+6. Can you export the complete meeting record in a useful format?
+7. What stops working when you leave Zoom or cancel the subscription?
+8. Does the free limit survive a normal week of meetings?
 
-- Default settings are intrusive (auto-joins meetings, spams participants)
-- Frequent upselling and aggressive upgrade prompts
-- Bot presence can feel disruptive in sensitive conversations
-- Free plan limitations aren't clearly communicated upfront
+## Frequently asked questions
 
-#### Pricing
+### Does Zoom have a built-in AI notetaker?
 
-Free plan with 800 minutes of storage and limited AI credits. Paid plans start at $18/user/month.
+Yes. Zoom My Notes can transcribe Zoom and supported third-party meetings, combine the transcript with notes you type, generate a summary and action items, and run follow-up workflows. It is included with eligible paid Zoom Workplace plans and has limited availability on Basic.
 
-**Also check:** [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+### Can an AI notetaker record Zoom without a bot?
 
-### 7. MeetGeek
+Yes. Anarlog and Granola capture system audio from a desktop app. Tactiq transcribes supported Zoom meetings through Chrome and supported desktop capture. Zoom My Notes is native to the Zoom client. Fathom, Otter, and Fireflies also offer bot-free capture paths alongside their visible meeting assistants.
 
-**Best for:** Teams wanting automated meeting workflows and seamless integration with existing tools.
+### What is the best free AI notetaker for Zoom?
 
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-7.webp" alt="meetgeek for zoom" />
+Use Anarlog when you want unlimited local transcription and can bring your own AI key or local model. Use Fathom for a generous cloud recording and transcription plan. Use Tactiq for up to 10 browser transcripts per month. Use Otter when 300 monthly minutes and 30-minute conversations fit your schedule.
 
-[MeetGeek](https://meetgeek.ai/?r=0) automatically joins your meetings, records them, and syncs content directly into tools like Slack, HubSpot, or project management apps. The focus is reducing the manual work that happens after meetings—no more copying notes between systems or forgetting to update your CRM.
+### Which Zoom notetaker is best for sensitive meetings?
 
-#### Key features
+There is no universal answer. Start with the approved data boundary. Anarlog can keep the canonical meeting record local and can use on-device transcription and local models. A cloud service may still be appropriate when your organization has reviewed its contract, retention, subprocessors, region, and admin controls. Confirm consent and every enabled AI, sync, and sharing path before recording sensitive material.
 
-- Automatic meeting type detection with context-aware summary templates
-- Comprehensive conversation analytics and engagement metrics
-- 7,000+ app integrations via Zapier and direct CRM connections
-- Support for 50+ languages with high transcription accuracy
-- Mobile apps for recording in-person meetings offline
+### Which Zoom notetaker is best for sales teams?
 
-#### Strengths
+Fathom and Fireflies are the clearest starting points when CRM updates, clips, follow-up emails, coaching, and conversation analytics matter. Otter is stronger when the team wants live transcript collaboration and searchable meeting history. Choose the workflow you will actually use, not the longest feature list.
 
-- Strong analytics and coaching insights for improving meeting culture
-- Excellent integration ecosystem for workflow automation
-- Good multilingual support for international teams
-- Free plan includes 300 minutes with basic features
+The main decision is not which tool has the most AI features. It is who joins the meeting, where the record lives, and whether you can still use that record after your workflow changes.
 
-#### Considerations
-
-- AI-generated summaries can be hit-or-miss, sometimes including irrelevant [small talk](https://www.g2.com/products/meetgeek/reviews/meetgeek-review-7361880)
-- Slower to set up new meetings ([requires 5+ minute advance calendar scheduling](https://www.g2.com/products/meetgeek/reviews/meetgeek-review-7361880))
-- Interface can feel complex for users wanting simple note-taking
-
-#### Pricing
-
-Free plan with 300 minutes monthly. Pro at $19/month for unlimited transcription. Business at $39/month with team features. Enterprise at $59/month.
-
-### 8. Avoma
-
-**Best for:** Customer-facing teams who need to extract revenue insights from their conversations.
-
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-8.webp" alt="avoma for zoom" />
-
-[Avoma](https://www.avoma.com) focuses on sales coaching and deal intelligence. The platform provides AI-powered scorecards for call performance, tracks talk patterns and engagement, and offers deal risk analysis. It can automatically update CRM fields based on conversation content and provides win-loss analysis to improve sales strategies.
-
-#### Key features
-
-- AI-powered conversation analysis with custom scorecards and coaching insights
-- Automatic CRM field updates for sales methodologies (MEDDIC, SPICED, etc.)
-- Deal risk alerts and automated win-loss analysis
-- Advanced scheduling with lead routing and qualification
-- Revenue intelligence with pipeline forecasting capabilities
-
-#### Strengths
-
-- Deep sales-focused features that competitors don't offer
-- Comprehensive coaching tools for sales team development
-- Good conversation intelligence with engagement metrics
-
-#### Considerations
-
-- Higher pricing compared to basic transcription tools
-- Can feel complex for teams wanting simple note-taking
-- Does not offer a free plan
-
-#### Pricing
-
-Offers a 14-day free trial, with paid plans starting at $29/month per recorder. Add-ons available for revenue intelligence ($99/month) and lead routing ($69/month).
-
-### 9. Tactiq
-
-**Best for:** Teams that live in Chrome and want real-time transcription without installing separate apps.
-
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-9.webp" alt="tactiq for zoom" />
-
-Unlike the standalone apps we've covered so far, [Tactiq](https://tactiq.io) works as a Chrome extension. This means no separate software to install—it just lives in your browser and captures audio directly from Google Meet, Zoom, and Teams tabs.
-
-The integration ecosystem is where Tactiq shines. It pushes meeting insights to Slack, HubSpot, Jira, and everywhere you actually work. You can turn frequent AI prompts into one-click actions, so you don't have to start from scratch every time you need follow-up tasks.
-
-#### Key features
-
-- Live transcription visible during meetings
-- 60+ languages with automatic detection
-- Rich integrations with workplace tools
-- Custom AI workflows for repetitive tasks
-- Automatic saving of in-call messages, links, and comments within transcripts
-
-#### Strengths
-
-- Browser-based approach means instant setup if you live in Chrome
-- Live transcription helps catch names or technical terms you might miss
-- Works seamlessly with your existing browser-based workflow
-
-#### Considerations
-
-- Chrome-only limits flexibility compared to universal tools like Anarlog
-- No audio or video capture capabilities for teams needing meeting recordings
-- Free plan restrictions with only 5 AI credits per month
-
-#### Pricing
-
-Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
-
-### 10. Krisp
-
-**Best for:** Teams dealing with noisy environments who need AI notes as a bonus feature.
-
-<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-10.webp" alt="krisp ai for zoom" />
-
-[Krisp](https://krisp.ai) cancels background noise AND takes meeting notes. The platform removes background noises, voices, and echoes from both sides of calls while transcribing meetings in real-time across all communication apps.
-
-The AI meeting notes are more basic than enhanced summaries from other tools, but they capture the essentials without fuss.
-
-#### Key features
-
-- AI-powered noise cancellation that removes background noises, voices, and echoes
-- Real-time transcription and meeting summaries across all communication apps
-- Support for transcripts and summaries in 16 languages
-- Direct integrations with Salesforce, HubSpot, Slack, Google Calendar, and Zapier
-- Mobile apps for iOS and Android to record in-person meetings
-
-#### Strengths
-
-- Works with any communication app as a smart layer between your device and platforms
-- Free plan offers unlimited transcriptions, making it accessible for testing
-- Strong privacy controls with encrypted data storage
-
-#### Considerations
-
-- AI note generation is basic with no ability to customize output beyond manual editing
-- Lacks an AI assistant for follow-up questions or deeper insights
-
-#### Pricing
-
-Offers a free plan with unlimited transcripts and 2 daily meeting notes. Paid plans start at $16/user/month.
-
-## My take
-
-If you already live entirely inside Zoom and want the path of least resistance, Zoom AI Companion may be enough.
-
-If you want notes you can keep, move, audit, and run outside Zoom's ecosystem, the list gets much shorter. That is why Anarlog is the one I would start with. The notes stay as files, the AI layer stays flexible, and the workflow does not collapse if you change providers later.
-
-[Download Anarlog for macOS](/download) if that is the setup you want to own.
+If local ownership and AI-provider choice are the requirements, [download Anarlog](/download) and test it on a normal Zoom call before moving a sensitive workflow.
 
 <CtaCard/>

--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -34,7 +34,16 @@
   "best-ai-notetaker": [],
   "best-ai-notetaker-for-in-person-meetings": [],
   "best-ai-notetaker-for-microsoft-teams": [],
-  "best-ai-notetaker-for-zoom": [],
+  "best-ai-notetaker-for-zoom": [
+    {
+      "filename": "zoom-capture-paths.png",
+      "content": "Title: Where Zoom Audio Goes\nZoom meeting to native Zoom AI to Zoom workspace\nZoom meeting to desktop capture to local record or vendor workspace\nZoom meeting to browser extension to vendor transcript workspace\nZoom meeting to visible meeting assistant to vendor cloud workspace",
+      "context": "Render four separate horizontal data paths from Zoom meeting to the final record. Do not merge the paths at the end. Keep every destination. Do not add review questions, product names, pros, cons, or invented labels.",
+      "visualQuery": "flowchart",
+      "orientation": "horizontal",
+      "width": 1200
+    }
+  ],
   "best-ai-notetakers-google-meet": [],
   "bot-free-ai-meeting-assistants": [],
   "can-you-transcribe-meetings-without-sending-data-to-cloud": [


### PR DESCRIPTION
## Why this target

Semrush US organic positions (Aug 24, 2026):
- Target keyword: `zoom notetaker`
- Volume: 320/month
- KD: 48
- Current Anarlog position: 14
- Target URL: `/blog/best-ai-notetaker-for-zoom`

This is the strongest current near-win outside the recently shipped slugs.

## What changed

- Rebuilt the dated 2025 top-10 list as a seven-tool decision guide organized by capture method, data model, and workflow fit
- Rechecked current official product, pricing, privacy, security, and help pages for Zoom My Notes, Granola, Tactiq, Fathom, Otter, and Fireflies
- Corrected stale claims, including Zoom My Notes live transcription and newer bot-free capture paths from Fathom, Otter, and Fireflies
- Added a practical comparison table, consent guidance, buying checklist, and expanded Zoom-specific FAQ cluster
- Removed ten legacy body images that now return 502
- Added and visually reviewed `zoom-capture-paths.png` through the figures manifest and batch pipeline

## Validation

- `pnpm exec dprint check --config dprint.json apps/web/content/articles/best-ai-notetaker-for-zoom.mdx apps/web/content/articles/figures.json`
- `pnpm -F @anlg/web typecheck`
- `pnpm -F @anlg/web media:figures:check` (26 figures across 65 articles)
- Production asset proxy returns 200 for the new figure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing content and figure manifest only; no application logic, auth, or data handling changes.
> 
> **Overview**
> Replaces the dated **top-10 Zoom notetaker list** with a **seven-tool decision guide** framed around **capture path** (native Zoom, desktop audio, browser extension, visible bot), **where records live**, and **workflow fit**.
> 
> **`best-ai-notetaker-for-zoom.mdx`** gets new 2026 SEO front matter, a comparison table, consent and buying-checklist sections, and an expanded FAQ. Vendor coverage is trimmed (e.g. tl;dv, MeetGeek, Avoma, Krisp out; **Granola** in) and copy is updated from current vendor docs—notably **Zoom My Notes** (replacing stale AI Companion claims, including **live transcription**) and **bot-free** options from Fathom, Otter, and Fireflies. Legacy body **webp** images are removed; a single **`zoom-capture-paths.png`** diagram is embedded instead.
> 
> **`figures.json`** registers that figure for the article’s media pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c4e731306a43126210d82bcb698291e809cb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->