### PR TITLE
Optimize meeting accessibility capture

### DIFF
--- a/apps/desktop/src/stt/meeting-chat-capture.test.ts
+++ b/apps/desktop/src/stt/meeting-chat-capture.test.ts
@@ -6,7 +6,6 @@ import { startMeetingChatCapture } from "./meeting-chat-capture";
 
 const {
   captureMeetingChatMessagesMock,
-  listMicUsingApplicationsMock,
   persistMeetingChatRecordsMock,
   persistParticipantConsentMock,
   sonnerToastWarningMock,
@@ -14,7 +13,6 @@ const {
   captureSettingState,
 } = vi.hoisted(() => ({
   captureMeetingChatMessagesMock: vi.fn(),
-  listMicUsingApplicationsMock: vi.fn(),
   persistMeetingChatRecordsMock: vi.fn(),
   persistParticipantConsentMock: vi.fn(),
   sonnerToastWarningMock: vi.fn(),
@@ -25,7 +23,6 @@ const {
 vi.mock("@anlg/plugin-detect", () => ({
   commands: {
     captureMeetingChatMessages: captureMeetingChatMessagesMock,
-    listMicUsingApplications: listMicUsingApplicationsMock,
   },
 }));
 
@@ -67,10 +64,6 @@ describe("startMeetingChatCapture", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     captureSettingState.value = true;
-    listMicUsingApplicationsMock.mockResolvedValue({
-      status: "ok",
-      data: [{ id: "us.zoom.xos", name: "Zoom" }],
-    });
     captureMeetingChatMessagesMock.mockResolvedValue(
       captureResult([capturedMessage]),
     );
@@ -447,7 +440,32 @@ describe("startMeetingChatCapture", () => {
     expect(persistMeetingChatRecordsMock).not.toHaveBeenCalled();
   });
 
-  test("does not inspect apps while disabled and re-baselines when enabled", async () => {
+  test("waits a full interval after a slow capture finishes", async () => {
+    let resolveCapture: ((value: unknown) => void) | undefined;
+    captureMeetingChatMessagesMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCapture = resolve;
+      }),
+    );
+    const stop = startMeetingChatCapture({
+      sessionId: "session-1",
+      isEnabled: () => true,
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledOnce();
+
+    resolveCapture?.(captureResult([capturedMessage]));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledTimes(2);
+    await stop();
+  });
+
+  test("does not capture while disabled and re-baselines when enabled", async () => {
     let enabled = false;
     const stop = startMeetingChatCapture({
       sessionId: "session-1",
@@ -455,13 +473,11 @@ describe("startMeetingChatCapture", () => {
     });
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(listMicUsingApplicationsMock).not.toHaveBeenCalled();
+    expect(captureMeetingChatMessagesMock).not.toHaveBeenCalled();
 
     enabled = true;
     await vi.advanceTimersByTimeAsync(5_000);
-    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith([
-      "us.zoom.xos",
-    ]);
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith();
     expect(persistMeetingChatRecordsMock).not.toHaveBeenCalled();
 
     enabled = false;
@@ -479,14 +495,7 @@ describe("startMeetingChatCapture", () => {
     expect(persistMeetingChatRecordsMock).not.toHaveBeenCalled();
   });
 
-  test("lets Rust fail closed when multiple recognized meeting apps use the mic", async () => {
-    listMicUsingApplicationsMock.mockResolvedValue({
-      status: "ok",
-      data: [
-        { id: "us.zoom.xos", name: "Zoom" },
-        { id: "com.tinyspeck.slackmacgap", name: "Slack" },
-      ],
-    });
+  test("delegates mic-active app scoping to the native capture command", async () => {
     captureMeetingChatMessagesMock.mockResolvedValue({
       status: "ok",
       data: {
@@ -505,18 +514,11 @@ describe("startMeetingChatCapture", () => {
     await vi.advanceTimersByTimeAsync(0);
     stop();
 
-    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith([
-      "us.zoom.xos",
-      "com.tinyspeck.slackmacgap",
-    ]);
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith();
     expect(persistMeetingChatRecordsMock).not.toHaveBeenCalled();
   });
 
-  test("recognizes the alternate Slack bundle id", async () => {
-    listMicUsingApplicationsMock.mockResolvedValue({
-      status: "ok",
-      data: [{ id: "com.slack.Slack", name: "Slack" }],
-    });
+  test("accepts the alternate Slack bundle id selected natively", async () => {
     captureMeetingChatMessagesMock.mockResolvedValue({
       status: "ok",
       data: {
@@ -535,16 +537,10 @@ describe("startMeetingChatCapture", () => {
     await vi.advanceTimersByTimeAsync(0);
     stop();
 
-    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith([
-      "com.slack.Slack",
-    ]);
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith();
   });
 
-  test("passes a mic-active browser to Rust for provider resolution", async () => {
-    listMicUsingApplicationsMock.mockResolvedValue({
-      status: "ok",
-      data: [{ id: "com.google.Chrome", name: "Google Chrome" }],
-    });
+  test("accepts a browser meeting resolved natively", async () => {
     captureMeetingChatMessagesMock.mockResolvedValue({
       status: "ok",
       data: {
@@ -563,50 +559,7 @@ describe("startMeetingChatCapture", () => {
     await vi.advanceTimersByTimeAsync(0);
     stop();
 
-    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith([
-      "com.google.Chrome",
-    ]);
-    expect(persistMeetingChatRecordsMock).not.toHaveBeenCalled();
-  });
-
-  test("rejects capture results for an app outside the caller-observed mic scope", async () => {
-    captureMeetingChatMessagesMock.mockResolvedValue({
-      status: "ok",
-      data: {
-        app: { id: "com.tinyspeck.slackmacgap", name: "Slack" },
-        contextId: "slack:test",
-        platform: "slack",
-        surface: "native",
-        messages: [{ ...capturedMessage, platform: "slack" }],
-        warnings: [],
-      },
-    });
-    const stop = startMeetingChatCapture({
-      sessionId: "session-1",
-      isEnabled: () => true,
-    });
-    await vi.advanceTimersByTimeAsync(0);
-
-    captureMeetingChatMessagesMock.mockResolvedValue({
-      status: "ok",
-      data: {
-        app: { id: "com.tinyspeck.slackmacgap", name: "Slack" },
-        contextId: "slack:test",
-        platform: "slack",
-        surface: "native",
-        messages: [
-          { ...capturedMessage, platform: "slack" },
-          { ...capturedMessage, id: "msg-2", platform: "slack" },
-        ],
-        warnings: [],
-      },
-    });
-    await vi.advanceTimersByTimeAsync(5_000);
-    stop();
-
-    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith([
-      "us.zoom.xos",
-    ]);
+    expect(captureMeetingChatMessagesMock).toHaveBeenCalledWith();
     expect(persistMeetingChatRecordsMock).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/stt/meeting-chat-capture.ts
+++ b/apps/desktop/src/stt/meeting-chat-capture.ts
@@ -34,6 +34,7 @@ export function startMeetingChatCapture({
   let stopped = false;
   let inFlight: Promise<void> | null = null;
   let pendingPersistence: Promise<void> | null = null;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
   let lastWarning = "";
   const captureIsEnabled =
     isEnabled ??
@@ -50,27 +51,7 @@ export function startMeetingChatCapture({
         return;
       }
 
-      const applications = await detectCommands.listMicUsingApplications();
-      if (stopped || !(await captureIsEnabled())) {
-        baselineContext = null;
-        return;
-      }
-      if (applications.status === "error") {
-        console.warn(
-          "[listener] failed to identify active meeting app",
-          applications.error,
-        );
-        return;
-      }
-
-      const bundleIds = [
-        ...new Set(applications.data.map((app) => app.id).filter(Boolean)),
-      ];
-      if (bundleIds.length === 0) {
-        return;
-      }
-
-      const result = await detectCommands.captureMeetingChatMessages(bundleIds);
+      const result = await detectCommands.captureMeetingChatMessages();
       if (stopped || !(await captureIsEnabled())) {
         baselineContext = null;
         return;
@@ -85,7 +66,7 @@ export function startMeetingChatCapture({
 
       const contextId = result.data.contextId?.trim();
       const bundleId = result.data.app?.id;
-      if (!bundleId || !bundleIds.includes(bundleId) || !contextId) {
+      if (!bundleId || !contextId) {
         return;
       }
 
@@ -203,6 +184,17 @@ export function startMeetingChatCapture({
     }
   };
 
+  const scheduleCapture = () => {
+    if (stopped || timeout) {
+      return;
+    }
+
+    timeout = setTimeout(() => {
+      timeout = null;
+      void capture();
+    }, MEETING_CHAT_CAPTURE_INTERVAL_MS);
+  };
+
   const capture = () => {
     if (stopped || inFlight) {
       return inFlight ?? Promise.resolve();
@@ -211,6 +203,7 @@ export function startMeetingChatCapture({
     const pendingCapture = captureOnce().finally(() => {
       if (inFlight === pendingCapture) {
         inFlight = null;
+        scheduleCapture();
       }
     });
     inFlight = pendingCapture;
@@ -218,13 +211,13 @@ export function startMeetingChatCapture({
   };
 
   void capture();
-  const interval = setInterval(() => {
-    void capture();
-  }, MEETING_CHAT_CAPTURE_INTERVAL_MS);
 
   return async () => {
     stopped = true;
-    clearInterval(interval);
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
     await pendingPersistence;
   };
 }

--- a/crates/detect/src/meeting_ax.rs
+++ b/crates/detect/src/meeting_ax.rs
@@ -64,7 +64,7 @@ use node::node_text;
 #[cfg(any(test, target_os = "macos", target_os = "linux"))]
 use node::{
     is_platform_active_call_control, is_platform_meeting_control, node_has_positive_bounds,
-    node_labels, searchable_node_text, teams_has_active_call_evidence,
+    node_labels, node_needs_bounds, searchable_node_text, teams_has_active_call_evidence,
 };
 #[cfg(any(test, target_os = "linux"))]
 use platform::is_browser_active_call_control;
@@ -2039,15 +2039,21 @@ fn snapshot_node(element: &ax::UiElement, index: usize) -> AxNode {
     let role = string_attr(element, ax::attr::role());
     let identifier = string_attr(element, ax::attr::id());
     let title = string_attr(element, ax::attr::title());
-    let value = string_attr(element, ax::attr::value());
+    let settable_value = ax_is_settable(element, ax::attr::value());
+    let value = (!settable_value)
+        .then(|| string_attr(element, ax::attr::value()))
+        .flatten();
     let description =
         string_attr(element, ax::attr::desc()).or_else(|| string_attr(element, ax::attr::help()));
     let placeholder = string_attr(element, ax::attr::placeholder_value());
     let enabled = ax_bool_attr(element, ax::attr::enabled());
-    let settable_value = ax_is_settable(element, ax::attr::value());
-    let bounds = ax_frame(element)
-        .or_else(|| rect_from_position_and_size(element))
-        .map(AxRect::from);
+    let bounds = node_needs_bounds(&role, settable_value, title.as_deref())
+        .then(|| {
+            ax_frame(element)
+                .or_else(|| rect_from_position_and_size(element))
+                .map(AxRect::from)
+        })
+        .flatten();
     let text = searchable_node_text(
         &role,
         &title,

--- a/crates/detect/src/meeting_ax/linux.rs
+++ b/crates/detect/src/meeting_ax/linux.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::hash::{Hash, Hasher};
+use std::sync::{OnceLock, mpsc};
 
 use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
 use atspi::proxy::action::ActionProxy;
@@ -18,7 +19,7 @@ use super::context::{
     native_capture_context_id, slack_capture_context_id, validated_chat_scope,
     zoom_capture_context_id,
 };
-use super::node::{node_labels, searchable_node_text};
+use super::node::{node_labels, node_needs_bounds, searchable_node_text};
 use super::platform::{
     MEETING_APP_BUNDLES, classify_bundle, classify_platform, classify_surface, is_browser_bundle,
     meeting_app_family, running_apps_for_bundle, running_meeting_apps, select_active_bundle_ids,
@@ -45,25 +46,46 @@ struct LiveNode {
     path: String,
 }
 
-fn block_on_atspi<T>(future: impl Future<Output = T> + Send) -> T
-where
-    T: Send,
-{
-    // These sync entrypoints are invoked from async Tauri commands that already
-    // run on the desktop Tokio runtime. Handle::block_on / Runtime::block_on on
-    // that thread panics with "Cannot start a runtime from within a runtime".
-    std::thread::scope(|scope| {
-        scope
-            .spawn(|| {
-                tokio::runtime::Builder::new_current_thread()
+type AtspiJob = Box<dyn FnOnce(&tokio::runtime::Runtime) + Send + 'static>;
+
+fn atspi_worker() -> &'static mpsc::Sender<AtspiJob> {
+    static WORKER: OnceLock<mpsc::Sender<AtspiJob>> = OnceLock::new();
+
+    WORKER.get_or_init(|| {
+        let (sender, receiver) = mpsc::channel::<AtspiJob>();
+        std::thread::Builder::new()
+            .name("meeting-atspi".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
-                    .expect("linux AT-SPI runtime")
-                    .block_on(future)
+                    .expect("linux AT-SPI runtime");
+                while let Ok(job) = receiver.recv() {
+                    job(&runtime);
+                }
             })
-            .join()
-            .expect("linux AT-SPI thread panicked")
+            .expect("linux AT-SPI worker");
+        sender
     })
+}
+
+fn block_on_atspi<T>(future: impl Future<Output = T> + Send + 'static) -> T
+where
+    T: Send + 'static,
+{
+    let (sender, receiver) = mpsc::sync_channel(1);
+    atspi_worker()
+        .send(Box::new(move |runtime| {
+            let result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| runtime.block_on(future)));
+            let _ = sender.send(result);
+        }))
+        .expect("linux AT-SPI worker stopped");
+
+    match receiver.recv().expect("linux AT-SPI worker stopped") {
+        Ok(output) => output,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
 }
 
 fn ax_role(role: Role) -> &'static str {
@@ -174,7 +196,14 @@ async fn snapshot_live_node(
             Some("AXTextField") | Some("AXTextArea") | Some("AXSecureTextField")
         );
 
-    let text_value = if let Some(text) = TextProxy::builder(accessible.inner().connection())
+    let role = if editable && matches!(role.as_deref(), Some("AXStaticText") | Some("AXGroup")) {
+        Some("AXTextArea".to_string())
+    } else {
+        role
+    };
+    let text_value = if settable_value {
+        None
+    } else if let Some(text) = TextProxy::builder(accessible.inner().connection())
         .destination(bus_name.clone())
         .ok()
         .and_then(|builder| builder.path(object_path.clone()).ok())
@@ -198,37 +227,29 @@ async fn snapshot_live_node(
         .cloned()
         .filter(|value| !value.is_empty());
 
-    let bounds = match ComponentProxy::builder(accessible.inner().connection())
-        .destination(bus_name.clone())
-        .ok()?
-        .path(object_path.clone())
-        .ok()?
-        .build()
-        .await
-    {
-        Ok(component) => {
-            component
-                .get_extents(CoordType::Screen)
+    let bounds =
+        if node_needs_bounds(&role, settable_value, title.as_deref()) {
+            match ComponentProxy::builder(accessible.inner().connection())
+                .destination(bus_name.clone())
+                .ok()?
+                .path(object_path.clone())
+                .ok()?
+                .build()
                 .await
-                .ok()
-                .map(|(x, y, width, height)| AxRect {
-                    x: f64::from(x),
-                    y: f64::from(y),
-                    width: f64::from(width),
-                    height: f64::from(height),
-                })
-        }
-        Err(_) => None,
-    };
-
-    if matches!(role.as_deref(), Some("AXStaticText")) && editable {
-        // Chromium often exposes editable composers as Role::Text.
-    }
-    let role = if editable && matches!(role.as_deref(), Some("AXStaticText") | Some("AXGroup")) {
-        Some("AXTextArea".to_string())
-    } else {
-        role
-    };
+            {
+                Ok(component) => component.get_extents(CoordType::Screen).await.ok().map(
+                    |(x, y, width, height)| AxRect {
+                        x: f64::from(x),
+                        y: f64::from(y),
+                        width: f64::from(width),
+                        height: f64::from(height),
+                    },
+                ),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
 
     let text = searchable_node_text(
         &role,
@@ -1458,6 +1479,14 @@ pub(super) fn capture_meeting_chat_messages(bundle_ids: Vec<String>) -> MeetingC
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn atspi_worker_is_reused() {
+        let first = block_on_atspi(async { std::thread::current().id() });
+        let second = block_on_atspi(async { std::thread::current().id() });
+
+        assert_eq!(first, second);
+    }
 
     #[test]
     fn object_replacement_text_does_not_pollute_accessible_labels() {

--- a/crates/detect/src/meeting_ax/node.rs
+++ b/crates/detect/src/meeting_ax/node.rs
@@ -44,6 +44,31 @@ pub(super) fn is_text_input_role(role: &Option<String>) -> bool {
     )
 }
 
+pub(super) fn node_needs_bounds(
+    role: &Option<String>,
+    settable_value: bool,
+    title: Option<&str>,
+) -> bool {
+    settable_value
+        || matches!(
+            role.as_deref(),
+            Some("AXButton")
+                | Some("AXMenuItem")
+                | Some("AXPopUpButton")
+                | Some("AXTextArea")
+                | Some("AXTextField")
+                | Some("AXSecureTextField")
+                | Some("AXComboBox")
+        )
+        || (role.as_deref() == Some("AXStaticText")
+            && title.is_some_and(|title| {
+                title
+                    .trim()
+                    .to_ascii_lowercase()
+                    .starts_with("write a message to ")
+            }))
+}
+
 pub(super) fn node_labels(node: &AxNode) -> impl Iterator<Item = &str> {
     [
         node.title.as_deref(),

--- a/crates/detect/src/meeting_ax/tests/inspection.rs
+++ b/crates/detect/src/meeting_ax/tests/inspection.rs
@@ -1,6 +1,26 @@
 use super::*;
 
 #[test]
+fn test_bounds_are_only_requested_for_visibility_sensitive_nodes() {
+    assert!(!node_needs_bounds(
+        &Some("AXStaticText".to_string()),
+        false,
+        Some("meeting transcript"),
+    ));
+    assert!(node_needs_bounds(
+        &Some("AXButton".to_string()),
+        false,
+        Some("leave call"),
+    ));
+    assert!(node_needs_bounds(&Some("AXGroup".to_string()), true, None,));
+    assert!(node_needs_bounds(
+        &Some("AXStaticText".to_string()),
+        false,
+        Some("Write a message to everyone, press Shift + Enter for new line"),
+    ));
+}
+
+#[test]
 fn test_chat_inspection_does_not_use_writable_value_as_label() {
     let mut input = node(6, "AXTextArea", "", None);
     input.title = None;

--- a/plugins/detect/js/bindings.gen.ts
+++ b/plugins/detect/js/bindings.gen.ts
@@ -94,9 +94,9 @@ async sendMeetingChatMessage(message: string, micActiveBundleIds: string[]) : Pr
     else return { status: "error", error: e  as any };
 }
 },
-async captureMeetingChatMessages(bundleIds: string[]) : Promise<Result<MeetingChatCaptureResult, string>> {
+async captureMeetingChatMessages() : Promise<Result<MeetingChatCaptureResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("plugin:detect|capture_meeting_chat_messages", { bundleIds }) };
+    return { status: "ok", data: await TAURI_INVOKE("plugin:detect|capture_meeting_chat_messages") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/plugins/detect/src/commands.rs
+++ b/plugins/detect/src/commands.rs
@@ -182,13 +182,15 @@ pub(crate) async fn send_meeting_chat_message<R: tauri::Runtime>(
 #[specta::specta]
 pub(crate) async fn capture_meeting_chat_messages<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
-    bundle_ids: Vec<String>,
 ) -> Result<anlg_detect::MeetingChatCaptureResult, String> {
     let current_mic_apps = app
         .detect()
         .list_mic_using_applications()
         .map_err(|error| error.to_string())?;
-    let verified_bundle_ids = intersect_mic_active_bundle_ids(&bundle_ids, &current_mic_apps);
+    let verified_bundle_ids = current_mic_apps
+        .into_iter()
+        .map(|application| application.id)
+        .collect::<Vec<_>>();
 
     Ok(anlg_detect::capture_meeting_chat_messages(
         verified_bundle_ids,


### PR DESCRIPTION
## Summary
- keep mic-active app discovery inside the native capture command so each poll scans it once
- schedule the next poll five seconds after completion to prevent slow AX scans from bunching
- reuse one Linux AT-SPI runtime and only request text values or geometry when capture logic needs them

## Validation
- pnpm fmt:check
- pnpm -F desktop typecheck
- pnpm -F desktop test
- pnpm exec oxlint --quiet --format=github apps/desktop/src/
- cargo check
- cargo check -p desktop --features direct-distribution
- cargo check -p desktop --features app-store
- cargo test --locked -p detect
- cargo test --locked -p tauri-plugin-detect
- Linux container: cargo test --locked -p detect --lib meeting_ax

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes meeting chat capture timing, API surface, and where mic/app scoping happens—areas that affect consent-related chat ingestion, though native code still enforces single-app rules.
> 
> **Overview**
> **Meeting chat capture** no longer lists mic-active apps in the desktop layer or passes bundle IDs into `captureMeetingChatMessages`. The Tauri command resolves mic users once and delegates app selection and fail-closed scoping to native detect code; the listener drops the extra bundle-ID guard and calls capture with no arguments.
> 
> **Polling behavior** changes from a fixed `setInterval` to scheduling the next poll **five seconds after each capture finishes**, so slow accessibility scans do not stack. Tests were updated for the parameterless API, native scoping, and the post-completion interval (including a slow-capture case).
> 
> **Accessibility tree work** is cheaper on macOS and Linux: new `node_needs_bounds` limits geometry reads to controls/composers that matter for visibility; settable values are not read as labels/text during snapshot. On Linux, AT-SPI runs on a **reused worker thread** with a dedicated runtime instead of spinning a new thread per call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5805b6182fb03e4d41d0f996d551534bf4af4fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->