### PR TITLE
Include Linux chat capture in the 1.4.14 changelog

### DIFF
--- a/packages/changelog/content/1.4.14.md
+++ b/packages/changelog/content/1.4.14.md
@@ -69,3 +69,5 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
 
 - Keep the app running when the audio device glitches instead of crashing on
   an ALSA stream error
+- Capture Slack Huddle chat and Firefox Google Meet link-only messages from
+  the current Linux window layout


### PR DESCRIPTION
#7125 landed on main after the first changelog merge. Record Linux Slack Huddle and Firefox Google Meet chat capture before the stable 1.4.14 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only edit with no application, build, or configuration impact.
> 
> **Overview**
> Adds a **Linux** section bullet to the **1.4.14** changelog for chat capture that shipped in #7125 after the initial changelog merge: **Slack Huddle** chat and **Firefox Google Meet** link-only messages read from the current window layout.
> 
> No product or runtime code changes—release notes only so stable **1.4.14** reflects what’s on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23dd29f1cc058dffaf9284d2132c6af3a7386629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->