### PR TITLE
Stop automatic Mac App Store submissions

### DIFF
--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -573,7 +573,7 @@ jobs:
     with:
       version: ${{ needs.parse.outputs.version }}
       candidate_sha: ${{ needs.parse.outputs.candidate_sha }}
-      include_macos: true
+      include_macos: false
       include_windows: true
       submit_to_stores: true
     secrets:

--- a/.github/workflows/desktop_store_publish.yaml
+++ b/.github/workflows/desktop_store_publish.yaml
@@ -19,7 +19,7 @@ on:
       include_macos:
         description: "Build the signed Mac App Store package"
         type: boolean
-        default: true
+        default: false
       include_windows:
         description: "Prepare the Microsoft Store package update"
         type: boolean
@@ -83,7 +83,7 @@ on:
       include_macos:
         description: "Build the signed Mac App Store package"
         type: boolean
-        default: true
+        default: false
       include_windows:
         description: "Prepare the Microsoft Store package update"
         type: boolean

--- a/scripts/desktop-release-provenance.test.mjs
+++ b/scripts/desktop-release-provenance.test.mjs
@@ -268,7 +268,7 @@ test("repository release workflows match the authored release plan", async () =>
   verifyWorkflowPlatformCoverage({ publishWorkflow, cdWorkflow });
 });
 
-test("stable desktop releases submit both store packages", async () => {
+test("stable desktop releases submit only the Microsoft Store package", async () => {
   const [publishWorkflow, storeWorkflow] = await Promise.all([
     readFile(".github/workflows/desktop_publish.yaml", "utf8"),
     readFile(".github/workflows/desktop_store_publish.yaml", "utf8"),
@@ -294,7 +294,7 @@ test("stable desktop releases submit both store packages", async () => {
     storePublishJob,
     /uses: \.\/\.github\/workflows\/desktop_store_publish\.yaml/,
   );
-  assert.match(storePublishJob, /include_macos: true/);
+  assert.match(storePublishJob, /include_macos: false/);
   assert.match(storePublishJob, /include_windows: true/);
   assert.match(storePublishJob, /submit_to_stores: true/);
   assert.doesNotMatch(storePublishJob, /secrets: inherit/);


### PR DESCRIPTION
- disable macOS App Store publishing for stable desktop releases
- default manual store runs to macOS disabled
- keep Microsoft Store publishing unchanged

Test: node --test scripts/desktop-release-provenance.test.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which store channels receive updates on every stable release; Microsoft Store behavior is unchanged but Mac App Store updates now require a deliberate manual workflow run.
> 
> **Overview**
> **Stable desktop releases no longer build or submit to the Mac App Store** as part of the automated `store-publish` step. The publish workflow now calls `desktop_store_publish` with `include_macos: false` while keeping `include_windows: true` and `submit_to_stores: true`, so **Microsoft Store submission stays automatic**.
> 
> The reusable store workflow’s `include_macos` input **defaults to `false`** for both `workflow_call` and manual `workflow_dispatch`, so ad-hoc runs opt out of macOS unless explicitly enabled. The Mac App Store job path in that workflow is unchanged and can still be triggered manually.
> 
> Release provenance tests were updated to assert **Microsoft Store–only** automatic store submission (`include_macos: false` on the `store-publish` job).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc738c1463cc578aaa3e8f8dfa4d954252bb53b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->