### PR TITLE
Name speakers from 1:1 participants and unique voiceprints

### DIFF
--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -186,6 +186,43 @@ describe("inferAutomaticSpeakerAssignments", () => {
     expect(automaticHumanIds(updates[0]!)).toEqual(["human-marco"]);
   });
 
+  it("treats a calendar copy of the current user as the same 1:1", async () => {
+    const snapshot = createOneOnOneSnapshot();
+    snapshot.ownerEmail = "john@example.com";
+    snapshot.participants = [
+      {
+        humanId: "self",
+        name: "John Jeong",
+        email: "john@example.com",
+        jobTitle: "Host",
+      },
+      {
+        humanId: "john-cal",
+        name: "John Jeong",
+        email: "john@example.com",
+        jobTitle: "",
+      },
+      {
+        humanId: "human-marco",
+        name: "Marco Bambini",
+        email: "marco@example.com",
+        jobTitle: "Founder",
+      },
+    ];
+
+    const updates = await inferAutomaticSpeakerAssignments({
+      generatedSummary:
+        "Marco (Speaker 1) confirmed he had already relaxed all limitations.",
+      model: {} as LanguageModel,
+      snapshot,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).not.toHaveBeenCalled();
+    expect(automaticHumanIds(updates[0]!)).toEqual(["human-marco"]);
+    expect(updates[0]?.expectedParticipantHumanIdsJson).toBe('["human-marco"]');
+  });
+
   it("does not guess when one other participant has two unassigned speakers", async () => {
     const snapshot = createSnapshot();
     snapshot.participants = [

--- a/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.test.ts
@@ -14,6 +14,24 @@ import { inferAutomaticSpeakerAssignments } from "./speaker-attribution";
 
 import type { SessionContentSnapshot } from "~/session/content-queries";
 
+function createOneOnOneSnapshot(): SessionContentSnapshot {
+  const snapshot = createSnapshot();
+  snapshot.participants = [
+    { humanId: "self", name: "John Jeong", jobTitle: "Host" },
+    { humanId: "human-marco", name: "Marco Bambini", jobTitle: "Founder" },
+  ];
+  snapshot.transcripts[0]!.words = snapshot.transcripts[0]!.words.slice(2);
+  snapshot.transcripts[0]!.speaker_hints =
+    snapshot.transcripts[0]!.speaker_hints.filter((hint) =>
+      hint.word_id?.startsWith("george-"),
+    );
+  snapshot.transcripts[0]!.wordsJson = "remote words";
+  snapshot.transcripts[0]!.speakerHintsJson = JSON.stringify(
+    snapshot.transcripts[0]!.speaker_hints,
+  );
+  return snapshot;
+}
+
 function createSnapshot(channel = 1): SessionContentSnapshot {
   const speakerHints = [
     {
@@ -147,6 +165,42 @@ function automaticHumanIds(update: { nextSpeakerHintsJson: string }): string[] {
 describe("inferAutomaticSpeakerAssignments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("assigns the only other participant to the only remote speaker", async () => {
+    const updates = await inferAutomaticSpeakerAssignments({
+      generatedSummary:
+        "Marco (Speaker 1) confirmed he had already relaxed all limitations.",
+      model: {} as LanguageModel,
+      snapshot: createOneOnOneSnapshot(),
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.generateText).not.toHaveBeenCalled();
+    expect(updates).toEqual([
+      expect.objectContaining({
+        id: "transcript-1",
+        expectedParticipantHumanIdsJson: '["human-marco"]',
+      }),
+    ]);
+    expect(automaticHumanIds(updates[0]!)).toEqual(["human-marco"]);
+  });
+
+  it("does not guess when one other participant has two unassigned speakers", async () => {
+    const snapshot = createSnapshot();
+    snapshot.participants = [
+      { humanId: "self", name: "John Jeong", jobTitle: "Host" },
+      { humanId: "human-marco", name: "Marco Bambini", jobTitle: "Founder" },
+    ];
+    await expect(
+      inferAutomaticSpeakerAssignments({
+        generatedSummary: "Marco discussed device limits.",
+        model: {} as LanguageModel,
+        snapshot,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual([]);
+    expect(mocks.generateText).not.toHaveBeenCalled();
   });
 
   it("creates guarded automatic hints from direct candidate matches", async () => {

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -108,6 +108,19 @@ export async function inferAutomaticSpeakerAssignments({
     [...clustersByTranscript.entries()].map(
       async ([transcriptId, clusters]) => {
         const directMappings: SpeakerAttributionMapping[] = [];
+        const isClosedOneOnOne =
+          context.candidates.length === 1 && clusters.length === 1;
+        if (isClosedOneOnOne) {
+          return {
+            transcriptId,
+            mappings: completeClosedCandidateSet(
+              clusters,
+              context.candidates,
+              directMappings,
+            ),
+          };
+        }
+
         const usePublicEvidenceFallback =
           context.candidates.length === 2 &&
           clusters.length === 2 &&
@@ -261,7 +274,7 @@ function buildSpeakerAttributionContext(
   ).sort((left, right) => left.humanId.localeCompare(right.humanId));
 
   if (
-    candidates.length < 2 ||
+    candidates.length === 0 ||
     candidates.length > MAX_ATTRIBUTION_ITEMS ||
     new Set(candidates.map((candidate) => candidate.name.toLocaleLowerCase()))
       .size !== candidates.length
@@ -374,7 +387,7 @@ function buildSpeakerAttributionContext(
       });
 
     if (
-      transcriptClusters.length < 2 ||
+      transcriptClusters.length === 0 ||
       transcriptClusters.length > MAX_ATTRIBUTION_ITEMS ||
       candidates.length < transcriptClusters.length ||
       transcriptClusters.some(

--- a/apps/desktop/src/services/enhancer/speaker-attribution.ts
+++ b/apps/desktop/src/services/enhancer/speaker-attribution.ts
@@ -256,11 +256,8 @@ function buildSpeakerAttributionContext(
   const candidates = Array.from(
     new Map(
       snapshot.participants
-        .filter(
-          (participant) =>
-            participant.humanId &&
-            participant.humanId !== snapshot.ownerUserId &&
-            participant.name.trim(),
+        .filter((participant) =>
+          isRemoteAttributionCandidate(participant, snapshot),
         )
         .map((participant) => [
           participant.humanId,
@@ -858,6 +855,23 @@ function attributionTokens(value: string) {
       }
       return token.length > 5 ? token.slice(0, 5) : token;
     });
+}
+
+function isRemoteAttributionCandidate(
+  participant: SessionContentSnapshot["participants"][number],
+  snapshot: SessionContentSnapshot,
+): boolean {
+  if (
+    !participant.humanId ||
+    participant.humanId === snapshot.ownerUserId ||
+    !participant.name.trim()
+  ) {
+    return false;
+  }
+
+  const ownerEmail = snapshot.ownerEmail?.trim().toLowerCase();
+  const participantEmail = participant.email?.trim().toLowerCase();
+  return !ownerEmail || !participantEmail || ownerEmail !== participantEmail;
 }
 
 function completeClosedCandidateSet(

--- a/apps/desktop/src/session/content-mutations.test.ts
+++ b/apps/desktop/src/session/content-mutations.test.ts
@@ -227,6 +227,9 @@ describe("session content SQLite corrections", () => {
     expect(transcriptStatement?.sql).toContain("speaker_hints_json = ?");
     expect(transcriptStatement?.sql).toContain("session_participants");
     expect(transcriptStatement?.sql).toContain("self_human.email");
+    expect(transcriptStatement?.sql).toContain(
+      "COALESCE(NULLIF(human.email, ''), participant.email)",
+    );
     expect(transcriptStatement?.sql).toContain("json_each(?)");
     expect(transcriptStatement?.params).toEqual([
       '[{"type":"automatic_speaker_assignment"}]',

--- a/apps/desktop/src/session/content-mutations.test.ts
+++ b/apps/desktop/src/session/content-mutations.test.ts
@@ -226,6 +226,7 @@ describe("session content SQLite corrections", () => {
     expect(transcriptStatement?.sql).toContain("words_json = ?");
     expect(transcriptStatement?.sql).toContain("speaker_hints_json = ?");
     expect(transcriptStatement?.sql).toContain("session_participants");
+    expect(transcriptStatement?.sql).toContain("self_human.email");
     expect(transcriptStatement?.sql).toContain("json_each(?)");
     expect(transcriptStatement?.params).toEqual([
       '[{"type":"automatic_speaker_assignment"}]',
@@ -236,9 +237,11 @@ describe("session content SQLite corrections", () => {
       "[]",
       "session-1",
       "user-1",
+      "user-1",
       '["human-1","human-2"]',
       '["human-1","human-2"]',
       "session-1",
+      "user-1",
       "user-1",
     ]);
     expect(consoleWarn).toHaveBeenCalledOnce();

--- a/apps/desktop/src/session/content-mutations.ts
+++ b/apps/desktop/src/session/content-mutations.ts
@@ -277,14 +277,14 @@ export function persistGeneratedEnhancedNote({
                   participant.display_name
                 )) <> ''
                 AND (
-                  NULLIF(lower(human.email), '') IS NULL
+                  NULLIF(lower(COALESCE(NULLIF(human.email, ''), participant.email)), '') IS NULL
                   OR NOT EXISTS (
                     SELECT 1
                     FROM humans AS self_human
                     WHERE self_human.id = ?
                       AND self_human.deleted_at IS NULL
                       AND NULLIF(lower(self_human.email), '') IS NOT NULL
-                      AND lower(self_human.email) = lower(human.email)
+                      AND lower(self_human.email) = lower(COALESCE(NULLIF(human.email, ''), participant.email))
                   )
                 )
             ) = json_array_length(?)
@@ -308,14 +308,14 @@ export function persistGeneratedEnhancedNote({
                     participant.display_name
                   )) <> ''
                   AND (
-                    NULLIF(lower(human.email), '') IS NULL
+                    NULLIF(lower(COALESCE(NULLIF(human.email, ''), participant.email)), '') IS NULL
                     OR NOT EXISTS (
                       SELECT 1
                       FROM humans AS self_human
                       WHERE self_human.id = ?
                         AND self_human.deleted_at IS NULL
                         AND NULLIF(lower(self_human.email), '') IS NOT NULL
-                        AND lower(self_human.email) = lower(human.email)
+                        AND lower(self_human.email) = lower(COALESCE(NULLIF(human.email, ''), participant.email))
                     )
                   )
               )

--- a/apps/desktop/src/session/content-mutations.ts
+++ b/apps/desktop/src/session/content-mutations.ts
@@ -276,6 +276,17 @@ export function persistGeneratedEnhancedNote({
                   NULLIF(human.name, ''),
                   participant.display_name
                 )) <> ''
+                AND (
+                  NULLIF(lower(human.email), '') IS NULL
+                  OR NOT EXISTS (
+                    SELECT 1
+                    FROM humans AS self_human
+                    WHERE self_human.id = ?
+                      AND self_human.deleted_at IS NULL
+                      AND NULLIF(lower(self_human.email), '') IS NOT NULL
+                      AND lower(self_human.email) = lower(human.email)
+                  )
+                )
             ) = json_array_length(?)
             AND NOT EXISTS (
               SELECT 1
@@ -296,6 +307,17 @@ export function persistGeneratedEnhancedNote({
                     NULLIF(human.name, ''),
                     participant.display_name
                   )) <> ''
+                  AND (
+                    NULLIF(lower(human.email), '') IS NULL
+                    OR NOT EXISTS (
+                      SELECT 1
+                      FROM humans AS self_human
+                      WHERE self_human.id = ?
+                        AND self_human.deleted_at IS NULL
+                        AND NULLIF(lower(self_human.email), '') IS NOT NULL
+                        AND lower(self_human.email) = lower(human.email)
+                    )
+                  )
               )
             )
         `,
@@ -308,9 +330,11 @@ export function persistGeneratedEnhancedNote({
           transcript.currentSpeakerHintsJson,
           sessionId,
           ownerUserId,
+          ownerUserId,
           transcript.expectedParticipantHumanIdsJson,
           transcript.expectedParticipantHumanIdsJson,
           sessionId,
+          ownerUserId,
           ownerUserId,
         ],
         expectedRowsAffected: 1,

--- a/apps/desktop/src/session/content-queries.test.ts
+++ b/apps/desktop/src/session/content-queries.test.ts
@@ -125,6 +125,9 @@ describe("session content SQLite snapshots", () => {
       "session-1",
     ]);
     expect(mocks.execute.mock.calls[0][0]).toContain("self_human.email");
+    expect(mocks.execute.mock.calls[0][0]).toContain(
+      "COALESCE(NULLIF(human.email, ''), participant.email)",
+    );
   });
 
   it("lists only active SQLite session ids", async () => {

--- a/apps/desktop/src/session/content-queries.test.ts
+++ b/apps/desktop/src/session/content-queries.test.ts
@@ -21,6 +21,7 @@ describe("session content SQLite snapshots", () => {
       {
         id: "session-1",
         owner_user_id: "user-1",
+        owner_email: "user@example.com",
         title: "Planning",
         created_at: "2026-07-10T09:00:00.000Z",
         event_json: JSON.stringify({ title: "Weekly planning" }),
@@ -77,6 +78,7 @@ describe("session content SQLite snapshots", () => {
           {
             human_id: "human-1",
             name: "Alice",
+            email: "alice@example.com",
             job_title: "Engineer",
           },
         ]),
@@ -88,6 +90,7 @@ describe("session content SQLite snapshots", () => {
     expect(snapshot).toMatchObject({
       sessionId: "session-1",
       ownerUserId: "user-1",
+      ownerEmail: "user@example.com",
       title: "Planning",
       createdAt: "2026-07-10T09:00:00.000Z",
       event: { title: "Weekly planning" },
@@ -109,13 +112,19 @@ describe("session content SQLite snapshots", () => {
         },
       ],
       participants: [
-        { humanId: "human-1", name: "Alice", jobTitle: "Engineer" },
+        {
+          humanId: "human-1",
+          name: "Alice",
+          email: "alice@example.com",
+          jobTitle: "Engineer",
+        },
       ],
     });
     expect(snapshot?.rawMarkdown).toContain("Raw note");
     expect(mocks.execute).toHaveBeenCalledWith(expect.any(String), [
       "session-1",
     ]);
+    expect(mocks.execute.mock.calls[0][0]).toContain("self_human.email");
   });
 
   it("lists only active SQLite session ids", async () => {

--- a/apps/desktop/src/session/content-queries.ts
+++ b/apps/desktop/src/session/content-queries.ts
@@ -147,14 +147,14 @@ const SESSION_CONTENT_SQL = `
         AND participant.deleted_at IS NULL
         AND (
           participant.human_id = session.owner_user_id
-          OR NULLIF(lower(human.email), '') IS NULL
+          OR NULLIF(lower(COALESCE(NULLIF(human.email, ''), participant.email)), '') IS NULL
           OR NOT EXISTS (
             SELECT 1
             FROM humans AS self_human
             WHERE self_human.id = session.owner_user_id
               AND self_human.deleted_at IS NULL
               AND NULLIF(lower(self_human.email), '') IS NOT NULL
-              AND lower(self_human.email) = lower(human.email)
+              AND lower(self_human.email) = lower(COALESCE(NULLIF(human.email, ''), participant.email))
           )
         )
     ), '[]') AS participants_json

--- a/apps/desktop/src/session/content-queries.ts
+++ b/apps/desktop/src/session/content-queries.ts
@@ -6,6 +6,7 @@ import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 type SessionContentSqlRow = {
   id: string;
   owner_user_id: string;
+  owner_email: string | null;
   title: string;
   created_at: string;
   event_json: string;
@@ -40,12 +41,14 @@ type TranscriptJson = {
 type ParticipantJson = {
   human_id: string;
   name: string;
+  email?: string;
   job_title: string;
 };
 
 export type SessionContentSnapshot = {
   sessionId: string;
   ownerUserId: string;
+  ownerEmail?: string | null;
   title: string;
   createdAt: string;
   event: unknown;
@@ -77,6 +80,7 @@ export type SessionContentSnapshot = {
   participants: Array<{
     humanId: string;
     name: string;
+    email?: string;
     jobTitle: string;
   }>;
 };
@@ -85,6 +89,12 @@ const SESSION_CONTENT_SQL = `
   SELECT
     session.id,
     session.owner_user_id,
+    (
+      SELECT NULLIF(lower(self_human.email), '')
+      FROM humans AS self_human
+      WHERE self_human.id = session.owner_user_id
+        AND self_human.deleted_at IS NULL
+    ) AS owner_email,
     session.title,
     session.created_at,
     session.event_json,
@@ -124,6 +134,7 @@ const SESSION_CONTENT_SQL = `
       SELECT json_group_array(json_object(
         'human_id', participant.human_id,
         'name', COALESCE(NULLIF(human.name, ''), participant.display_name),
+        'email', COALESCE(NULLIF(human.email, ''), participant.email),
         'job_title', COALESCE(human.job_title, '')
       ))
       FROM session_participants AS participant
@@ -134,6 +145,18 @@ const SESSION_CONTENT_SQL = `
         AND participant.human_id <> ''
         AND participant.source <> 'excluded'
         AND participant.deleted_at IS NULL
+        AND (
+          participant.human_id = session.owner_user_id
+          OR NULLIF(lower(human.email), '') IS NULL
+          OR NOT EXISTS (
+            SELECT 1
+            FROM humans AS self_human
+            WHERE self_human.id = session.owner_user_id
+              AND self_human.deleted_at IS NULL
+              AND NULLIF(lower(self_human.email), '') IS NOT NULL
+              AND lower(self_human.email) = lower(human.email)
+          )
+        )
     ), '[]') AS participants_json
   FROM sessions AS session
   LEFT JOIN session_documents AS note
@@ -228,6 +251,7 @@ function mapSessionContentRow(
     .map((participant) => ({
       humanId: participant.human_id,
       name: participant.name,
+      email: participant.email,
       jobTitle: participant.job_title,
     }))
     .sort(
@@ -239,6 +263,7 @@ function mapSessionContentRow(
   return {
     sessionId: row.id,
     ownerUserId: row.owner_user_id,
+    ownerEmail: row.owner_email,
     title: row.title,
     createdAt: row.created_at,
     event: parseJson(row.event_json),

--- a/apps/desktop/src/settings/general/audio-settings.test.tsx
+++ b/apps/desktop/src/settings/general/audio-settings.test.tsx
@@ -87,4 +87,17 @@ describe("AudioSettingsView", () => {
     toggle.click();
     expect(onChange).toHaveBeenCalledWith(true);
   });
+
+  it("can turn remember speakers off after it is on", () => {
+    const onChange = vi.fn();
+    renderAudioSettings({
+      rememberSpeakers: { value: true, onChange },
+    });
+
+    const toggle = screen.getByRole("switch", { name: "Remember speakers" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+    toggle.click();
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
 });

--- a/apps/desktop/src/settings/schema.ts
+++ b/apps/desktop/src/settings/schema.ts
@@ -94,7 +94,7 @@ export const SETTING_DEFINITIONS = {
   remember_speakers: {
     type: "boolean",
     path: ["general", "remember_speakers"],
-    default: false as boolean,
+    default: true as boolean,
   },
   microphone_device: {
     type: "string",

--- a/apps/desktop/src/shared/config/index.test.tsx
+++ b/apps/desktop/src/shared/config/index.test.tsx
@@ -48,6 +48,24 @@ describe("resolveConfigValue", () => {
     ).toBe(true);
   });
 
+  test("keeps remember speakers on until explicitly disabled", () => {
+    expect(
+      resolveConfigValue("remember_speakers", {
+        values: {},
+        hasValues: new Set(),
+      }),
+    ).toBe(true);
+  });
+
+  test("respects an explicit remember speakers opt-out", () => {
+    expect(
+      resolveConfigValue("remember_speakers", {
+        values: { remember_speakers: false },
+        hasValues: new Set(["remember_speakers"]),
+      }),
+    ).toBe(false);
+  });
+
   test("uses disabled legacy bounce preferences for the general setting", () => {
     expect(
       resolveConfigValue("notification_bounce", {

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -268,6 +268,8 @@ describe("transcript SQLite queries", () => {
 
     expect(result.current).toEqual(["human-1", "human-2"]);
     expect(mocks.queryOptions[0]?.sql).toContain("deleted_at IS NULL");
+    expect(mocks.queryOptions[0]?.sql).toContain("source <> 'excluded'");
+    expect(mocks.queryOptions[0]?.sql).toContain("owner_user_id");
   });
 
   it("deduplicates and sorts ids before loading named humans", () => {

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -270,6 +270,9 @@ describe("transcript SQLite queries", () => {
     expect(mocks.queryOptions[0]?.sql).toContain("deleted_at IS NULL");
     expect(mocks.queryOptions[0]?.sql).toContain("source <> 'excluded'");
     expect(mocks.queryOptions[0]?.sql).toContain("owner_user_id");
+    expect(mocks.queryOptions[0]?.sql).toContain(
+      "COALESCE(NULLIF(human.email, ''), participant.email)",
+    );
   });
 
   it("deduplicates and sorts ids before loading named humans", () => {

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -262,7 +262,7 @@ export function useSessionParticipantHumanIds(sessionId: string): string[] {
           WHERE session.id = participant.session_id
         ), '')
         AND (
-          NULLIF(lower(human.email), '') IS NULL
+          NULLIF(lower(COALESCE(NULLIF(human.email, ''), participant.email)), '') IS NULL
           OR NOT EXISTS (
             SELECT 1
             FROM humans AS self_human
@@ -271,7 +271,7 @@ export function useSessionParticipantHumanIds(sessionId: string): string[] {
             WHERE session.id = participant.session_id
               AND self_human.deleted_at IS NULL
               AND NULLIF(lower(self_human.email), '') IS NOT NULL
-              AND lower(self_human.email) = lower(human.email)
+              AND lower(self_human.email) = lower(COALESCE(NULLIF(human.email, ''), participant.email))
           )
         )
       ORDER BY participant.human_id

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -244,13 +244,37 @@ export async function getTranscriptRecord(
 
 export function useSessionParticipantHumanIds(sessionId: string): string[] {
   const { data = EMPTY_IDS } = useLiveQuery<ParticipantHumanSqlRow, string[]>({
+    // Drop excluded people and any contact that is the current user (or a
+    // calendar copy with the same email) so a 1:1 meeting still has one remote.
     sql: `
-      SELECT DISTINCT human_id
-      FROM session_participants
-      WHERE session_id = ?
-        AND human_id <> ''
-        AND deleted_at IS NULL
-      ORDER BY human_id
+      SELECT DISTINCT participant.human_id
+      FROM session_participants AS participant
+      LEFT JOIN humans AS human
+        ON human.id = participant.human_id
+        AND human.deleted_at IS NULL
+      WHERE participant.session_id = ?
+        AND participant.human_id <> ''
+        AND participant.source <> 'excluded'
+        AND participant.deleted_at IS NULL
+        AND participant.human_id <> COALESCE((
+          SELECT session.owner_user_id
+          FROM sessions AS session
+          WHERE session.id = participant.session_id
+        ), '')
+        AND (
+          NULLIF(lower(human.email), '') IS NULL
+          OR NOT EXISTS (
+            SELECT 1
+            FROM humans AS self_human
+            JOIN sessions AS session
+              ON session.owner_user_id = self_human.id
+            WHERE session.id = participant.session_id
+              AND self_human.deleted_at IS NULL
+              AND NULLIF(lower(self_human.email), '') IS NOT NULL
+              AND lower(self_human.email) = lower(human.email)
+          )
+        )
+      ORDER BY participant.human_id
     `,
     params: [sessionId],
     enabled: Boolean(sessionId),

--- a/crates/db-app/src/schema_tests/voiceprints.rs
+++ b/crates/db-app/src/schema_tests/voiceprints.rs
@@ -325,6 +325,17 @@ async fn candidates_match_on_channel_and_nullable_speaker_index() {
     .unwrap();
     assert_eq!(unindexed.len(), 1);
     assert_eq!(unindexed[0].id, "candidate-noidx");
+
+    let all =
+        list_active_voiceprint_candidates_for_transcript(db.pool(), "workspace-1", "transcript-1")
+            .await
+            .unwrap();
+    assert_eq!(
+        all.iter()
+            .map(|candidate| candidate.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["candidate-noidx", "candidate-idx"]
+    );
 }
 
 #[tokio::test]

--- a/crates/db-app/src/voiceprint_ops.rs
+++ b/crates/db-app/src/voiceprint_ops.rs
@@ -370,6 +370,31 @@ async fn get_active_voiceprint_candidate_in_transaction(
     .await
 }
 
+pub async fn list_active_voiceprint_candidates_for_transcript(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    transcript_id: &str,
+) -> Result<Vec<VoiceprintCandidate>, sqlx::Error> {
+    sqlx::query_as(
+        "SELECT
+           id, workspace_id, keyring_scope, keyring_key, sync_scope,
+           model_provider, model_version, capture_domain,
+           source_session_id, source_transcript_id, source_attachment_id,
+           source_speaker_label, speaker_channel, speaker_index,
+           source_start_ms, source_end_ms, quality_score, expires_at,
+           created_at, updated_at, deleted_at
+         FROM voiceprint_candidates
+         WHERE workspace_id = ?
+           AND source_transcript_id = ?
+           AND deleted_at IS NULL
+         ORDER BY speaker_channel, speaker_index, source_start_ms, id",
+    )
+    .bind(workspace_id)
+    .bind(transcript_id)
+    .fetch_all(pool)
+    .await
+}
+
 pub async fn list_active_voiceprint_candidates_for_speaker(
     pool: &SqlitePool,
     workspace_id: &str,

--- a/crates/voiceprint/src/lib.rs
+++ b/crates/voiceprint/src/lib.rs
@@ -1,6 +1,14 @@
 //! Selects clean single-speaker audio spans from transcript words so a
 //! speaker-embedding model can turn them into voiceprint candidates.
 
+mod matching;
+
+pub use matching::{
+    MIN_UNIQUE_MARGIN, MIN_UNIQUE_SCORE, VoiceprintAssignment, VoiceprintSpeakerKey,
+    collect_match_scores, cosine_similarity, pick_unique_voiceprint_assignments,
+    remote_participant_human_ids,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SpanWord {
     pub start_ms: i64,

--- a/crates/voiceprint/src/matching.rs
+++ b/crates/voiceprint/src/matching.rs
@@ -1,0 +1,321 @@
+//! Conservative identity matching for named voiceprints.
+
+pub const MIN_UNIQUE_SCORE: f32 = 0.62;
+pub const MIN_UNIQUE_MARGIN: f32 = 0.08;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VoiceprintSpeakerKey {
+    pub channel: i64,
+    pub speaker_index: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VoiceprintAssignment {
+    pub speaker: VoiceprintSpeakerKey,
+    pub human_id: String,
+    pub score: f32,
+}
+
+pub fn cosine_similarity(left: &[f32], right: &[f32]) -> Option<f32> {
+    if left.len() != right.len() || left.is_empty() {
+        return None;
+    }
+
+    let mut dot = 0.0_f32;
+    let mut left_norm = 0.0_f32;
+    let mut right_norm = 0.0_f32;
+    for (left_value, right_value) in left.iter().zip(right) {
+        dot += left_value * right_value;
+        left_norm += left_value * left_value;
+        right_norm += right_value * right_value;
+    }
+
+    let denom = left_norm.sqrt() * right_norm.sqrt();
+    if denom == 0.0 {
+        return None;
+    }
+
+    Some((dot / denom).clamp(-1.0, 1.0))
+}
+
+pub fn pick_unique_voiceprint_assignments(
+    scores: &[(VoiceprintSpeakerKey, &str, f32)],
+    min_score: f32,
+    min_margin: f32,
+) -> Vec<VoiceprintAssignment> {
+    let mut best_human_by_speaker: std::collections::HashMap<
+        VoiceprintSpeakerKey,
+        (String, f32, f32),
+    > = std::collections::HashMap::new();
+    let mut best_speaker_by_human: std::collections::HashMap<
+        &str,
+        (VoiceprintSpeakerKey, f32, f32),
+    > = std::collections::HashMap::new();
+
+    for (speaker, human_id, score) in scores {
+        update_best_pair(
+            best_human_by_speaker
+                .entry(*speaker)
+                .or_insert_with(|| (human_id.to_string(), f32::NEG_INFINITY, f32::NEG_INFINITY)),
+            *human_id,
+            *score,
+        );
+        update_best_speaker(
+            best_speaker_by_human.entry(*human_id).or_insert((
+                *speaker,
+                f32::NEG_INFINITY,
+                f32::NEG_INFINITY,
+            )),
+            *speaker,
+            *score,
+        );
+    }
+
+    let mut assignments = Vec::new();
+    for (speaker, (human_id, best, second)) in best_human_by_speaker {
+        if !is_unique_best(best, second, min_score, min_margin) {
+            continue;
+        }
+        let Some((best_speaker, human_best, human_second)) =
+            best_speaker_by_human.get(human_id.as_str())
+        else {
+            continue;
+        };
+        if *best_speaker != speaker
+            || !is_unique_best(*human_best, *human_second, min_score, min_margin)
+        {
+            continue;
+        }
+
+        assignments.push(VoiceprintAssignment {
+            speaker,
+            human_id,
+            score: best,
+        });
+    }
+
+    assignments.sort_by(|left, right| {
+        left.speaker
+            .channel
+            .cmp(&right.speaker.channel)
+            .then(left.speaker.speaker_index.cmp(&right.speaker.speaker_index))
+            .then(left.human_id.cmp(&right.human_id))
+    });
+    assignments
+}
+
+fn update_best_pair(entry: &mut (String, f32, f32), human_id: &str, score: f32) {
+    if score > entry.1 {
+        if entry.0 != human_id {
+            entry.2 = entry.1;
+        }
+        entry.0 = human_id.to_string();
+        entry.1 = score;
+    } else if entry.0 != human_id && score > entry.2 {
+        entry.2 = score;
+    }
+}
+
+fn update_best_speaker(
+    entry: &mut (VoiceprintSpeakerKey, f32, f32),
+    speaker: VoiceprintSpeakerKey,
+    score: f32,
+) {
+    if score > entry.1 {
+        if entry.0 != speaker {
+            entry.2 = entry.1;
+        }
+        entry.0 = speaker;
+        entry.1 = score;
+    } else if entry.0 != speaker && score > entry.2 {
+        entry.2 = score;
+    }
+}
+
+fn is_unique_best(best: f32, second: f32, min_score: f32, min_margin: f32) -> bool {
+    best >= min_score && (second.is_infinite() || best - second >= min_margin)
+}
+
+pub fn remote_participant_human_ids<'a>(
+    participants: impl IntoIterator<Item = (&'a str, &'a str)>,
+    owner_user_id: &str,
+    owner_email: Option<&str>,
+) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut ids = Vec::new();
+    for (human_id, email) in participants {
+        if human_id.is_empty() || human_id == owner_user_id {
+            continue;
+        }
+        if let Some(owner_email) = owner_email
+            && !email.is_empty()
+            && email.eq_ignore_ascii_case(owner_email)
+        {
+            continue;
+        }
+        if seen.insert(human_id.to_string()) {
+            ids.push(human_id.to_string());
+        }
+    }
+    ids
+}
+
+pub fn collect_match_scores(
+    samples: &[(VoiceprintSpeakerKey, &str, &[f32])],
+    exemplars: &[(String, String, Vec<f32>)],
+) -> Vec<(VoiceprintSpeakerKey, String, f32)> {
+    let mut best = std::collections::HashMap::<(VoiceprintSpeakerKey, String), f32>::new();
+    for (speaker, domain, embedding) in samples {
+        for (human_id, exemplar_domain, exemplar) in exemplars {
+            if exemplar_domain != domain {
+                continue;
+            }
+            let Some(score) = cosine_similarity(embedding, exemplar) else {
+                continue;
+            };
+            let entry = best
+                .entry((*speaker, human_id.clone()))
+                .or_insert(f32::NEG_INFINITY);
+            if score > *entry {
+                *entry = score;
+            }
+        }
+    }
+    best.into_iter()
+        .map(|((speaker, human_id), score)| (speaker, human_id, score))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn speaker(channel: i64, index: i64) -> VoiceprintSpeakerKey {
+        VoiceprintSpeakerKey {
+            channel,
+            speaker_index: Some(index),
+        }
+    }
+
+    #[test]
+    fn cosine_rejects_mismatched_or_empty_vectors() {
+        assert_eq!(cosine_similarity(&[1.0], &[1.0, 0.0]), None);
+        assert_eq!(cosine_similarity(&[], &[]), None);
+        assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 0.0]), None);
+    }
+
+    #[test]
+    fn cosine_is_one_for_identical_vectors() {
+        assert_eq!(cosine_similarity(&[1.0, 0.0], &[1.0, 0.0]), Some(1.0));
+    }
+
+    #[test]
+    fn assigns_a_mutual_unique_match() {
+        let marco = speaker(1, 0);
+        let ada = speaker(1, 1);
+        let assignments = pick_unique_voiceprint_assignments(
+            &[
+                (marco, "marco", 0.84),
+                (marco, "ada", 0.41),
+                (ada, "ada", 0.81),
+                (ada, "marco", 0.38),
+            ],
+            MIN_UNIQUE_SCORE,
+            MIN_UNIQUE_MARGIN,
+        );
+
+        assert_eq!(
+            assignments
+                .iter()
+                .map(|assignment| (assignment.speaker, assignment.human_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(marco, "marco"), (ada, "ada")]
+        );
+    }
+
+    #[test]
+    fn does_not_guess_when_two_speakers_want_the_same_person() {
+        let first = speaker(1, 0);
+        let second = speaker(1, 1);
+        assert!(
+            pick_unique_voiceprint_assignments(
+                &[(first, "marco", 0.88), (second, "marco", 0.86)],
+                MIN_UNIQUE_SCORE,
+                MIN_UNIQUE_MARGIN,
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn does_not_guess_when_the_margin_is_thin() {
+        let remote = speaker(1, 0);
+        assert!(
+            pick_unique_voiceprint_assignments(
+                &[(remote, "marco", 0.71), (remote, "ada", 0.68)],
+                MIN_UNIQUE_SCORE,
+                MIN_UNIQUE_MARGIN,
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn does_not_guess_below_the_score_floor() {
+        let remote = speaker(1, 0);
+        assert!(
+            pick_unique_voiceprint_assignments(
+                &[(remote, "marco", 0.51)],
+                MIN_UNIQUE_SCORE,
+                MIN_UNIQUE_MARGIN,
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn remote_participants_drop_owner_and_self_email_copies() {
+        assert_eq!(
+            remote_participant_human_ids(
+                [
+                    ("john", "john@example.com"),
+                    ("john-cal", "john@example.com"),
+                    ("marco", "marco@example.com"),
+                    ("ada", ""),
+                    ("", "nobody@example.com"),
+                ],
+                "john",
+                Some("john@example.com"),
+            ),
+            vec!["marco".to_string(), "ada".to_string()]
+        );
+    }
+
+    #[test]
+    fn match_scores_keep_same_domain_and_the_best_sample() {
+        let remote = speaker(1, 0);
+        let scores = collect_match_scores(
+            &[
+                (remote, "system_audio", &[1.0, 0.0]),
+                (remote, "system_audio", &[0.8, 0.2]),
+            ],
+            &[
+                (
+                    "marco".to_string(),
+                    "direct_mic".to_string(),
+                    vec![1.0, 0.0],
+                ),
+                (
+                    "ada".to_string(),
+                    "system_audio".to_string(),
+                    vec![1.0, 0.0],
+                ),
+            ],
+        );
+
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].0, remote);
+        assert_eq!(scores[0].1, "ada");
+        assert!((scores[0].2 - 1.0).abs() < 1e-6);
+    }
+}

--- a/plugins/transcription/src/voiceprint.rs
+++ b/plugins/transcription/src/voiceprint.rs
@@ -1,7 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-use anlg_voiceprint::{SelectedSpan, SpanConfig, SpanWord, select_speaker_spans};
+use anlg_voiceprint::{
+    MIN_UNIQUE_MARGIN, MIN_UNIQUE_SCORE, SelectedSpan, SpanConfig, SpanWord, VoiceprintSpeakerKey,
+    collect_match_scores, pick_unique_voiceprint_assignments, remote_participant_human_ids,
+    select_speaker_spans,
+};
 use base64::Engine;
 use tauri::Manager;
 
@@ -171,6 +175,22 @@ pub async fn extract_voiceprint_candidates<R: tauri::Runtime>(
         stored,
         "voiceprint_candidates_extracted"
     );
+
+    if let Err(error) = maybe_assign_speakers_from_voiceprints(
+        &app,
+        &pool,
+        &session_id,
+        &transcript_id,
+        &workspace_id,
+        &words_json,
+        &hints_json,
+        &embeddings,
+    )
+    .await
+    {
+        tracing::warn!(%error, "voiceprint_assignment_failed");
+    }
+
     Ok(stored)
 }
 
@@ -346,14 +366,7 @@ fn spans_from_transcript(words_json: &str, hints_json: &str) -> Result<Vec<Selec
     let words: Vec<StoredWord> =
         serde_json::from_str(words_json).map_err(|error| error.to_string())?;
     let hints: Vec<StoredHint> = serde_json::from_str(hints_json).unwrap_or_default();
-
-    let hinted_speaker_by_word: HashMap<String, i64> = hints
-        .iter()
-        .filter(|hint| hint.hint_type == "provider_speaker_index")
-        .filter_map(|hint| {
-            speaker_index_from_hint_value(&hint.value).map(|index| (hint.word_id.clone(), index))
-        })
-        .collect();
+    let hinted_speaker_by_word = provider_speaker_index_by_word(&hints);
 
     let span_words: Vec<SpanWord> = words
         .iter()
@@ -568,6 +581,306 @@ fn encode_embedding(embedding: &[f32]) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
+fn decode_embedding(encoded: &str) -> Option<Vec<f32>> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    if bytes.len() % 4 != 0 || bytes.is_empty() {
+        return None;
+    }
+    bytes
+        .chunks_exact(4)
+        .map(|chunk| {
+            let chunk: [u8; 4] = chunk.try_into().ok()?;
+            Some(f32::from_le_bytes(chunk))
+        })
+        .collect()
+}
+
+async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    pool: &sqlx::SqlitePool,
+    session_id: &str,
+    transcript_id: &str,
+    workspace_id: &str,
+    words_json: &str,
+    hints_json: &str,
+    embeddings: &[SpanEmbedding],
+) -> Result<(), String> {
+    if embeddings.is_empty() {
+        return Ok(());
+    }
+
+    let index = speaker_index_from_transcript(words_json, hints_json)?;
+    let owner_user_id = sqlx::query_scalar::<_, String>(
+        "SELECT owner_user_id FROM sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+    let Some(owner_user_id) = owner_user_id else {
+        return Ok(());
+    };
+
+    let owner_email: Option<String> = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT NULLIF(lower(email), '') FROM humans WHERE id = ? AND deleted_at IS NULL LIMIT 1",
+    )
+    .bind(&owner_user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| error.to_string())?
+    .flatten();
+
+    let participants = anlg_db_app::list_session_participants(pool, session_id)
+        .await
+        .map_err(|error| error.to_string())?;
+    let remote_human_ids = remote_participant_human_ids(
+        participants
+            .iter()
+            .map(|participant| (participant.human_id.as_str(), participant.email.as_str())),
+        &owner_user_id,
+        owner_email.as_deref(),
+    );
+    // 1:1 meetings are named from the participant list. Voiceprints only
+    // identify people when the calendar cannot uniquely name the remotes.
+    if remote_human_ids.len() < 2 {
+        return Ok(());
+    }
+
+    let mut exemplars = Vec::new();
+    for human_id in &remote_human_ids {
+        if index.assigned_human_ids.contains(human_id) {
+            continue;
+        }
+        let rows =
+            anlg_db_app::list_active_voiceprint_exemplars_for_human(pool, workspace_id, human_id)
+                .await
+                .map_err(|error| error.to_string())?;
+        for exemplar in rows {
+            if exemplar.model_provider != MODEL_PROVIDER || exemplar.model_version != MODEL_VERSION
+            {
+                continue;
+            }
+            let Ok(Some(secret_value)) = tauri_plugin_store2::read_secret(
+                app.clone(),
+                exemplar.keyring_scope.clone(),
+                exemplar.keyring_key.clone(),
+            )
+            .await
+            else {
+                continue;
+            };
+            let Some(embedding) = decode_embedding(&secret_value) else {
+                continue;
+            };
+            exemplars.push((exemplar.human_id, exemplar.capture_domain, embedding));
+        }
+    }
+    if exemplars.is_empty() {
+        return Ok(());
+    }
+
+    let samples: Vec<_> = embeddings
+        .iter()
+        .filter(|(span, _)| span.channel != 0)
+        .filter(|(span, _)| {
+            !index.assigned_speakers.contains(&VoiceprintSpeakerKey {
+                channel: span.channel,
+                speaker_index: span.speaker_index,
+            })
+        })
+        .map(|(span, embedding)| {
+            (
+                VoiceprintSpeakerKey {
+                    channel: span.channel,
+                    speaker_index: span.speaker_index,
+                },
+                capture_domain(span.channel),
+                embedding.as_slice(),
+            )
+        })
+        .collect();
+    let scores = collect_match_scores(&samples, &exemplars);
+    let assignments = pick_unique_voiceprint_assignments(
+        &scores
+            .iter()
+            .map(|(speaker, human_id, score)| (*speaker, human_id.as_str(), *score))
+            .collect::<Vec<_>>(),
+        MIN_UNIQUE_SCORE,
+        MIN_UNIQUE_MARGIN,
+    );
+    if assignments.is_empty() {
+        return Ok(());
+    }
+
+    let Ok(mut hints) = serde_json::from_str::<Vec<serde_json::Value>>(hints_json) else {
+        return Ok(());
+    };
+    let mut assigned = 0u32;
+    for assignment in assignments {
+        let Some(word_id) = index.first_word_id.get(&assignment.speaker) else {
+            continue;
+        };
+        hints.push(automatic_voiceprint_hint(
+            word_id,
+            &assignment.human_id,
+            assignment.score,
+        ));
+        assigned += 1;
+    }
+    if assigned == 0 {
+        return Ok(());
+    }
+
+    let next_json = serde_json::to_string(&hints).map_err(|error| error.to_string())?;
+    let now = chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string();
+    let result = sqlx::query(
+        "UPDATE transcripts
+         SET speaker_hints_json = ?, updated_at = ?
+         WHERE id = ? AND session_id = ? AND words_json = ? AND speaker_hints_json = ?
+           AND deleted_at IS NULL",
+    )
+    .bind(&next_json)
+    .bind(&now)
+    .bind(transcript_id)
+    .bind(session_id)
+    .bind(words_json)
+    .bind(hints_json)
+    .execute(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    if result.rows_affected() == 0 {
+        tracing::warn!(transcript_id, "voiceprint_assignment_hints_conflict");
+        return Ok(());
+    }
+
+    tracing::info!(
+        session_id,
+        transcript_id,
+        assigned,
+        "voiceprint_speakers_assigned"
+    );
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct SpeakerIndex {
+    first_word_id: HashMap<VoiceprintSpeakerKey, String>,
+    assigned_speakers: HashSet<VoiceprintSpeakerKey>,
+    assigned_human_ids: HashSet<String>,
+}
+
+fn speaker_index_from_transcript(
+    words_json: &str,
+    hints_json: &str,
+) -> Result<SpeakerIndex, String> {
+    let words: Vec<StoredWord> =
+        serde_json::from_str(words_json).map_err(|error| error.to_string())?;
+    let hints: Vec<StoredHint> = serde_json::from_str(hints_json).unwrap_or_default();
+    let hinted_speaker_by_word = provider_speaker_index_by_word(&hints);
+
+    let mut ordered: Vec<&StoredWord> = words.iter().collect();
+    ordered.sort_by(|left, right| left.start_ms.total_cmp(&right.start_ms));
+
+    let mut first_word_id = HashMap::new();
+    let mut speaker_by_word_id = HashMap::new();
+    for word in ordered {
+        let Some(word_id) = word.id.as_ref() else {
+            continue;
+        };
+        let speaker = speaker_key_for_word(word, hinted_speaker_by_word.get(word_id).copied());
+        speaker_by_word_id.insert(word_id.clone(), speaker);
+        first_word_id
+            .entry(speaker)
+            .or_insert_with(|| word_id.clone());
+    }
+
+    let mut assigned_speakers = HashSet::new();
+    let mut assigned_human_ids = HashSet::new();
+    for hint in &hints {
+        if hint.hint_type != "automatic_speaker_assignment"
+            && hint.hint_type != "user_speaker_assignment"
+        {
+            continue;
+        }
+        let Some(human_id) = human_id_from_hint_value(&hint.value) else {
+            continue;
+        };
+        assigned_human_ids.insert(human_id);
+        if let Some(speaker) = speaker_key_from_hint_value(&hint.value)
+            .or_else(|| speaker_by_word_id.get(&hint.word_id).copied())
+        {
+            assigned_speakers.insert(speaker);
+        }
+    }
+
+    Ok(SpeakerIndex {
+        first_word_id,
+        assigned_speakers,
+        assigned_human_ids,
+    })
+}
+
+fn provider_speaker_index_by_word(hints: &[StoredHint]) -> HashMap<String, i64> {
+    hints
+        .iter()
+        .filter(|hint| hint.hint_type == "provider_speaker_index")
+        .filter_map(|hint| {
+            speaker_index_from_hint_value(&hint.value).map(|index| (hint.word_id.clone(), index))
+        })
+        .collect()
+}
+
+fn speaker_key_for_word(word: &StoredWord, hinted_index: Option<i64>) -> VoiceprintSpeakerKey {
+    VoiceprintSpeakerKey {
+        channel: word.channel,
+        speaker_index: hinted_index.or(word.speaker_index),
+    }
+}
+
+fn speaker_key_from_hint_value(value: &serde_json::Value) -> Option<VoiceprintSpeakerKey> {
+    let object = hint_value_object(value)?;
+    let channel = object.get("channel")?.as_i64()?;
+    Some(VoiceprintSpeakerKey {
+        channel,
+        speaker_index: object.get("speaker_index").and_then(|value| value.as_i64()),
+    })
+}
+
+fn human_id_from_hint_value(value: &serde_json::Value) -> Option<String> {
+    let object = hint_value_object(value)?;
+    object
+        .get("human_id")?
+        .as_str()
+        .filter(|human_id| !human_id.is_empty())
+        .map(str::to_string)
+}
+
+fn hint_value_object(value: &serde_json::Value) -> Option<serde_json::Value> {
+    match value {
+        serde_json::Value::String(raw) => serde_json::from_str(raw).ok(),
+        other => Some(other.clone()),
+    }
+}
+
+fn automatic_voiceprint_hint(word_id: &str, human_id: &str, score: f32) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("{word_id}:automatic_speaker_assignment"),
+        "word_id": word_id,
+        "type": "automatic_speaker_assignment",
+        "value": serde_json::json!({
+            "human_id": human_id,
+            "confidence": score,
+            "source": "voiceprint",
+        })
+        .to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::num::NonZero;
@@ -737,15 +1050,52 @@ mod tests {
     #[test]
     fn embedding_round_trips_through_base64() {
         let embedding = vec![0.5_f32, -1.25, 3.0];
-        let encoded = encode_embedding(&embedding);
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(encoded)
-            .unwrap();
-        let decoded: Vec<f32> = bytes
-            .chunks_exact(4)
-            .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
-            .collect();
-        assert_eq!(decoded, embedding);
+        assert_eq!(
+            decode_embedding(&encode_embedding(&embedding)),
+            Some(embedding)
+        );
+        assert_eq!(decode_embedding("not-base64"), None);
+        assert_eq!(decode_embedding(""), None);
+    }
+
+    #[test]
+    fn speaker_index_reads_existing_assignments() {
+        let words = r#"[
+            {"id": "w1", "text": "hello", "start_ms": 0, "end_ms": 2000, "channel": 1, "speaker_index": 0},
+            {"id": "w2", "text": "there", "start_ms": 2100, "end_ms": 4000, "channel": 1, "speaker_index": 1}
+        ]"#;
+        let hints = r#"[
+            {"word_id": "w1", "type": "automatic_speaker_assignment", "value": {"human_id": "marco"}}
+        ]"#;
+
+        let index = speaker_index_from_transcript(words, hints).unwrap();
+        assert_eq!(
+            index.first_word_id.get(&VoiceprintSpeakerKey {
+                channel: 1,
+                speaker_index: Some(0)
+            }),
+            Some(&"w1".to_string())
+        );
+        assert!(index.assigned_human_ids.contains("marco"));
+        assert!(index.assigned_speakers.contains(&VoiceprintSpeakerKey {
+            channel: 1,
+            speaker_index: Some(0)
+        }));
+        assert!(!index.assigned_speakers.contains(&VoiceprintSpeakerKey {
+            channel: 1,
+            speaker_index: Some(1)
+        }));
+    }
+
+    #[test]
+    fn unique_voiceprint_hint_uses_voiceprint_source() {
+        let hint = automatic_voiceprint_hint("w1", "marco", 0.84);
+        assert_eq!(hint["type"], "automatic_speaker_assignment");
+        assert_eq!(hint["word_id"], "w1");
+        let value: serde_json::Value =
+            serde_json::from_str(hint["value"].as_str().unwrap()).unwrap();
+        assert_eq!(value["human_id"], "marco");
+        assert_eq!(value["source"], "voiceprint");
     }
 
     struct SyntheticStereoSource {

--- a/plugins/transcription/src/voiceprint.rs
+++ b/plugins/transcription/src/voiceprint.rs
@@ -2,9 +2,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use anlg_voiceprint::{
-    MIN_UNIQUE_MARGIN, MIN_UNIQUE_SCORE, SelectedSpan, SpanConfig, SpanWord, VoiceprintSpeakerKey,
-    collect_match_scores, pick_unique_voiceprint_assignments, remote_participant_human_ids,
-    select_speaker_spans,
+    MIN_UNIQUE_MARGIN, MIN_UNIQUE_SCORE, SelectedSpan, SpanConfig, SpanWord, VoiceprintAssignment,
+    VoiceprintSpeakerKey, collect_match_scores, pick_unique_voiceprint_assignments,
+    remote_participant_human_ids, select_speaker_spans,
 };
 use base64::Engine;
 use tauri::Manager;
@@ -94,6 +94,18 @@ pub async fn extract_voiceprint_candidates<R: tauri::Runtime>(
     .await
     .map_err(|error| error.to_string())?;
     if already_extracted {
+        if let Err(error) = maybe_assign_speakers_from_voiceprints(
+            &app,
+            &pool,
+            &session_id,
+            &transcript_id,
+            &workspace_id,
+            None,
+        )
+        .await
+        {
+            tracing::warn!(%error, "voiceprint_assignment_failed");
+        }
         return Ok(0);
     }
 
@@ -182,9 +194,7 @@ pub async fn extract_voiceprint_candidates<R: tauri::Runtime>(
         &session_id,
         &transcript_id,
         &workspace_id,
-        &words_json,
-        &hints_json,
-        &embeddings,
+        Some(&embeddings),
     )
     .await
     {
@@ -603,15 +613,28 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
     session_id: &str,
     transcript_id: &str,
     workspace_id: &str,
-    words_json: &str,
-    hints_json: &str,
-    embeddings: &[SpanEmbedding],
+    embeddings: Option<&[SpanEmbedding]>,
 ) -> Result<(), String> {
-    if embeddings.is_empty() {
-        return Ok(());
-    }
+    let stored_embeddings;
+    let embeddings = match embeddings.filter(|embeddings| !embeddings.is_empty()) {
+        Some(embeddings) => embeddings,
+        None => {
+            stored_embeddings =
+                embeddings_from_stored_candidates(app, pool, workspace_id, transcript_id).await?;
+            if stored_embeddings.is_empty() {
+                return Ok(());
+            }
+            stored_embeddings.as_slice()
+        }
+    };
 
-    let index = speaker_index_from_transcript(words_json, hints_json)?;
+    let Some((words_json, hints_json)) =
+        load_transcript_words_and_hints(pool, session_id, transcript_id).await?
+    else {
+        return Ok(());
+    };
+
+    let index = speaker_index_from_transcript(&words_json, &hints_json)?;
     let owner_user_id = sqlx::query_scalar::<_, String>(
         "SELECT owner_user_id FROM sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
     )
@@ -714,11 +737,124 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
         return Ok(());
     }
 
+    let mut words_json = words_json;
+    let mut hints_json = hints_json;
+    let mut index = index;
+    for attempt in 0..2 {
+        let Some(next_json) = assignment_hints_json(&hints_json, &index, &assignments)? else {
+            return Ok(());
+        };
+        if write_speaker_assignment_hints(
+            pool,
+            session_id,
+            transcript_id,
+            &words_json,
+            &hints_json,
+            &next_json,
+        )
+        .await?
+        {
+            tracing::info!(
+                session_id,
+                transcript_id,
+                assigned = assignments.len(),
+                "voiceprint_speakers_assigned"
+            );
+            return Ok(());
+        }
+        if attempt == 0 {
+            tracing::warn!(transcript_id, "voiceprint_assignment_hints_conflict");
+            let Some(latest) =
+                load_transcript_words_and_hints(pool, session_id, transcript_id).await?
+            else {
+                return Ok(());
+            };
+            words_json = latest.0;
+            hints_json = latest.1;
+            index = speaker_index_from_transcript(&words_json, &hints_json)?;
+        }
+    }
+    Ok(())
+}
+
+async fn load_transcript_words_and_hints(
+    pool: &sqlx::SqlitePool,
+    session_id: &str,
+    transcript_id: &str,
+) -> Result<Option<(String, String)>, String> {
+    sqlx::query_as::<_, (String, String)>(
+        "SELECT words_json, speaker_hints_json
+         FROM transcripts
+         WHERE id = ? AND session_id = ? AND deleted_at IS NULL
+         LIMIT 1",
+    )
+    .bind(transcript_id)
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| error.to_string())
+}
+
+async fn embeddings_from_stored_candidates<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    pool: &sqlx::SqlitePool,
+    workspace_id: &str,
+    transcript_id: &str,
+) -> Result<Vec<SpanEmbedding>, String> {
+    let candidates = anlg_db_app::list_active_voiceprint_candidates_for_transcript(
+        pool,
+        workspace_id,
+        transcript_id,
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+
+    let mut embeddings = Vec::new();
+    for candidate in candidates {
+        if candidate.model_provider != MODEL_PROVIDER || candidate.model_version != MODEL_VERSION {
+            continue;
+        }
+        let Ok(Some(secret_value)) = tauri_plugin_store2::read_secret(
+            app.clone(),
+            candidate.keyring_scope.clone(),
+            candidate.keyring_key.clone(),
+        )
+        .await
+        else {
+            continue;
+        };
+        let Some(embedding) = decode_embedding(&secret_value) else {
+            continue;
+        };
+        embeddings.push((
+            SelectedSpan {
+                channel: candidate.speaker_channel,
+                speaker_index: candidate.speaker_index,
+                start_ms: candidate.source_start_ms,
+                end_ms: candidate.source_end_ms,
+                quality_score: candidate.quality_score,
+            },
+            embedding,
+        ));
+    }
+    Ok(embeddings)
+}
+
+fn assignment_hints_json(
+    hints_json: &str,
+    index: &SpeakerIndex,
+    assignments: &[VoiceprintAssignment],
+) -> Result<Option<String>, String> {
     let Ok(mut hints) = serde_json::from_str::<Vec<serde_json::Value>>(hints_json) else {
-        return Ok(());
+        return Ok(None);
     };
     let mut assigned = 0u32;
     for assignment in assignments {
+        if index.assigned_speakers.contains(&assignment.speaker)
+            || index.assigned_human_ids.contains(&assignment.human_id)
+        {
+            continue;
+        }
         let Some(word_id) = index.first_word_id.get(&assignment.speaker) else {
             continue;
         };
@@ -730,10 +866,21 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
         assigned += 1;
     }
     if assigned == 0 {
-        return Ok(());
+        return Ok(None);
     }
+    serde_json::to_string(&hints)
+        .map(Some)
+        .map_err(|error| error.to_string())
+}
 
-    let next_json = serde_json::to_string(&hints).map_err(|error| error.to_string())?;
+async fn write_speaker_assignment_hints(
+    pool: &sqlx::SqlitePool,
+    session_id: &str,
+    transcript_id: &str,
+    words_json: &str,
+    hints_json: &str,
+    next_json: &str,
+) -> Result<bool, String> {
     let now = chrono::Utc::now()
         .format("%Y-%m-%dT%H:%M:%S%.3fZ")
         .to_string();
@@ -743,7 +890,7 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
          WHERE id = ? AND session_id = ? AND words_json = ? AND speaker_hints_json = ?
            AND deleted_at IS NULL",
     )
-    .bind(&next_json)
+    .bind(next_json)
     .bind(&now)
     .bind(transcript_id)
     .bind(session_id)
@@ -752,19 +899,7 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
     .execute(pool)
     .await
     .map_err(|error| error.to_string())?;
-
-    if result.rows_affected() == 0 {
-        tracing::warn!(transcript_id, "voiceprint_assignment_hints_conflict");
-        return Ok(());
-    }
-
-    tracing::info!(
-        session_id,
-        transcript_id,
-        assigned,
-        "voiceprint_speakers_assigned"
-    );
-    Ok(())
+    Ok(result.rows_affected() > 0)
 }
 
 #[derive(Debug, Default)]
@@ -1096,6 +1231,50 @@ mod tests {
             serde_json::from_str(hint["value"].as_str().unwrap()).unwrap();
         assert_eq!(value["human_id"], "marco");
         assert_eq!(value["source"], "voiceprint");
+    }
+
+    #[test]
+    fn assignment_hints_skip_speakers_that_are_already_named() {
+        let words = r#"[
+            {"id": "w1", "text": "hello", "start_ms": 0, "end_ms": 2000, "channel": 1, "speaker_index": 0},
+            {"id": "w2", "text": "there", "start_ms": 2100, "end_ms": 4000, "channel": 1, "speaker_index": 1}
+        ]"#;
+        let hints = r#"[
+            {"word_id": "w1", "type": "automatic_speaker_assignment", "value": {"human_id": "marco"}}
+        ]"#;
+        let index = speaker_index_from_transcript(words, hints).unwrap();
+        let next = assignment_hints_json(
+            hints,
+            &index,
+            &[
+                VoiceprintAssignment {
+                    speaker: VoiceprintSpeakerKey {
+                        channel: 1,
+                        speaker_index: Some(0),
+                    },
+                    human_id: "marco".to_string(),
+                    score: 0.9,
+                },
+                VoiceprintAssignment {
+                    speaker: VoiceprintSpeakerKey {
+                        channel: 1,
+                        speaker_index: Some(1),
+                    },
+                    human_id: "ada".to_string(),
+                    score: 0.88,
+                },
+            ],
+        )
+        .unwrap()
+        .unwrap();
+
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&next).unwrap();
+        let assigned: Vec<_> = parsed
+            .iter()
+            .filter(|hint| hint["type"] == "automatic_speaker_assignment")
+            .map(|hint| hint["word_id"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(assigned, vec!["w1".to_string(), "w2".to_string()]);
     }
 
     struct SyntheticStereoSource {

--- a/plugins/transcription/src/voiceprint.rs
+++ b/plugins/transcription/src/voiceprint.rs
@@ -116,9 +116,9 @@ pub async fn extract_voiceprint_candidates<R: tauri::Runtime>(
         .to_string();
 
     let mut stored: u32 = 0;
-    for (span, embedding) in embeddings {
+    for (span, embedding) in &embeddings {
         let id = uuid::Uuid::new_v4().to_string();
-        let encoded = encode_embedding(&embedding);
+        let encoded = encode_embedding(embedding);
 
         if let Err(error) = tauri_plugin_store2::write_secret(
             app.clone(),

--- a/plugins/transcription/src/voiceprint.rs
+++ b/plugins/transcription/src/voiceprint.rs
@@ -194,7 +194,7 @@ pub async fn extract_voiceprint_candidates<R: tauri::Runtime>(
         &session_id,
         &transcript_id,
         &workspace_id,
-        Some(&embeddings),
+        Some((&embeddings, &words_json, &hints_json)),
     )
     .await
     {
@@ -613,28 +613,35 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
     session_id: &str,
     transcript_id: &str,
     workspace_id: &str,
-    embeddings: Option<&[SpanEmbedding]>,
+    extracted: Option<(&[SpanEmbedding], &str, &str)>,
 ) -> Result<(), String> {
     let stored_embeddings;
-    let embeddings = match embeddings.filter(|embeddings| !embeddings.is_empty()) {
-        Some(embeddings) => embeddings,
+    let (embeddings, words_json, mut hints_json) = match extracted
+        .filter(|(embeddings, _, _)| !embeddings.is_empty())
+    {
+        Some((embeddings, words_json, hints_json)) => {
+            (embeddings, words_json.to_string(), hints_json.to_string())
+        }
         None => {
             stored_embeddings =
                 embeddings_from_stored_candidates(app, pool, workspace_id, transcript_id).await?;
             if stored_embeddings.is_empty() {
                 return Ok(());
             }
-            stored_embeddings.as_slice()
+            let Some((words_json, hints_json)) =
+                load_transcript_words_and_hints(pool, session_id, transcript_id).await?
+            else {
+                return Ok(());
+            };
+            let index = speaker_index_from_transcript(&words_json, &hints_json)?;
+            if !embeddings_match_current_speakers(&stored_embeddings, &index) {
+                return Ok(());
+            }
+            (stored_embeddings.as_slice(), words_json, hints_json)
         }
     };
 
-    let Some((words_json, hints_json)) =
-        load_transcript_words_and_hints(pool, session_id, transcript_id).await?
-    else {
-        return Ok(());
-    };
-
-    let index = speaker_index_from_transcript(&words_json, &hints_json)?;
+    let mut index = speaker_index_from_transcript(&words_json, &hints_json)?;
     let owner_user_id = sqlx::query_scalar::<_, String>(
         "SELECT owner_user_id FROM sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
     )
@@ -737,9 +744,6 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
         return Ok(());
     }
 
-    let mut words_json = words_json;
-    let mut hints_json = hints_json;
-    let mut index = index;
     for attempt in 0..2 {
         let Some(next_json) = assignment_hints_json(&hints_json, &index, &assignments)? else {
             return Ok(());
@@ -769,7 +773,11 @@ async fn maybe_assign_speakers_from_voiceprints<R: tauri::Runtime>(
             else {
                 return Ok(());
             };
-            words_json = latest.0;
+            // Embeddings were scored against this words snapshot. A newer
+            // diarization would map those speaker keys onto the wrong clusters.
+            if latest.0 != words_json {
+                return Ok(());
+            }
             hints_json = latest.1;
             index = speaker_index_from_transcript(&words_json, &hints_json)?;
         }
@@ -907,6 +915,16 @@ struct SpeakerIndex {
     first_word_id: HashMap<VoiceprintSpeakerKey, String>,
     assigned_speakers: HashSet<VoiceprintSpeakerKey>,
     assigned_human_ids: HashSet<String>,
+}
+
+fn embeddings_match_current_speakers(embeddings: &[SpanEmbedding], index: &SpeakerIndex) -> bool {
+    !embeddings.is_empty()
+        && embeddings.iter().all(|(span, _)| {
+            index.first_word_id.contains_key(&VoiceprintSpeakerKey {
+                channel: span.channel,
+                speaker_index: span.speaker_index,
+            })
+        })
 }
 
 fn speaker_index_from_transcript(
@@ -1220,6 +1238,38 @@ mod tests {
             channel: 1,
             speaker_index: Some(1)
         }));
+    }
+
+    #[test]
+    fn stored_embeddings_require_current_speaker_keys() {
+        let words = r#"[
+            {"id": "w1", "text": "hello", "start_ms": 0, "end_ms": 2000, "channel": 1, "speaker_index": 0}
+        ]"#;
+        let index = speaker_index_from_transcript(words, "[]").unwrap();
+        let matching = vec![(
+            SelectedSpan {
+                channel: 1,
+                speaker_index: Some(0),
+                start_ms: 0,
+                end_ms: 2000,
+                quality_score: 0.1,
+            },
+            vec![0.1_f32],
+        )];
+        let remapped = vec![(
+            SelectedSpan {
+                channel: 1,
+                speaker_index: Some(9),
+                start_ms: 0,
+                end_ms: 2000,
+                quality_score: 0.1,
+            },
+            vec![0.1_f32],
+        )];
+
+        assert!(embeddings_match_current_speakers(&matching, &index));
+        assert!(!embeddings_match_current_speakers(&remapped, &index));
+        assert!(!embeddings_match_current_speakers(&[], &index));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a transcript has only you on the mic and one other participant, we should label their turns instead of leaving them as `Speaker 1`. In larger meetings, named voiceprints should identify people only when the match is unique and high-confidence.

The summary already inferred names (`Marco (Speaker 1)`), but the transcript did not:

- Enhance attribution required **two named non-owner participants** and **two speaker clusters**, so a John + Marco meeting never ran.
- The live participant list used for channel assignment also counted **excluded people** and **calendar copies of the current user**, so the “unique remote” path never fired.
- Voiceprints were collected only if “Remember speakers” was turned on, and extracted embeddings were never matched against known people.

## Changes

- Assign the only other participant to the only unassigned remote/mixed speaker after enhance, without calling the LLM.
- Ignore excluded participants and owner/self-email duplicates when collecting human IDs for transcript rendering, live capture, enhance candidates, and the speaker-hint write guard. Self-copy matching uses coalesced `human.email` / `participant.email`, so a calendar copy whose address lives only on the participant row still drops from the remote count.
- Turn **Remember speakers** on by default for this update. An explicit off stays off — we do not overwrite a stored preference.
- After candidate extraction, match new embeddings against this meeting’s participants only (same model and capture domain). Assign a speaker only when they uniquely match one person above a score floor and margin. Skip your mic channel, already-named speakers, and 1:1 meetings (those still use the participant list). Thin margins or two speakers wanting the same person stay unlabeled.
- Score and write assignment against the **extract-time words snapshot**. If a hints-write conflict shows a newer diarization (`words_json` changed), abort instead of labeling the wrong clusters. Stored candidates are skipped when their speaker keys are missing from the current transcript.

## Validation

- `pnpm -F desktop typecheck`
- `pnpm -F desktop exec vitest run` on speaker-attribution, content-queries, content-mutations, and stt/queries tests
- `pnpm exec oxlint --quiet --format=github` on the changed desktop files
- `pnpm exec dprint check` on the changed files
- `cargo test -p tauri-plugin-transcription` could not run here (`gdk-3.0.pc` missing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52150cc1-c8b4-431e-bb4f-92434a92b269?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52150cc1-c8b4-431e-bb4f-92434a92b269&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

