### PR TITLE
Avoid duplicate App Review submission items

### DIFF
--- a/scripts/app-store-connect-submit.mjs
+++ b/scripts/app-store-connect-submit.mjs
@@ -328,27 +328,29 @@ async function ensureReviewSubmission(client, appId, appStoreVersionId) {
     submission = response.data;
   }
 
-  const itemsResponse = await client.request(
-    "GET",
-    `/v1/reviewSubmissions/${submission.id}/items`,
-    { query: { limit: 50 } },
-  );
-  if (!submissionContainsVersion(itemsResponse.data, appStoreVersionId)) {
-    await client.request("POST", "/v1/reviewSubmissionItems", {
-      body: {
-        data: {
-          relationships: {
-            appStoreVersion: {
-              data: { id: appStoreVersionId, type: "appStoreVersions" },
+  if (submission.attributes?.state !== "UNRESOLVED_ISSUES") {
+    const itemsResponse = await client.request(
+      "GET",
+      `/v1/reviewSubmissions/${submission.id}/items`,
+      { query: { limit: 50 } },
+    );
+    if (!submissionContainsVersion(itemsResponse.data, appStoreVersionId)) {
+      await client.request("POST", "/v1/reviewSubmissionItems", {
+        body: {
+          data: {
+            relationships: {
+              appStoreVersion: {
+                data: { id: appStoreVersionId, type: "appStoreVersions" },
+              },
+              reviewSubmission: {
+                data: { id: submission.id, type: "reviewSubmissions" },
+              },
             },
-            reviewSubmission: {
-              data: { id: submission.id, type: "reviewSubmissions" },
-            },
+            type: "reviewSubmissionItems",
           },
-          type: "reviewSubmissionItems",
         },
-      },
-    });
+      });
+    }
   }
 
   await client.request("PATCH", `/v1/reviewSubmissions/${submission.id}`, {

--- a/scripts/app-store-connect-submit.test.mjs
+++ b/scripts/app-store-connect-submit.test.mjs
@@ -290,6 +290,86 @@ test("reuses an existing processing build instead of uploading it again", async 
   assert.equal(buildRequestCount, 2);
 });
 
+test("resubmits an unresolved review without adding its item twice", async () => {
+  const requests = [];
+  const client = {
+    async request(method, pathname, options = {}) {
+      requests.push({ method, pathname, ...options });
+      if (pathname === "/v1/apps") {
+        return { data: [resource("apps", "app-id")] };
+      }
+      if (pathname === "/v1/apps/app-id/appStoreVersions") {
+        return {
+          data: [
+            resource("appStoreVersions", "version-id", {
+              appStoreState: "REJECTED",
+              platform: "MAC_OS",
+              releaseType: "AFTER_APPROVAL",
+              versionString: "1.4.13",
+            }),
+          ],
+        };
+      }
+      if (pathname === "/v1/builds") {
+        return {
+          data: [
+            resource("builds", "replacement-build-id", {
+              processingState: "VALID",
+              version: "2608.26.1",
+            }),
+          ],
+        };
+      }
+      if (pathname === "/v1/appStoreVersions/version-id/relationships/build") {
+        return null;
+      }
+      if (pathname === "/v1/apps/app-id/reviewSubmissions") {
+        return {
+          data: [
+            resource("reviewSubmissions", "submission-id", {
+              platform: "MAC_OS",
+              state: "UNRESOLVED_ISSUES",
+            }),
+          ],
+        };
+      }
+      if (
+        method === "PATCH" &&
+        pathname === "/v1/reviewSubmissions/submission-id"
+      ) {
+        return { data: resource("reviewSubmissions", "submission-id") };
+      }
+      throw new Error(`Unexpected request ${method} ${pathname}`);
+    },
+  };
+
+  const result = await publishMacApp({
+    buildVersion: "2608.26.1",
+    bundleId: "com.hyprnote.desktop",
+    client,
+    packagePath: "/tmp/Anarlog.pkg",
+    pollIntervalMs: 0,
+    sleep: async () => {},
+    upload: async () => assert.fail("replacement build already exists"),
+    version: "1.4.13",
+  });
+
+  assert.deepEqual(result, {
+    alreadySubmitted: false,
+    appStoreVersionId: "version-id",
+    buildId: "replacement-build-id",
+    reviewSubmissionId: "submission-id",
+  });
+  assert.equal(
+    requests.some(
+      (request) =>
+        request.pathname === "/v1/reviewSubmissions/submission-id/items" ||
+        request.pathname === "/v1/reviewSubmissionItems",
+    ),
+    false,
+  );
+});
+
 test("treats an already submitted version as an idempotent success", async () => {
   const requests = [];
   const client = {


### PR DESCRIPTION
## Summary
- reuse an unresolved review submission without adding its existing app-version item again
- keep the normal item-creation path for new ready-for-review submissions
- add a regression test for rejected build replacement and resubmission

## Validation
- 31 targeted release and App Store Connect tests pass
- formatting checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script-only change with a narrow guard on review state; normal first-time submission behavior is unchanged and covered by existing tests plus the new regression case.
> 
> **Overview**
> Fixes App Store Connect resubmission when a review is in **`UNRESOLVED_ISSUES`** (e.g. after rejection and a replacement build). **`ensureReviewSubmission`** now skips listing submission items and creating **`reviewSubmissionItems`** for that state, since the app version is already on the submission—only the final **`submitted: true`** PATCH runs.
> 
> New submissions in **`READY_FOR_REVIEW`** still use the existing add-item-if-missing path. A regression test covers rejected version + replacement build resubmit and asserts no **`/items`** or **`reviewSubmissionItems`** calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5c2a5713a359ef7c603324feb7b4da592e1a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->