### PR TITLE
Record already-applied OAuth repair migrations

### DIFF
--- a/supabase/migrations/20260825172931_repair_cloud_mcp_oauth_hook.sql
+++ b/supabase/migrations/20260825172931_repair_cloud_mcp_oauth_hook.sql
@@ -1,0 +1,40 @@
+-- Repair environments where the OAuth audience wrapper was recorded but the
+-- underlying function replacement did not persist.
+DO $$
+BEGIN
+  IF to_regprocedure('public.custom_access_token_hook_base(jsonb)') IS NULL THEN
+    ALTER FUNCTION public.custom_access_token_hook(jsonb)
+      RENAME TO custom_access_token_hook_base;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+DECLARE
+  claims jsonb;
+BEGIN
+  event := public.custom_access_token_hook_base(event);
+  claims := event->'claims';
+
+  IF NULLIF(claims->>'client_id', '') IS NOT NULL THEN
+    claims := jsonb_set(
+      claims,
+      '{aud}',
+      '["authenticated", "https://api.anarlog.so/mcp"]'::jsonb
+    );
+    event := jsonb_set(event, '{claims}', claims);
+  END IF;
+
+  RETURN event;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+  TO supabase_auth_admin;
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+  FROM authenticated, anon, public;

--- a/supabase/migrations/20260825173233_repair_cloud_mcp_oauth_user_verification.sql
+++ b/supabase/migrations/20260825173233_repair_cloud_mcp_oauth_user_verification.sql
@@ -1,0 +1,40 @@
+-- Repair environments where this RPC was recorded in migration history but
+-- is missing from the deployed schema.
+CREATE OR REPLACE FUNCTION public.verify_cloud_api_user(p_user_id uuid)
+RETURNS TABLE (status text)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_enabled boolean;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RETURN QUERY SELECT 'unauthorized'::text;
+    RETURN;
+  END IF;
+
+  IF NOT private.cloud_api_user_has_pro(p_user_id) THEN
+    RETURN QUERY SELECT 'subscription_required'::text;
+    RETURN;
+  END IF;
+
+  SELECT COALESCE(settings.enabled, false) INTO v_enabled
+  FROM (SELECT 1) AS singleton
+  LEFT JOIN public.api_cloud_settings AS settings
+    ON settings.user_id = p_user_id;
+
+  IF NOT v_enabled THEN
+    RETURN QUERY SELECT 'cloud_api_not_enabled'::text;
+    RETURN;
+  END IF;
+
+  RETURN QUERY SELECT 'ok'::text;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.verify_cloud_api_user(uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.verify_cloud_api_user(uuid)
+  TO service_role;


### PR DESCRIPTION
Production already has 20260825172931 and 20260825173233 from the oauth-connector branch deploy. Add those files on main so db_cd can apply the pending SSO and invitation migrations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth token claims and a SECURITY DEFINER RPC used for cloud API access checks; repair logic is conditional but wrong ordering could affect JWT audience or verification behavior on fresh applies.
> 
> **Overview**
> Adds two Supabase migration files that were already deployed from the oauth-connector branch but were missing on **main**, so `db_cd` can reconcile history and run later SSO/invitation migrations.
> 
> The first migration **repairs** the access-token hook: if needed it renames the existing `custom_access_token_hook` to `custom_access_token_hook_base`, then installs a wrapper that delegates to the base hook and, when `client_id` is present, sets JWT `aud` to `authenticated` and `https://api.anarlog.so/mcp`. Execute is limited to `supabase_auth_admin`.
> 
> The second **re-creates** `verify_cloud_api_user(uuid)` for environments where the migration was recorded but the function is absent. It returns status codes for unauthorized users, missing Pro subscription, disabled cloud API settings, or `ok`, and grants execute only to `service_role`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 327f21878404b2373a56b96a31db99708e5716ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->