### PR TITLE
Include meeting chat capture in the 1.4.14 changelog

### DIFF
--- a/packages/changelog/content/1.4.14.md
+++ b/packages/changelog/content/1.4.14.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-08-27"
-summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, lets you pick local Whisper models and speaker devices, and makes sharing, sync, and speaker names more reliable."
+summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, captures meeting chat more reliably, lets you pick local Whisper models and speaker devices, and makes sharing, sync, and speaker names more reliable."
 ---
 
 ## Meetings and recording
@@ -11,7 +11,11 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
 - Pick a speaker output in Settings → Meetings so loopback capture follows
   the device you are actually using on Windows and Linux
 - Label the other person in a 1:1 transcript, and name speakers in larger
-  meetings when a unique high-confidence voiceprint match is available
+  meetings only when a unique high-confidence voiceprint match is available
+- Capture visible meeting chat from Zoom, Google Meet, Teams, Slack, and
+  Webex, including more Chromium and Firefox-based browsers, then search it
+  in the session
+- Post a recording disclosure into the meeting chat when that setting is on
 - Quit Completely from the tray or Dock confirmation without waiting for a
   background flush
 


### PR DESCRIPTION
## Summary
- Add the meeting chat capture, disclosure, and voiceprint-only speaker naming that landed in #7034

## Test plan
- [x] Changelog still at `packages/changelog/content/1.4.14.md`
- [x] `pnpm -F @anlg/changelog typecheck`
- [x] `pnpm fmt:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or product behavior changes.
> 
> **Overview**
> Updates the **1.4.14** release notes so they match meeting-related work from #7034 that was missing from the initial draft.
> 
> The front-matter **summary** now calls out more reliable meeting chat capture. Under **Meetings and recording**, speaker naming in larger meetings is clarified to apply **only** with a unique high-confidence voiceprint match, and two bullets are added: visible in-meeting chat capture (Zoom, Google Meet, Teams, Slack, Webex, plus broader Chromium/Firefox support) with in-session search, and optional **recording disclosure** posts to the meeting chat when the setting is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ac8f9e4b007c7c005e5d0820e333568e5321f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->