### PR TITLE
Keep live STT connections across API deploys

### DIFF
--- a/.github/scripts/deploy_api_drain.py
+++ b/.github/scripts/deploy_api_drain.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Deploy anarlog-ai without cutting live STT meetings.
+
+Fly blue/green cordons old machines and then SIGTERMs them immediately.
+`kill_timeout` maxes out at 300s, which is shorter than a meeting, so this
+script instead:
+
+1. Builds and pushes a new image
+2. Starts cordoned replacements with the current machine configs and new image
+3. Adds the replacements to Fly Proxy and waits for routing to propagate
+4. Cordons the previous serving set and waits for routing to propagate
+5. Sends SIGUSR1 so those machines reject new STT and exit once idle
+6. Destroys leftover stopped+cordoned machines from earlier drains
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import subprocess
+import sys
+import time
+import tomllib
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+FLY_API_TIMEOUT_SECONDS = 60
+FLY_API_RETRY_ATTEMPTS = 5
+FLY_API_RETRY_INITIAL_DELAY_SECONDS = 0.5
+PROXY_PROPAGATION_SECONDS = 10
+DRAIN_PROTOCOL_METADATA_KEY = "anarlog_drain_protocol"
+DRAIN_PROTOCOL_METADATA_VALUE = "sigusr1-v1"
+
+
+class DeployError(RuntimeError):
+    pass
+
+
+class FlyApiError(DeployError):
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def is_cordoned(machine: dict[str, Any]) -> bool:
+    if "cordoned" in machine:
+        return bool(machine["cordoned"])
+    config = machine.get("config") or {}
+    metadata = config.get("metadata") or {}
+    return str(metadata.get("fly_cordoned", "")).lower() in {"1", "true"}
+
+
+def is_stopped(machine: dict[str, Any]) -> bool:
+    return machine.get("state") in {"stopped", "suspended"}
+
+
+def is_started(machine: dict[str, Any]) -> bool:
+    return machine.get("state") == "started"
+
+
+def supports_session_drain(machine: dict[str, Any]) -> bool:
+    config = machine.get("config") or {}
+    metadata = config.get("metadata") or {}
+    return metadata.get(DRAIN_PROTOCOL_METADATA_KEY) == DRAIN_PROTOCOL_METADATA_VALUE
+
+
+def serving_machines(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [machine for machine in machines if not is_cordoned(machine)]
+
+
+def stopped_cordoned_machines(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        machine for machine in machines if is_cordoned(machine) and is_stopped(machine)
+    ]
+
+
+def checks_passing(machine: dict[str, Any]) -> bool:
+    if not is_started(machine) or machine.get("host_status") not in {None, "ok"}:
+        return False
+
+    raw_checks = machine.get("checks") or machine.get("Checks")
+    if isinstance(raw_checks, dict):
+        checks = list(raw_checks.values())
+    elif isinstance(raw_checks, list):
+        checks = raw_checks
+    else:
+        return False
+
+    statuses = [
+        str(
+            check.get("status") or check.get("Status") or ""
+            if isinstance(check, dict)
+            else check
+        ).lower()
+        for check in checks
+    ]
+    return bool(statuses) and all(
+        status in {"passing", "success"} for status in statuses
+    )
+
+
+def image_ref(app: str, version: str) -> str:
+    return f"registry.fly.io/{app}:api-{version}"
+
+
+def fly(*args: str) -> None:
+    command = ["flyctl", *args]
+    print("+", " ".join(command), file=sys.stderr)
+    subprocess.run(command, check=True)
+
+
+def api_request(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    query: dict[str, str] | None = None,
+) -> Any:
+    token = os.environ.get("FLY_API_TOKEN")
+    if not token:
+        raise DeployError("FLY_API_TOKEN is required")
+
+    hostname = os.environ.get("FLY_API_HOSTNAME", "https://api.machines.dev")
+    if "://" not in hostname:
+        hostname = f"https://{hostname}"
+    url = f"{hostname.rstrip('/')}/v1{path}"
+    if query:
+        url = f"{url}?{urlencode(query)}"
+
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "anarlog-drain-deploy/1",
+        },
+    )
+    print(f"+ Fly Machines API {method} {path}", file=sys.stderr)
+
+    try:
+        with urlopen(request, timeout=FLY_API_TIMEOUT_SECONDS) as response:
+            body = response.read()
+    except HTTPError as error:
+        body = error.read().decode(errors="replace").strip()
+        detail = f": {body}" if body else ""
+        raise FlyApiError(
+            f"Fly Machines API {method} {path} failed with HTTP {error.code}{detail}",
+            error.code,
+        ) from error
+    except URLError as error:
+        raise FlyApiError(
+            f"Fly Machines API {method} {path} failed: {error.reason}"
+        ) from error
+
+    if not body:
+        return None
+    return json.loads(body)
+
+
+def app_path(app: str) -> str:
+    return f"/apps/{quote(app, safe='')}"
+
+
+def machine_path(app: str, machine_id: str) -> str:
+    return f"{app_path(app)}/machines/{quote(machine_id, safe='')}"
+
+
+def list_machines(app: str) -> list[dict[str, Any]]:
+    machines = api_request("GET", f"{app_path(app)}/machines")
+    if machines is None:
+        return []
+    if isinstance(machines, dict):
+        machines = machines.get("machines") or []
+    return list(machines)
+
+
+def get_machine(app: str, machine_id: str) -> dict[str, Any]:
+    machine = api_request("GET", machine_path(app, machine_id))
+    if not isinstance(machine, dict):
+        raise DeployError(f"Fly returned no status for machine {machine_id}")
+    return machine
+
+
+def destroy_machine(app: str, machine_id: str) -> None:
+    api_request(
+        "DELETE",
+        machine_path(app, machine_id),
+        query={"force": "true"},
+    )
+
+
+def change_machine_routing(method: str, path: str) -> None:
+    delay = FLY_API_RETRY_INITIAL_DELAY_SECONDS
+    for attempt in range(1, FLY_API_RETRY_ATTEMPTS + 1):
+        try:
+            api_request(method, path)
+            return
+        except FlyApiError as error:
+            retryable = (
+                error.status_code is None
+                or error.status_code
+                in {
+                    408,
+                    425,
+                    429,
+                }
+                or (error.status_code is not None and error.status_code >= 500)
+            )
+            if not retryable or attempt == FLY_API_RETRY_ATTEMPTS:
+                raise
+            print(
+                f"routing change failed (attempt {attempt}/{FLY_API_RETRY_ATTEMPTS}); "
+                f"retrying in {delay:g}s: {error}",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+            delay *= 2
+
+    raise AssertionError("unreachable")
+
+
+def cordon_machine(app: str, machine_id: str) -> None:
+    change_machine_routing("POST", f"{machine_path(app, machine_id)}/cordon")
+
+
+def uncordon_machine(app: str, machine_id: str) -> None:
+    change_machine_routing("POST", f"{machine_path(app, machine_id)}/uncordon")
+
+
+def signal_machine(app: str, machine_id: str) -> None:
+    api_request(
+        "POST",
+        f"{machine_path(app, machine_id)}/signal",
+        {"signal": "SIGUSR1"},
+    )
+
+
+def destroy_drained_machines(app: str) -> None:
+    for machine in stopped_cordoned_machines(list_machines(app)):
+        print(
+            f"destroying drained machine {machine['id']} ({machine.get('state')})",
+            file=sys.stderr,
+        )
+        destroy_machine(app, machine["id"])
+
+
+def resume_draining_machines(app: str) -> None:
+    for machine in list_machines(app):
+        if (
+            is_cordoned(machine)
+            and is_started(machine)
+            and supports_session_drain(machine)
+        ):
+            print(f"resuming drain for machine {machine['id']}", file=sys.stderr)
+            signal_machine(app, machine["id"])
+
+
+def wait_until_healthy(app: str, machine_id: str, timeout_seconds: int = 180) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = get_machine(app, machine_id)
+        if checks_passing(status):
+            print(f"machine {machine_id} is healthy", file=sys.stderr)
+            return
+        time.sleep(5)
+    raise DeployError(f"machine {machine_id} did not become healthy")
+
+
+def stop_config(config_path: str) -> dict[str, str]:
+    with open(config_path, "rb") as config_file:
+        config = tomllib.load(config_file)
+
+    signal = str(config.get("kill_signal", "SIGINT"))
+    timeout = config.get("kill_timeout")
+    result = {"signal": signal}
+    if timeout is not None:
+        result["timeout"] = f"{timeout}s" if isinstance(timeout, int) else str(timeout)
+    return result
+
+
+def replacement_config(
+    machine: dict[str, Any],
+    image: str,
+    desired_stop_config: dict[str, str],
+) -> dict[str, Any]:
+    host_status = machine.get("host_status")
+    if host_status not in {None, "ok"}:
+        raise DeployError(
+            f"machine {machine.get('id')} is on an unhealthy host ({host_status})"
+        )
+    config = machine.get("config")
+    if not isinstance(config, dict):
+        raise DeployError(f"machine {machine.get('id')} has no reusable config")
+    if config.get("mounts"):
+        raise DeployError(
+            f"machine {machine.get('id')} has volume mounts; drain deploy cannot safely duplicate it"
+        )
+
+    replacement = copy.deepcopy(config)
+    replacement["image"] = image
+    replacement["restart"] = {"policy": "on-failure"}
+    replacement["stop_config"] = desired_stop_config
+    metadata = replacement.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        replacement["metadata"] = metadata
+    metadata.pop("fly_cordoned", None)
+    metadata[DRAIN_PROTOCOL_METADATA_KEY] = DRAIN_PROTOCOL_METADATA_VALUE
+    return replacement
+
+
+def create_replacement_machine(
+    app: str,
+    machine: dict[str, Any],
+    image: str,
+    desired_stop_config: dict[str, str],
+) -> str:
+    payload: dict[str, Any] = {
+        "config": replacement_config(machine, image, desired_stop_config),
+        "skip_service_registration": True,
+    }
+    if machine.get("region"):
+        payload["region"] = machine["region"]
+
+    created = api_request("POST", f"{app_path(app)}/machines", payload)
+    if not isinstance(created, dict) or not created.get("id"):
+        raise DeployError(f"Fly returned no id for replacement of {machine.get('id')}")
+    machine_id = str(created["id"])
+    print(
+        f"created cordoned replacement {machine_id} for {machine['id']}",
+        file=sys.stderr,
+    )
+    return machine_id
+
+
+def validate_serving_set(
+    app: str,
+    expected_ids: set[str],
+    replacement_ids: set[str],
+) -> None:
+    machines = list_machines(app)
+    actual_ids = {
+        machine["id"]
+        for machine in serving_machines(machines)
+        if machine["id"] not in replacement_ids
+    }
+    if actual_ids != expected_ids:
+        raise DeployError(
+            "serving machine set changed during deploy "
+            f"(expected {sorted(expected_ids)}, found {sorted(actual_ids)})"
+        )
+
+    machines_by_id = {str(machine["id"]): machine for machine in machines}
+    unsafe_replacements = [
+        machine_id
+        for machine_id in replacement_ids
+        if machine_id not in machines_by_id
+        or not is_cordoned(machines_by_id[machine_id])
+    ]
+    if unsafe_replacements:
+        raise DeployError(
+            "replacement machines were not safely cordoned: "
+            + ", ".join(sorted(unsafe_replacements))
+        )
+
+
+def cut_over(
+    app: str,
+    old_ids: list[str],
+    new_ids: list[str],
+    propagation_seconds: float = PROXY_PROPAGATION_SECONDS,
+) -> None:
+    attempted_new_ids: list[str] = []
+    attempted_old_ids: list[str] = []
+    try:
+        for machine_id in new_ids:
+            print(f"uncordoning {machine_id}", file=sys.stderr)
+            attempted_new_ids.append(machine_id)
+            uncordon_machine(app, machine_id)
+        if propagation_seconds:
+            print(
+                f"waiting {propagation_seconds:g}s for Fly Proxy to register replacements",
+                file=sys.stderr,
+            )
+            time.sleep(propagation_seconds)
+        for machine_id in old_ids:
+            print(f"cordoning {machine_id}", file=sys.stderr)
+            attempted_old_ids.append(machine_id)
+            cordon_machine(app, machine_id)
+        if propagation_seconds:
+            print(
+                f"waiting {propagation_seconds:g}s for Fly Proxy to drain old routes",
+                file=sys.stderr,
+            )
+            time.sleep(propagation_seconds)
+    except Exception:
+        for machine_id in attempted_old_ids:
+            try:
+                uncordon_machine(app, machine_id)
+            except Exception as rollback_error:
+                print(
+                    f"failed to uncordon {machine_id} during rollback: {rollback_error}",
+                    file=sys.stderr,
+                )
+        if attempted_old_ids and propagation_seconds:
+            time.sleep(propagation_seconds)
+        for machine_id in attempted_new_ids:
+            try:
+                cordon_machine(app, machine_id)
+            except Exception as rollback_error:
+                print(
+                    f"failed to cordon replacement {machine_id} during rollback: {rollback_error}",
+                    file=sys.stderr,
+                )
+            try:
+                signal_machine(app, machine_id)
+            except Exception as rollback_error:
+                print(
+                    f"failed to signal replacement {machine_id} during rollback: {rollback_error}",
+                    file=sys.stderr,
+                )
+        destroy_replacements(
+            app,
+            [
+                machine_id
+                for machine_id in new_ids
+                if machine_id not in attempted_new_ids
+            ],
+        )
+        raise
+
+
+def destroy_replacements(app: str, machine_ids: list[str]) -> None:
+    for machine_id in machine_ids:
+        try:
+            destroy_machine(app, machine_id)
+        except Exception as error:
+            print(
+                f"failed to destroy replacement {machine_id}: {error}",
+                file=sys.stderr,
+            )
+
+
+def drain_old_machines(app: str, machine_ids: list[str]) -> None:
+    failures: list[str] = []
+    for machine_id in machine_ids:
+        try:
+            machine = get_machine(app, machine_id)
+            if is_started(machine) and supports_session_drain(machine):
+                signal_machine(app, machine_id)
+            elif is_started(machine):
+                print(
+                    f"leaving legacy machine {machine_id} cordoned until Fly auto-stops it",
+                    file=sys.stderr,
+                )
+            elif is_stopped(machine):
+                destroy_machine(app, machine_id)
+            else:
+                failures.append(f"{machine_id} is {machine.get('state')}")
+        except Exception as error:
+            failures.append(f"{machine_id}: {error}")
+
+    if failures:
+        raise DeployError(
+            "traffic cut over, but old machine drain failed: " + "; ".join(failures)
+        )
+
+
+def bootstrap_deploy(app: str, config: str, dockerfile: str, version: str) -> None:
+    fly(
+        "deploy",
+        "--app",
+        app,
+        "--config",
+        config,
+        "--dockerfile",
+        dockerfile,
+        "--remote-only",
+        "--build-arg",
+        f"APP_VERSION={version}",
+    )
+
+
+def build_and_push_image(app: str, config: str, dockerfile: str, version: str) -> str:
+    image = image_ref(app, version)
+    fly(
+        "deploy",
+        "--app",
+        app,
+        "--config",
+        config,
+        "--dockerfile",
+        dockerfile,
+        "--remote-only",
+        "--build-only",
+        "--push",
+        "--image-label",
+        f"api-{version}",
+        "--build-arg",
+        f"APP_VERSION={version}",
+    )
+    return image
+
+
+def deploy(app: str, config: str, dockerfile: str, version: str) -> None:
+    destroy_drained_machines(app)
+    resume_draining_machines(app)
+    machines = list_machines(app)
+    serving = serving_machines(machines)
+    if not machines:
+        print("no machines present; running a bootstrap fly deploy", file=sys.stderr)
+        bootstrap_deploy(app, config, dockerfile, version)
+        return
+
+    if not serving:
+        raise SystemExit(
+            "all machines are cordoned; wait for in-meeting drains to finish before deploying"
+        )
+
+    desired_stop_config = stop_config(config)
+    image = build_and_push_image(app, config, dockerfile, version)
+    old_ids = [machine["id"] for machine in serving]
+    replacement_ids: list[str] = []
+    try:
+        for machine in serving:
+            replacement_ids.append(
+                create_replacement_machine(app, machine, image, desired_stop_config)
+            )
+        for machine_id in replacement_ids:
+            wait_until_healthy(app, machine_id)
+        validate_serving_set(app, set(old_ids), set(replacement_ids))
+    except Exception:
+        destroy_replacements(app, replacement_ids)
+        raise
+
+    cut_over(app, old_ids, replacement_ids)
+    drain_old_machines(app, old_ids)
+    destroy_drained_machines(app)
+    print("deployed new machines; old meetings will keep their current connections")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--dockerfile", required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+    deploy(args.app, args.config, args.dockerfile, args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_deploy_api_drain.py
+++ b/.github/scripts/test_deploy_api_drain.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import deploy_api_drain
+from deploy_api_drain import (
+    DeployError,
+    FlyApiError,
+    change_machine_routing,
+    checks_passing,
+    create_replacement_machine,
+    cut_over,
+    image_ref,
+    is_cordoned,
+    is_started,
+    is_stopped,
+    replacement_config,
+    serving_machines,
+    stop_config,
+    stopped_cordoned_machines,
+    supports_session_drain,
+    validate_serving_set,
+)
+
+
+def test_classifies_serving_and_drained_machines():
+    machines = [
+        {"id": "serving-started", "state": "started", "cordoned": False},
+        {"id": "serving-idle", "state": "stopped", "cordoned": False},
+        {"id": "draining", "state": "started", "cordoned": True},
+        {"id": "drained", "state": "stopped", "cordoned": True},
+        {"id": "deleted", "state": "destroyed", "cordoned": True},
+    ]
+
+    assert [machine["id"] for machine in serving_machines(machines)] == [
+        "serving-started",
+        "serving-idle",
+    ]
+    assert [machine["id"] for machine in stopped_cordoned_machines(machines)] == [
+        "drained"
+    ]
+    assert is_started(machines[0])
+    assert is_stopped(machines[1])
+    assert not is_stopped(machines[4])
+    assert is_cordoned(machines[2])
+    assert not is_cordoned(machines[0])
+
+
+def test_reads_cordon_from_metadata_when_top_level_flag_is_absent():
+    machine = {
+        "id": "legacy",
+        "state": "stopped",
+        "config": {"metadata": {"fly_cordoned": "true"}},
+    }
+    assert is_cordoned(machine)
+    assert stopped_cordoned_machines([machine]) == [machine]
+
+
+def test_checks_passing_requires_every_reported_check():
+    assert not checks_passing({"state": "started"})
+    assert checks_passing(
+        {
+            "state": "started",
+            "checks": {
+                "http": {"status": "passing"},
+                "tcp": {"Status": "success"},
+            },
+        }
+    )
+    assert not checks_passing(
+        {"state": "started", "checks": [{"status": "passing"}, {"status": "critical"}]}
+    )
+    assert not checks_passing(
+        {
+            "state": "started",
+            "host_status": "unreachable",
+            "checks": [{"status": "passing"}],
+        }
+    )
+    assert not checks_passing({"state": "stopped", "checks": [{"status": "passing"}]})
+
+
+def test_image_ref_uses_the_fly_registry_tag():
+    assert image_ref("anarlog-ai", "1.4.14") == "registry.fly.io/anarlog-ai:api-1.4.14"
+
+
+def test_stop_config_reads_graceful_shutdown_settings():
+    with NamedTemporaryFile("wb") as config:
+        config.write(b"kill_signal = 'SIGTERM'\nkill_timeout = 300\n")
+        config.flush()
+        assert stop_config(config.name) == {
+            "signal": "SIGTERM",
+            "timeout": "300s",
+        }
+
+
+def test_replacement_config_updates_image_without_mutating_source():
+    machine = {
+        "id": "old",
+        "config": {
+            "image": "registry.fly.io/anarlog-ai:old",
+            "metadata": {
+                "fly_cordoned": "true",
+                "fly_process_group": "app",
+            },
+        },
+    }
+
+    config = replacement_config(
+        machine,
+        "registry.fly.io/anarlog-ai:new",
+        {"signal": "SIGTERM", "timeout": "300s"},
+    )
+
+    assert config["image"] == "registry.fly.io/anarlog-ai:new"
+    assert config["metadata"] == {
+        "anarlog_drain_protocol": "sigusr1-v1",
+        "fly_process_group": "app",
+    }
+    assert config["restart"] == {"policy": "on-failure"}
+    assert config["stop_config"] == {"signal": "SIGTERM", "timeout": "300s"}
+    assert supports_session_drain({"config": config})
+    assert machine["config"]["image"] == "registry.fly.io/anarlog-ai:old"
+    assert machine["config"]["metadata"]["fly_cordoned"] == "true"
+
+
+def test_replacement_config_rejects_volume_mounts():
+    machine = {
+        "id": "old",
+        "config": {
+            "image": "registry.fly.io/anarlog-ai:old",
+            "mounts": [{"volume": "vol_123", "path": "/data"}],
+        },
+    }
+
+    try:
+        replacement_config(
+            machine,
+            "registry.fly.io/anarlog-ai:new",
+            {"signal": "SIGTERM", "timeout": "300s"},
+        )
+    except DeployError as error:
+        assert "volume mounts" in str(error)
+    else:
+        raise AssertionError("expected volume-backed machine to be rejected")
+
+
+def test_replacement_config_rejects_unhealthy_hosts():
+    machine = {
+        "id": "old",
+        "host_status": "unreachable",
+        "config": {"image": "registry.fly.io/anarlog-ai:old"},
+    }
+
+    try:
+        replacement_config(
+            machine,
+            "registry.fly.io/anarlog-ai:new",
+            {"signal": "SIGTERM", "timeout": "300s"},
+        )
+    except DeployError as error:
+        assert "unhealthy host" in str(error)
+    else:
+        raise AssertionError("expected an unreachable machine host to be rejected")
+
+
+def test_create_replacement_starts_cordoned_in_the_source_region():
+    machine = {
+        "id": "old",
+        "region": "sjc",
+        "config": {"image": "registry.fly.io/anarlog-ai:old"},
+    }
+    calls = []
+
+    def fake_api_request(method, path, payload=None, query=None):
+        calls.append((method, path, payload, query))
+        return {"id": "new"}
+
+    with patch.object(deploy_api_drain, "api_request", fake_api_request):
+        created = create_replacement_machine(
+            "anarlog-ai",
+            machine,
+            "registry.fly.io/anarlog-ai:new",
+            {"signal": "SIGTERM", "timeout": "300s"},
+        )
+
+    assert created == "new"
+    assert calls == [
+        (
+            "POST",
+            "/apps/anarlog-ai/machines",
+            {
+                "config": {
+                    "image": "registry.fly.io/anarlog-ai:new",
+                    "metadata": {
+                        "anarlog_drain_protocol": "sigusr1-v1",
+                    },
+                    "restart": {"policy": "on-failure"},
+                    "stop_config": {"signal": "SIGTERM", "timeout": "300s"},
+                },
+                "skip_service_registration": True,
+                "region": "sjc",
+            },
+            None,
+        )
+    ]
+
+
+def test_validate_serving_set_requires_cordoned_replacements():
+    machines = [
+        {"id": "old", "state": "started", "cordoned": False},
+        {"id": "new", "state": "started", "cordoned": False},
+    ]
+
+    with patch.object(deploy_api_drain, "list_machines", lambda _app: machines):
+        try:
+            validate_serving_set("anarlog-ai", {"old"}, {"new"})
+        except DeployError as error:
+            assert "not safely cordoned" in str(error)
+        else:
+            raise AssertionError("expected an uncordoned replacement to be rejected")
+
+
+def test_cut_over_registers_new_machines_before_cordoning_old_machines():
+    operations = []
+
+    with (
+        patch.object(
+            deploy_api_drain,
+            "cordon_machine",
+            lambda _app, machine_id: operations.append(("cordon", machine_id)),
+        ),
+        patch.object(
+            deploy_api_drain,
+            "uncordon_machine",
+            lambda _app, machine_id: operations.append(("uncordon", machine_id)),
+        ),
+    ):
+        cut_over(
+            "anarlog-ai",
+            ["old-a", "old-b"],
+            ["new-a", "new-b"],
+            propagation_seconds=0,
+        )
+
+    assert operations == [
+        ("uncordon", "new-a"),
+        ("uncordon", "new-b"),
+        ("cordon", "old-a"),
+        ("cordon", "old-b"),
+    ]
+
+
+def test_cut_over_drains_an_attempted_replacement_when_activation_fails():
+    operations = []
+
+    def uncordon(_app, machine_id):
+        operations.append(("uncordon", machine_id))
+        if machine_id == "new":
+            raise DeployError("uncordon failed")
+
+    with (
+        patch.object(
+            deploy_api_drain,
+            "cordon_machine",
+            lambda _app, machine_id: operations.append(("cordon", machine_id)),
+        ),
+        patch.object(deploy_api_drain, "uncordon_machine", uncordon),
+        patch.object(
+            deploy_api_drain,
+            "signal_machine",
+            lambda _app, machine_id: operations.append(("signal", machine_id)),
+        ),
+    ):
+        try:
+            cut_over(
+                "anarlog-ai",
+                ["old"],
+                ["new"],
+                propagation_seconds=0,
+            )
+        except DeployError:
+            pass
+        else:
+            raise AssertionError("expected cutover to fail")
+
+    assert operations == [
+        ("uncordon", "new"),
+        ("cordon", "new"),
+        ("signal", "new"),
+    ]
+
+
+def test_cut_over_restores_old_routing_before_draining_replacements():
+    operations = []
+
+    def cordon(_app, machine_id):
+        operations.append(("cordon", machine_id))
+        if machine_id == "old":
+            raise DeployError("cordon failed")
+
+    with (
+        patch.object(deploy_api_drain, "cordon_machine", cordon),
+        patch.object(
+            deploy_api_drain,
+            "uncordon_machine",
+            lambda _app, machine_id: operations.append(("uncordon", machine_id)),
+        ),
+        patch.object(
+            deploy_api_drain,
+            "signal_machine",
+            lambda _app, machine_id: operations.append(("signal", machine_id)),
+        ),
+    ):
+        try:
+            cut_over(
+                "anarlog-ai",
+                ["old"],
+                ["new"],
+                propagation_seconds=0,
+            )
+        except DeployError:
+            pass
+        else:
+            raise AssertionError("expected cutover to fail")
+
+    assert operations == [
+        ("uncordon", "new"),
+        ("cordon", "old"),
+        ("uncordon", "old"),
+        ("cordon", "new"),
+        ("signal", "new"),
+    ]
+
+
+def test_routing_changes_retry_transient_api_failures():
+    calls = []
+
+    def fake_api_request(method, path):
+        calls.append((method, path))
+        if len(calls) == 1:
+            raise FlyApiError("timeout", 408)
+
+    with (
+        patch.object(deploy_api_drain, "api_request", fake_api_request),
+        patch.object(deploy_api_drain.time, "sleep") as sleep,
+    ):
+        change_machine_routing("POST", "/machines/new/uncordon")
+
+    assert calls == [
+        ("POST", "/machines/new/uncordon"),
+        ("POST", "/machines/new/uncordon"),
+    ]
+    sleep.assert_called_once_with(0.5)
+
+
+def test_partial_replacement_failure_destroys_created_machines():
+    machines = [
+        {
+            "id": "old-a",
+            "state": "started",
+            "cordoned": False,
+            "config": {"image": "old"},
+        },
+        {
+            "id": "old-b",
+            "state": "started",
+            "cordoned": False,
+            "config": {"image": "old"},
+        },
+    ]
+    destroyed = []
+
+    def create_replacement(_app, machine, _image, _stop_config):
+        if machine["id"] == "old-b":
+            raise DeployError("launch failed")
+        return "new-a"
+
+    with (
+        patch.object(deploy_api_drain, "destroy_drained_machines"),
+        patch.object(deploy_api_drain, "resume_draining_machines"),
+        patch.object(deploy_api_drain, "list_machines", return_value=machines),
+        patch.object(
+            deploy_api_drain,
+            "stop_config",
+            return_value={"signal": "SIGTERM", "timeout": "300s"},
+        ),
+        patch.object(
+            deploy_api_drain,
+            "build_and_push_image",
+            return_value="registry.fly.io/anarlog-ai:new",
+        ),
+        patch.object(
+            deploy_api_drain,
+            "create_replacement_machine",
+            side_effect=create_replacement,
+        ),
+        patch.object(
+            deploy_api_drain,
+            "destroy_machine",
+            side_effect=lambda _app, machine_id: destroyed.append(machine_id),
+        ),
+        patch.object(deploy_api_drain, "cut_over") as cut_over_mock,
+    ):
+        try:
+            deploy_api_drain.deploy(
+                "anarlog-ai",
+                "apps/api/fly.toml",
+                "apps/api/Dockerfile",
+                "1.4.14",
+            )
+        except DeployError as error:
+            assert "launch failed" in str(error)
+        else:
+            raise AssertionError("expected replacement launch to fail")
+
+    assert destroyed == ["new-a"]
+    cut_over_mock.assert_not_called()
+
+
+def test_drain_only_signals_machines_with_protocol_support():
+    machines = {
+        "legacy": {
+            "id": "legacy",
+            "state": "started",
+            "cordoned": True,
+            "config": {},
+        },
+        "supported": {
+            "id": "supported",
+            "state": "started",
+            "cordoned": True,
+            "config": {
+                "metadata": {"anarlog_drain_protocol": "sigusr1-v1"},
+            },
+        },
+        "stopped": {
+            "id": "stopped",
+            "state": "stopped",
+            "cordoned": True,
+            "config": {},
+        },
+    }
+    signaled = []
+    destroyed = []
+
+    with (
+        patch.object(
+            deploy_api_drain,
+            "get_machine",
+            side_effect=lambda _app, machine_id: machines[machine_id],
+        ),
+        patch.object(
+            deploy_api_drain,
+            "signal_machine",
+            side_effect=lambda _app, machine_id: signaled.append(machine_id),
+        ),
+        patch.object(
+            deploy_api_drain,
+            "destroy_machine",
+            side_effect=lambda _app, machine_id: destroyed.append(machine_id),
+        ),
+    ):
+        deploy_api_drain.drain_old_machines(
+            "anarlog-ai",
+            ["legacy", "supported", "stopped"],
+        )
+
+    assert signaled == ["supported"]
+    assert destroyed == ["stopped"]
+
+
+def test_resume_only_signals_supported_draining_machines():
+    machines = [
+        {
+            "id": "legacy",
+            "state": "started",
+            "cordoned": True,
+            "config": {},
+        },
+        {
+            "id": "supported",
+            "state": "started",
+            "cordoned": True,
+            "config": {
+                "metadata": {"anarlog_drain_protocol": "sigusr1-v1"},
+            },
+        },
+    ]
+    signaled = []
+
+    with (
+        patch.object(deploy_api_drain, "list_machines", return_value=machines),
+        patch.object(
+            deploy_api_drain,
+            "signal_machine",
+            side_effect=lambda _app, machine_id: signaled.append(machine_id),
+        ),
+    ):
+        deploy_api_drain.resume_draining_machines("anarlog-ai")
+
+    assert signaled == ["supported"]
+
+
+if __name__ == "__main__":
+    test_classifies_serving_and_drained_machines()
+    test_reads_cordon_from_metadata_when_top_level_flag_is_absent()
+    test_checks_passing_requires_every_reported_check()
+    test_image_ref_uses_the_fly_registry_tag()
+    test_stop_config_reads_graceful_shutdown_settings()
+    test_replacement_config_updates_image_without_mutating_source()
+    test_replacement_config_rejects_volume_mounts()
+    test_replacement_config_rejects_unhealthy_hosts()
+    test_create_replacement_starts_cordoned_in_the_source_region()
+    test_validate_serving_set_requires_cordoned_replacements()
+    test_cut_over_registers_new_machines_before_cordoning_old_machines()
+    test_cut_over_drains_an_attempted_replacement_when_activation_fails()
+    test_cut_over_restores_old_routing_before_draining_replacements()
+    test_routing_changes_retry_transient_api_failures()
+    test_partial_replacement_failure_destroys_created_machines()
+    test_drain_only_signals_machines_with_protocol_support()
+    test_resume_only_signals_supported_draining_machines()
+    print("ok")

--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -28,7 +28,9 @@ jobs:
     needs: compute-version
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    concurrency: api-fly-deploy
+    concurrency:
+      group: api-fly-deploy
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -157,9 +159,10 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
-      - run: flyctl deploy --config apps/api/fly.toml --dockerfile apps/api/Dockerfile --remote-only --build-arg APP_VERSION=${{ needs.compute-version.outputs.version }}
+      - run: python3 .github/scripts/deploy_api_drain.py --app "$FLY_APP" --config apps/api/fly.toml --dockerfile apps/api/Dockerfile --version "$API_VERSION"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          API_VERSION: ${{ needs.compute-version.outputs.version }}
       - name: Verify Fly deployment
         run: curl --fail --silent --show-error --retry 10 --retry-all-errors --retry-delay 3 "https://${FLY_APP}.fly.dev/health"
       - if: failure()

--- a/.github/workflows/api_ci.yaml
+++ b/.github/workflows/api_ci.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
     paths:
+      - .github/scripts/deploy_api_drain.py
+      - .github/scripts/test_deploy_api_drain.py
       - .github/scripts/test_verify_cloudsync_e2ee.py
       - .github/scripts/verify_cloudsync_e2ee.py
       - .github/workflows/api_cd.yaml
@@ -14,6 +16,8 @@ on:
       - crates/transcribe-proxy/**
   pull_request:
     paths:
+      - .github/scripts/deploy_api_drain.py
+      - .github/scripts/test_deploy_api_drain.py
       - .github/scripts/test_verify_cloudsync_e2ee.py
       - .github/scripts/verify_cloudsync_e2ee.py
       - .github/workflows/api_cd.yaml
@@ -37,7 +41,10 @@ jobs:
           platform: linux
       - run: cargo check -p api
       - run: cargo test -p api-sync
+      - run: cargo test -p transcribe-proxy --lib
+      - run: cargo test -p api drain_status_reports_live_streams_without_failing_health
       - run: python3 .github/scripts/test_verify_cloudsync_e2ee.py
+      - run: python3 .github/scripts/test_deploy_api_drain.py
       - run: |
           cargo test -p api gen_openapi_json
           git diff --exit-code -- apps/api/openapi.gen.json

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -1,11 +1,14 @@
 app = 'anarlog-ai'
 primary_region = 'sjc'
 kill_signal = 'SIGTERM'
-kill_timeout = 30
+# Fly caps this at 300s. Meeting streams can last longer, so api_cd uses
+# cordoned replacement Machines + SIGUSR1 and leaves old Machines up until idle.
+kill_timeout = 300
 swap_size_mb = 512
 
-[deploy]
-strategy = "bluegreen"
+[[restart]]
+policy = "on-failure"
+processes = ["app"]
 
 [env]
 ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED = "true"

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -148,12 +148,15 @@ fn build_sync_routes(
         .merge(web_edit_routes)
 }
 
-async fn app() -> Router {
-    let env = env();
-    app_with_env(env).await
+#[cfg(test)]
+async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
+    app_with_session_gate(env, anlg_transcribe_proxy::SessionGate::new()).await
 }
 
-async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
+async fn app_with_session_gate(
+    env: &'static crate::env::RuntimeConfig,
+    session_gate: anlg_transcribe_proxy::SessionGate,
+) -> Router {
     let analytics = build_analytics_client(env);
 
     let llm_config =
@@ -411,8 +414,14 @@ async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
     };
 
     let stt_routes = Router::new()
-        .merge(anlg_transcribe_proxy::listen_router(stt_config.clone()))
-        .nest("/stt", anlg_transcribe_proxy::router(stt_config))
+        .merge(anlg_transcribe_proxy::listen_router_with_session_gate(
+            stt_config.clone(),
+            session_gate.clone(),
+        ))
+        .nest(
+            "/stt",
+            anlg_transcribe_proxy::router_with_session_gate(stt_config, session_gate.clone()),
+        )
         .route_layer(middleware::from_fn_with_state(
             stt_rate_limit,
             rate_limit::rate_limit,
@@ -450,9 +459,14 @@ async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
             auth::require_auth,
         ));
 
+    let drain_routes = Router::new()
+        .route("/drain", axum::routing::get(drain_status))
+        .with_state(session_gate);
+
     Router::new()
         .route("/health", axum::routing::get(version))
         .route("/openapi.json", axum::routing::get(openapi_json))
+        .merge(drain_routes)
         .merge(webhook_routes)
         .merge(paid_routes)
         .merge(shared_notes_routes)
@@ -484,7 +498,7 @@ async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
                         .make_span_with(|request: &Request<Body>| {
                             let path = request.uri().path();
 
-                            if path == "/health" {
+                            if path == "/health" || path == "/drain" {
                                 return tracing::Span::none();
                             }
 
@@ -553,7 +567,8 @@ async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
                         })
                         .on_request(|request: &Request<Body>, span: &tracing::Span| {
                             // Skip logging for health checks
-                            if request.uri().path() == "/health" {
+                            if request.uri().path() == "/health" || request.uri().path() == "/drain"
+                            {
                                 return;
                             }
                             if let Some(request_id) = request
@@ -685,7 +700,8 @@ fn main() -> std::io::Result<()> {
         .block_on(async {
             let addr = SocketAddr::from(([0, 0, 0, 0], env.port));
             let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-            let app = app().await;
+            let session_gate = anlg_transcribe_proxy::SessionGate::new();
+            let app = app_with_session_gate(env, session_gate.clone()).await;
             let cancellation = CancellationToken::new();
             let worker_task = env.anarlog_attachment_backup_gc_enabled.then(|| {
                 let (stripe, loops) = env
@@ -720,9 +736,10 @@ fn main() -> std::io::Result<()> {
             tracing::info!(addr = %addr, "server_listening");
 
             let shutdown_cancellation = cancellation.clone();
+            let shutdown_gate = session_gate.clone();
             let server_result = axum::serve(listener, app)
                 .with_graceful_shutdown(async move {
-                    shutdown_signal().await;
+                    drain_after_shutdown_signal(shutdown_gate).await;
                     shutdown_cancellation.cancel();
                 })
                 .await;
@@ -747,7 +764,53 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-async fn shutdown_signal() {
+const TERM_DRAIN_TIMEOUT: Duration = Duration::from_secs(270);
+
+async fn drain_status(
+    axum::extract::State(gate): axum::extract::State<anlg_transcribe_proxy::SessionGate>,
+) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({
+        "draining": gate.is_draining(),
+        "active_streams": gate.active(),
+    }))
+}
+
+async fn drain_after_shutdown_signal(gate: anlg_transcribe_proxy::SessionGate) {
+    let force_timeout = wait_for_shutdown_kind().await;
+    gate.begin_drain();
+    tracing::info!(
+        active_streams = gate.active(),
+        force_timeout_ms = force_timeout.map(|timeout| timeout.as_millis() as u64),
+        "api_drain_started"
+    );
+
+    let idle = gate.wait_until_idle();
+    tokio::pin!(idle);
+
+    match force_timeout {
+        Some(timeout) => {
+            if tokio::time::timeout(timeout, idle).await.is_err() {
+                tracing::warn!(active_streams = gate.active(), "api_drain_timeout");
+            }
+        }
+        None => {
+            tokio::select! {
+                _ = &mut idle => {}
+                _ = stop_signal() => {
+                    tracing::info!(
+                        active_streams = gate.active(),
+                        "api_drain_force_stop_received"
+                    );
+                    if tokio::time::timeout(TERM_DRAIN_TIMEOUT, idle).await.is_err() {
+                        tracing::warn!(active_streams = gate.active(), "api_drain_timeout");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn wait_for_shutdown_kind() -> Option<Duration> {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
@@ -755,23 +818,50 @@ async fn shutdown_signal() {
     };
 
     #[cfg(unix)]
-    let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM signal handler")
-            .recv()
-            .await;
-    };
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to install SIGTERM signal handler");
+        let mut drain =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+                .expect("failed to install SIGUSR1 signal handler");
 
-    #[cfg(unix)]
-    tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        tokio::select! {
+            _ = ctrl_c => Some(TERM_DRAIN_TIMEOUT),
+            _ = terminate.recv() => Some(TERM_DRAIN_TIMEOUT),
+            _ = drain.recv() => None,
+        }
     }
 
     #[cfg(not(unix))]
-    ctrl_c.await;
+    {
+        ctrl_c.await;
+        Some(TERM_DRAIN_TIMEOUT)
+    }
+}
 
-    tracing::info!("shutdown_signal_received");
+async fn stop_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C signal handler");
+    };
+
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to install SIGTERM signal handler");
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = terminate.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await;
+    }
 }
 
 async fn openapi_json() -> axum::Json<utoipa::openapi::OpenApi> {

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -188,6 +188,51 @@ async fn boots_with_minimal_self_hosted_configuration() {
 }
 
 #[tokio::test]
+async fn drain_status_reports_live_streams_without_failing_health() {
+    let gate = anlg_transcribe_proxy::SessionGate::new();
+    let permit = gate.try_acquire().unwrap();
+    let app = app_with_session_gate(api_env(false), gate.clone()).await;
+
+    assert_eq!(
+        request_status(&app, Method::GET, "/health").await,
+        StatusCode::OK
+    );
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/drain")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&response_bytes(response).await).unwrap();
+    assert_eq!(body["draining"], false);
+    assert_eq!(body["active_streams"], 1);
+
+    gate.begin_drain();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/drain")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&response_bytes(response).await).unwrap();
+    assert_eq!(body["draining"], true);
+    assert_eq!(body["active_streams"], 1);
+    drop(permit);
+}
+
+#[tokio::test]
 async fn hosted_configuration_keeps_optional_routes_mounted() {
     let app = app_with_env(api_env(true)).await;
 

--- a/crates/transcribe-proxy/src/lib.rs
+++ b/crates/transcribe-proxy/src/lib.rs
@@ -8,6 +8,7 @@ mod provider_selector;
 mod query_params;
 mod relay;
 mod routes;
+mod session_gate;
 mod supabase;
 mod upstream_url;
 
@@ -20,5 +21,9 @@ pub use error::*;
 pub use openapi::openapi;
 pub use provider_selector::{ProviderSelector, SelectedProvider};
 pub use relay::{ClientRequestBuilder, UpstreamError, WebSocketProxy, detect_upstream_error};
-pub use routes::{callback_router, listen_router, router};
+pub use routes::{
+    callback_router, listen_router, listen_router_with_session_gate, router,
+    router_with_session_gate,
+};
+pub use session_gate::{ServerDraining, SessionGate, SessionPermit};
 pub use upstream_url::UpstreamUrlBuilder;

--- a/crates/transcribe-proxy/src/relay/channel_split/mod.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split/mod.rs
@@ -109,11 +109,16 @@ impl ChannelSplitProxy {
         }
     }
 
-    pub async fn handle_upgrade(&self, ws: WebSocketUpgrade) -> Response<Body> {
+    pub async fn handle_upgrade_with_guard<G: Send + 'static>(
+        &self,
+        ws: WebSocketUpgrade,
+        guard: G,
+    ) -> Response<Body> {
         let proxy = self.clone();
         let hub = sentry::Hub::current();
         ws.on_upgrade(move |socket| {
             async move {
+                let _guard = guard;
                 if let Err(error) = proxy.handle(socket).await {
                     tracing::error!(error = %error, "channel_split_proxy_error");
                 }

--- a/crates/transcribe-proxy/src/relay/handler.rs
+++ b/crates/transcribe-proxy/src/relay/handler.rs
@@ -136,11 +136,16 @@ impl WebSocketProxy {
         Ok(())
     }
 
-    pub async fn handle_upgrade(&self, ws: WebSocketUpgrade) -> Response<Body> {
+    pub async fn handle_upgrade_with_guard<G: Send + 'static>(
+        &self,
+        ws: WebSocketUpgrade,
+        guard: G,
+    ) -> Response<Body> {
         let proxy = self.clone();
         let hub = sentry::Hub::current();
         ws.on_upgrade(move |socket| {
             async move {
+                let _guard = guard;
                 if let Err(e) = proxy.handle(socket).await {
                     tracing::error!(
                         error = %e,

--- a/crates/transcribe-proxy/src/relay/mod.rs
+++ b/crates/transcribe-proxy/src/relay/mod.rs
@@ -325,10 +325,14 @@ impl StreamingProxy {
         }
     }
 
-    pub async fn handle_upgrade(&self, ws: WebSocketUpgrade) -> Response<Body> {
+    pub async fn handle_upgrade_with_guard<G: Send + 'static>(
+        &self,
+        ws: WebSocketUpgrade,
+        guard: G,
+    ) -> Response<Body> {
         match self {
-            Self::Single(proxy) => proxy.handle_upgrade(ws).await,
-            Self::ChannelSplit(proxy) => proxy.handle_upgrade(ws).await,
+            Self::Single(proxy) => proxy.handle_upgrade_with_guard(ws, guard).await,
+            Self::ChannelSplit(proxy) => proxy.handle_upgrade_with_guard(ws, guard).await,
         }
     }
 }

--- a/crates/transcribe-proxy/src/routes/mod.rs
+++ b/crates/transcribe-proxy/src/routes/mod.rs
@@ -21,6 +21,7 @@ use crate::anarlog_routing::{AnarlogRouter, RoutingMode, should_use_anarlog_rout
 use crate::config::SttProxyConfig;
 use crate::provider_selector::{ProviderSelector, SelectedProvider};
 use crate::query_params::QueryParams;
+use crate::session_gate::SessionGate;
 use crate::supabase::SupabaseClient;
 
 pub(crate) use error::{RouteError, parse_async_provider};
@@ -38,6 +39,7 @@ pub(crate) struct AppState {
     pub selector: ProviderSelector,
     pub router: Option<Arc<AnarlogRouter>>,
     pub client: reqwest::Client,
+    pub session_gate: SessionGate,
     batch_requests: Arc<Semaphore>,
 }
 
@@ -154,7 +156,7 @@ impl AppState {
     }
 }
 
-fn make_state(config: SttProxyConfig) -> AppState {
+fn make_state(config: SttProxyConfig, session_gate: SessionGate) -> AppState {
     let selector = config.provider_selector();
     let router = config.anarlog_router().map(Arc::new);
 
@@ -163,6 +165,7 @@ fn make_state(config: SttProxyConfig) -> AppState {
         selector,
         router,
         client: reqwest::Client::new(),
+        session_gate,
         batch_requests: BATCH_REQUEST_SLOTS.clone(),
     }
 }
@@ -172,7 +175,11 @@ fn with_common_layers(router: Router) -> Router {
 }
 
 pub fn router(config: SttProxyConfig) -> Router {
-    let state = make_state(config);
+    router_with_session_gate(config, SessionGate::new())
+}
+
+pub fn router_with_session_gate(config: SttProxyConfig, session_gate: SessionGate) -> Router {
+    let state = make_state(config, session_gate);
 
     with_common_layers(
         Router::new()
@@ -186,7 +193,14 @@ pub fn router(config: SttProxyConfig) -> Router {
 }
 
 pub fn listen_router(config: SttProxyConfig) -> Router {
-    let state = make_state(config);
+    listen_router_with_session_gate(config, SessionGate::new())
+}
+
+pub fn listen_router_with_session_gate(
+    config: SttProxyConfig,
+    session_gate: SessionGate,
+) -> Router {
+    let state = make_state(config, session_gate);
 
     with_common_layers(
         Router::new()
@@ -197,7 +211,7 @@ pub fn listen_router(config: SttProxyConfig) -> Router {
 }
 
 pub fn callback_router(config: SttProxyConfig) -> Router {
-    let state = make_state(config);
+    let state = make_state(config, SessionGate::new());
 
     Router::new()
         .route("/callback/{provider}/{id}", post(callback::handler))
@@ -219,7 +233,7 @@ mod tests {
             supabase_service_role_key: String::new(),
         };
 
-        make_state(SttProxyConfig::new(&env, &supabase))
+        make_state(SttProxyConfig::new(&env, &supabase), SessionGate::new())
     }
 
     #[test]
@@ -230,6 +244,37 @@ mod tests {
         let selected = state.resolve_provider(&mut params).unwrap();
 
         assert_eq!(selected.provider(), Provider::Deepgram);
+    }
+
+    #[tokio::test]
+    async fn draining_rejects_new_streaming_sessions() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let mut env = Env::default();
+        env.stt.deepgram_api_key = Some("deepgram-key".to_string());
+        let supabase = anlg_api_env::SupabaseEnv {
+            supabase_url: String::new(),
+            supabase_anon_key: String::new(),
+            supabase_service_role_key: String::new(),
+        };
+        let gate = SessionGate::new();
+        gate.begin_drain();
+        let app = listen_router_with_session_gate(SttProxyConfig::new(&env, &supabase), gate);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/listen")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers().get("retry-after").unwrap(), "2");
     }
 
     #[test]

--- a/crates/transcribe-proxy/src/routes/streaming/mod.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{FromRequestParts, State, WebSocketUpgrade},
-    http::{StatusCode, request::Parts},
+    http::{StatusCode, header::RETRY_AFTER, request::Parts},
     response::{IntoResponse, Response},
 };
 use owhisper_client::Provider;
@@ -17,6 +17,7 @@ use owhisper_client::Provider;
 use crate::anarlog_routing::should_use_anarlog_routing;
 use crate::query_params::{QueryParams, QueryValue};
 use crate::relay::OnCloseCallback;
+use crate::session_gate::SessionPermit;
 
 use super::AppState;
 
@@ -43,6 +44,30 @@ pub fn parse_param<T: std::str::FromStr>(params: &QueryParams, key: &str, defaul
 pub struct AnalyticsContext {
     pub fingerprint: Option<String>,
     pub user_id: Option<String>,
+}
+
+pub struct DrainPermit(SessionPermit);
+
+impl FromRequestParts<AppState> for DrainPermit {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        match state.session_gate.try_acquire() {
+            Ok(permit) => Ok(Self(permit)),
+            Err(_) => {
+                tracing::info!("stt_ws_rejected_draining");
+                Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    [(RETRY_AFTER, "2")],
+                    "server is draining existing sessions",
+                )
+                    .into_response())
+            }
+        }
+    }
 }
 
 pub fn build_on_close_callback(
@@ -97,7 +122,7 @@ where
 
 #[tracing::instrument(
     name = "stt.ws.upgrade",
-    skip(state, analytics_ctx, ws, params),
+    skip(state, permit, analytics_ctx, ws, params),
     fields(
         anarlog.subsystem = "stt",
         http.response.status_code = tracing::field::Empty,
@@ -115,6 +140,7 @@ where
 )]
 pub async fn handler(
     State(state): State<AppState>,
+    DrainPermit(permit): DrainPermit,
     analytics_ctx: AnalyticsContext,
     ws: WebSocketUpgrade,
     mut params: QueryParams,
@@ -264,5 +290,8 @@ pub async fn handler(
         }
     };
 
-    proxy.handle_upgrade(ws).await.into_response()
+    proxy
+        .handle_upgrade_with_guard(ws, permit)
+        .await
+        .into_response()
 }

--- a/crates/transcribe-proxy/src/session_gate.rs
+++ b/crates/transcribe-proxy/src/session_gate.rs
@@ -1,0 +1,158 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerDraining;
+
+#[derive(Clone)]
+pub struct SessionGate {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    state: watch::Sender<State>,
+}
+
+#[derive(Clone, Copy)]
+struct State {
+    draining: bool,
+    active: usize,
+}
+
+pub struct SessionPermit {
+    inner: Arc<Inner>,
+}
+
+impl SessionGate {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                state: watch::channel(State {
+                    draining: false,
+                    active: 0,
+                })
+                .0,
+            }),
+        }
+    }
+
+    pub fn begin_drain(&self) {
+        self.inner.state.send_if_modified(|state| {
+            if state.draining {
+                return false;
+            }
+            state.draining = true;
+            true
+        });
+    }
+
+    pub fn is_draining(&self) -> bool {
+        self.inner.state.borrow().draining
+    }
+
+    pub fn active(&self) -> usize {
+        self.inner.state.borrow().active
+    }
+
+    pub fn try_acquire(&self) -> Result<SessionPermit, ServerDraining> {
+        let mut acquired = false;
+        self.inner.state.send_if_modified(|state| {
+            if state.draining {
+                return false;
+            }
+            state.active += 1;
+            acquired = true;
+            true
+        });
+        if !acquired {
+            return Err(ServerDraining);
+        }
+
+        Ok(SessionPermit {
+            inner: self.inner.clone(),
+        })
+    }
+
+    pub async fn wait_until_idle(&self) {
+        let mut state = self.inner.state.subscribe();
+        while state.borrow_and_update().active != 0 {
+            if state.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+impl Default for SessionGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for SessionPermit {
+    fn drop(&mut self) {
+        self.inner.release();
+    }
+}
+
+impl Inner {
+    fn release(&self) {
+        self.state.send_modify(|state| {
+            debug_assert!(state.active > 0);
+            state.active -= 1;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn acquire_is_rejected_after_drain_starts() {
+        let gate = SessionGate::new();
+        let permit = gate.try_acquire().unwrap();
+        assert_eq!(gate.active(), 1);
+
+        gate.begin_drain();
+        assert!(gate.is_draining());
+        assert_eq!(gate.try_acquire().map(|_| ()), Err(ServerDraining));
+        assert_eq!(gate.active(), 1);
+
+        drop(permit);
+        assert_eq!(gate.active(), 0);
+    }
+
+    #[tokio::test]
+    async fn wait_until_idle_resolves_when_the_last_permit_drops() {
+        let gate = SessionGate::new();
+        let permit = gate.try_acquire().unwrap();
+        gate.begin_drain();
+
+        let wait = gate.wait_until_idle();
+        tokio::pin!(wait);
+        tokio::select! {
+            _ = &mut wait => panic!("gate became idle while a session was still held"),
+            _ = tokio::time::sleep(Duration::from_millis(20)) => {}
+        }
+
+        drop(permit);
+        tokio::time::timeout(Duration::from_secs(1), wait)
+            .await
+            .expect("idle wait should finish after the last session ends");
+    }
+
+    #[tokio::test]
+    async fn idle_transition_is_observed_before_the_waiter_subscribes() {
+        let gate = SessionGate::new();
+        let permit = gate.try_acquire().unwrap();
+        gate.begin_drain();
+        drop(permit);
+
+        tokio::time::timeout(Duration::from_secs(1), gate.wait_until_idle())
+            .await
+            .expect("idle state should be retained for late waiters");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fly blue/green deploys were cutting hosted transcription mid-meeting. New machines came up healthy, traffic switched, and old machines got SIGTERM with a 30s `kill_timeout`. Fly caps that timeout at 5 minutes, which is still shorter than a meeting.

This changes deploys so in-progress STT streams stay on the old version until those meetings end, while new meetings go to the new version.

## What changes

- Track live STT websocket sessions and reject new `/listen` upgrades once a machine is draining
- `/health` stays 200 during drain so Fly does not restart a machine that still has meetings
- `/drain` reports `{ draining, active_streams }`
- `SIGUSR1` starts an unbounded drain (used by the new deploy path)
- `SIGTERM` / Ctrl+C still drain, but give up before Fly's 300s kill
- `api_cd` now builds a new image, clones serving machines, cordons the previous set, and signals them to exit only after their last stream closes
- Stopped+cordoned leftovers from earlier drains are destroyed on the next deploy

## Why not just raise `kill_timeout`

Fly's max is 300 seconds, and `fly deploy` blue/green SIGTERMs old machines immediately after the switch. Meetings need the old process to keep running, not a longer grace period on a hard stop.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2421a07-4ccd-4b19-a19a-5506fad4e13a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2421a07-4ccd-4b19-a19a-5506fad4e13a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

