### PR TITLE
Move sign out controls to the Account tab

### DIFF
--- a/apps/web/src/lib/account-tabs.test.ts
+++ b/apps/web/src/lib/account-tabs.test.ts
@@ -10,6 +10,7 @@ import {
 test("maps section hashes to the tab that contains them", () => {
   assert.equal(accountTabForSection("plan"), "account");
   assert.equal(accountTabForSection("referrals"), "account");
+  assert.equal(accountTabForSection("session"), "account");
   assert.equal(accountTabForSection("integrations"), "connections");
   assert.equal(accountTabForSection("shares"), "connections");
   assert.equal(accountTabForSection("api-keys"), "developer");
@@ -19,6 +20,10 @@ test("maps section hashes to the tab that contains them", () => {
 test("prefers a section hash over the tab search param", () => {
   assert.equal(
     resolveAccountTab({ tab: "developer", hash: "#referrals" }),
+    "account",
+  );
+  assert.equal(
+    resolveAccountTab({ tab: "developer", hash: "#session" }),
     "account",
   );
   assert.equal(
@@ -44,6 +49,10 @@ test("an empty hash after a tab click does not override the tab param", () => {
 test("lists the sections for a tab in page order", () => {
   assert.deepEqual(
     sectionsForAccountTab("account").map((section) => section.id),
-    ["profile", "plan", "referrals", "danger"],
+    ["profile", "plan", "referrals", "session", "danger"],
+  );
+  assert.deepEqual(
+    sectionsForAccountTab("developer").map((section) => section.id),
+    ["api-keys"],
   );
 });

--- a/apps/web/src/lib/account-tabs.ts
+++ b/apps/web/src/lib/account-tabs.ts
@@ -16,7 +16,7 @@ export const ACCOUNT_TABS = [
   {
     id: "account",
     label: "Account",
-    sectionIds: ["profile", "plan", "referrals", "danger"],
+    sectionIds: ["profile", "plan", "referrals", "session", "danger"],
   },
   {
     id: "connections",
@@ -26,7 +26,7 @@ export const ACCOUNT_TABS = [
   {
     id: "developer",
     label: "Developer",
-    sectionIds: ["api-keys", "session"],
+    sectionIds: ["api-keys"],
   },
 ] as const;
 
@@ -38,12 +38,12 @@ const SECTION_TAB: Record<AccountSectionId, AccountTabId> = {
   profile: "account",
   plan: "account",
   referrals: "account",
+  session: "account",
   danger: "account",
   integrations: "connections",
   devices: "connections",
   shares: "connections",
   "api-keys": "developer",
-  session: "developer",
 };
 
 export function isAccountTabId(value: string): value is AccountTabId {

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -79,6 +79,7 @@ const accountTabPreloaders: Record<AccountTabId, () => Promise<unknown>> = {
       loadProfileInfoSection(),
       loadPlanSection(),
       loadReferralSection(),
+      loadAccountAccessSection(),
       loadDangerAreaSection(),
     ]),
   connections: () =>
@@ -87,8 +88,7 @@ const accountTabPreloaders: Record<AccountTabId, () => Promise<unknown>> = {
       loadDevicesSection(),
       loadSharedNotesSection(),
     ]),
-  developer: () =>
-    Promise.all([loadApiKeysSection(), loadAccountAccessSection()]),
+  developer: () => Promise.all([loadApiKeysSection()]),
 };
 
 function preloadAccountTab(tabId: AccountTabId) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Session controls (sign out / sign out everywhere) currently live on the Developer tab next to Cloud API keys. That’s the wrong home — signing out is an account action, not a developer setting.

This moves the Session controls section onto the Account tab, just above Danger area. `#session` deep links now open Account instead of Developer. Developer keeps only Cloud API keys.

## Testing
- `node --test --experimental-strip-types src/lib/account-tabs.test.ts` (web)
- `pnpm -F web typecheck`
- `dprint fmt` / `dprint check` on the changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4098ca0-bf0e-41e9-97d3-13bf774ec143?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4098ca0-bf0e-41e9-97d3-13bf774ec143&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

