### PR TITLE
Improve meeting resilience during transient outages

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -123,12 +123,18 @@ export function getTranscriptTimelineOffsetMs(
     : 0;
 }
 
-export function useTranscriptTimelineMetadata(transcriptId: string): {
+export function useTranscriptTimelineMetadata(
+  transcriptId: string,
+  includePendingDeltas = true,
+): {
   offsetMs: number;
   sessionId?: string;
 } {
-  const transcript = useTranscriptMetadata(transcriptId);
-  const transcripts = useSessionTranscriptMetadata(transcript?.sessionId ?? "");
+  const transcript = useTranscriptMetadata(transcriptId, includePendingDeltas);
+  const transcripts = useSessionTranscriptMetadata(
+    transcript?.sessionId ?? "",
+    includePendingDeltas,
+  );
 
   return useMemo(() => {
     if (!transcript) {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
@@ -112,6 +112,7 @@ describe("RenderTranscript", () => {
     expect(mocks.useTranscriptTimelineMetadata).toHaveBeenCalledTimes(1);
     expect(mocks.useTranscriptTimelineMetadata).toHaveBeenCalledWith(
       "transcript-1",
+      false,
     );
   });
 
@@ -177,6 +178,10 @@ describe("RenderTranscript", () => {
       "transcript-1",
       false,
       0,
+    );
+    expect(mocks.useTranscriptTimelineMetadata).toHaveBeenCalledWith(
+      "transcript-1",
+      true,
     );
     expect(document.querySelectorAll("section")).toHaveLength(1);
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -136,6 +136,7 @@ function PersistedTranscript({
       segments={mergedSegments}
       scrollElement={scrollElement}
       transcriptId={transcriptId}
+      currentActive={currentActive}
       shouldScrollToEnd={shouldScrollToEnd}
       currentMs={currentMs}
       seek={seek}
@@ -152,6 +153,7 @@ function TranscriptSegments({
   segments: rawSegments,
   scrollElement,
   transcriptId,
+  currentActive,
   shouldScrollToEnd,
   currentMs,
   seek,
@@ -164,6 +166,7 @@ function TranscriptSegments({
   segments: Segment[];
   scrollElement: HTMLDivElement | null;
   transcriptId: string;
+  currentActive: boolean;
   shouldScrollToEnd: boolean;
   currentMs: number;
   seek: (sec: number) => void;
@@ -174,7 +177,10 @@ function TranscriptSegments({
   editMode: boolean;
 }) {
   const segments = useStableSegments(rawSegments);
-  const { offsetMs, sessionId } = useTranscriptTimelineMetadata(transcriptId);
+  const { offsetMs, sessionId } = useTranscriptTimelineMetadata(
+    transcriptId,
+    !currentActive,
+  );
   const labelContext = useMemo<RenderLabelContext | undefined>(() => {
     if (!request) return undefined;
 
@@ -304,6 +310,7 @@ const SegmentsList = memo(
       segmentKeys,
       scrollElement,
       activeMatchId: transcriptSearch.activeMatchId,
+      searchEnabled: transcriptSearch.query.length > 0,
       currentMs,
       offsetMs,
     });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/virtual-segments.tsx
@@ -47,6 +47,7 @@ export function useVirtualSegments({
   segmentKeys,
   scrollElement,
   activeMatchId,
+  searchEnabled,
   currentMs,
   offsetMs,
 }: {
@@ -54,6 +55,7 @@ export function useVirtualSegments({
   segmentKeys: string[];
   scrollElement: HTMLDivElement | null;
   activeMatchId: string | null;
+  searchEnabled: boolean;
   currentMs: number;
   offsetMs: number;
 }) {
@@ -222,19 +224,23 @@ export function useVirtualSegments({
 
   const searchIndex = useMemo(
     () =>
-      createTranscriptSearchIndex(
-        segments.flatMap((segment, index) =>
-          segment.words.map((word) => ({
-            id: word.id ?? null,
-            text: word.text.trim(),
-            scrollIntoView: () => scrollToIndexRef.current(index, "smooth"),
-          })),
-        ),
-      ),
-    [segments],
+      searchEnabled
+        ? createTranscriptSearchIndex(
+            segments.flatMap((segment, index) =>
+              segment.words.map((word) => ({
+                id: word.id ?? null,
+                text: word.text.trim(),
+                scrollIntoView: () => scrollToIndexRef.current(index, "smooth"),
+              })),
+            ),
+          )
+        : null,
+    [searchEnabled, segments],
   );
   searchSourceRef.current = (preparedQuery, options) =>
-    getTranscriptSearchIndexMatches(searchIndex, preparedQuery, options);
+    searchIndex
+      ? getTranscriptSearchIndexMatches(searchIndex, preparedQuery, options)
+      : [];
 
   const listRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/apps/desktop/src/session/components/note-input/transcript/state.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/state.ts
@@ -63,12 +63,10 @@ export function useTranscriptScreen({
     sessionMode: state.getSessionMode(sessionId),
   }));
   const { audioExists } = useAudioPlayer();
-
-  const { transcriptIds, liveSegments, hasTranscriptWords } =
-    useTranscriptContent(sessionId);
-
   const currentActive =
     sessionMode === "active" || sessionMode === "finalizing";
+  const { transcriptIds, liveSegments, hasTranscriptWords } =
+    useTranscriptContent(sessionId, !currentActive);
   const isRecordOnlyMode = sessionMode === "active" && captureMode !== "live";
   const hasVisibleTranscriptState =
     hasTranscriptWords || liveSegments.length > 0 || !!batchError;
@@ -113,8 +111,14 @@ export function useTranscriptScreen({
   };
 }
 
-function useTranscriptContent(sessionId: string) {
-  const transcripts = useSessionTranscriptMetadata(sessionId);
+function useTranscriptContent(
+  sessionId: string,
+  includePendingDeltas: boolean,
+) {
+  const transcripts = useSessionTranscriptMetadata(
+    sessionId,
+    includePendingDeltas,
+  );
   const liveSegments = useListener((state) => state.liveSegments);
 
   return {

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -396,13 +396,19 @@ const createSessionEventHandlers = <T extends LiveStore>(
 
     if (payload.type === "transcript_delta") {
       const delta = payload.delta as unknown as LiveTranscriptDelta;
+      const currentLive = get().live;
+      const hasFinalWords = delta.new_words.length > 0;
       if (
-        get().live.sessionId === targetSessionId &&
-        (delta.new_words.length > 0 || delta.partials.length > 0)
+        currentLive.sessionId === targetSessionId &&
+        (hasFinalWords || delta.partials.length > 0) &&
+        (currentLive.stallAudibleSeconds !== 0 ||
+          (hasFinalWords &&
+            (currentLive.finalStallAudibleSeconds !== 0 ||
+              currentLive.transcriptionStalled)))
       ) {
         setLiveState(set, (live) => {
           noteLiveTranscriptActivity(live, {
-            hasFinalWords: delta.new_words.length > 0,
+            hasFinalWords,
           });
         });
       }

--- a/apps/desktop/src/store/zustand/listener/transcript.test.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.test.ts
@@ -91,6 +91,18 @@ describe("transcript slice", () => {
     ]);
   });
 
+  test("does not publish an identical partial snapshot twice", () => {
+    const delta = createDelta({ 0: 0, 2: 1 });
+    store.getState().handleTranscriptDelta("session-1", delta);
+    const subscriber = vi.fn();
+    const unsubscribe = store.subscribe(subscriber);
+
+    store.getState().handleTranscriptDelta("session-1", delta);
+
+    expect(subscriber).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
   test("forwards persisted transcript deltas to the callback", () => {
     const persist = vi.fn();
     store.getState().setTranscriptPersist("session-1", persist);
@@ -344,6 +356,19 @@ describe("transcript slice", () => {
 
     expect(store.getState().liveSegments).toEqual([segment("later", 150)]);
     expect(store.getState()).not.toHaveProperty("liveSegmentsById");
+  });
+
+  test("does not publish an empty segment delta", () => {
+    const subscriber = vi.fn();
+    const unsubscribe = store.subscribe(subscriber);
+
+    store.getState().handleTranscriptSegmentDelta({
+      upserts: [],
+      removed_ids: [],
+    });
+
+    expect(subscriber).not.toHaveBeenCalled();
+    unsubscribe();
   });
 
   test("bounds the retained segment preview independently of persistence", () => {

--- a/apps/desktop/src/store/zustand/listener/transcript.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.ts
@@ -9,7 +9,7 @@ import type {
 
 import type { RuntimeSpeakerHint, WordLike } from "~/stt/segment";
 
-type WordsByChannel = Record<number, WordLike[]>;
+type WordsByChannel = Record<number, LiveTranscriptDelta["partials"][number][]>;
 type LiveCaptionFinalWord = LiveTranscriptDelta["new_words"][number];
 const LIVE_CAPTION_HISTORY_CHARACTERS = 2048;
 const LIVE_CAPTION_HISTORY_WORDS = 2048;
@@ -103,12 +103,17 @@ export const createTranscriptSlice = <
     );
   },
   handleTranscriptDelta: (sessionId, delta, options) => {
-    const handlePersist = get().handlePersistBySession[sessionId];
+    const state = get();
+    const handlePersist = state.handlePersistBySession[sessionId];
     const { wordsByChannel, hintsByChannel } = groupPartialsByChannel(
       delta.partials,
     );
+    const previewChanged =
+      delta.new_words.length > 0 ||
+      delta.replaced_ids.length > 0 ||
+      !partialWordsByChannelEqual(state.partialWordsByChannel, wordsByChannel);
 
-    if (options?.updateLivePreview !== false) {
+    if (options?.updateLivePreview !== false && previewChanged) {
       set((state) =>
         mutate(state, (draft) => {
           updateLiveCaptionFinalWords(draft.liveCaptionFinalWordsById, delta);
@@ -130,6 +135,9 @@ export const createTranscriptSlice = <
     handlePersist?.(delta);
   },
   handleTranscriptSegmentDelta: (delta) => {
+    if (delta.upserts.length === 0 && delta.removed_ids.length === 0) {
+      return;
+    }
     set((state) =>
       mutate(state, (draft) => {
         draft.liveSegments = applyLiveSegmentDelta(draft.liveSegments, delta);
@@ -190,6 +198,37 @@ function groupPartialsByChannel(partials: LiveTranscriptDelta["partials"]): {
   });
 
   return { wordsByChannel, hintsByChannel };
+}
+
+function partialWordsByChannelEqual(
+  left: WordsByChannel,
+  right: WordsByChannel,
+): boolean {
+  const leftChannels = Object.keys(left);
+  const rightChannels = Object.keys(right);
+  if (leftChannels.length !== rightChannels.length) {
+    return false;
+  }
+
+  return leftChannels.every((channelKey) => {
+    const channel = Number(channelKey);
+    const leftWords = left[channel] ?? [];
+    const rightWords = right[channel] ?? [];
+    return (
+      leftWords.length === rightWords.length &&
+      leftWords.every((word, index) => {
+        const other = rightWords[index];
+        return (
+          other !== undefined &&
+          word.text === other.text &&
+          word.start_ms === other.start_ms &&
+          word.end_ms === other.end_ms &&
+          word.channel === other.channel &&
+          word.speaker_index === other.speaker_index
+        );
+      })
+    );
+  });
 }
 
 function getCaptionTextFromDelta(

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -231,6 +231,18 @@ describe("transcript SQLite queries", () => {
       expect(query.sql).not.toContain(
         "json_array_length(transcript.words_json)",
       );
+      expect(query.sql).toContain("FROM transcript_live_deltas AS delta");
+      expect(query.sql).toContain("'$.new_words'");
+      expect(query.sql).not.toContain("'$.partials'");
+    }
+  });
+
+  it("skips pending transcript journals while live state is visible", () => {
+    renderHook(() => useSessionTranscriptMetadata("session-1", false));
+    renderHook(() => useTranscriptMetadata("transcript-1", false));
+
+    for (const query of mocks.queryOptions) {
+      expect(query.sql).not.toContain("transcript_live_deltas");
     }
   });
 

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -129,15 +129,27 @@ const TRANSCRIPT_METADATA_COLUMNS = `
   transcript.ended_at_ms,
   CASE
     WHEN trim(transcript.words_json) NOT IN ('', '[]', '{}', 'null')
+    THEN 1
+    ELSE 0
+  END AS has_words
+`;
+
+const TRANSCRIPT_METADATA_WITH_PENDING_COLUMNS = `
+  transcript.id,
+  transcript.session_id,
+  transcript.started_at_ms,
+  transcript.ended_at_ms,
+  CASE
+    WHEN trim(transcript.words_json) NOT IN ('', '[]', '{}', 'null')
     OR EXISTS (
       SELECT 1
       FROM transcript_live_deltas AS delta
       WHERE delta.transcript_id = transcript.id
         AND json_valid(delta.delta_json)
-        AND (
-          COALESCE(json_array_length(delta.delta_json, '$.new_words'), 0) > 0
-          OR COALESCE(json_array_length(delta.delta_json, '$.partials'), 0) > 0
-        )
+        AND COALESCE(
+          json_array_length(delta.delta_json, '$.new_words'),
+          0
+        ) > 0
     ) THEN 1
     ELSE 0
   END AS has_words
@@ -184,13 +196,18 @@ export function useTranscript(
 
 export function useSessionTranscriptMetadata(
   sessionId: string,
+  includePendingDeltas = true,
 ): TranscriptMetadata[] {
   const { data = EMPTY_TRANSCRIPT_METADATA } = useLiveQuery<
     TranscriptMetadataSqlRow,
     TranscriptMetadata[]
   >({
     sql: `
-      SELECT ${TRANSCRIPT_METADATA_COLUMNS}
+      SELECT ${
+        includePendingDeltas
+          ? TRANSCRIPT_METADATA_WITH_PENDING_COLUMNS
+          : TRANSCRIPT_METADATA_COLUMNS
+      }
       FROM transcripts AS transcript
       WHERE transcript.session_id = ? AND transcript.deleted_at IS NULL
       ORDER BY transcript.started_at_ms, transcript.created_at, transcript.id
@@ -204,13 +221,18 @@ export function useSessionTranscriptMetadata(
 
 export function useTranscriptMetadata(
   transcriptId: string,
+  includePendingDeltas = true,
 ): TranscriptMetadata | null {
   const { data = null } = useLiveQuery<
     TranscriptMetadataSqlRow,
     TranscriptMetadata | null
   >({
     sql: `
-      SELECT ${TRANSCRIPT_METADATA_COLUMNS}
+      SELECT ${
+        includePendingDeltas
+          ? TRANSCRIPT_METADATA_WITH_PENDING_COLUMNS
+          : TRANSCRIPT_METADATA_COLUMNS
+      }
       FROM transcripts AS transcript
       WHERE transcript.id = ? AND transcript.deleted_at IS NULL
       LIMIT 1

--- a/apps/desktop/src/stt/transcript-persistence-worker.test.ts
+++ b/apps/desktop/src/stt/transcript-persistence-worker.test.ts
@@ -121,6 +121,27 @@ describe("createTranscriptPersistenceWorker", () => {
     expect(afterFlush).toHaveBeenCalledOnce();
   });
 
+  it("does not persist UI-only partials", async () => {
+    const persist = vi.fn(async (_delta: LiveTranscriptDelta) => undefined);
+    const worker = createImmediateTranscriptPersistenceWorker(persist, vi.fn());
+
+    worker.enqueue({
+      new_words: [],
+      replaced_ids: [],
+      partials: [
+        {
+          text: "still speaking",
+          start_ms: 0,
+          end_ms: 1,
+          channel: 0,
+        },
+      ],
+    });
+    await worker.flush();
+
+    expect(persist).not.toHaveBeenCalled();
+  });
+
   it("coalesces a long burst behind one in-flight write and flushes later work", async () => {
     const firstWrite = deferred();
     const secondWrite = deferred();
@@ -156,9 +177,7 @@ describe("createTranscriptPersistenceWorker", () => {
     await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(2));
 
     expect(writes[1]?.new_words).toHaveLength(1_000);
-    expect(writes[1]?.partials).toEqual([
-      expect.objectContaining({ text: "partial-1000" }),
-    ]);
+    expect(writes[1]?.partials).toEqual([]);
 
     secondWrite.resolve();
     worker.enqueue(delta("word-1001"));
@@ -204,9 +223,7 @@ describe("createTranscriptPersistenceWorker", () => {
       expect.objectContaining({ id: "word-5" }),
     ]);
     expect(writes[1]?.replaced_ids).toEqual(["word-1", "word-2"]);
-    expect(writes[1]?.partials).toEqual([
-      expect.objectContaining({ text: "latest partial" }),
-    ]);
+    expect(writes[1]?.partials).toEqual([]);
   });
 
   it("bounds a delayed correction burst while preserving final words and speaker hints", async () => {

--- a/apps/desktop/src/stt/transcript-persistence-worker.ts
+++ b/apps/desktop/src/stt/transcript-persistence-worker.ts
@@ -9,7 +9,6 @@ type PendingTranscriptWrite = {
     }
   >;
   replacedRootIds: Set<string>;
-  partials: LiveTranscriptDelta["partials"];
   wordCount: number;
   textLength: number;
 };
@@ -157,7 +156,11 @@ export function createTranscriptPersistenceWorker(
   };
 
   const enqueue = (delta: LiveTranscriptDelta) => {
-    if (overflowed || timedOut) {
+    if (
+      overflowed ||
+      timedOut ||
+      (delta.new_words.length === 0 && delta.replaced_ids.length === 0)
+    ) {
       return;
     }
 
@@ -242,7 +245,6 @@ function createPendingWrite(): PendingTranscriptWrite {
   return {
     wordsById: new Map(),
     replacedRootIds: new Set(),
-    partials: [],
     wordCount: 0,
     textLength: 0,
   };
@@ -290,16 +292,6 @@ function mergeDelta(
       0,
     );
   }
-
-  pendingWrite.textLength -= pendingWrite.partials.reduce(
-    (length, word) => length + word.text.length,
-    0,
-  );
-  pendingWrite.partials = [...delta.partials];
-  pendingWrite.textLength += pendingWrite.partials.reduce(
-    (length, word) => length + word.text.length,
-    0,
-  );
 }
 
 function toDelta(pendingWrite: PendingTranscriptWrite): LiveTranscriptDelta {
@@ -311,7 +303,7 @@ function toDelta(pendingWrite: PendingTranscriptWrite): LiveTranscriptDelta {
   return {
     new_words: newWords,
     replaced_ids: [...pendingWrite.replacedRootIds],
-    partials: pendingWrite.partials,
+    partials: [],
   };
 }
 
@@ -339,7 +331,6 @@ function removePendingWords(
 function exceedsSafeBounds(pendingWrite: PendingTranscriptWrite) {
   return (
     pendingWrite.wordCount > MAX_PENDING_WORDS ||
-    pendingWrite.partials.length > MAX_PENDING_WORDS ||
     pendingWrite.textLength > MAX_PENDING_TEXT_LENGTH ||
     pendingWrite.replacedRootIds.size > MAX_PENDING_REPLACED_IDS
   );

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -16,7 +16,7 @@ use owhisper_interface::{ControlMessage, MixedMessage};
 use super::stream::process_stream;
 use super::{
     ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg, actor_error,
-    actor_error_with_degraded,
+    actor_error_with_degraded, actor_error_with_degraded_retry,
 };
 
 use crate::{DegradedError, SessionErrorEvent};
@@ -79,7 +79,12 @@ fn ws_connect_error(args: &ListenerArgs, error: anlg_ws_client::Error) -> ActorP
         error: message.clone(),
     });
 
-    actor_error_with_degraded(message, classify_ws_connect_failure(&provider, &error))
+    let retry_after = error.retry_after_secs().map(Duration::from_secs);
+    actor_error_with_degraded_retry(
+        message,
+        classify_ws_connect_failure(&provider, &error),
+        retry_after,
+    )
 }
 
 pub(super) async fn spawn_rx_task(
@@ -513,7 +518,7 @@ fn build_extra(args: &ListenerArgs) -> (f64, Extra) {
 fn desktop_connect_policy() -> anlg_ws_client::client::WebSocketConnectPolicy {
     anlg_ws_client::client::WebSocketConnectPolicy {
         connect_timeout: Duration::from_secs(4),
-        max_attempts: 2,
+        max_attempts: 1,
         retry_delay: Duration::from_secs(1),
     }
 }
@@ -779,12 +784,41 @@ mod tests {
         let error = anlg_ws_client::Error::ConnectRetriesExhausted {
             attempts: 3,
             last_error: "HTTP 503 Service Unavailable".to_string(),
+            retry_after_secs: None,
         };
 
         assert!(matches!(
             classify_ws_connect_failure("deepgram", &error),
             DegradedError::UpstreamUnavailable { .. }
         ));
+    }
+
+    #[test]
+    fn websocket_retry_after_reaches_the_session_supervisor() {
+        let error = anlg_ws_client::Error::ConnectFailed {
+            attempt: 1,
+            max_attempts: 1,
+            message: "HTTP 503 Service Unavailable".to_string(),
+            is_auth: false,
+            status_code: Some(503),
+            retryable: true,
+            retry_after_secs: Some(7),
+        };
+
+        let error = ws_connect_error(&listener_args("https://api.anarlog.so/stt", "cloud"), error);
+        let error = error
+            .downcast_ref::<super::super::ListenerInitError>()
+            .expect("listener init error");
+
+        assert_eq!(error.retry_after, Some(Duration::from_secs(7)));
+    }
+
+    #[test]
+    fn desktop_connection_attempts_are_owned_by_the_session_supervisor() {
+        let policy = desktop_connect_policy();
+
+        assert_eq!(policy.max_attempts, 1);
+        assert_eq!(policy.connect_timeout, Duration::from_secs(4));
     }
 
     #[test]

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -94,6 +94,7 @@ impl ListenerActor {
 pub(super) struct ListenerInitError {
     pub(super) message: String,
     pub(super) degraded: Option<DegradedError>,
+    pub(super) retry_after: Option<Duration>,
 }
 
 impl std::fmt::Display for ListenerInitError {
@@ -108,6 +109,7 @@ pub(super) fn actor_error(msg: impl Into<String>) -> ActorProcessingErr {
     Box::new(ListenerInitError {
         message: msg.into(),
         degraded: None,
+        retry_after: None,
     })
 }
 
@@ -115,9 +117,18 @@ pub(super) fn actor_error_with_degraded(
     msg: impl Into<String>,
     degraded: DegradedError,
 ) -> ActorProcessingErr {
+    actor_error_with_degraded_retry(msg, degraded, None)
+}
+
+pub(super) fn actor_error_with_degraded_retry(
+    msg: impl Into<String>,
+    degraded: DegradedError,
+    retry_after: Option<Duration>,
+) -> ActorProcessingErr {
     Box::new(ListenerInitError {
         message: msg.into(),
         degraded: Some(degraded),
+        retry_after,
     })
 }
 

--- a/crates/listener-core/src/actors/recorder/mod.rs
+++ b/crates/listener-core/src/actors/recorder/mod.rs
@@ -35,7 +35,7 @@ enum WriteRequest {
     AudioDual(Arc<[f32]>, Arc<[f32]>),
 }
 
-const WRITE_QUEUE_CAPACITY: usize = 8;
+const WRITE_QUEUE_CAPACITY: usize = 32;
 const MAX_CONCURRENT_WRITERS: usize = 4;
 const WRITER_SHUTDOWN_WARNING: Duration = Duration::from_secs(10);
 

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -1,6 +1,8 @@
 mod children;
 mod mode;
 
+use std::hash::{DefaultHasher, Hash, Hasher};
+
 use ractor::concurrency::Duration;
 use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, SupervisionEvent};
 use tracing::Instrument;
@@ -22,6 +24,7 @@ const LISTENER_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_secs(20),
     Duration::from_secs(30),
 ];
+const MAX_LISTENER_RETRY_AFTER: Duration = Duration::from_secs(30);
 
 pub struct SessionState {
     ctx: SessionContext,
@@ -115,8 +118,9 @@ impl Actor for SessionActor {
                 }
                 Err(error) => {
                     tracing::warn!(?error, "listener_spawn_failed");
+                    let retry_after = listener_retry_after(&error);
                     let degraded = classify_listener_spawn_failure(state, &error);
-                    handle_listener_failure(&myself, state, degraded).await;
+                    handle_listener_failure(&myself, state, degraded, retry_after).await;
                 }
             }
 
@@ -179,6 +183,7 @@ impl Actor for SessionActor {
                                 &myself,
                                 state,
                                 mode::parse_degraded_reason(reason.as_ref()),
+                                None,
                             )
                             .await;
                         }
@@ -222,6 +227,7 @@ impl Actor for SessionActor {
                                 DegradedError::StreamError {
                                     message: format!("{:?}", error),
                                 },
+                                None,
                             )
                             .await;
                         }
@@ -329,8 +335,9 @@ async fn refresh_listener(myself: ActorRef<SessionMsg>, state: &mut SessionState
         }
         Err(error) => {
             tracing::warn!(?error, "listener_refresh_failed");
+            let retry_after = listener_retry_after(&error);
             let degraded = classify_listener_spawn_failure(state, &error);
-            handle_listener_failure(&myself, state, degraded).await;
+            handle_listener_failure(&myself, state, degraded, retry_after).await;
         }
     }
 }
@@ -357,6 +364,7 @@ async fn handle_listener_failure(
     myself: &ActorRef<SessionMsg>,
     state: &mut SessionState,
     degraded: DegradedError,
+    retry_after: Option<Duration>,
 ) {
     if should_stop_on_listener_failure(state) {
         tracing::warn!("listener_failed_stopping_session");
@@ -365,7 +373,7 @@ async fn handle_listener_failure(
         let should_retry = should_retry_listener_failure(&degraded);
         enter_batch_fallback(state, degraded).await;
         if should_retry {
-            schedule_listener_retry(myself, state);
+            schedule_listener_retry(myself, state, retry_after);
         }
     }
 }
@@ -399,19 +407,55 @@ fn classify_listener_spawn_failure(
     }
 }
 
-fn schedule_listener_retry(myself: &ActorRef<SessionMsg>, state: &mut SessionState) {
-    let delay = listener_retry_delay(state.listener_retry_attempt);
+fn listener_retry_after(error: &ractor::SpawnErr) -> Option<Duration> {
+    let ractor::SpawnErr::StartupFailed(error) = error else {
+        return None;
+    };
+    error
+        .downcast_ref::<ListenerInitError>()
+        .and_then(|error| error.retry_after)
+}
+
+fn schedule_listener_retry(
+    myself: &ActorRef<SessionMsg>,
+    state: &mut SessionState,
+    retry_after: Option<Duration>,
+) {
+    let delay = listener_retry_delay(
+        state.listener_retry_attempt,
+        retry_after,
+        &state.ctx.params.session_id,
+    );
     state.listener_retry_attempt = state.listener_retry_attempt.saturating_add(1);
     tracing::info!(
         ?delay,
+        ?retry_after,
         attempt = state.listener_retry_attempt,
         "listener_retry_scheduled"
     );
     myself.send_after(delay, || SessionMsg::RetryListener);
 }
 
-fn listener_retry_delay(attempt: usize) -> Duration {
+fn listener_retry_base_delay(attempt: usize) -> Duration {
     LISTENER_RETRY_DELAYS[attempt.min(LISTENER_RETRY_DELAYS.len() - 1)]
+}
+
+fn listener_retry_delay(
+    attempt: usize,
+    retry_after: Option<Duration>,
+    session_id: &str,
+) -> Duration {
+    let scheduled = listener_retry_base_delay(attempt);
+    let base = retry_after.map_or(scheduled, |minimum| {
+        scheduled.max(minimum.min(MAX_LISTENER_RETRY_AFTER))
+    });
+    let base_ms = base.as_millis().min(u64::MAX as u128) as u64;
+    let jitter_limit_ms = base_ms / 5;
+    let mut hasher = DefaultHasher::new();
+    session_id.hash(&mut hasher);
+    attempt.hash(&mut hasher);
+    let jitter_ms = hasher.finish() % jitter_limit_ms.saturating_add(1);
+    Duration::from_millis(base_ms.saturating_add(jitter_ms))
 }
 
 async fn retry_listener(myself: ActorRef<SessionMsg>, state: &mut SessionState) {
@@ -437,8 +481,9 @@ async fn retry_listener(myself: ActorRef<SessionMsg>, state: &mut SessionState) 
         }
         Err(error) => {
             tracing::warn!(?error, "listener_retry_failed");
+            let retry_after = listener_retry_after(&error);
             let degraded = classify_listener_spawn_failure(state, &error);
-            handle_listener_failure(&myself, state, degraded).await;
+            handle_listener_failure(&myself, state, degraded, retry_after).await;
         }
     }
 }
@@ -768,9 +813,20 @@ mod tests {
         assert!(should_retry_listener_failure(
             &DegradedError::ConnectionTimeout
         ));
-        assert_eq!(listener_retry_delay(0), Duration::from_secs(2));
-        assert_eq!(listener_retry_delay(3), Duration::from_secs(20));
-        assert_eq!(listener_retry_delay(20), Duration::from_secs(30));
+        assert_eq!(listener_retry_base_delay(0), Duration::from_secs(2));
+        assert_eq!(listener_retry_base_delay(3), Duration::from_secs(20));
+        assert_eq!(listener_retry_base_delay(20), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn listener_retry_delay_adds_jitter_and_honors_retry_after() {
+        let normal = listener_retry_delay(0, None, "session-a");
+        assert!(normal >= Duration::from_secs(2));
+        assert!(normal <= Duration::from_millis(2_400));
+
+        let rate_limited = listener_retry_delay(0, Some(Duration::from_secs(60)), "session-a");
+        assert!(rate_limited >= Duration::from_secs(30));
+        assert!(rate_limited <= Duration::from_secs(36));
     }
 
     #[test]
@@ -793,7 +849,9 @@ mod tests {
         let error = ractor::SpawnErr::StartupFailed(Box::new(ListenerInitError {
             message: "listener failed".to_string(),
             degraded: Some(degraded),
+            retry_after: Some(Duration::from_secs(7)),
         }));
+        assert_eq!(listener_retry_after(&error), Some(Duration::from_secs(7)));
         assert!(matches!(
             classify_listener_spawn_failure(&test_state(test_ctx()), &error),
             DegradedError::ProviderConfiguration { .. }

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -6,6 +6,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::{self, Receiver},
 };
+use std::time::Duration;
 
 use ractor::{Actor, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort};
 use tokio_util::sync::CancellationToken;
@@ -18,7 +19,7 @@ use crate::{
 };
 use anlg_audio::{AudioProvider, CaptureFrame};
 
-use pipeline::Pipeline;
+use pipeline::{DispatchFrameResult, Pipeline};
 use stream::start_source_loop;
 
 use anlg_device_monitor::{DeviceMonitorHandle, DeviceSwitch, DeviceSwitchMonitor};
@@ -85,6 +86,7 @@ pub struct SourceState {
 pub struct SourceActor;
 
 const MAX_CAPTURE_FRAMES_PER_TICK: usize = 4;
+const RECORDER_BACKPRESSURE_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 struct DeviceChangeWatcher {
     _handle: DeviceMonitorHandle,
@@ -219,41 +221,57 @@ impl Actor for SourceActor {
                 SourceMsg::CaptureFramesReady => {
                     st.capture_wake_pending.store(false, Ordering::Release);
 
-                    for _ in 0..MAX_CAPTURE_FRAMES_PER_TICK {
-                        let frame = st
-                            .capture_frames
-                            .as_mut()
-                            .and_then(|frames| frames.try_recv().ok());
-                        let Some(frame) = frame else {
-                            break;
-                        };
+                    let pending_result = st
+                        .pipeline
+                        .retry_pending_recorder(&st.listener_routing, st.recorder.as_ref())
+                        .await;
+                    let mut recorder_backpressured = match pending_result {
+                        Ok(DispatchFrameResult::Complete) => false,
+                        Ok(DispatchFrameResult::RecorderBackpressured) => true,
+                        Err(reason) => return recorder_failure(st, reason),
+                    };
 
-                        if let Err(reason) = st
-                            .pipeline
-                            .dispatch_frame(
-                                frame,
-                                st.current_mode,
-                                &st.listener_routing,
-                                st.recorder.as_ref(),
-                            )
-                            .await
-                        {
-                            tracing::error!(%reason, "recorder_audio_write_failed");
-                            st.runtime.emit_error(SessionErrorEvent::AudioError {
-                                session_id: st.session_id.clone(),
-                                error: reason.clone(),
-                                device: st.mic_device.clone(),
-                                is_fatal: true,
-                            });
-                            return Err(std::io::Error::other(reason).into());
+                    if !recorder_backpressured {
+                        for _ in 0..MAX_CAPTURE_FRAMES_PER_TICK {
+                            let frame = st
+                                .capture_frames
+                                .as_mut()
+                                .and_then(|frames| frames.try_recv().ok());
+                            let Some(frame) = frame else {
+                                break;
+                            };
+
+                            match st
+                                .pipeline
+                                .dispatch_frame(
+                                    frame,
+                                    st.current_mode,
+                                    &st.listener_routing,
+                                    st.recorder.as_ref(),
+                                )
+                                .await
+                            {
+                                Ok(DispatchFrameResult::Complete) => {}
+                                Ok(DispatchFrameResult::RecorderBackpressured) => {
+                                    recorder_backpressured = true;
+                                    break;
+                                }
+                                Err(reason) => return recorder_failure(st, reason),
+                            }
                         }
                     }
 
-                    let has_more = st
+                    let has_queued_frames = st
                         .capture_frames
                         .as_ref()
                         .is_some_and(|frames| !frames.is_empty());
-                    if has_more
+                    if recorder_backpressured || st.pipeline.has_pending_recorder_item() {
+                        if !st.capture_wake_pending.swap(true, Ordering::AcqRel) {
+                            myself.send_after(RECORDER_BACKPRESSURE_RETRY_DELAY, || {
+                                SourceMsg::CaptureFramesReady
+                            });
+                        }
+                    } else if has_queued_frames
                         && !st.capture_wake_pending.swap(true, Ordering::AcqRel)
                         && myself.cast(SourceMsg::CaptureFramesReady).is_err()
                     {
@@ -296,6 +314,17 @@ impl Actor for SourceActor {
 
         Ok(())
     }
+}
+
+fn recorder_failure(state: &SourceState, reason: String) -> Result<(), ActorProcessingErr> {
+    tracing::error!(%reason, "recorder_audio_write_failed");
+    state.runtime.emit_error(SessionErrorEvent::AudioError {
+        session_id: state.session_id.clone(),
+        error: reason.clone(),
+        device: state.mic_device.clone(),
+        is_fatal: true,
+    });
+    Err(std::io::Error::other(reason).into())
 }
 
 #[cfg(test)]

--- a/crates/listener-core/src/actors/source/pipeline.rs
+++ b/crates/listener-core/src/actors/source/pipeline.rs
@@ -28,9 +28,8 @@ const LISTENER_AUDIO_ACK_TIMEOUT: Duration = Duration::from_secs(1);
 const LISTENER_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(1);
 const LISTENER_BACKPRESSURE_RETRY_DELAY: Duration = Duration::from_millis(10);
 const MAX_BACKLOG_DISPATCH_PER_FRAME: usize = 2;
-const RECORDER_ENQUEUE_TIMEOUT: Duration = Duration::from_millis(500);
+const RECORDER_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(2);
 const RECORDER_RPC_TIMEOUT: Duration = Duration::from_millis(100);
-const RECORDER_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Clone)]
 struct BufferedAudio {
@@ -49,12 +48,20 @@ impl BufferedAudio {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DispatchFrameResult {
+    Complete,
+    RecorderBackpressured,
+}
+
 pub(in crate::actors) struct Pipeline {
     vad_mask: VadMask,
     amplitude: AmplitudeEmitter,
     audio_buffer: AudioBuffer,
     replay_history: ReplayHistory,
     listener_dispatcher: ListenerDispatcher,
+    pending_recorder_item: Option<BufferedAudio>,
+    recorder_backpressure_started_at: Option<Instant>,
 }
 
 impl Pipeline {
@@ -64,6 +71,8 @@ impl Pipeline {
             audio_buffer: AudioBuffer::new(MAX_BUFFER_CHUNKS),
             replay_history: ReplayHistory::new(SAMPLE_RATE as usize * REPLAY_HISTORY_SECS),
             listener_dispatcher: ListenerDispatcher::new(),
+            pending_recorder_item: None,
+            recorder_backpressure_started_at: None,
             vad_mask: VadMask::default(),
         }
     }
@@ -73,6 +82,8 @@ impl Pipeline {
         self.audio_buffer.clear();
         self.replay_history.clear();
         self.listener_dispatcher.reset();
+        self.pending_recorder_item = None;
+        self.recorder_backpressure_started_at = None;
         self.vad_mask = VadMask::default();
     }
 
@@ -82,8 +93,44 @@ impl Pipeline {
         mode: ChannelMode,
         listener_routing: &ListenerRouting,
         recorder: Option<&ActorRef<RecMsg>>,
-    ) -> Result<(), String> {
+    ) -> Result<DispatchFrameResult, String> {
         self.dispatch(frame, mode, listener_routing, recorder).await
+    }
+
+    pub(super) fn has_pending_recorder_item(&self) -> bool {
+        self.pending_recorder_item.is_some()
+    }
+
+    pub(super) async fn retry_pending_recorder(
+        &mut self,
+        listener_routing: &ListenerRouting,
+        recorder: Option<&ActorRef<RecMsg>>,
+    ) -> Result<DispatchFrameResult, String> {
+        let Some(item) = self.pending_recorder_item.clone() else {
+            return Ok(DispatchFrameResult::Complete);
+        };
+        let Some(recorder) = recorder else {
+            return Ok(DispatchFrameResult::RecorderBackpressured);
+        };
+
+        match Self::write_to_recorder(recorder, &item).await? {
+            RecorderEnqueueResult::Accepted => {
+                self.pending_recorder_item = None;
+                self.recorder_backpressure_started_at = None;
+                self.complete_item(item, listener_routing);
+                Ok(DispatchFrameResult::Complete)
+            }
+            RecorderEnqueueResult::Backpressured => {
+                if self
+                    .recorder_backpressure_started_at
+                    .is_some_and(|started_at| started_at.elapsed() >= RECORDER_BACKPRESSURE_TIMEOUT)
+                {
+                    return Err("recorder queue remained full".into());
+                }
+                Ok(DispatchFrameResult::RecorderBackpressured)
+            }
+            RecorderEnqueueResult::Closed => Err("recorder writer is unavailable".into()),
+        }
     }
 
     pub(super) fn on_listener_routing_changed(&mut self, listener_routing: &ListenerRouting) {
@@ -118,20 +165,38 @@ impl Pipeline {
         mode: ChannelMode,
         listener_routing: &ListenerRouting,
         recorder: Option<&ActorRef<RecMsg>>,
-    ) -> Result<(), String> {
+    ) -> Result<DispatchFrameResult, String> {
+        if self.pending_recorder_item.is_some() {
+            return Err("recorder audio must be retried before dispatching another frame".into());
+        }
+
         let (mut processed_mic, processed_spk) = Self::select_tracks(frame, mode);
         self.vad_mask.process(&mut processed_mic);
         let processed_mic = Arc::<[f32]>::from(processed_mic);
         let item = BufferedAudio::new(processed_mic, processed_spk, mode);
 
-        self.replay_history.push(item.clone());
+        if let Some(actor) = recorder {
+            match Self::write_to_recorder(actor, &item).await? {
+                RecorderEnqueueResult::Accepted => {}
+                RecorderEnqueueResult::Backpressured => {
+                    self.pending_recorder_item = Some(item);
+                    self.recorder_backpressure_started_at = Some(Instant::now());
+                    return Ok(DispatchFrameResult::RecorderBackpressured);
+                }
+                RecorderEnqueueResult::Closed => {
+                    return Err("recorder writer is unavailable".into());
+                }
+            }
+        }
 
+        self.complete_item(item, listener_routing);
+        Ok(DispatchFrameResult::Complete)
+    }
+
+    fn complete_item(&mut self, item: BufferedAudio, listener_routing: &ListenerRouting) {
+        self.replay_history.push(item.clone());
         self.amplitude.observe_mic(&item.mic);
         self.amplitude.observe_spk(&item.spk);
-
-        if let Some(actor) = recorder {
-            Self::write_to_recorder(actor, &item).await?;
-        }
 
         match listener_routing {
             ListenerRouting::Buffering => {
@@ -153,70 +218,50 @@ impl Pipeline {
             }
             ListenerRouting::Dropped => {}
         }
-
-        Ok(())
     }
 
     async fn write_to_recorder(
         actor: &ActorRef<RecMsg>,
         item: &BufferedAudio,
-    ) -> Result<(), String> {
-        let started_at = Instant::now();
-
-        loop {
-            if started_at.elapsed() >= RECORDER_ENQUEUE_TIMEOUT {
-                return Err("recorder queue remained full".into());
+    ) -> Result<RecorderEnqueueResult, String> {
+        let result = match item.mode {
+            ChannelMode::MicOnly => {
+                let audio = Arc::clone(&item.mic);
+                actor
+                    .call(
+                        move |reply| RecMsg::AudioSingle(audio, reply),
+                        Some(RECORDER_RPC_TIMEOUT),
+                    )
+                    .await
             }
-
-            let result = match item.mode {
-                ChannelMode::MicOnly => {
-                    let audio = Arc::clone(&item.mic);
-                    actor
-                        .call(
-                            move |reply| RecMsg::AudioSingle(audio, reply),
-                            Some(RECORDER_RPC_TIMEOUT),
-                        )
-                        .await
-                }
-                ChannelMode::SpeakerOnly => {
-                    let audio = Arc::clone(&item.spk);
-                    actor
-                        .call(
-                            move |reply| RecMsg::AudioSingle(audio, reply),
-                            Some(RECORDER_RPC_TIMEOUT),
-                        )
-                        .await
-                }
-                ChannelMode::MicAndSpeaker => {
-                    let mic = Arc::clone(&item.mic);
-                    let spk = Arc::clone(&item.spk);
-                    actor
-                        .call(
-                            move |reply| RecMsg::AudioDual(mic, spk, reply),
-                            Some(RECORDER_RPC_TIMEOUT),
-                        )
-                        .await
-                }
-            };
-
-            match result {
-                Ok(CallResult::Success(RecorderEnqueueResult::Accepted)) => return Ok(()),
-                Ok(CallResult::Success(RecorderEnqueueResult::Backpressured)) => {
-                    tokio::time::sleep(RECORDER_RETRY_DELAY).await;
-                }
-                Ok(CallResult::Success(RecorderEnqueueResult::Closed)) => {
-                    return Err("recorder writer is unavailable".into());
-                }
-                Ok(CallResult::SenderError) => {
-                    return Err("recorder stopped before acknowledging audio".into());
-                }
-                Ok(CallResult::Timeout) => {
-                    return Err("recorder enqueue acknowledgement timed out".into());
-                }
-                Err(error) => {
-                    return Err(format!("failed to send audio to recorder: {error}"));
-                }
+            ChannelMode::SpeakerOnly => {
+                let audio = Arc::clone(&item.spk);
+                actor
+                    .call(
+                        move |reply| RecMsg::AudioSingle(audio, reply),
+                        Some(RECORDER_RPC_TIMEOUT),
+                    )
+                    .await
             }
+            ChannelMode::MicAndSpeaker => {
+                let mic = Arc::clone(&item.mic);
+                let spk = Arc::clone(&item.spk);
+                actor
+                    .call(
+                        move |reply| RecMsg::AudioDual(mic, spk, reply),
+                        Some(RECORDER_RPC_TIMEOUT),
+                    )
+                    .await
+            }
+        };
+
+        match result {
+            Ok(CallResult::Success(result)) => Ok(result),
+            Ok(CallResult::SenderError) => {
+                Err("recorder stopped before acknowledging audio".into())
+            }
+            Ok(CallResult::Timeout) => Err("recorder enqueue acknowledgement timed out".into()),
+            Err(error) => Err(format!("failed to send audio to recorder: {error}")),
         }
     }
 
@@ -706,6 +751,8 @@ mod tests {
 
     struct BackpressuredRecorderProbe;
 
+    struct RecoveringRecorderProbe(tokio::sync::mpsc::UnboundedSender<ProbeEvent>);
+
     struct BackpressuredListenerProbe(tokio::sync::mpsc::UnboundedSender<ProbeEvent>);
 
     struct StuckListenerProbe;
@@ -844,6 +891,42 @@ mod tests {
             match message {
                 RecMsg::AudioSingle(_, reply) | RecMsg::AudioDual(_, _, reply) => {
                     let _ = reply.send(RecorderEnqueueResult::Backpressured);
+                }
+                RecMsg::WriterFailed(_) => {}
+            }
+            Ok(())
+        }
+    }
+
+    #[ractor::async_trait]
+    impl Actor for RecoveringRecorderProbe {
+        type Msg = RecMsg;
+        type State = bool;
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(false)
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            message: Self::Msg,
+            backpressured_once: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            match message {
+                RecMsg::AudioSingle(_, reply) | RecMsg::AudioDual(_, _, reply) => {
+                    if *backpressured_once {
+                        let _ = self.0.send(ProbeEvent::RecorderDual);
+                        let _ = reply.send(RecorderEnqueueResult::Accepted);
+                    } else {
+                        *backpressured_once = true;
+                        let _ = reply.send(RecorderEnqueueResult::Backpressured);
+                    }
                 }
                 RecMsg::WriterFailed(_) => {}
             }
@@ -1234,14 +1317,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recorder_backpressure_fails_within_a_finite_deadline() {
+    async fn recorder_backpressure_yields_before_a_finite_deadline() {
         let mut pipeline = test_pipeline();
         let (recorder_ref, handle) = Actor::spawn(None, BackpressuredRecorderProbe, ())
             .await
             .unwrap();
         let started_at = Instant::now();
 
-        let error = pipeline
+        let result = pipeline
             .dispatch_frame(
                 source_frame(false),
                 ChannelMode::MicAndSpeaker,
@@ -1249,13 +1332,105 @@ mod tests {
                 Some(&recorder_ref),
             )
             .await
+            .unwrap();
+
+        assert_eq!(result, DispatchFrameResult::RecorderBackpressured);
+        assert!(pipeline.has_pending_recorder_item());
+        assert!(started_at.elapsed() < RECORDER_BACKPRESSURE_TIMEOUT);
+
+        pipeline.recorder_backpressure_started_at =
+            Some(Instant::now() - RECORDER_BACKPRESSURE_TIMEOUT);
+        let error = pipeline
+            .retry_pending_recorder(&ListenerRouting::Dropped, Some(&recorder_ref))
+            .await
             .unwrap_err();
 
         assert_eq!(error, "recorder queue remained full");
-        assert!(started_at.elapsed() >= RECORDER_ENQUEUE_TIMEOUT);
-        assert!(started_at.elapsed() < Duration::from_secs(1));
 
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn recorder_backpressure_retries_the_same_frame_without_dropping_it() {
+        let mut pipeline = test_pipeline();
+        let (probe_tx, mut probe_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (recorder_ref, handle) = Actor::spawn(None, RecoveringRecorderProbe(probe_tx), ())
+            .await
+            .unwrap();
+
+        let first_result = pipeline
+            .dispatch_frame(
+                source_frame(false),
+                ChannelMode::MicAndSpeaker,
+                &ListenerRouting::Dropped,
+                Some(&recorder_ref),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_result, DispatchFrameResult::RecorderBackpressured);
+
+        let retry_result = pipeline
+            .retry_pending_recorder(&ListenerRouting::Dropped, Some(&recorder_ref))
+            .await
+            .unwrap();
+        assert_eq!(retry_result, DispatchFrameResult::Complete);
+        assert!(!pipeline.has_pending_recorder_item());
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), probe_rx.recv())
+                .await
+                .unwrap(),
+            Some(ProbeEvent::RecorderDual)
+        ));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn recorder_backpressure_survives_recorder_restart() {
+        let mut pipeline = test_pipeline();
+        let (backpressured_ref, backpressured_handle) =
+            Actor::spawn(None, BackpressuredRecorderProbe, ())
+                .await
+                .unwrap();
+
+        let first_result = pipeline
+            .dispatch_frame(
+                source_frame(false),
+                ChannelMode::MicAndSpeaker,
+                &ListenerRouting::Dropped,
+                Some(&backpressured_ref),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_result, DispatchFrameResult::RecorderBackpressured);
+
+        let missing_result = pipeline
+            .retry_pending_recorder(&ListenerRouting::Dropped, None)
+            .await
+            .unwrap();
+        assert_eq!(missing_result, DispatchFrameResult::RecorderBackpressured);
+        assert!(pipeline.has_pending_recorder_item());
+
+        let (probe_tx, mut probe_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (replacement_ref, replacement_handle) = Actor::spawn(None, RecorderProbe(probe_tx), ())
+            .await
+            .unwrap();
+        let retry_result = pipeline
+            .retry_pending_recorder(&ListenerRouting::Dropped, Some(&replacement_ref))
+            .await
+            .unwrap();
+
+        assert_eq!(retry_result, DispatchFrameResult::Complete);
+        assert!(!pipeline.has_pending_recorder_item());
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), probe_rx.recv())
+                .await
+                .unwrap(),
+            Some(ProbeEvent::RecorderDual)
+        ));
+
+        backpressured_handle.abort();
+        replacement_handle.abort();
     }
 
     #[test]

--- a/crates/listener-core/src/actors/source/stream.rs
+++ b/crates/listener-core/src/actors/source/stream.rs
@@ -9,7 +9,7 @@ use anlg_audio_utils::chunk_size_for_stt;
 
 use super::{SourceFrame, SourceMsg, SourceState};
 
-const CAPTURE_FRAME_QUEUE_CAPACITY: usize = 8;
+const CAPTURE_FRAME_QUEUE_CAPACITY: usize = 32;
 
 pub(super) async fn start_source_loop(
     myself: &ActorRef<SourceMsg>,

--- a/crates/ws-client/src/error.rs
+++ b/crates/ws-client/src/error.rs
@@ -1,3 +1,5 @@
+const MAX_RETRY_AFTER_SECONDS: u64 = 30;
+
 #[derive(thiserror::Error)]
 pub enum Error {
     #[error("unknown error")]
@@ -17,7 +19,11 @@ pub enum Error {
         retry_after_secs: Option<u64>,
     },
     #[error("connect retries exhausted after {attempts} attempts: {last_error}")]
-    ConnectRetriesExhausted { attempts: usize, last_error: String },
+    ConnectRetriesExhausted {
+        attempts: usize,
+        last_error: String,
+        retry_after_secs: Option<u64>,
+    },
     #[error("remote closed websocket{code_suffix}: {reason}")]
     RemoteClosed {
         code: Option<u16>,
@@ -73,7 +79,11 @@ impl std::fmt::Debug for Error {
             Error::ConnectRetriesExhausted {
                 attempts,
                 last_error,
-            } => write!(f, "ConnectRetriesExhausted({attempts}, {last_error})"),
+                retry_after_secs,
+            } => write!(
+                f,
+                "ConnectRetriesExhausted({attempts}, retry_after={retry_after_secs:?}, {last_error})"
+            ),
             Error::RemoteClosed { code, reason, .. } => {
                 write!(f, "RemoteClosed(code={code:?}, reason={reason})")
             }
@@ -127,10 +137,27 @@ impl Error {
         }
     }
 
-    pub fn connect_retries_exhausted(attempts: usize, last_error: impl Into<String>) -> Self {
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        match self {
+            Error::ConnectFailed {
+                retry_after_secs, ..
+            }
+            | Error::ConnectRetriesExhausted {
+                retry_after_secs, ..
+            } => *retry_after_secs,
+            _ => None,
+        }
+    }
+
+    pub fn connect_retries_exhausted(
+        attempts: usize,
+        last_error: impl Into<String>,
+        retry_after_secs: Option<u64>,
+    ) -> Self {
         Self::ConnectRetriesExhausted {
             attempts,
             last_error: last_error.into(),
+            retry_after_secs,
         }
     }
 
@@ -221,7 +248,8 @@ fn extract_retry_after(error: &tokio_tungstenite::tungstenite::Error) -> Option<
             .headers()
             .get("retry-after")
             .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(|seconds| seconds.clamp(1, MAX_RETRY_AFTER_SECONDS));
     }
     None
 }

--- a/crates/ws-client/src/retry.rs
+++ b/crates/ws-client/src/retry.rs
@@ -41,6 +41,10 @@ pub(crate) async fn connect_with_retry(
     crate::Error,
 > {
     let max_attempts = policy.max_attempts.max(1);
+    if max_attempts == 1 {
+        return try_connect(request, policy.connect_timeout, 1, max_attempts).await;
+    }
+
     let attempts_made = Arc::new(AtomicUsize::new(0));
     let attempts_ref = attempts_made.clone();
 
@@ -94,9 +98,11 @@ pub(crate) async fn connect_with_retry(
         Err(error) if !error.is_retryable_connect_error() => Err(error),
         Err(error) => {
             let attempts = attempts_made.load(Ordering::SeqCst);
+            let retry_after_secs = error.retry_after_secs();
             Err(crate::Error::connect_retries_exhausted(
                 attempts,
                 error.to_string(),
+                retry_after_secs,
             ))
         }
     }

--- a/crates/ws-client/tests/client_retry.rs
+++ b/crates/ws-client/tests/client_retry.rs
@@ -47,6 +47,7 @@ async fn test_retry_exhausted_returns_explicit_error() {
         ws_client::Error::ConnectRetriesExhausted {
             attempts,
             last_error,
+            ..
         } => {
             assert_eq!(attempts, 2);
             assert!(!last_error.is_empty());
@@ -57,7 +58,7 @@ async fn test_retry_exhausted_returns_explicit_error() {
 
 #[tokio::test]
 async fn test_non_retryable_http_handshake_error_fails_fast() {
-    let (addr, attempts) = http_error_server("400 Bad Request", "bad request").await;
+    let (addr, attempts) = http_error_server("400 Bad Request", "bad request", "").await;
     let client = test_client(addr).with_connect_policy(WebSocketConnectPolicy {
         connect_timeout: Duration::from_secs(1),
         max_attempts: 3,
@@ -82,6 +83,90 @@ async fn test_non_retryable_http_handshake_error_fails_fast() {
         other => panic!("expected connect failure, got {other:?}"),
     }
 
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_single_attempt_preserves_retry_after() {
+    let (addr, attempts) =
+        http_error_server("503 Service Unavailable", "draining", "Retry-After: 7\r\n").await;
+    let client = test_client(addr).with_connect_policy(WebSocketConnectPolicy {
+        connect_timeout: Duration::from_secs(1),
+        max_attempts: 1,
+        retry_delay: Duration::from_millis(10),
+    });
+
+    let error = match start_test_client(client, message_stream("retry-after")).await {
+        Ok(_) => panic!("expected connection failure"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.retry_after_secs(), Some(7));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_retryable_http_statuses_use_the_connection_budget() {
+    for status in ["429 Too Many Requests", "503 Service Unavailable"] {
+        let (addr, attempts) = http_error_server(status, "temporarily unavailable", "").await;
+        let client = test_client(addr).with_connect_policy(WebSocketConnectPolicy {
+            connect_timeout: Duration::from_secs(1),
+            max_attempts: 2,
+            retry_delay: Duration::from_millis(1),
+        });
+
+        let error = start_test_client(client, message_stream("retryable-http")).await;
+        assert!(matches!(
+            error,
+            Err(ws_client::Error::ConnectRetriesExhausted { attempts: 2, .. })
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+}
+
+#[tokio::test]
+async fn test_retry_after_is_capped() {
+    let (addr, attempts) = http_error_server(
+        "503 Service Unavailable",
+        "draining",
+        "Retry-After: 3600\r\n",
+    )
+    .await;
+    let client = test_client(addr).with_connect_policy(WebSocketConnectPolicy {
+        connect_timeout: Duration::from_secs(1),
+        max_attempts: 1,
+        retry_delay: Duration::from_millis(10),
+    });
+
+    let error = match start_test_client(client, message_stream("capped-retry-after")).await {
+        Ok(_) => panic!("expected connection failure"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.retry_after_secs(), Some(30));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_zero_retry_after_uses_a_nonzero_minimum() {
+    let (addr, attempts) = http_error_server(
+        "429 Too Many Requests",
+        "rate limited",
+        "Retry-After: 0\r\n",
+    )
+    .await;
+    let client = test_client(addr).with_connect_policy(WebSocketConnectPolicy {
+        connect_timeout: Duration::from_secs(1),
+        max_attempts: 1,
+        retry_delay: Duration::from_millis(10),
+    });
+
+    let error = match start_test_client(client, message_stream("minimum-retry-after")).await {
+        Ok(_) => panic!("expected connection failure"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.retry_after_secs(), Some(1));
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }
 

--- a/crates/ws-client/tests/common/mod.rs
+++ b/crates/ws-client/tests/common/mod.rs
@@ -205,6 +205,7 @@ pub(crate) async fn reset_without_close_server() -> SocketAddr {
 pub(crate) async fn http_error_server(
     status_line: &'static str,
     body: &'static str,
+    headers: &'static str,
 ) -> (SocketAddr, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -215,7 +216,7 @@ pub(crate) async fn http_error_server(
         while let Ok((mut stream, _)) = listener.accept().await {
             attempts_for_task.fetch_add(1, Ordering::SeqCst);
             let response = format!(
-                "HTTP/1.1 {status_line}\r\nContent-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{body}",
+                "HTTP/1.1 {status_line}\r\n{headers}Content-Length: {}\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n{body}",
                 body.len()
             );
             let _ = stream.write_all(response.as_bytes()).await;


### PR DESCRIPTION
## Summary
- bound server-directed reconnect delays and centralize jittered retries in the session supervisor
- keep recorder backpressure off the source actor while preserving queued audio
- reduce transcript search, Zustand, and SQLite journal churn during meetings

## Test plan
- [x] cargo test -p ws-client
- [x] cargo test -p listener-core
- [x] pnpm -F desktop test
- [x] pnpm -F desktop typecheck
- [x] pnpm exec oxlint --quiet --format=github apps/desktop/src/
- [x] pnpm fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live capture, persistence, and reconnection paths where regressions could drop audio or delay transcripts, though behavior is covered by expanded unit tests.
> 
> **Overview**
> Improves how live meetings survive transient STT/network issues and cuts unnecessary work while capture is running.
> 
> **Reconnection and audio (native)**  
> Listener WebSocket connects now fail fast at the client (`max_attempts: 1`) and surface **Retry-After** (clamped) through init errors. The **session supervisor** owns backoff retries with jitter and honors upstream rate limits. **Recorder backpressure** no longer blocks the source actor in a tight loop: full queues stash the current frame, retry on a timer, and use larger capture/recorder queues so audio is less likely to be dropped under load.
> 
> **Live transcript (desktop)**  
> **Partial words stay UI-only**: the persistence worker and SQLite journal ignore partial-only deltas; `has_words` metadata only considers pending **`new_words`**, not partials. During an **active** session, transcript metadata/render paths pass `includePendingDeltas: false` so live queries skip `transcript_live_deltas` while Zustand already shows live text. **Zustand** skips store updates when partial snapshots are unchanged or segment deltas are empty; stall-activity resets are tightened so partial-only traffic does not clear stall state. **Transcript search** builds its word index only when the user has a non-empty query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05665c95e250fbdc970786a5078d9b0fb0ff6680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->