### PR TITLE
Split GPT-4o Transcribe Diarize uploads under OpenAI's 1400s cap

### DIFF
--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -332,6 +332,7 @@ pub(super) fn format_user_friendly_error(error: &str) -> String {
         || error_lower.contains("payload too large")
         || error_lower.contains("file too large")
         || error_lower.contains("upload limit")
+        || error_lower.contains("audio duration")
     {
         return "This recording is too large for the selected transcription provider. Try another provider or split the recording.".to_string();
     }
@@ -478,6 +479,15 @@ mod tests {
     fn provider_upload_limit_errors_are_explained() {
         let message = format_user_friendly_error(
             r#"UnexpectedStatus { status: 400, body: "Audio file exceeds the 25 MB multipart upload limit." }"#,
+        );
+
+        assert!(message.starts_with("This recording is too large"));
+    }
+
+    #[test]
+    fn provider_duration_limit_errors_are_explained() {
+        let message = format_user_friendly_error(
+            r#"UnexpectedStatus { status: 400, body: "{\"error\":{\"message\":\"audio duration 1500.012 seconds is longer than 1400 seconds which is the maximum for this model\"}}" }"#,
         );
 
         assert!(message.starts_with("This recording is too large"));

--- a/crates/listener2-core/src/batch/progressive/bootstrap.rs
+++ b/crates/listener2-core/src/batch/progressive/bootstrap.rs
@@ -170,7 +170,13 @@ async fn spawn_openai_batch_task(
 
     let rx_task = tokio::spawn(
         async move {
-            let plan = match plan_openai_segments(&args.file_path, &args.provider_label).await {
+            let plan = match plan_openai_segments(
+                &args.file_path,
+                &args.provider_label,
+                args.listen_params.model.as_deref(),
+            )
+            .await
+            {
                 Ok(plan) => plan,
                 Err(error) => {
                     report_start_failure(

--- a/crates/listener2-core/src/batch/progressive/segmented.rs
+++ b/crates/listener2-core/src/batch/progressive/segmented.rs
@@ -24,9 +24,10 @@ pub(super) struct SegmentedPlan {
 pub(super) async fn plan_openai_segments(
     file_path: &str,
     provider: &str,
+    model: Option<&str>,
 ) -> crate::Result<Option<SegmentedPlan>> {
     let total_duration = audio_duration(file_path);
-    let limit = AdapterKind::OpenAI.batch_upload_limit();
+    let limit = AdapterKind::OpenAI.batch_upload_limit(model);
 
     let Some(segment_duration) = segment_plan(file_path, total_duration, limit) else {
         return Ok(None);

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -67,7 +67,7 @@ pub(in crate::batch) async fn run_direct_batch_for_adapter_kind(
         return run_anarlog_batch(params, listen_params).await;
     }
 
-    let limit = adapter_kind.batch_upload_limit();
+    let limit = adapter_kind.batch_upload_limit(listen_params.model.as_deref());
 
     dispatch_batch!(adapter_kind, params, listen_params, limit, {
         Argmax => ArgmaxAdapter,

--- a/crates/listener2-core/src/batch/simple/tests.rs
+++ b/crates/listener2-core/src/batch/simple/tests.rs
@@ -201,6 +201,39 @@ fn segments_only_when_a_provider_limit_is_exceeded() {
 }
 
 #[test]
+fn openai_diarize_splits_below_the_shared_openai_duration_cap() {
+    let source = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+    write_test_wav_samples(source.path(), TARGET_SAMPLE_RATE as usize);
+    let path = source.path().to_str().unwrap();
+    let size = std::fs::metadata(source.path()).unwrap().len();
+    let diarize = owhisper_client::AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe-diarize"))
+        .unwrap();
+    let transcribe = owhisper_client::AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe"))
+        .unwrap();
+    let meeting = Some(Duration::from_secs_f64(1500.012));
+
+    assert!(
+        size < transcribe.max_bytes,
+        "fixture must be size-eligible so duration is the trigger"
+    );
+    assert_eq!(
+        segment_plan(path, Some(Duration::from_secs(1450)), Some(transcribe)),
+        None
+    );
+    assert_eq!(
+        segment_plan(path, Some(Duration::from_secs(1450)), Some(diarize)),
+        Some(diarize.max_duration)
+    );
+    assert_eq!(
+        segment_plan(path, meeting, Some(diarize)),
+        Some(diarize.max_duration)
+    );
+    assert!(diarize.max_duration < Duration::from_secs(1400));
+}
+
+#[test]
 fn merges_segment_transcripts_onto_a_single_timeline() {
     let segment = |transcript: &str, start: f64| Response {
         metadata: serde_json::json!({ "provider": "openrouter" }),

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -423,6 +423,10 @@ pub fn append_provider_param(base_url: &str, provider: &str) -> String {
 }
 
 const OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES: u64 = 25 * 1024 * 1024;
+const OPENAI_COMPATIBLE_MAX_DURATION: Duration = Duration::from_secs(25 * 60);
+/// `gpt-4o-transcribe-diarize` rejects audio longer than 1400s. Stay 10s under
+/// so MP3 re-encode padding cannot push a segment over the API cap.
+const OPENAI_DIARIZE_MAX_DURATION: Duration = Duration::from_secs(1390);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BatchUploadLimit {
@@ -533,7 +537,7 @@ impl AdapterKind {
     /// Providers that reject oversized multipart uploads or time out on long
     /// audio. Recordings past either bound are split into one request per segment
     /// instead of failing at the provider.
-    pub fn batch_upload_limit(&self) -> Option<BatchUploadLimit> {
+    pub fn batch_upload_limit(&self, model: Option<&str>) -> Option<BatchUploadLimit> {
         let (max_bytes, max_duration) = match self {
             // OpenRouter's upstream providers time out after 60s per request, so
             // its segments stay well below the size cap.
@@ -541,9 +545,13 @@ impl AdapterKind {
                 OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
                 Duration::from_secs(10 * 60),
             ),
-            Self::OpenAI | Self::Groq | Self::Together | Self::Xai => (
+            Self::OpenAI => (
                 OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
-                Duration::from_secs(25 * 60),
+                openai_batch_max_duration(model),
+            ),
+            Self::Groq | Self::Together | Self::Xai => (
+                OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
+                OPENAI_COMPATIBLE_MAX_DURATION,
             ),
             Self::Zai => (OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES, Duration::from_secs(25)),
             Self::SiliconFlow => (50 * 1024 * 1024, Duration::from_secs(50 * 60)),
@@ -725,6 +733,15 @@ impl From<crate::providers::Provider> for AdapterKind {
             Provider::Together => Self::Together,
             Provider::Xai => Self::Xai,
         }
+    }
+}
+
+fn openai_batch_max_duration(model: Option<&str>) -> Duration {
+    match openai::OpenAIAdapter::resolve_batch_model(model) {
+        openai_transcription::batch::AudioModel::Gpt4oTranscribeDiarize => {
+            OPENAI_DIARIZE_MAX_DURATION
+        }
+        _ => OPENAI_COMPATIBLE_MAX_DURATION,
     }
 }
 

--- a/crates/owhisper-client/src/adapter/tests.rs
+++ b/crates/owhisper-client/src/adapter/tests.rs
@@ -535,3 +535,28 @@ fn test_append_provider_param_no_existing_provider() {
     assert!(url.contains("provider=anarlog"));
     assert_eq!(url.matches("provider=").count(), 1);
 }
+
+#[test]
+fn openai_diarize_batch_limit_stays_under_api_duration_cap() {
+    let diarize = AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe-diarize"))
+        .expect("openai has a batch upload limit");
+    let transcribe = AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe"))
+        .expect("openai has a batch upload limit");
+
+    assert_eq!(diarize.max_duration, Duration::from_secs(1390));
+    assert!(diarize.max_duration < Duration::from_secs(1400));
+    assert_eq!(transcribe.max_duration, Duration::from_secs(25 * 60));
+    assert_eq!(diarize.max_bytes, transcribe.max_bytes);
+}
+
+#[test]
+fn openai_compatible_providers_keep_shared_duration_cap() {
+    for kind in [AdapterKind::Groq, AdapterKind::Together, AdapterKind::Xai] {
+        let limit = kind
+            .batch_upload_limit(None)
+            .expect("openai-compatible providers have a batch upload limit");
+        assert_eq!(limit.max_duration, Duration::from_secs(25 * 60));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** OpenAI `gpt-4o-transcribe-diarize` rejects audio longer than 1400 seconds (~23m20s). Batch transcription used the shared OpenAI 25-minute (1500s) upload cap, so a ~25-minute meeting (1500.012s in the report) was sent as one request — or split into 1500s segments that still exceeded 1400s — and failed with `400 invalid_value`. Users had to fall back to a local model.

**Fix:** Make OpenAI batch upload limits model-aware. `gpt-4o-transcribe-diarize` now splits at 1390s (10s under the 1400s API cap so MP3 re-encode padding cannot push a segment over). Other OpenAI-compatible models keep the 25-minute cap. Duration-limit API errors are also mapped to the existing “recording is too large” user-facing message.

## Verification

- `cargo test --locked -p owhisper-client --lib duration_cap`
- `cargo test --locked -p owhisper-client --lib adapter::` (333 passed)
- `cargo test --locked -p listener2-core --lib openai_diarize_splits`
- `cargo test --locked -p listener2-core --lib batch::` (50 passed)
- `cargo check --locked -p owhisper-client -p listener2-core`
- `pnpm exec dprint check` on the changed files

Could not live-verify against OpenAI (no provider key / 25-minute recording in this environment).

Speaker labels are still remapped as distinct across split segments (existing merge behavior). Consistent diarize IDs across chunks would need `known_speaker_references` as a follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d531d47-bb57-4a51-9dee-be617e81481b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d531d47-bb57-4a51-9dee-be617e81481b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

