### PR TITLE
Capture current Linux meeting chat shapes

### DIFF
--- a/crates/detect/src/meeting_ax/analysis.rs
+++ b/crates/detect/src/meeting_ax/analysis.rs
@@ -278,6 +278,15 @@ pub(super) fn extract_chat_messages(
         parsed_nodes.extend(extract_google_meet_timestamp_sibling_messages(
             nodes, scope_path,
         ));
+        let parsed_paths = parsed_nodes
+            .iter()
+            .map(|(node, _)| node.tree_path.clone())
+            .collect::<Vec<_>>();
+        parsed_nodes.extend(extract_google_meet_link_only_messages(
+            nodes,
+            scope_path,
+            &parsed_paths,
+        ));
     }
     if *platform == MeetingPlatform::Webex
         && let Some(scope_path) = generic_scope_path.as_deref()
@@ -518,6 +527,92 @@ fn google_meet_chat_fragment(node: &AxNode) -> Option<String> {
         "hover over a message to pin it" | "pin message"
     ))
     .then_some(fragment)
+}
+
+fn extract_google_meet_link_only_messages<'a>(
+    nodes: &'a [AxNode],
+    scope_path: &[usize],
+    parsed_paths: &[Vec<usize>],
+) -> Vec<(&'a AxNode, ParsedChatMessage)> {
+    let pin_paths = nodes
+        .iter()
+        .filter(|node| {
+            node.tree_path.starts_with(scope_path)
+                && node.role.as_deref() == Some("AXButton")
+                && node_labels(node).any(|label| label.trim().eq_ignore_ascii_case("pin message"))
+        })
+        .map(|node| node.tree_path.as_slice())
+        .collect::<Vec<_>>();
+
+    let mut rows = Vec::<(Vec<usize>, Vec<(&AxNode, String)>)>::new();
+    for node in nodes.iter().filter(|node| {
+        node.tree_path.starts_with(scope_path)
+            && matches!(node.role.as_deref(), Some("AXLink") | Some("AXButton"))
+    }) {
+        let Some(url) = [
+            node.title.as_deref(),
+            node.description.as_deref(),
+            node.value.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(normalize_chat_text)
+        .find(|value| value.starts_with("http://") || value.starts_with("https://")) else {
+            continue;
+        };
+        let Some(row_path) = (scope_path.len() + 1..node.tree_path.len())
+            .rev()
+            .find_map(|depth| {
+                let candidate = &node.tree_path[..depth];
+                (pin_paths
+                    .iter()
+                    .filter(|pin_path| {
+                        pin_path.starts_with(candidate)
+                            && pin_path.len() - candidate.len() <= 2
+                            && node.tree_path.len() - candidate.len() <= 2
+                    })
+                    .count()
+                    == 1)
+                    .then(|| candidate.to_vec())
+            })
+        else {
+            continue;
+        };
+        if parsed_paths
+            .iter()
+            .any(|path| path_is_ancestor(&row_path, path) || path_is_ancestor(path, &row_path))
+        {
+            continue;
+        }
+
+        if let Some((_, fragments)) = rows.iter_mut().find(|(path, _)| path == &row_path) {
+            if !fragments.iter().any(|(_, existing)| existing == &url) {
+                fragments.push((node, url));
+            }
+        } else {
+            rows.push((row_path, vec![(node, url)]));
+        }
+    }
+
+    rows.into_iter()
+        .filter_map(|(_, fragments)| {
+            let source = fragments.first()?.0;
+            let text = fragments
+                .into_iter()
+                .map(|(_, fragment)| fragment)
+                .collect::<Vec<_>>()
+                .join(" ");
+            (!text.is_empty()).then_some((
+                source,
+                ParsedChatMessage {
+                    sender: None,
+                    timestamp: None,
+                    direction: None,
+                    text,
+                },
+            ))
+        })
+        .collect()
 }
 
 fn extract_google_meet_timestamp_sibling_messages<'a>(

--- a/crates/detect/src/meeting_ax/linux.rs
+++ b/crates/detect/src/meeting_ax/linux.rs
@@ -485,6 +485,38 @@ fn slack_roots_from_windows(
         .collect()
 }
 
+fn slack_chat_roots_from_windows(
+    windows: Vec<(Option<String>, Vec<LiveNode>, bool)>,
+) -> Vec<(String, String, Vec<LiveNode>)> {
+    let mut contexts = windows
+        .iter()
+        .filter(|(_, _, complete)| *complete)
+        .filter_map(|(_, live, _)| slack_huddle_context(&ax_nodes(live)))
+        .collect::<Vec<_>>();
+    contexts.sort();
+    contexts.dedup();
+    let [(label, channel)] = contexts.as_slice() else {
+        return Vec::new();
+    };
+
+    windows
+        .into_iter()
+        .filter_map(|(_, live, complete)| {
+            if !complete {
+                return None;
+            }
+            let mut composers = live.iter().filter(|node| {
+                is_slack_huddle_composer_in_thread(&node.node, &node.ancestors, channel)
+            });
+            composers.next()?;
+            if composers.next().is_some() {
+                return None;
+            }
+            Some((channel.clone(), label.clone(), live))
+        })
+        .collect()
+}
+
 fn browser_roots_from_windows(
     windows: Vec<(Option<String>, Vec<LiveNode>, bool)>,
     warnings: &mut Vec<String>,
@@ -1323,7 +1355,7 @@ pub(super) fn capture_meeting_chat_messages(bundle_ids: Vec<String>) -> MeetingC
                         }
                     }
                     MeetingPlatform::Slack => {
-                        for (channel, label, live) in slack_roots_from_windows(windows) {
+                        for (channel, label, live) in slack_chat_roots_from_windows(windows) {
                             let composer = live.iter().find(|node| {
                                 is_slack_huddle_composer_in_thread(
                                     &node.node,
@@ -1439,6 +1471,103 @@ mod tests {
             bus_name: "org.test.Browser".to_string(),
             path: format!("/org/test/{index}"),
         }
+    }
+
+    fn live_node(index: usize, role: &str, title: &str, path: &[usize]) -> LiveNode {
+        LiveNode {
+            node: AxNode {
+                index,
+                tree_path: path.to_vec(),
+                element_hash: Some(index),
+                role: Some(role.to_string()),
+                identifier: None,
+                title: Some(title.to_string()),
+                value: None,
+                description: None,
+                placeholder: None,
+                enabled: Some(true),
+                settable_value: false,
+                bounds: Some(AxRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 320.0,
+                    height: 48.0,
+                }),
+                text: title.to_ascii_lowercase(),
+                within_zoom_meeting_scope: false,
+                within_zoom_chat_scope: false,
+                within_slack_huddle_scope: false,
+            },
+            ancestors: Vec::new(),
+            bus_name: "org.test.Slack".to_string(),
+            path: format!("/org/test/{index}"),
+        }
+    }
+
+    #[test]
+    fn slack_chat_scope_pairs_main_huddle_identity_with_popout_thread() {
+        let main = vec![
+            live_node(0, "AXGroup", "Huddle in test", &[0]),
+            live_node(1, "AXButton", "Leave Huddle", &[1]),
+        ];
+        let mut composer = live_node(2, "AXTextArea", "Message to test", &[2, 0]);
+        composer.node.settable_value = true;
+        composer.ancestors.push(AxAncestor {
+            path: vec![2],
+            labels: vec!["Thread in test (private channel, 1 reply)".to_string()],
+        });
+        let message = live_node(3, "AXCell", "John Jeong: Ship it. 12:03 PM.", &[2, 1]);
+
+        let roots = slack_chat_roots_from_windows(vec![
+            (
+                Some("test (Channel) - Fastrepl - Slack".to_string()),
+                main,
+                true,
+            ),
+            (
+                Some("test - Fastrepl - Slack".to_string()),
+                vec![composer, message],
+                true,
+            ),
+        ]);
+
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].0, "test");
+        assert_eq!(roots[0].1, "Huddle in test");
+        assert!(roots[0].2.iter().any(|node| node.node.index == 3));
+    }
+
+    #[test]
+    fn slack_chat_scope_rejects_ambiguous_huddle_identity() {
+        let mut composer = live_node(4, "AXTextArea", "Message to test", &[4, 0]);
+        composer.node.settable_value = true;
+        composer.ancestors.push(AxAncestor {
+            path: vec![4],
+            labels: vec!["Thread in test".to_string()],
+        });
+
+        assert!(
+            slack_chat_roots_from_windows(vec![
+                (
+                    Some("test".to_string()),
+                    vec![
+                        live_node(0, "AXGroup", "Huddle in test", &[0]),
+                        live_node(1, "AXButton", "Leave Huddle", &[1]),
+                    ],
+                    true,
+                ),
+                (
+                    Some("random".to_string()),
+                    vec![
+                        live_node(2, "AXGroup", "Huddle in random", &[0]),
+                        live_node(3, "AXButton", "Leave Huddle", &[1]),
+                    ],
+                    true,
+                ),
+                (Some("thread".to_string()), vec![composer], true),
+            ])
+            .is_empty()
+        );
     }
 
     #[test]

--- a/crates/detect/src/meeting_ax/linux.rs
+++ b/crates/detect/src/meeting_ax/linux.rs
@@ -10,7 +10,9 @@ use atspi::{AccessibilityConnection, CoordType, ObjectRef, Role, State};
 use zbus::fdo::DBusProxy;
 use zbus::names::BusName;
 
-use super::analysis::{extract_chat_messages, meeting_chat_surface_is_visible};
+use super::analysis::{
+    extract_chat_messages, meeting_chat_surface_is_visible, slack_huddle_is_active,
+};
 use super::context::{
     browser_capture_context_id, is_platform_chat_composer, is_platform_send_button,
     native_capture_context_id, slack_capture_context_id, validated_chat_scope,
@@ -29,12 +31,13 @@ use super::types::{
 use super::{
     BrowserMeetingSnapshot, MAX_NODES, MAX_TREE_DEPTH, MeetingAccessibilityInspection,
     browser_meeting_root_from_snapshot, browser_window_has_provider_signal, chat_input_is_owned,
-    inspection_label, is_chat_priority_label, is_slack_huddle_composer_in_thread,
-    is_slack_send_now_in_thread, is_slack_thread_control, native_meeting_window_is_validated,
-    slack_huddle_context, slack_thread_container_path, unique_scope_for_count,
-    validate_meeting_chat_message,
+    inspection_label, is_chat_priority_label, is_enabled_slack_leave_control,
+    is_slack_huddle_composer_in_thread, is_slack_send_now_in_thread, is_slack_thread_control,
+    native_meeting_window_is_validated, slack_huddle_context, slack_thread_container_path,
+    unique_scope_for_count, validate_meeting_chat_message,
 };
 
+#[derive(Clone)]
 struct LiveNode {
     node: AxNode,
     ancestors: Vec<AxAncestor>,
@@ -498,19 +501,42 @@ fn slack_chat_roots_from_windows(
     let [(label, channel)] = contexts.as_slice() else {
         return Vec::new();
     };
+    let Some(active_control) = windows.iter().find_map(|(_, live, complete)| {
+        if !complete
+            || slack_huddle_context(&ax_nodes(live)).as_ref()
+                != Some(&(label.clone(), channel.clone()))
+        {
+            return None;
+        }
+        live.iter()
+            .find(|node| is_enabled_slack_leave_control(&node.node))
+            .cloned()
+    }) else {
+        return Vec::new();
+    };
 
     windows
         .into_iter()
-        .filter_map(|(_, live, complete)| {
+        .filter_map(|(_, mut live, complete)| {
             if !complete {
                 return None;
             }
-            let mut composers = live.iter().filter(|node| {
+            let mut composers = live.iter().filter_map(|node| {
                 is_slack_huddle_composer_in_thread(&node.node, &node.ancestors, channel)
+                    .then(|| slack_thread_container_path(&node.ancestors, channel))
+                    .flatten()
             });
-            composers.next()?;
+            let thread_path = composers.next()?.to_vec();
             if composers.next().is_some() {
                 return None;
+            }
+            for node in &mut live {
+                if node.node.tree_path.starts_with(&thread_path) {
+                    node.node.within_slack_huddle_scope = true;
+                }
+            }
+            if !slack_huddle_is_active(&ax_nodes(&live)) {
+                live.push(active_control.clone());
             }
             Some((channel.clone(), label.clone(), live))
         })
@@ -1535,6 +1561,15 @@ mod tests {
         assert_eq!(roots[0].0, "test");
         assert_eq!(roots[0].1, "Huddle in test");
         assert!(roots[0].2.iter().any(|node| node.node.index == 3));
+        let messages = extract_chat_messages(
+            &MeetingPlatform::Slack,
+            &MeetingSurface::Native,
+            &ax_nodes(&roots[0].2),
+        );
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].sender.as_deref(), Some("John Jeong"));
+        assert_eq!(messages[0].timestamp.as_deref(), Some("12:03 PM"));
+        assert_eq!(messages[0].text, "Ship it");
     }
 
     #[test]

--- a/crates/detect/src/meeting_ax/tests/message_parsing.rs
+++ b/crates/detect/src/meeting_ax/tests/message_parsing.rs
@@ -569,6 +569,51 @@ fn test_google_meet_capture_assembles_live_structured_message_leaves() {
 }
 
 #[test]
+fn test_google_meet_capture_keeps_firefox_link_only_message_rows() {
+    let active_control = fixture_node(0, "AXButton", "Leave call", &[1]);
+    let heading = fixture_node(1, "AXHeading", "In-call messages", &[4, 0]);
+    let composer = fixture_composer(2, "Send a message", &[4, 2, 0, 1, 2]);
+    let banner_link = fixture_node(
+        3,
+        "AXButton",
+        "https://support.google.com/meet/chat",
+        &[4, 2, 0, 0, 1],
+    );
+    let message_link = fixture_node(
+        4,
+        "AXButton",
+        "https://anarlog.so/linux-firefox-meet-atspi",
+        &[4, 2, 0, 1, 1, 0],
+    );
+    let pin = fixture_node(5, "AXButton", "Pin message", &[4, 2, 0, 1, 2, 0]);
+
+    let messages = extract_chat_messages(
+        &MeetingPlatform::GoogleMeet,
+        &MeetingSurface::Web,
+        &[
+            active_control,
+            heading,
+            composer,
+            banner_link,
+            message_link,
+            pin,
+        ],
+    );
+
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].sender, None);
+    assert_eq!(messages[0].timestamp, None);
+    assert_eq!(
+        messages[0].text,
+        "https://anarlog.so/linux-firefox-meet-atspi"
+    );
+    assert_eq!(
+        messages[0].links,
+        ["https://anarlog.so/linux-firefox-meet-atspi"]
+    );
+}
+
+#[test]
 fn test_google_meet_capture_assembles_timestamp_sibling_messages() {
     let active_control = fixture_node(0, "AXButton", "Leave call", &[1]);
     let heading = fixture_node(1, "AXHeading", "In-call messages", &[4, 0]);


### PR DESCRIPTION
Fixes the final live Linux chat-capture shapes required by ANLG-297.

- pair a unique native Slack Huddle identity with its separate pop-out thread window
- capture Firefox Google Meet link-only message rows when they are tightly scoped by the adjacent Pin message control
- fail closed on ambiguous Slack Huddle identities and ignore unrelated Meet links

Live validation:
- native Slack Linux Huddle: exact sender, timestamp, text, and link captured with no warnings
- Firefox Linux Google Meet: exact link captured from the current AT-SPI shape with no warnings

Checks:
- pnpm exec dprint fmt
- pnpm fmt:check
- cargo check (1,484 crates; 0 errors)
- cargo test --locked -p detect (91 passed)
- Linux amd64 cargo test -p detect --lib meeting_ax (98 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes accessibility heuristics for chat extraction and multi-window Slack scoping; wrong pairing could miss or mis-attribute messages, but ambiguous cases fail closed.
> 
> **Overview**
> Improves **Linux AT-SPI meeting chat capture** for two live shapes from ANLG-297.
> 
> **Slack Huddle:** Chat capture now uses `slack_chat_roots_from_windows` instead of per-window huddle roots. It requires a **single** huddle identity across windows, finds the main window’s enabled **Leave Huddle** control, and pairs it with a pop-out thread that has exactly one channel composer. Thread nodes get `within_slack_huddle_scope`; the leave control is merged into the pop-out snapshot when the huddle isn’t active there. **Ambiguous** or duplicate huddle identities return no roots (fail closed).
> 
> **Google Meet (Firefox):** After existing Meet parsers run, **`extract_google_meet_link_only_messages`** adds URL-only rows from `AXLink`/`AXButton` nodes when a nearby **Pin message** control uniquely scopes the row, skipping paths already covered and unrelated banner links.
> 
> Unit tests cover Meet link-only capture and Slack pairing / ambiguity rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d98d02a47cb095fdc1833965d17329e4f43445b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->