### PR TITLE
docs: explain what Cloud Sync replicates

### DIFF
--- a/docs/ai-setup.mdx
+++ b/docs/ai-setup.mdx
@@ -22,7 +22,7 @@ Open **Settings → Transcription** or **Settings → Intelligence** to choose a
     Download Soniqo on a supported Apple Silicon Mac, or use Apple Speech when macOS 26 reports it available.
   </Card>
   <Card title="Your API key" icon="key">
-    Configure a provider, enter its API key, then select it under Model being used.
+    Configure a provider, enter its API key, then select it under Model being used. API keys stay on this computer and do not sync to other devices.
   </Card>
   <Card title="Local language model" icon="server">
     Connect LM Studio, Ollama, or Unsloth, or use Apple Intelligence on an eligible Mac.

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -9,6 +9,8 @@ Anarlog stores its app data on your computer and captures meetings without addin
 
 Your notes, local transcripts, settings, recordings you choose to keep, and downloaded local models are stored locally. You can write notes, record audio, and use configured local models without sending meeting content to Anarlog Cloud.
 
+[Cloud Sync](/sync#what-cloud-sync-replicates) can copy encrypted notes to your other signed-in devices. Transcription and Intelligence API keys, model selections, calendar connections, and most other settings stay on the computer where you set them.
+
 Use Anarlog's export tools when you need a portable copy. Do not edit the app database directly.
 
 ## When content is sent elsewhere
@@ -18,7 +20,7 @@ The destination depends on the feature you choose:
 - A hosted **Transcription** provider receives the audio needed to create a transcript.
 - A hosted **Intelligence** provider receives the text and instructions needed to create a summary or chat response.
 - Connected calendars send the calendar and event details needed to show upcoming events and associate them with your notes.
-- [Sync](/sync) sends end-to-end encrypted content to keep your devices up to date. Anarlog cannot read the recovery key.
+- [Sync](/sync#what-cloud-sync-replicates) sends end-to-end encrypted notes to keep your devices up to date. Anarlog cannot read the recovery key. API keys and most settings stay on each device.
 - [Sharing](/sharing) uploads the generated summary and any audio you explicitly include. Your private memo is not part of the shared note.
 - [Chat](/chat) sends the prompt and required context to your selected Intelligence provider. Public web search also sends the search query to the search service.
 - [Cloud API & Connectors](/reference/api-cloud), when you explicitly enable it, uploads a separate server-readable copy of meeting titles, notes, summaries, participants, action items, and transcripts so remote agents can work while your desktop is offline. Turning it off deletes those copies.

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -57,6 +57,10 @@ Anarlog shares the generated summary, not your private memo. Retained audio is o
 
 No. The key is shown only during setup and Anarlog cannot read or recover it. Save it in a password manager before closing the setup window. See [Cloud sync](/sync#save-the-recovery-key).
 
+### Do my API keys sync to another device?
+
+No. Cloud Sync copies encrypted notes, not Transcription or Intelligence API keys. Enter each key again on the new computer, then select those models in Settings. See [What Cloud Sync replicates](/sync#what-cloud-sync-replicates).
+
 ### Can I automate follow-up work?
 
 Yes, with Anarlog Pro. Built-in starters can post a Slack recap, update a Notion page, create Linear issues, or export each meeting as Markdown. See [Automate meeting follow-up](/automations).

--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -91,7 +91,7 @@ When you configure a provider with your own API key:
 
 - Anarlog sends requests directly from the desktop app to the configured base URL.
 - The provider and exact model shown in Settings handle the request.
-- Anarlog stores the API key in your operating system's secure credential store, not in the app's SQLite database.
+- Anarlog stores the API key in your operating system's secure credential store, not in the app database. Keys stay on that computer and do not [sync](/sync#what-cloud-sync-replicates) to your other devices.
 - The provider's pricing, retention, and training policies apply.
 
 Anarlog supports dedicated provider integrations and OpenAI-compatible endpoints. Intelligence model lists are loaded from the provider when its API supports discovery, so **Settings → Intelligence** is the current source of truth for available model IDs.

--- a/docs/sync.mdx
+++ b/docs/sync.mdx
@@ -14,6 +14,30 @@ Sync runs automatically in the background. Use **Sync now** to send and receive 
 
 Pause sync when you want changes to remain only on the current device for a while. Resume it to send pending changes and receive updates from your other devices.
 
+## What Cloud Sync replicates
+
+Cloud Sync copies end-to-end encrypted notes across your signed-in devices. Anarlog cannot read this data.
+
+Each synced device receives:
+
+- Meeting notes, including titles, memos, and generated summaries
+- Transcripts and speaker assignments
+- Participants, people, and organizations
+- Action items
+- A few preferences: **Theme**, **App icon**, **Week starts on**, and **Default sharing**
+
+API keys, model selections, and most other settings stay on the computer where you entered them. After you add a new device, enter each Transcription and Intelligence API key again and choose the models you want on that computer. Anarlog stores those keys in the operating system's credential store and does not copy them between devices.
+
+Also set up on each device:
+
+- Calendar connections
+- Downloaded local models
+- Device-specific options such as audio devices, autostart, notifications, and recording retention
+
+Saved recordings and file attachments remain in the local storage folder on that computer. See [Don't combine sync with a cloud-storage folder](#dont-combine-sync-with-a-cloud-storage-folder).
+
+See [Data, privacy, and retention](/data-and-privacy) for what can leave your computer for hosted AI, sharing, and other features.
+
 ## Save the recovery key
 
 Your recovery key encrypts synced notes before they leave your device, so Anarlog cannot read or recover it.
@@ -36,10 +60,9 @@ The key is shown only during setup. Clipboard copies clear after 60 seconds when
 2. Open **Settings → Sync** and turn on Cloud sync.
 3. Choose the option to enter an existing recovery key.
 4. Paste the key from your password manager, then wait for the first sync to finish.
+5. Re-enter any Transcription or Intelligence API keys you use on this computer, then select those models under **Settings → Transcription** and **Settings → Intelligence**.
 
 One account can sync up to five devices. If you reach the limit, remove an unused device before enabling sync on another one.
-
-See [Data, privacy, and retention](/data-and-privacy) for what stays on your computer.
 
 Cloud API & Connectors is a separate, optional feature. If you enable it under **Settings → Developers**, Anarlog uploads a server-readable copy for remote agents; it does not decrypt or weaken your end-to-end encrypted sync data. See [Cloud API and connectors](/reference/api-cloud).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Sync copies encrypted notes across devices, not API keys or most settings. This was easy to miss when setting up a second computer.

## Changes

- Add **What Cloud Sync replicates** to [Cloud sync](https://docs.anarlog.so/sync): notes, transcripts, people, action items, and a few preferences (theme, app icon, week start, default sharing).
- Call out that Transcription/Intelligence API keys stay in the OS credential store on each device, so you re-enter them after adding a computer.
- Point to the same inventory from Data & privacy, Models and providers, Transcription and AI, and the FAQ.

## Verification

- `pnpm exec dprint fmt 'docs/**/*'` and `pnpm exec dprint check 'docs/**/*'`
- `npx mint@4.2.687 validate` and `npx mint@4.2.687 broken-links --check-anchors --check-redirects` from `docs/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f359c510-26ac-4dc0-8191-c606e85d25f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f359c510-26ac-4dc0-8191-c606e85d25f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

