### PR TITLE
Align auth sign-in icons and add SSO icon

### DIFF
--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -849,11 +849,11 @@ function AuthProviderContent({
   children: ReactNode;
 }) {
   return (
-    <span className="flex w-56 items-center gap-3 text-left">
-      <span className="flex size-[18px] shrink-0 items-center justify-center">
+    <span className="grid w-56 grid-cols-[18px_1fr] items-center gap-3 text-left">
+      <span className="flex size-[18px] items-center justify-center overflow-hidden [&_iconify-icon]:block">
         {icon}
       </span>
-      {children}
+      <span>{children}</span>
     </span>
   );
 }

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -1,8 +1,8 @@
 import { Icon } from "@iconify-icon/react";
-import { ArrowLeft, Envelope } from "@phosphor-icons/react";
+import { ArrowLeft, Buildings, Envelope } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
-import { useRef, useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { z } from "zod";
 
 import { cn } from "@anlg/utils";
@@ -177,8 +177,11 @@ function Component() {
                 onClick={() => setView("email")}
                 className={authSecondaryButtonClassName}
               >
-                <Envelope className="size-4" />
-                Sign in with Email
+                <AuthProviderContent
+                  icon={<Envelope className="size-[18px]" aria-hidden="true" />}
+                >
+                  Sign in with Email
+                </AuthProviderContent>
               </button>
             )}
             {showEmail && (
@@ -186,7 +189,13 @@ function Component() {
                 onClick={() => setView("sso")}
                 className={authSecondaryButtonClassName}
               >
-                Sign in with SSO
+                <AuthProviderContent
+                  icon={
+                    <Buildings className="size-[18px]" aria-hidden="true" />
+                  }
+                >
+                  Sign in with SSO
+                </AuthProviderContent>
               </button>
             )}
           </div>
@@ -832,6 +841,23 @@ function MagicLinkForm({
   );
 }
 
+function AuthProviderContent({
+  icon,
+  children,
+}: {
+  icon: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <span className="flex w-56 items-center gap-3 text-left">
+      <span className="flex size-[18px] shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      {children}
+    </span>
+  );
+}
+
 function OAuthButton({
   flow,
   scheme,
@@ -901,16 +927,19 @@ function OAuthButton({
       disabled={isPending}
       className={authSecondaryButtonClassName}
     >
-      {provider === "google" && (
-        <Icon icon="logos:google-icon" width="18" height="18" />
-      )}
-      {provider === "github" && (
-        <Icon icon="logos:github-icon" width="18" height="18" />
-      )}
-      {provider === "azure" && (
-        <Icon icon="logos:microsoft-icon" width="18" height="18" />
-      )}
-      Sign in with {getOAuthProviderName(provider)}
+      <AuthProviderContent
+        icon={
+          provider === "google" ? (
+            <Icon icon="logos:google-icon" width="18" height="18" />
+          ) : provider === "github" ? (
+            <Icon icon="logos:github-icon" width="18" height="18" />
+          ) : (
+            <Icon icon="logos:microsoft-icon" width="18" height="18" />
+          )
+        }
+      >
+        Sign in with {getOAuthProviderName(provider)}
+      </AuthProviderContent>
     </button>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The welcome card’s provider buttons were centered as independent groups, so “Sign in with” drifted per row and SSO had no icon.

This keeps every button on a shared 18px icon column + label row so icons and “Sign in with” line up, and adds Phosphor’s `Buildings` icon for SSO to match the Email envelope.

## Testing
- [ ] Open `/auth` and confirm Google, Microsoft, GitHub, Email, and SSO icons and labels share one vertical alignment
- [ ] Confirm SSO shows the buildings icon and still opens the SSO domain view

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-805d4a8c-3881-48f3-9abb-440318801b34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-805d4a8c-3881-48f3-9abb-440318801b34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

