### PR TITLE
Decouple QA from desktop releases

### DIFF
--- a/.agents/skills/qa-cli-mcp-api/SKILL.md
+++ b/.agents/skills/qa-cli-mcp-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-cli-mcp-api
-description: Select and run risk-based QA for Anarlog's CLI, webhooks, stdio MCP, hosted Cloud API, and remote MCP. Test only affected lanes for a branch or regression; use every lane only for an explicit programmatic-interface release gate.
+description: Select and run explicitly requested, risk-based QA for Anarlog's CLI, webhooks, stdio MCP, hosted Cloud API, and remote MCP. Test only affected lanes unless comprehensive coverage is requested.
 ---
 
 # QA: CLI, MCP, and API
@@ -8,6 +8,9 @@ description: Select and run risk-based QA for Anarlog's CLI, webhooks, stdio MCP
 Default to the smallest set of programmatic-interface lanes that can prove the
 change. Automated tests are necessary but do not replace a live smoke test when
 the changed boundary is only exercised by a real client or deployment.
+
+This QA workflow is independent from releasing. A release request alone does
+not invoke it, and its results do not approve or block a release.
 
 ## Choose the scope first
 
@@ -44,12 +47,11 @@ deployment, account, fixture, or client is unavailable, mark that check
 `BLOCKED`; do not substitute unrelated lanes. Stop when the mapped risks are
 covered.
 
-### Full interface release-gate mode
+### Comprehensive Interface QA
 
 Run every fixture, baseline, live lane, lifecycle case, privacy check, and
-cross-surface comparison below only when the user explicitly requests full
-programmatic-interface QA or a release is being gated. Any required `FAIL` or
-`BLOCKED` result prevents release approval.
+cross-surface comparison below only when the user explicitly requests full or
+comprehensive programmatic-interface QA.
 
 ## Safety and evidence
 
@@ -63,13 +65,13 @@ programmatic-interface QA or a release is being gated. Any required `FAIL` or
   Remove that directory and revoke all generated keys after the run.
 - Record the exact candidate commit, app version, API deployment, Supabase
   migration version, operating system, and client versions.
-- In a GitButler workspace, use the selected branch tip from
-  `but status --format json`; do not use the synthetic workspace `HEAD` as
-  release provenance.
+- In a GitButler workspace, identify the selected branch tip with `but status`
+  and inspect it with `but show <branch>`; do not use the synthetic workspace
+  `HEAD` as the candidate identity.
 - Mark a lane `BLOCKED`, not `PASS`, when its required deployment, account,
   fixture, or client is unavailable.
 
-## Full release-gate fixture
+## Comprehensive QA Fixture
 
 Create two completed QA meetings through the desktop app:
 
@@ -90,7 +92,7 @@ The fixture must include:
 Record the meeting IDs and expected visible values. Do not seed SQLite or
 Postgres directly for the live happy-path tests.
 
-## Full release-gate automated baseline
+## Comprehensive Automated Baseline
 
 Run from the repository root:
 
@@ -110,7 +112,7 @@ pnpm exec dprint check
 
 Require the CLI and MCP contract snapshots, OpenAPI composition tests,
 authentication tests, desktop account-switch tests, and database policy tests
-to pass without updating snapshots or generated clients during the gate.
+to pass without updating snapshots or generated clients during the run.
 
 If the change touches a shared DTO or generated client, regenerate it using the
 repository command that owns the artifact, then require a clean second
@@ -248,10 +250,10 @@ or fields outside the disclosed server-readable copy.
 
 For targeted mode, report the candidate branch/commit, base, selected lane and
 risk, `PASS`/`FAIL`/`BLOCKED`, and a one-line evidence note. List unrelated
-lanes once as `NOT APPLICABLE`, and say explicitly that the result is not full
-interface release certification.
+lanes once as `NOT APPLICABLE`, and say explicitly that the result is not
+comprehensive interface QA.
 
-For full release-gate mode, produce one table with rows for:
+For comprehensive mode, produce one table with rows for:
 
 - automated baseline;
 - CLI;
@@ -267,4 +269,5 @@ Use `PASS`, `FAIL`, or `BLOCKED` with a one-line evidence note. Include the
 candidate and deployment identifiers, fixture marker, clients tested, and
 redacted response artifact locations. List every skipped negative case.
 
-Do not approve the release when any required row is `FAIL` or `BLOCKED`.
+Any required `FAIL` or `BLOCKED` result means comprehensive QA did not pass.
+Report that outcome without inferring release approval or blocking.

