### PR TITLE
Remove gray tiles around AI provider icons

### DIFF
--- a/apps/desktop/src/settings/ai/shared/ai-icon-slot.test.tsx
+++ b/apps/desktop/src/settings/ai/shared/ai-icon-slot.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { AiIconSlot, ProviderIconSlot } from "./index";
+
+describe("provider icon slot", () => {
+  test("renders product marks without gray tiles", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderIconSlot>
+        <svg />
+      </ProviderIconSlot>,
+    );
+
+    expect(markup).not.toContain("bg-muted");
+    expect(markup).not.toContain("rounded-md");
+    expect(markup).toContain("size-5");
+    expect(markup).toContain("size-full");
+  });
+
+  test("keeps letter-badge backgrounds when provided", () => {
+    const markup = renderToStaticMarkup(
+      <AiIconSlot className="rounded-md bg-amber-50">G</AiIconSlot>,
+    );
+
+    expect(markup).toContain("bg-amber-50");
+    expect(markup).toContain("rounded-md");
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -154,7 +154,7 @@ export function AiIconSlot({
       aria-label={title}
       data-slot="ai-icon"
       className={cn([
-        "bg-muted text-foreground flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-md",
+        "text-foreground flex size-5 shrink-0 items-center justify-center overflow-hidden",
         "[&_[data-slot=provider-brand-icon]]:[filter:var(--provider-brand-filter)]",
         className,
       ])}
@@ -162,7 +162,7 @@ export function AiIconSlot({
       <span
         data-slot="ai-icon-art"
         className={cn([
-          "flex size-3.5 items-center justify-center overflow-hidden",
+          "flex size-full items-center justify-center overflow-hidden",
           "[&>img]:block [&>img]:size-full [&>svg]:block [&>svg]:size-full [&>svg]:text-inherit",
         ])}
       >

--- a/apps/desktop/src/settings/ai/stt/model-icon.tsx
+++ b/apps/desktop/src/settings/ai/stt/model-icon.tsx
@@ -72,7 +72,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "G",
       title: "GGML",
-      className: "border-amber-200 bg-amber-50 text-amber-700",
+      className: "rounded-md border-amber-200 bg-amber-50 text-amber-700",
     };
   }
 
@@ -80,7 +80,7 @@ export function getLocalModelIcon(model: string): ModelIconSpec | null {
     return {
       label: "S",
       title: "Soniqo",
-      className: "border-blue-200 bg-blue-50 text-blue-700",
+      className: "rounded-md border-blue-200 bg-blue-50 text-blue-700",
     };
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Provider and model icons in Transcription and Intelligence settings were sitting inside small muted rounded squares, which made the marks look smaller and uneven.

This drops the gray tile wrapper and lets each mark fill the same 20px slot so brand logos, SVGs, and local model icons stay visually consistent. Letter-only fallbacks (GGML / Soniqo) still keep their colored rounded badges.

**Checks run**
- `pnpm exec dprint fmt` / `dprint check` on the changed files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93d80f85-06f3-41b5-9e80-ea0616429a90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93d80f85-06f3-41b5-9e80-ea0616429a90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

