### PR TITLE
Fix Mac App Store review blockers

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -11,6 +11,11 @@ on:
         description: "Exact 40-character commit tagged for the stable release"
         required: true
         type: string
+      build_number:
+        description: "Optional macOS CFBundleVersion for a replacement build"
+        required: false
+        type: string
+        default: ""
       include_macos:
         description: "Build the signed Mac App Store package"
         type: boolean
@@ -70,6 +75,11 @@ on:
         description: "Exact 40-character commit tagged for the stable release"
         required: true
         type: string
+      build_number:
+        description: "Optional macOS CFBundleVersion for a replacement build"
+        required: false
+        type: string
+        default: ""
       include_macos:
         description: "Build the signed Mac App Store package"
         type: boolean
@@ -175,9 +185,21 @@ jobs:
           fetch-tags: true
           persist-credentials: false
           submodules: recursive
-      - env:
+      - name: Set release and build versions
+        env:
+          BUILD_NUMBER: ${{ inputs.build_number || needs.validate.outputs.version }}
           VERSION: ${{ needs.validate.outputs.version }}
-        run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "$VERSION"
+        run: |
+          set -euo pipefail
+          ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "$VERSION"
+          if [[ ! "$BUILD_NUMBER" =~ ^[0-9]{1,4}(\.[0-9]{1,2}){0,2}$ ]]; then
+            echo "::error::macOS build number must contain one to three numeric components"
+            exit 1
+          fi
+          jq --arg build "$BUILD_NUMBER" '
+            .bundle.macOS.bundleVersion = $build
+          ' apps/desktop/src-tauri/tauri.conf.app-store.json > "$RUNNER_TEMP/tauri.conf.app-store.json"
+          mv "$RUNNER_TEMP/tauri.conf.app-store.json" apps/desktop/src-tauri/tauri.conf.app-store.json
       - name: Verify Mac App Store configuration
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -331,11 +353,34 @@ jobs:
           set -euo pipefail
 
           asset_output="$RUNNER_TEMP/mac-app-store-assets"
-          asset_source="$RUNNER_TEMP/AppIcon.icon"
+          asset_source="$RUNNER_TEMP/AnarlogAssets.xcassets"
+          extracted_iconset="$RUNNER_TEMP/AppIcon.iconset"
+          iconset="$asset_source/AppIcon.appiconset"
           asset_catalog="apps/desktop/src-tauri/resources/app-store/Assets.car"
           app_store_config="apps/desktop/src-tauri/tauri.conf.app-store.json"
-          mkdir -p "$asset_output" "$(dirname "$asset_catalog")"
-          cp -R apps/desktop/src-tauri/icons/src/stable.icon "$asset_source"
+          mkdir -p "$asset_output" "$asset_source" "$(dirname "$asset_catalog")"
+          iconutil \
+            --convert iconset \
+            --output "$extracted_iconset" \
+            apps/desktop/src-tauri/icons/stable/icon.icns
+          mv "$extracted_iconset" "$iconset"
+          cat > "$iconset/Contents.json" <<'JSON'
+          {
+            "images": [
+              { "filename": "icon_16x16.png", "idiom": "mac", "scale": "1x", "size": "16x16" },
+              { "filename": "icon_16x16@2x.png", "idiom": "mac", "scale": "2x", "size": "16x16" },
+              { "filename": "icon_32x32.png", "idiom": "mac", "scale": "1x", "size": "32x32" },
+              { "filename": "icon_32x32@2x.png", "idiom": "mac", "scale": "2x", "size": "32x32" },
+              { "filename": "icon_128x128.png", "idiom": "mac", "scale": "1x", "size": "128x128" },
+              { "filename": "icon_128x128@2x.png", "idiom": "mac", "scale": "2x", "size": "128x128" },
+              { "filename": "icon_256x256.png", "idiom": "mac", "scale": "1x", "size": "256x256" },
+              { "filename": "icon_256x256@2x.png", "idiom": "mac", "scale": "2x", "size": "256x256" },
+              { "filename": "icon_512x512.png", "idiom": "mac", "scale": "1x", "size": "512x512" },
+              { "filename": "icon_512x512@2x.png", "idiom": "mac", "scale": "2x", "size": "512x512" }
+            ],
+            "info": { "author": "xcode", "version": 1 }
+          }
+          JSON
           xcrun actool \
             "$asset_source" \
             --compile "$asset_output" \
