### PR TITLE
Include anarlog.so updates in the 1.4.14 changelog

### DIFF
--- a/packages/changelog/content/1.4.14.md
+++ b/packages/changelog/content/1.4.14.md
@@ -55,6 +55,11 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
 - Create a contact from **Enhance contact** when the participant is not already
   in your address book
 
+## Updates
+
+- Check for Updates and installer downloads from anarlog.so after the rename,
+  instead of the old Hyprnote desktop host
+
 ## Developers
 
 - Propose a summary or memo replacement from the CLI or MCP, then apply or


### PR DESCRIPTION
Check for Updates and installer downloads now use anarlog.so after the rename. Add that to the desktop 1.4.14 notes before the stable release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only change with no runtime or release-pipeline impact.
> 
> **Overview**
> Adds an **Updates** section to the 1.4.14 release notes so stable users see that **Check for Updates** and installer downloads now come from **anarlog.so** after the Hyprnote rename, not the old desktop update host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e98dbfa0f5fb641c93c05bbc3e62edcd56e00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->