### PR TITLE
Allow safe App Store replacement builds

### DIFF
--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -115,6 +115,7 @@ jobs:
           persist-credentials: false
       - id: validate
         env:
+          BUILD_NUMBER: ${{ inputs.build_number }}
           CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           EXECUTION_REF: ${{ github.ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -150,7 +151,22 @@ jobs:
             echo "::error::Checked out $checked_out_sha instead of candidate $candidate_sha"
             exit 1
           fi
-          if [[ "$tag_sha" != "$candidate_sha" ]]; then
+          if [[ -n "$BUILD_NUMBER" ]]; then
+            if [[ ! "$BUILD_NUMBER" =~ ^[0-9]{1,4}(\.[0-9]{1,2}){0,2}$ ]]; then
+              echo "::error::macOS build number must contain one to three numeric components"
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$tag_sha" "$candidate_sha"; then
+              echo "::error::Replacement candidate $candidate_sha does not include release tag $tag"
+              exit 1
+            fi
+            comparison=$(gh api "repos/$GITHUB_REPOSITORY/compare/$candidate_sha...main")
+            comparison_status=$(jq -r '.status' <<< "$comparison")
+            if [[ "$comparison_status" != "identical" && "$comparison_status" != "ahead" ]]; then
+              echo "::error::Replacement candidate $candidate_sha is not on main"
+              exit 1
+            fi
+          elif [[ "$tag_sha" != "$candidate_sha" ]]; then
             echo "::error::Tag $tag points to $tag_sha instead of candidate $candidate_sha"
             exit 1
           fi

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -399,6 +399,9 @@ test("keeps Mac App Store privacy metadata and replacement builds reviewable", a
     /match calendar attendees with names and email addresses saved on your Mac/,
   );
   assert.match(storeWorkflow, /build_number:/);
+  assert.match(storeWorkflow, /git merge-base --is-ancestor/);
+  assert.match(storeWorkflow, /compare\/\$candidate_sha\.\.\.main/);
+  assert.match(storeWorkflow, /comparison_status.*identical/);
   assert.match(storeWorkflow, /bundleVersion = \$build/);
   assert.match(storeWorkflow, /--build-version "\$BUILD_NUMBER"/);
   assert.match(submitScript, /"filter\[version\]": buildVersion/);


### PR DESCRIPTION
## Summary
- allow an explicit replacement build number to use a candidate newer than the published release tag
- require the original release tag to be an ancestor of the candidate
- require the candidate to be on main
- preserve exact tag matching for ordinary store releases

## Validation
- 30 targeted release and App Store Connect tests pass
- live 1.4.13 tag is an ancestor of current main
- current main comparison reports identical

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release validation gates for store publication; mistakes could allow publishing from the wrong commit, though ancestor and main checks constrain replacement builds.
> 
> **Overview**
> When **`build_number`** is supplied for a Mac App Store publish, the **`validate`** job no longer requires the candidate commit to match the release tag exactly. Instead it validates the build-number format, requires the published **`desktop_v*`** tag to be an **ancestor** of the candidate, and checks via **`compare/candidate...main`** that the candidate is **identical or ahead** of **`main`**.
> 
> Standard store releases without **`build_number`** keep the existing rule: the release tag must point at the candidate SHA.
> 
> Provenance tests now assert the workflow contains these replacement-build guards alongside the existing **`build_number`** / App Store Connect submit wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06414a27196e24010f22f3f0d454bb07ccd0716a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->