--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -1,26 +1,29 @@
 ---
 name: qa-critical-ux
-description: QA the critical Pro user journey before a desktop release — onboards from scratch, launches without hanging, captures microphone and system audio, and produces an automated summary. Use before cutting a stable release or when asked to QA the app.
+description: QA Anarlog's critical Pro user journey when explicitly asked — onboarding, responsive launch, microphone and system-audio capture, and automated summaries.
 ---
 
 # QA: Critical User Experience
 
-The release gate is one thing: **the Pro user journey works, starting from
-onboarding**.
+This is a standalone QA workflow. Run it only when the user explicitly asks
+for QA; a release request alone does not invoke it. QA results do not approve
+or block a release.
+
+Keep the QA scope focused on the Pro user journey, starting from onboarding:
 
 1. The app launches and never hangs.
 2. Onboarding completes from scratch: permissions, sign-in, provider setup.
 3. A recording captures both microphone and system audio.
 4. Stopping the recording produces an automated summary.
 
-Everything else is explicitly not a gate. Do not expand the run because more
-checks are imaginable.
+Everything else is outside this skill's scope. Do not expand the run because
+more checks are imaginable.
 
-## Not a gate — tracked in Linear instead
+## Out of Scope — Tracked in Linear Instead
 
 If you hit a failure in one of these areas incidentally, record it as an
-informational note against the ticket and keep going. Do not patch the release
-candidate, block publication, or run dedicated fixtures/matrices for them.
+informational note against the ticket and keep the requested QA focused. Do
+not run dedicated fixtures or matrices for them.
 
 - AEC quality (echo leakage, residual-echo metrics, double-talk): `ANLG-98`
 - Automatic speaker identification / voiceprints: `ANLG-222`
@@ -30,9 +33,8 @@ candidate, block publication, or run dedicated fixtures/matrices for them.
 - CloudSync activity deferral, leases, transcript-integrity hashes: `ANLG-287`
 - On-device STT/LLM provider matrix: `ANLG-288`
 
-AEC and speaker identification return to being gates only when their issues
-are completed; real-device and real-participant evaluation belongs to
-`ANLG-284`, not to this checklist.
+Real-device and real-participant evaluation belongs to `ANLG-284`, not to this
+checklist.
 
 ## Setup
 
@@ -52,16 +54,16 @@ evaluates process-scoped permissions against the bundle identity. Do not run
 the executable under `Contents/MacOS` directly. Reuse an already-current
 bundle with `--launch-only`.
 
-Pin release-gate builds to the intended candidate commit:
+When QA targets a specific candidate, pin the build to that commit:
 
 ```bash
 ANARLOG_QA_GIT_SHA=<candidate-commit-sha> \
   .agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
 ```
 
-In a GitButler workspace, take the branch tip's full `commitId` from
-`but status --format json`; `git rev-parse HEAD` is a synthetic workspace
-commit and is not release provenance.
+In a GitButler workspace, identify the branch tip with `but status` and inspect
+it with `but show <branch>`; `git rev-parse HEAD` is a synthetic workspace
+commit and is not the candidate identity.
 
 A freshly rebuilt Dev bundle can trigger a login-Keychain prompt for the E2EE
 recovery key (its code-signing hash changed). Enter the password the user
@@ -75,8 +77,8 @@ helper's preflight enforces this.
 
 ### Start from onboarding
 
-Dev and staging runs begin at first launch, not in an already-configured app.
-Reset the channel before the run:
+When Dev or staging QA is requested from first launch, reset that channel
+before the run:
 
 1. Quit the app, then delete its app data so `app.db` is gone:
 
@@ -157,22 +159,24 @@ From-scratch onboarding evidence comes from the Dev and staging passes.
   for the untitled note, and a transcript is attached to the session.
 - Restart the app: the note, transcript, and summary are still there.
 
-## Release-candidate order
+## Choose the Requested Channel
 
