### PR TITLE
fix(desktop): quit immediately after confirmed complete quit

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -92,6 +92,7 @@ anlg-db-app = { workspace = true }
 anlg-db-core = { workspace = true }
 anlg-db-sync = { workspace = true }
 anlg-host = { workspace = true }
+anlg-intercept = { workspace = true }
 anlg-storage = { workspace = true }
 anlg-supervisor = { workspace = true }
 
@@ -123,7 +124,6 @@ automation = ["tauri-plugin-automation"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-plugin-automation = { version = "0.1", optional = true }
-anlg-intercept = { workspace = true }
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 tauri-plugin-local-stt = { workspace = true, features = ["metal"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -126,14 +126,8 @@ fn start_exit_hard_fallback() {
     });
 }
 
-fn should_force_quit() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        return anlg_intercept::should_force_quit();
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    false
+fn should_allow_immediate_exit() -> bool {
+    EXIT_FLUSH_COMPLETE.load(Ordering::SeqCst) || anlg_intercept::should_force_quit()
 }
 
 fn create_audio_provider(_bundle_id: &str) -> std::sync::Arc<dyn anlg_audio_actual::AudioProvider> {
@@ -568,7 +562,7 @@ pub fn main() {
                 ctx.mark_exiting();
             }
 
-            if EXIT_FLUSH_COMPLETE.load(Ordering::SeqCst) || should_force_quit() {
+            if should_allow_immediate_exit() {
                 return;
             }
 
@@ -796,6 +790,13 @@ mod test {
             message,
             "Anarlog failed to start: legacy import did not pass parity verification"
         );
+    }
+
+    #[test]
+    fn complete_quit_allows_immediate_exit_without_frontend_flush() {
+        assert!(!should_allow_immediate_exit());
+        anlg_intercept::set_force_quit();
+        assert!(should_allow_immediate_exit());
     }
 
     #[test]

--- a/crates/intercept/src/lib.rs
+++ b/crates/intercept/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(target_os = "macos")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "macos")]
@@ -16,7 +15,6 @@ swift!(fn _demo_quit_progress());
 #[cfg(target_os = "macos")]
 static HANDLER_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-#[cfg(target_os = "macos")]
 static FORCE_QUIT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_os = "macos")]
@@ -28,12 +26,10 @@ pub fn setup_force_quit_handler() {
     }
 }
 
-#[cfg(target_os = "macos")]
 pub fn should_force_quit() -> bool {
     FORCE_QUIT.load(Ordering::SeqCst)
 }
 
-#[cfg(target_os = "macos")]
 pub fn set_force_quit() {
     FORCE_QUIT.store(true, Ordering::SeqCst);
 }
@@ -55,5 +51,17 @@ pub fn demo_quit_progress() {
 #[unsafe(no_mangle)]
 #[cfg(target_os = "macos")]
 pub extern "C" fn rust_set_force_quit() {
-    FORCE_QUIT.store(true, Ordering::SeqCst);
+    set_force_quit();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_force_quit_skips_later_flush_check() {
+        assert!(!should_force_quit());
+        set_force_quit();
+        assert!(should_force_quit());
+    }
 }

--- a/plugins/dock/src/menu_items/quit.rs
+++ b/plugins/dock/src/menu_items/quit.rs
@@ -8,6 +8,6 @@ impl DockMenuItem for DockQuit {
     }
 
     fn handle(app: &tauri::AppHandle<tauri::Wry>) {
-        tauri_plugin_tray::AnlgMenuItem::TrayQuit.handle(app);
+        tauri_plugin_tray::quit_completely(app);
     }
 }

--- a/plugins/tray/Cargo.toml
+++ b/plugins/tray/Cargo.toml
@@ -18,6 +18,7 @@ specta-typescript = { workspace = true }
 
 [dependencies]
 anlg-host = { workspace = true }
+anlg-intercept = { workspace = true }
 
 tauri = { workspace = true, features = ["tray-icon", "image-png"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
@@ -36,9 +37,6 @@ specta = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 unicode-width = { workspace = true }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-anlg-intercept = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = { workspace = true }

--- a/plugins/tray/src/lib.rs
+++ b/plugins/tray/src/lib.rs
@@ -7,7 +7,7 @@ mod tray_icon;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub use ext::*;
-pub use menu_items::{AnlgMenuItem, UpdateMenuState, handle_agenda_menu_event};
+pub use menu_items::{AnlgMenuItem, UpdateMenuState, handle_agenda_menu_event, quit_completely};
 
 const PLUGIN_NAME: &str = "anlg-tray";
 static UPDATES_ENABLED: AtomicBool = AtomicBool::new(true);

--- a/plugins/tray/src/menu_items/mod.rs
+++ b/plugins/tray/src/menu_items/mod.rs
@@ -22,7 +22,7 @@ pub use tray_check_update::{TrayCheckUpdate, UpdateMenuState};
 pub use tray_hide::TrayHide;
 pub use tray_open::TrayOpen;
 pub use tray_quit::TrayQuit;
-pub use tray_quit_completely::TrayQuitCompletely;
+pub use tray_quit_completely::{TrayQuitCompletely, quit_completely};
 pub use tray_settings::TraySettings;
 pub use tray_show_events::TrayShowEvents;
 pub use tray_start::TrayStart;

--- a/plugins/tray/src/menu_items/tray_quit_completely.rs
+++ b/plugins/tray/src/menu_items/tray_quit_completely.rs
@@ -29,8 +29,14 @@ impl MenuItemHandler for TrayQuitCompletely {
             ))
             .show(move |confirmed| {
                 if confirmed {
-                    app.exit(0);
+                    quit_completely(&app);
                 }
             });
     }
+}
+
+pub fn quit_completely(app: &AppHandle<tauri::Wry>) {
+    // Skip the frontend exit flush so the process terminates immediately.
+    anlg_intercept::set_force_quit();
+    app.exit(0);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking **Quit Completely** in the tray confirmation dialog did not terminate the app right away. `app.exit(0)` went through the normal `ExitRequested` flush (pending deletions, DB writes, store save) with a 10s fallback, so the process hung after the click.

Cmd+Shift+Q already skipped that flush via the force-quit flag. Confirmed complete quit did not.

## Fix

Set the force-quit flag before exiting from:

- Tray **Quit Completely** (after the confirmation dialog)
- Dock **Quit Anarlog Completely**

`ExitRequested` then allows the process to terminate immediately, while still running sidecar cleanup on `Exit`.

The force-quit flag is now cross-platform so Linux/Windows complete quit takes the same path.

## Testing

- `cargo test --locked -p intercept`
- `cargo check --locked -p tauri-plugin-anlg-tray`
- `cargo check --locked -p desktop`
- `cargo test --locked -p desktop complete_quit --lib`

Could not click the native macOS confirmation dialog in this Linux environment. The unit test covers the exit-path flag that was causing the delay.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f359c510-26ac-4dc0-8191-c606e85d25f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f359c510-26ac-4dc0-8191-c606e85d25f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