@@ -386,6 +431,7 @@ jobs:
         name: Verify and package Mac App Store application
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          BUILD_NUMBER: ${{ inputs.build_number || needs.validate.outputs.version }}
           INSTALLER_CERT_ID: ${{ steps.apple-store-cert.outputs.installer-cert-id }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
@@ -406,12 +452,19 @@ jobs:
           app_version=$(
             /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist"
           )
+          app_build_number=$(
+            /usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Contents/Info.plist"
+          )
           if [[ "$app_identifier" != "com.hyprnote.desktop" ]]; then
             echo "::error::Mac App Store application has bundle ID $app_identifier"
             exit 1
           fi
           if [[ "$app_version" != "$VERSION" ]]; then
             echo "::error::Mac App Store application has version $app_version, expected $VERSION"
+            exit 1
+          fi
+          if [[ "$app_build_number" != "$BUILD_NUMBER" ]]; then
+            echo "::error::Mac App Store application has build number $app_build_number, expected $BUILD_NUMBER"
             exit 1
           fi
           if [[ ! -f "$app/Contents/embedded.provisionprofile" ]]; then
@@ -507,6 +560,7 @@ jobs:
           APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          BUILD_NUMBER: ${{ inputs.build_number || needs.validate.outputs.version }}
           PKG_PATH: ${{ steps.package.outputs.path }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
@@ -537,6 +591,7 @@ jobs:
           chmod 600 "$key_path"
 
           node workflow-source/scripts/app-store-connect-submit.mjs \
+            --build-version "$BUILD_NUMBER" \
             --bundle-id com.hyprnote.desktop \
             --issuer-id "$APPSTORE_ISSUER_ID" \
             --key-id "$APPSTORE_API_KEY_ID" \
@@ -545,12 +600,14 @@ jobs:
             --version "$VERSION"
       - name: Summarize Mac App Store release
         env:
+          BUILD_NUMBER: ${{ inputs.build_number || needs.validate.outputs.version }}
           SUBMITTED: ${{ inputs.submit_to_stores }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           {
             echo "## Mac App Store"
             echo "- Version: \`$VERSION\`"
+            echo "- Build: \`$BUILD_NUMBER\`"
             echo "- Architecture: Apple Silicon"
             echo "- Submitted to App Review: \`$SUBMITTED\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/desktop/src-tauri/Entitlements.app-store.plist
+++ b/apps/desktop/src-tauri/Entitlements.app-store.plist
@@ -6,8 +6,6 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
-    <key>com.apple.security.network.server</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.personal-information.calendars</key>

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -7,7 +7,7 @@
     <key>NSAudioCaptureUsageDescription</key>
     <string>This app requires access to the system audio to record voice from other participants in the meeting.</string>
     <key>NSContactsUsageDescription</key>
-    <string>This app requires contacts access to function properly.</string>
+    <string>Anarlog uses your contacts to match calendar attendees with names and email addresses saved on your Mac.</string>
     <key>NSCalendarsFullAccessUsageDescription</key>
     <string>This app requires access to your calendar to read events.</string>
     <key>NSRemindersFullAccessUsageDescription</key>

--- a/scripts/app-store-connect-submit.mjs
+++ b/scripts/app-store-connect-submit.mjs
@@ -234,11 +234,12 @@ async function ensureMacVersion(client, app, version) {
   return { appStoreVersion: response.data, alreadySubmitted: false };
 }
 
-async function listBuilds(client, appId, version) {
+async function listBuilds(client, appId, version, buildVersion) {
   const response = await client.request("GET", "/v1/builds", {
     query: {
       "fields[builds]": "processingState,uploadedDate,version",
       "filter[app]": appId,
+      "filter[version]": buildVersion,
       "filter[preReleaseVersion.platform]": "MAC_OS",
       "filter[preReleaseVersion.version]": version,
       limit: 10,
@@ -250,6 +251,7 @@ async function listBuilds(client, appId, version) {
 
 async function waitForBuild({
   appId,
+  buildVersion,
   client,
   pollIntervalMs,
   sleep,
@@ -258,7 +260,7 @@ async function waitForBuild({
 }) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const builds = await listBuilds(client, appId, version);
+    const builds = await listBuilds(client, appId, version, buildVersion);
     const validBuild = builds.find(
       (build) => build.attributes.processingState === "VALID",
     );
@@ -278,7 +280,7 @@ async function waitForBuild({
   }
 
   throw new Error(
-    `Timed out waiting for App Store Connect to process macOS ${version}`,
+    `Timed out waiting for App Store Connect to process macOS ${version} build ${buildVersion}`,
   );
 }
 
@@ -305,7 +307,7 @@ async function ensureReviewSubmission(client, appId, appStoreVersionId) {
       query: {
         "fields[reviewSubmissions]": "platform,state",
         "filter[platform]": "MAC_OS",
-        "filter[state]": "READY_FOR_REVIEW",
+        "filter[state]": "READY_FOR_REVIEW,UNRESOLVED_ISSUES",
         limit: 10,
       },
     },
@@ -393,6 +395,7 @@ async function runAltool(packagePath, keyId, issuerId) {
 }
 
 export async function publishMacApp({
+  buildVersion,
   bundleId,
   client,
   packagePath,
@@ -411,12 +414,13 @@ export async function publishMacApp({
     };
   }
 
-  let builds = await listBuilds(client, app.id, version);
+  let builds = await listBuilds(client, app.id, version, buildVersion);
   if (builds.length === 0) {
     await upload(packagePath);
   }
   const build = await waitForBuild({
     appId: app.id,
+    buildVersion,
     client,
     pollIntervalMs,
     sleep,
@@ -454,6 +458,7 @@ function parseArgs(argv) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const required = [
+    "build-version",
     "bundle-id",
     "issuer-id",
     "key-id",
@@ -476,6 +481,7 @@ async function main() {
     privateKey,
   });
   const result = await publishMacApp({
+    buildVersion: args["build-version"],
     bundleId: args["bundle-id"],
     client,
     packagePath: args.package,

--- a/scripts/app-store-connect-submit.test.mjs
+++ b/scripts/app-store-connect-submit.test.mjs
@@ -137,7 +137,7 @@ test("reuses the editable first version and submits a processed build", async ()
                 resource("builds", "build-id", {
                   processingState: "VALID",
                   uploadedDate: "2026-08-25T00:00:00Z",
-                  version: "1.4.13",
+                  version: "2608.26.1",
                 }),
               ],
             }
@@ -171,6 +171,7 @@ test("reuses the editable first version and submits a processed build", async ()
   };
 
   const result = await publishMacApp({
+    buildVersion: "2608.26.1",
     bundleId: "com.hyprnote.desktop",
     client,
     packagePath: "/tmp/Anarlog.pkg",
@@ -196,6 +197,12 @@ test("reuses the editable first version and submits a processed build", async ()
         request.pathname === "/v1/appStoreVersions/placeholder-id",
     ).body.data.attributes,
     { releaseType: "AFTER_APPROVAL", versionString: "1.4.13" },
+  );
+  assert.equal(
+    requests.find((request) => request.pathname === "/v1/builds").query[
+      "filter[version]"
+    ],
+    "2608.26.1",
   );
   assert.deepEqual(requests.at(-1).body.data.attributes, { submitted: true });
 });
@@ -266,6 +273,7 @@ test("reuses an existing processing build instead of uploading it again", async 
   };
 
   const result = await publishMacApp({
+    buildVersion: "1.4.13",
     bundleId: "com.hyprnote.desktop",
     client,
     packagePath: "/tmp/Anarlog.pkg",
@@ -307,6 +315,7 @@ test("treats an already submitted version as an idempotent success", async () =>
   };
 
   const result = await publishMacApp({
+    buildVersion: "1.4.13",
     bundleId: "com.hyprnote.desktop",
     client,
     packagePath: "/tmp/Anarlog.pkg",
@@ -345,6 +354,7 @@ test("refuses to choose between multiple editable placeholder versions", async (
 
   await assert.rejects(
     publishMacApp({
+      buildVersion: "1.4.13",
       bundleId: "com.hyprnote.desktop",
       client,
       packagePath: "/tmp/Anarlog.pkg",

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -355,8 +355,10 @@ test("Mac App Store builds include a compiled app icon catalog", async () => {
 
   assert.match(storeWorkflow, /name: Compile Mac App Store asset catalog/);
   assert.match(storeWorkflow, /xcrun actool/);
-  assert.match(storeWorkflow, /icons\/src\/stable\.icon/);
-  assert.match(storeWorkflow, /AppIcon\.icon/);
+  assert.match(storeWorkflow, /icons\/stable\/icon\.icns/);
+  assert.match(storeWorkflow, /AppIcon\.appiconset/);
+  assert.match(storeWorkflow, /icon_512x512@2x\.png/);
+  assert.doesNotMatch(storeWorkflow, /icons\/src\/stable\.icon/);
   assert.match(storeWorkflow, /Contents\/Resources\/Assets\.car/);
   assert.match(
     storeWorkflow,
@@ -378,6 +380,31 @@ test("Mac App Store builds include a compiled app icon catalog", async () => {
   assert.equal(
     stableConfig.bundle.macOS.files["Resources/Assets.car"],
     undefined,
+  );
+});
+
+test("keeps Mac App Store privacy metadata and replacement builds reviewable", async () => {
+  const [entitlements, infoPlist, storeWorkflow, submitScript] =
+    await Promise.all([
+      readFile("apps/desktop/src-tauri/Entitlements.app-store.plist", "utf8"),
+      readFile("apps/desktop/src-tauri/Info.plist", "utf8"),
+      readFile(".github/workflows/desktop_store_publish.yaml", "utf8"),
+      readFile("scripts/app-store-connect-submit.mjs", "utf8"),
+    ]);
+
+  assert.doesNotMatch(entitlements, /com\.apple\.security\.network\.server/);
+  assert.match(infoPlist, /NSContactsUsageDescription/);
+  assert.match(
+    infoPlist,
+    /match calendar attendees with names and email addresses saved on your Mac/,
+  );
+  assert.match(storeWorkflow, /build_number:/);
+  assert.match(storeWorkflow, /bundleVersion = \$build/);
+  assert.match(storeWorkflow, /--build-version "\$BUILD_NUMBER"/);
+  assert.match(submitScript, /"filter\[version\]": buildVersion/);
+  assert.match(
+    submitScript,
+    /"filter\[state\]": "READY_FOR_REVIEW,UNRESOLVED_ISSUES"/,
   );
 });
 


### PR DESCRIPTION
## Summary
- remove the unused incoming-network server entitlement
- replace the placeholder Contacts purpose string with a specific explanation
- compile the App Store icon from the repository's existing padded stable icon
- support exact replacement build numbers and rejected-submission resubmission

## Validation
- 30 targeted release and App Store Connect tests pass
- plist validation passes
- generated App Store icon matches the repository's 826px padded stable rendition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Mac App Store signing entitlements, privacy strings, CI packaging, and App Store Connect submission logic—incorrect build numbers or submission handling could block releases, but scope is release automation rather than runtime user data paths.
> 
> **Overview**
> This PR clears Mac App Store review issues and tightens the store publish pipeline for **replacement builds** and **resubmission after rejection**.
> 
> **Privacy and entitlements:** The App Store sandbox plist drops the unused **incoming network server** entitlement. **Contacts** usage text now explains matching calendar attendees to Mac contacts instead of a generic placeholder.
> 
> **Icons:** CI no longer copies `stable.icon` for `actool`. It builds an **AppIcon.appiconset** from `icons/stable/icon.icns` via `iconutil`, then compiles `Assets.car` as before.
> 
> **Build numbers:** `desktop_store_publish` accepts optional **`build_number`** (defaults to the release version). The workflow validates the format, writes **`bundle.macOS.bundleVersion`**, checks **`CFBundleVersion`** on the signed app, and passes **`--build-version`** into App Store Connect submit. The submit script filters builds by **`filter[version]`** and reuses review submissions in **`READY_FOR_REVIEW,UNRESOLVED_ISSUES`** so rejected submissions can be resubmitted without starting from scratch.
> 
> **Tests:** Release provenance and App Store Connect tests assert the new icon path, build-number wiring, entitlement, contacts string, and submission state filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6890736823bb179313626efcc5ec6812fae1b179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->