### PR TITLE
fix(desktop): serve Check for Updates from anarlog.so

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.stable-macos.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable-macos.json
@@ -2,7 +2,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/{{target}}-{{arch}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/apps/desktop/src-tauri/tauri.conf.stable-macos.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable-macos.json
@@ -2,7 +2,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://anarlog.so/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -36,7 +36,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
+        "https://anarlog.so/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -36,7 +36,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://desktop2.hyprnote.com/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
+        "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -52,6 +52,21 @@ to = "https://github.com/fastrepl/anarlog/releases/download/:release/anarlog-lin
 status = 302
 force = true
 
+# Desktop updater JSON and installer binaries stay on CrabNebula; expose them
+# on anarlog.so so clients do not depend on desktop2.hyprnote.com. Keep
+# /download for the marketing page.
+[[redirects]]
+from = "/update/*"
+to = "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "/releases/*"
+to = "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/:splat"
+status = 302
+force = true
+
 [[headers]]
 for = "/apt/dists/*"
 [headers.values]

--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -20,6 +20,9 @@ test("offers macOS, Windows, and Linux downloads", () => {
     "Galaxy Watch",
   ]);
 
+  const macosDownloads = desktopDownloadSections.find(
+    (section) => section.platform === "macos",
+  )!.downloads;
   const windowsDownloads = desktopDownloadSections.find(
     (section) => section.platform === "windows",
   )!.downloads;
@@ -27,7 +30,14 @@ test("offers macOS, Windows, and Linux downloads", () => {
     (section) => section.platform === "linux",
   )!.downloads;
 
-  assert.match(windowsDownloads[0].url, /\/nsis-x86_64\?/);
+  assert.match(
+    macosDownloads[0].url,
+    /^https:\/\/anarlog\.so\/releases\/latest\/platform\/dmg-aarch64\?/,
+  );
+  assert.match(
+    windowsDownloads[0].url,
+    /^https:\/\/anarlog\.so\/releases\/latest\/platform\/nsis-x86_64\?/,
+  );
   assert.deepEqual(
     linuxDownloads.map((download) =>
       new URL(download.url).pathname.split("/").at(-1),

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -1,5 +1,4 @@
-const latestStableDownloadUrl =
-  "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/latest/platform";
+const latestStableDownloadUrl = "https://anarlog.so/releases/latest/platform";
 
 function getStableDownloadUrl(platform: string) {
   return `${latestStableDownloadUrl}/${platform}?channel=stable`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Check for Updates was failing because `desktop2.hyprnote.com` is NXDOMAIN. This PR unifies the public updater and installer URLs onto `anarlog.so`, matching the rest of the product.

## What was broken

- The tray **Check for Updates** item called `https://desktop2.hyprnote.com/update/...`
- That hostname no longer resolves. CrabNebula Cloud for `fastrepl/hyprnote2` is healthy and still serves **1.4.13**.

## Approach

Keep CrabNebula as the origin, but expose it on the canonical domain:

- `https://anarlog.so/update/*` → `https://cdn.crabnebula.app/update/fastrepl/hyprnote2/:splat`
- `https://anarlog.so/releases/*` → `https://cdn.crabnebula.app/download/fastrepl/hyprnote2/:splat`

`/download` stays the marketing page. Installer files go under `/releases` so they do not collide.

Stable desktop updater endpoints and website download buttons now use those `anarlog.so` URLs. macOS still uses the legacy updater path without `bundle_type` from #6296.

## Deploy order

Ship the website (these Netlify redirects) before the next desktop release. Until that deploy, `/update/...` is a trailing-slash 307 into the SPA.

Existing installs still have `desktop2.hyprnote.com` baked in. Restoring that DNS/redirect remains the only way those builds can self-update.

Homebrew casks in `fastrepl/homebrew-fastrepl` also still use `desktop2.hyprnote.com`; they can switch to `https://anarlog.so/releases/...` after this web deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a042bb-8ad9-7186-abbc-993fcc8aa4ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a042bb-8ad9-7186-abbc-993fcc8aa4ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

