### PR TITLE
fix(desktop): serve updates from desktop.anarlog.so

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.stable-macos.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable-macos.json
@@ -2,7 +2,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://anarlog.so/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
+        "https://desktop.anarlog.so/update/{{target}}-{{arch}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/apps/desktop/src-tauri/tauri.conf.stable.json
+++ b/apps/desktop/src-tauri/tauri.conf.stable.json
@@ -36,7 +36,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://anarlog.so/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
+        "https://desktop.anarlog.so/update/{{target}}-{{arch}}-{{bundle_type}}/{{current_version}}?channel=stable"
       ]
     }
   }

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -52,18 +52,24 @@ to = "https://github.com/fastrepl/anarlog/releases/download/:release/anarlog-lin
 status = 302
 force = true
 
-# Desktop updater JSON and installer binaries stay on CrabNebula; expose them
-# on anarlog.so so clients do not depend on desktop2.hyprnote.com. Keep
-# /download for the marketing page.
+# Desktop updater JSON and installer binaries stay on CrabNebula. Serve them
+# from desktop.anarlog.so so they do not collide with the marketing site.
+# Requires this hostname as a Netlify domain plus a Cloudflare CNAME.
 [[redirects]]
-from = "/update/*"
+from = "https://desktop.anarlog.so/update/*"
 to = "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/:splat"
 status = 302
 force = true
 
 [[redirects]]
-from = "/releases/*"
+from = "https://desktop.anarlog.so/download/*"
 to = "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/:splat"
+status = 302
+force = true
+
+[[redirects]]
+from = "https://desktop.anarlog.so/"
+to = "https://anarlog.so/download"
 status = 302
 force = true
 

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -54,7 +54,8 @@ force = true
 
 # Desktop updater JSON and installer binaries stay on CrabNebula. Serve them
 # from desktop.anarlog.so so they do not collide with the marketing site.
-# Requires this hostname as a Netlify domain plus a Cloudflare CNAME.
+# desktop2.hyprnote.com already CNAMEs here; also HTTP-redirect so existing
+# Homebrew/download URLs land on the canonical host.
 [[redirects]]
 from = "https://desktop.anarlog.so/update/*"
 to = "https://cdn.crabnebula.app/update/fastrepl/hyprnote2/:splat"
@@ -70,6 +71,12 @@ force = true
 [[redirects]]
 from = "https://desktop.anarlog.so/"
 to = "https://anarlog.so/download"
+status = 302
+force = true
+
+[[redirects]]
+from = "https://desktop2.hyprnote.com/*"
+to = "https://desktop.anarlog.so/:splat"
 status = 302
 force = true
 

--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -32,11 +32,11 @@ test("offers macOS, Windows, and Linux downloads", () => {
 
   assert.match(
     macosDownloads[0].url,
-    /^https:\/\/anarlog\.so\/releases\/latest\/platform\/dmg-aarch64\?/,
+    /^https:\/\/desktop\.anarlog\.so\/download\/latest\/platform\/dmg-aarch64\?/,
   );
   assert.match(
     windowsDownloads[0].url,
-    /^https:\/\/anarlog\.so\/releases\/latest\/platform\/nsis-x86_64\?/,
+    /^https:\/\/desktop\.anarlog\.so\/download\/latest\/platform\/nsis-x86_64\?/,
   );
   assert.deepEqual(
     linuxDownloads.map((download) =>

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -1,4 +1,5 @@
-const latestStableDownloadUrl = "https://anarlog.so/releases/latest/platform";
+const latestStableDownloadUrl =
+  "https://desktop.anarlog.so/download/latest/platform";
 
 function getStableDownloadUrl(platform: string) {
   return `${latestStableDownloadUrl}/${platform}?channel=stable`;

--- a/apps/web/src/lib/workspace-share-host.test.ts
+++ b/apps/web/src/lib/workspace-share-host.test.ts
@@ -10,6 +10,7 @@ test("accepts one valid enterprise workspace subdomain", () => {
 
 test("rejects reserved, nested, and malformed workspace hosts", () => {
   assert.equal(isWorkspaceShareHostname("api.anarlog.so"), false);
+  assert.equal(isWorkspaceShareHostname("desktop.anarlog.so"), false);
   assert.equal(isWorkspaceShareHostname("www.anarlog.so"), false);
   assert.equal(isWorkspaceShareHostname("a.b.anarlog.so"), false);
   assert.equal(isWorkspaceShareHostname("-fastrepl.anarlog.so"), false);

--- a/apps/web/src/lib/workspace-share-host.ts
+++ b/apps/web/src/lib/workspace-share-host.ts
@@ -5,6 +5,7 @@ const RESERVED_WORKSPACE_SHARE_HOSTS = new Set([
   "assets",
   "auth",
   "cdn",
+  "desktop",
   "dev",
   "docs",
   "mail",


### PR DESCRIPTION
## Summary
- Serve Check for Updates and installer downloads from `desktop.anarlog.so` instead of the `anarlog.so` marketing origin.
- Netlify 302s that host to CrabNebula (`fastrepl/hyprnote2`), matching the old `desktop2.hyprnote.com` shape.
- Reserve `desktop` so it is not treated as an enterprise workspace share subdomain.

## DNS / Netlify (required before this works)
- Add `desktop.anarlog.so` as a custom domain on the Netlify site.
- Cloudflare CNAME: `desktop` → the Netlify site hostname (`old-char.netlify.app` today for www).
- Existing installs still hit `desktop2.hyprnote.com` (NXDOMAIN). Restore that record too, CNAME/redirect to `desktop.anarlog.so`, or those builds cannot self-update.

## Test plan
- [ ] After DNS + Netlify domain: `curl -I https://desktop.anarlog.so/update/darwin-aarch64/1.0.0?channel=stable` returns 302 to CrabNebula and a follow-up 200 JSON.
- [ ] `curl -I https://desktop.anarlog.so/download/latest/platform/dmg-aarch64?channel=stable` 302s to CrabNebula.
- [ ] Marketing `/download` on anarlog.so is unchanged.
- [ ] Check for Updates in a new stable build talks to `desktop.anarlog.so`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes canonical URLs for desktop updates and downloads; misconfigured DNS/Netlify or broken legacy redirects would block self-updates for existing installs.
> 
> **Overview**
> Moves **desktop auto-update and installer download traffic** off the marketing origin (`anarlog.so`) onto **`desktop.anarlog.so`**, so updater/CDN paths no longer share the main site.
> 
> **Tauri** stable updater endpoints now call `https://desktop.anarlog.so/update/...`. The **marketing download helper** uses `https://desktop.anarlog.so/download/latest/platform/...` (path shape changes from `/releases/` to `/download/`).
> 
> **Netlify** rules are retargeted to the `desktop.anarlog.so` host: `/update/*` and `/download/*` still **302 to CrabNebula** (`fastrepl/hyprnote2`). New redirects send the desktop host root to `anarlog.so/download` and **`desktop2.hyprnote.com/*` → `desktop.anarlog.so`** for legacy clients.
> 
> **`desktop`** is added to reserved workspace-share hostnames so it is not treated as an enterprise workspace subdomain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0eacf16a4e32b4c44a13a831e96eeeebf7a5f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->