### PR TITLE
Require signed contributor agreements and intentional PR summaries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+Write this description yourself. Do not paste a generated commit log or a file-by-file recap.
+
+Title: state the intended outcome with a specific action. For example, use
+"Prevent duplicate notes after reconnect" instead of "Update session store" or "Fix #123".
+-->
+
+## Summary
+
+**Problem:** <!-- Replace this comment on the same line: what was wrong or missing, and why did it matter? -->
+
+**Fix:** <!-- Replace this comment on the same line: how does this PR resolve the problem at the decision and behavior level? -->
+
+## Verification
+
+<!-- List the commands and manual checks you ran. -->
+
+<!-- External contributors: CLA Assistant will post a signing link after the PR is opened. The CLA check must pass before merge. -->

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -693,8 +693,19 @@ jobs:
             exit 0
           fi
 
+          BODY=$(printf '%s\n' \
+            "## Summary" \
+            "" \
+            "**Problem:** The desktop_v$VERSION release changed Linux artifacts, leaving the AUR package and signed APT repository metadata on the previous version." \
+            "" \
+            "**Fix:** Refresh the AUR package and signed APT repository metadata so Linux package managers install the current desktop_v$VERSION release." \
+            "" \
+            "## Verification" \
+            "" \
+            "- Generated and verified the signed APT repository metadata during the desktop publish run.")
+
           gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore(packaging): publish Linux packages for $VERSION" \
-            --body "Automated follow-up from the desktop_v$VERSION publish run. Refreshes the AUR package and signed APT repository metadata for the current Linux release."
+            --body "$BODY"

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,175 @@
+name: PR description
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - env:
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          node <<'NODE'
+          const title = (process.env.PR_TITLE || "").trim();
+          const body = process.env.PR_BODY || "";
+          const errors = [];
+
+          if (process.env.PR_AUTHOR_TYPE === "Bot") {
+            console.log("Automated bot pull request; description validation is not required.");
+            process.exit(0);
+          }
+
+          if (title.length < 12) {
+            errors.push("Title must be at least 12 characters.");
+          }
+
+          if (title.split(/\s+/).length < 3) {
+            errors.push("Title must state the intended outcome in at least three words.");
+          }
+
+          if (/^(wip|draft|changes?|updates?|fix(?:es)?|pull request|pr)(?:\s*[:#-]?\s*\d+)?$/i.test(title)) {
+            errors.push("Title is too generic. State what this PR intends to accomplish.");
+          }
+
+          function stripHtmlComments(markdown) {
+            let inComment = false;
+            let fenceMarker = "";
+
+            return markdown.split("\n").map((line) => {
+              const leadingMarker = line.match(/^ {0,3}(`+|~+)/)?.[1] || "";
+              if (!inComment && leadingMarker.length >= 3) {
+                if (!fenceMarker) {
+                  fenceMarker = leadingMarker;
+                } else if (
+                  leadingMarker[0] === fenceMarker[0] &&
+                  leadingMarker.length >= fenceMarker.length &&
+                  line.trimStart().slice(leadingMarker.length).trim() === ""
+                ) {
+                  fenceMarker = "";
+                }
+                return line;
+              }
+
+              if (fenceMarker) return line;
+
+              let visible = "";
+              let inlineTicks = 0;
+              for (let index = 0; index < line.length;) {
+                if (inComment) {
+                  const commentEnd = line.indexOf("-->", index);
+                  if (commentEnd === -1) return visible;
+                  inComment = false;
+                  index = commentEnd + 3;
+                  continue;
+                }
+
+                if (line[index] === "`") {
+                  let tickEnd = index + 1;
+                  while (line[tickEnd] === "`") tickEnd++;
+                  const tickCount = tickEnd - index;
+                  if (inlineTicks === 0) {
+                    const closingTicks = new RegExp("(^|[^`])" + "`".repeat(tickCount) + "(?!`)");
+                    if (closingTicks.test(line.slice(tickEnd))) inlineTicks = tickCount;
+                  } else if (tickCount === inlineTicks) {
+                    inlineTicks = 0;
+                  }
+                  visible += line.slice(index, tickEnd);
+                  index = tickEnd;
+                  continue;
+                }
+
+                if (inlineTicks === 0 && line[index - 1] !== "\\" && line.startsWith("<!--", index)) {
+                  inComment = true;
+                  index += 4;
+                  continue;
+                }
+
+                visible += line[index];
+                index++;
+              }
+              return visible;
+            }).join("\n");
+          }
+
+          function markCodeLines(markdown) {
+            let fenceMarker = "";
+
+            return markdown.split("\n").map((text) => {
+              const leadingMarker = text.match(/^ {0,3}(`+|~+)/)?.[1] || "";
+              if (!fenceMarker && leadingMarker.length >= 3) {
+                fenceMarker = leadingMarker;
+                return { text, isCode: true };
+              }
+
+              if (fenceMarker) {
+                if (
+                  leadingMarker[0] === fenceMarker[0] &&
+                  leadingMarker.length >= fenceMarker.length &&
+                  text.trimStart().slice(leadingMarker.length).trim() === ""
+                ) {
+                  fenceMarker = "";
+                }
+                return { text, isCode: true };
+              }
+
+              return { text, isCode: /^(?: {4}|\t)/.test(text) };
+            });
+          }
+
+          const visibleLines = markCodeLines(stripHtmlComments(body));
+          const summaryHeading = /^##\s+summary\s*$/i;
+          const verificationHeading = /^##\s+verification\s*$/i;
+          const summaryIndex = visibleLines.findIndex(
+            (line) => !line.isCode && summaryHeading.test(line.text.trim()),
+          );
+          const verificationIndex = visibleLines.findIndex(
+            (line, index) =>
+              index > summaryIndex && !line.isCode && verificationHeading.test(line.text.trim()),
+          );
+          const summaryLines = summaryIndex === -1
+            ? []
+            : visibleLines.slice(
+                summaryIndex + 1,
+                verificationIndex === -1 ? visibleLines.length : verificationIndex,
+              );
+          const problemLabel = /^\*\*Problem:\*\*\s*/i;
+          const fixLabel = /^\*\*Fix:\*\*\s*/i;
+          const problemIndex = summaryLines.findIndex(
+            (line) => !line.isCode && problemLabel.test(line.text),
+          );
+          const fixIndex = summaryLines.findIndex(
+            (line, index) => index > problemIndex && !line.isCode && fixLabel.test(line.text),
+          );
+          const problem = problemIndex === -1
+            ? ""
+            : summaryLines[problemIndex].text.replace(problemLabel, "").trim();
+          const fix = fixIndex === -1
+            ? ""
+            : summaryLines[fixIndex].text.replace(fixLabel, "").trim();
+
+          if (problem.length < 40) {
+            errors.push("Write at least 40 characters after **Problem:** on its labeled line.");
+          }
+
+          if (fix.length < 40) {
+            errors.push("Write at least 40 characters after **Fix:** on its labeled line.");
+          }
+
+          if (errors.length) {
+            console.error(errors.map((error) => `- ${error}`).join("\n"));
+            process.exit(1);
+          }
+
+          console.log("PR title and summary are complete.");
+          NODE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,13 @@ mint broken-links --check-anchors --check-redirects
 
 Check the affected workflow under `.github/workflows/` for stricter package-specific commands.
 
+## Open a pull request
+
+- Write the title as a specific action that states the intended outcome. Do not use a file name, ticket number, or a generic label as the title.
+- Write the description yourself as a concise executive summary: on the labeled `Problem` and `Fix` lines, explain the problem, why it mattered, and how the change fixes it. Do not paste a generated commit log or a file-by-file recap.
+- List the commands and manual checks you used to verify the change.
+- External contributors must sign the [Fastrepl Contributor License Agreement](https://gist.github.com/ComputelessComputer/9d8243ec8e2ce92541c5b67462f092a0) through CLA Assistant when prompted.
+
 ## Licensing and contribution boundary
 
 By submitting a contribution outside `enterprise/`, you agree that it may be distributed under the repository's [MIT License](LICENSE). Only submit material you have the right to license this way.


### PR DESCRIPTION
## Summary

**Problem:** Anarlog is public and already accepts pull requests from forks, but outside contributors had no signed agreement gate and pull requests had no enforced statement of the problem or intended fix.

**Fix:** Install CLA Assistant only on `fastrepl/anarlog` and link it to Fastrepl's public individual CLA for non-maintainer contributions. Add a PR template and validation check that require an intentional title plus concise, hand-written Problem and Fix statements.

## Verification

- Confirmed repository interaction limits are disabled and users without write access can open unlimited pull requests.
- Confirmed CLA Assistant is installed only for `fastrepl/anarlog`, linked to the published Fastrepl CLA, and required for changes affecting at least one file.
- Exempted the two direct collaborators and bot accounts from the external-contributor CLA check.
- `pnpm exec dprint check CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md .github/workflows/pr-description.yml`
- Ran the PR description validator locally against passing and failing fixtures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub templates, docs, and a read-only PR validation workflow; application runtime behavior is unaffected.
> 
> **Overview**
> Adds contributor-facing **Problem / Fix / Verification** PR structure and enforces it in CI for human-authored pull requests.
> 
> A new **`.github/PULL_REQUEST_TEMPLATE.md`** steers authors away from commit logs and toward outcome-focused titles plus labeled **Problem** and **Fix** lines. **`CONTRIBUTING.md`** documents the same expectations and notes CLA Assistant for external contributors.
> 
> A new **`pr-description`** workflow runs on PR open/update: it skips **Bot** authors, rejects overly short or generic titles, strips HTML comments and code from the body, and requires at least 40 characters on each labeled **Problem:** and **Fix:** line under **## Summary**.
> 
> The **desktop publish** workflow’s automated Linux packaging follow-up PR now uses that same structured body instead of a one-line blurb, so bot-opened packaging PRs stay consistent with the template (while remaining exempt from the validator).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe339a25aae18ca4ac536d87bce6ddba49bfb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->