-1. Run the checklist on a Dev build of the exact candidate SHA from a clean
-   checkout (`git_dirty=false` in the helper manifest; `git_head_sha` is the
-   candidate commit, not GitButler's synthetic HEAD). The manifest is
-   `${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target-v2}/.anarlog-native-dev-qa-manifest`.
-2. Trigger `desktop_cd.yaml` with `channel=staging` from that exact SHA and
-   verify the Actions run's head SHA matches the manifest. Download that
-   run's artifact (`gh run download <run-id> --name
-   hyprnote-staging-macos-silicon` — never a "latest staging" download),
-   record the DMG SHA-256, install it, reset the staging channel, and repeat
-   the checklist from onboarding.
-3. Stable is allowed only when Dev and that exact staging artifact pass for
-   the final `main` SHA. After stable publishes, download the release DMG,
-   record its SHA-256, install, verify the reported version, and run the
-   checklist once more against the existing stable data (no reset).
+Run only the channel or channels the user requests. If no channel is
+specified, default to the native Dev build and report staging and stable as
+`NOT REQUESTED`.
+
+- **Dev:** Run the checklist on the requested commit from a clean checkout
+  (`git_dirty=false` in the helper manifest; `git_head_sha` is the candidate
+  commit, not GitButler's synthetic HEAD). The manifest is
+  `${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target-v2}/.anarlog-native-dev-qa-manifest`.
+- **Staging:** Trigger `desktop_cd.yaml` with `channel=staging` from the
+  requested SHA. Verify the Actions run's head SHA, download that run's
+  artifact (`gh run download <run-id> --name
+  hyprnote-staging-macos-silicon` — never a "latest staging" download), record
+  the DMG SHA-256, install it, reset staging, and run from onboarding.
+- **Stable:** When explicitly requested, download the named release DMG,
+  record its SHA-256, install it, verify the reported version, and run against
+  the existing stable data without resetting it.
 
 Do not repurpose the Dev helper as a staging build; staging evidence must come
 from the signed `desktop_cd.yaml` artifact.
@@ -188,7 +192,8 @@ from the signed `desktop_cd.yaml` artifact.
 
 ## Reporting
 
-Report the candidate SHA, app version, artifact SHA-256s (staging/stable when
-applicable), and PASS/FAIL with one line of evidence for each of the four
-checklist items. Any FAIL or SHA mismatch blocks release. Failures in
-non-gate areas go to their Linear ticket as informational notes.
+Report the requested channel, candidate SHA, app version, applicable artifact
+SHA-256s, and PASS/FAIL with one line of evidence for each of the four
+checklist items. A FAIL or SHA mismatch means the QA run failed; it does not
+automatically block a release. Out-of-scope failures go to their Linear ticket
+as informational notes.

--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -13,34 +13,17 @@ Use this for stable desktop releases. A stable release must come from `main`, af
 
 Do not trigger a stable release from an unmerged branch. First make the changelog up to date, merge that changelog change to `main`, then run the stable release from `main`.
 
-## QA Gate
+## Scope Boundary
 
-After the changelog is merged to `main`, read and run
-`../qa-critical-ux/SKILL.md` against that final commit. Require a recorded PASS
-for both:
+Release and QA are separate, explicitly requested workflows. Do not read or
+run `qa-critical-ux` or `qa-cli-mcp-api` solely because the user asked for a
+release. A release does not require a QA report or QA PASS.
 
-- native Dev QA pinned with `ANARLOG_QA_GIT_SHA` and a helper manifest with
-  `git_dirty=false`
-- the run-scoped staging artifact whose Actions head SHA exactly matches the
-  Dev manifest's `git_head_sha`
+If the user explicitly asks for both release and QA, follow the requested
+order and report the outcomes separately. Do not infer that a QA result
+approves or blocks the release.
 
-The QA gate is the Pro user journey only: launch without hanging, capture
-microphone and system audio, and produce an automated summary. AEC quality
-(`ANLG-98`), automatic speaker identification (`ANLG-222`), real-world capture
-(`ANLG-284`), and the deferred QA lanes (`ANLG-285`–`ANLG-288`) are explicitly
-non-blocking; record incidental failures against their tickets and do not
-delay a release, patch the candidate, or run dedicated fixtures or matrices
-for them. AEC and speaker identification resume as gates only when their
-issues are completed.
-
-The manifest's `git_head_sha` is the exact final `main` commit, including the
-changelog, not a synthetic GitButler workspace HEAD. The report must include
-that Dev SHA, staging run URL and head SHA, staging artifact SHA-256, and the
-applicable critical checklist results. Any applicable failure, missing
-evidence, SHA mismatch, rebuild, or later source change blocks stable unless
-the user explicitly waives that specific gate. The non-gate exclusions above
-(`ANLG-98`, `ANLG-222`, `ANLG-284`–`ANLG-288`) are already authorized policy,
-not missing evidence.
+## Release Workflow Requirements
 
 This release path approves macOS, Windows, and Linux. Mobile remains closed.
 The patched CloudSync vendor bundle is rebuilt from source and
@@ -123,8 +106,7 @@ Only after the changelog is accurate and validation passes:
 3. Wait for CI and required review state to be clear.
 4. Merge the changelog PR to `main`.
 5. Verify `main` contains `packages/changelog/content/<version>.md`.
-6. Record the resulting `main` SHA and complete the QA Gate against that exact
-   commit before triggering stable.
+6. Record the resulting `main` SHA as the release candidate.
 
 If using GitButler, prefer:
 
@@ -140,8 +122,8 @@ Use actual IDs from `but diff` / `but status -fv`; do not invent IDs.
 
 ## Trigger Stable Release
 
-After the changelog merge and QA Gate pass on the same `main` SHA, verify
-`main` has not moved, then build the stable candidate without publishing:
+After the changelog merge, verify `main` has not moved, then build the stable
+candidate without publishing:
 
 ```bash
 gh workflow run desktop_cd.yaml \
@@ -158,12 +140,12 @@ gh run view <run-id> --json headSha,url
 gh run watch <run-id>
 ```
 
-The run's `headSha` must equal the Dev/staging candidate SHA. A mismatch blocks
-acceptance even if the workflow succeeds.
+The run's `headSha` must equal the recorded release-candidate SHA. A mismatch
+blocks acceptance even if the workflow succeeds.
 
-Do not use GitHub's rerun button for a failed stable candidate or Linux audio
-gate. Dispatch a fresh run instead; publication only accepts first-attempt run
-IDs so evidence cannot be mixed across attempts.
+Do not use GitHub's rerun button for a failed stable candidate or optional
+Linux audio QA run. Dispatch a fresh run instead; publication only accepts
+first-attempt run IDs so evidence cannot be mixed across attempts.
 
 The dry-run workflow must:
 
@@ -205,15 +187,9 @@ Before reporting success, capture:
 - whether CrabNebula publish completed
 - changelog URL
 - stable DMG SHA-256
-- installed stable critical-QA PASS
 
 If the workflow fails, inspect the failed job logs with:
 
 ```bash
 gh run view <run-id> --log-failed
 ```
-
-After the workflow succeeds, follow the QA skill's post-publish stable gate:
-download the matching DMG from the GitHub release, install it, and use Computer
-Use to repeat the core checks. Do not declare the release complete until both
-the stable workflow and installed stable QA succeed.

--- a/.cursor/skills/qa-cli-mcp-api/SKILL.md
+++ b/.cursor/skills/qa-cli-mcp-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-cli-mcp-api
-description: Select and run risk-based QA for Anarlog's CLI, webhooks, stdio MCP, hosted Cloud API, and remote MCP. Test only affected lanes for a branch or regression; use every lane only for an explicit programmatic-interface release gate.
+description: Select and run explicitly requested, risk-based QA for Anarlog's CLI, webhooks, stdio MCP, hosted Cloud API, and remote MCP. Test only affected lanes unless comprehensive coverage is requested.
 ---
 
 # QA: CLI, MCP, and API

--- a/.cursor/skills/qa-critical-ux/SKILL.md
+++ b/.cursor/skills/qa-critical-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-critical-ux
-description: QA the critical Pro user journey before a desktop release — onboards from scratch, launches without hanging, captures microphone and system audio, and produces an automated summary. Use before cutting a stable release or when asked to QA the app.
+description: QA Anarlog's critical Pro user journey when explicitly asked — onboarding, responsive launch, microphone and system-audio capture, and automated summaries.
 ---
 
 # QA: Critical User Experience


### PR DESCRIPTION
Make release and QA skills independently invoked workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill instructions; no runtime, CI, or release workflow code is modified.
> 
> **Overview**
> **Release and QA agent skills are now separate, opt-in workflows.** Asking for a stable release no longer instructs agents to run `qa-critical-ux` or `qa-cli-mcp-api`, and QA PASS/FAIL is documented as not approving or blocking a release.
> 
> The **release** skill drops the former QA Gate (Dev + staging artifact critical UX) and post-publish stable QA; after changelog merge it only records the `main` SHA and continues with `desktop_cd` / publish. Linux audio QA is framed as optional, not a publish gate.
> 
> **QA skills** state they run only when explicitly requested. CLI/MCP/API “full release-gate” language becomes **Comprehensive Interface QA** (user-requested only). Critical UX replaces the fixed Dev→staging→stable release-candidate sequence with **requested channels** (default Dev; staging/stable as `NOT REQUESTED` unless asked). GitButler guidance is aligned (`but status` / `but show` instead of JSON-only provenance wording).
> 
> Cursor skill stubs mirror the updated descriptions and still point at `.agents/skills/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5bc74bcd3202c8f5bc6bdea380b5d9842fdc12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->