### PR TITLE
Split GPT-4o Transcribe Diarize uploads under OpenAI's 1400s cap

### DIFF
--- a/crates/listener2-core/src/batch/progressive/bootstrap.rs
+++ b/crates/listener2-core/src/batch/progressive/bootstrap.rs
@@ -170,7 +170,13 @@ async fn spawn_openai_batch_task(
 
     let rx_task = tokio::spawn(
         async move {
-            let plan = match plan_openai_segments(&args.file_path, &args.provider_label).await {
+            let plan = match plan_openai_segments(
+                &args.file_path,
+                &args.provider_label,
+                args.listen_params.model.as_deref(),
+            )
+            .await
+            {
                 Ok(plan) => plan,
                 Err(error) => {
                     report_start_failure(

--- a/crates/listener2-core/src/batch/progressive/segmented.rs
+++ b/crates/listener2-core/src/batch/progressive/segmented.rs
@@ -24,9 +24,10 @@ pub(super) struct SegmentedPlan {
 pub(super) async fn plan_openai_segments(
     file_path: &str,
     provider: &str,
+    model: Option<&str>,
 ) -> crate::Result<Option<SegmentedPlan>> {
     let total_duration = audio_duration(file_path);
-    let limit = AdapterKind::OpenAI.batch_upload_limit();
+    let limit = AdapterKind::OpenAI.batch_upload_limit(model);
 
     let Some(segment_duration) = segment_plan(file_path, total_duration, limit) else {
         return Ok(None);

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -67,7 +67,7 @@ pub(in crate::batch) async fn run_direct_batch_for_adapter_kind(
         return run_anarlog_batch(params, listen_params).await;
     }
 
-    let limit = adapter_kind.batch_upload_limit();
+    let limit = adapter_kind.batch_upload_limit(listen_params.model.as_deref());
 
     dispatch_batch!(adapter_kind, params, listen_params, limit, {
         Argmax => ArgmaxAdapter,

--- a/crates/listener2-core/src/batch/simple/tests.rs
+++ b/crates/listener2-core/src/batch/simple/tests.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{Router, extract::State, http::StatusCode};
-use owhisper_client::BatchSttAdapter;
+use owhisper_client::{AdapterKind, BatchSttAdapter};
 use owhisper_interface::batch::Response;
 use tokio::sync::Notify;
 
@@ -197,6 +197,48 @@ fn segments_only_when_a_provider_limit_is_exceeded() {
             limit(size, Duration::from_secs(60))
         ),
         Some(Duration::from_secs(60))
+    );
+}
+
+#[test]
+fn openai_diarize_meetings_just_over_25_minutes_are_split() {
+    let source = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+    write_test_wav_samples(source.path(), TARGET_SAMPLE_RATE as usize);
+    let path = source.path().to_str().unwrap();
+    let size = std::fs::metadata(source.path()).unwrap().len();
+    let diarize = AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe-diarize"))
+        .expect("openai has an upload limit");
+    let transcribe = AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe"))
+        .expect("openai has an upload limit");
+
+    let just_over_25_min = Duration::from_millis(1_500_012);
+    assert_eq!(
+        segment_plan(
+            path,
+            Some(just_over_25_min),
+            Some(owhisper_client::BatchUploadLimit {
+                max_bytes: size,
+                max_duration: diarize.max_duration,
+            })
+        ),
+        Some(diarize.max_duration)
+    );
+    assert_eq!(
+        segment_plan(
+            path,
+            Some(just_over_25_min),
+            Some(owhisper_client::BatchUploadLimit {
+                max_bytes: size,
+                max_duration: transcribe.max_duration,
+            })
+        ),
+        Some(transcribe.max_duration)
+    );
+    assert!(
+        diarize.max_duration < Duration::from_secs(1400),
+        "diarize segments must stay under OpenAI's 1400s hard cap"
     );
 }
 

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -423,6 +423,10 @@ pub fn append_provider_param(base_url: &str, provider: &str) -> String {
 }
 
 const OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES: u64 = 25 * 1024 * 1024;
+const OPENAI_COMPATIBLE_MAX_DURATION: Duration = Duration::from_secs(25 * 60);
+/// `gpt-4o-transcribe-diarize` rejects audio longer than 1400s. Stay 10s under
+/// so MP3 re-encode padding cannot push a segment over the API cap.
+const OPENAI_DIARIZE_MAX_DURATION: Duration = Duration::from_secs(1390);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BatchUploadLimit {
@@ -533,7 +537,7 @@ impl AdapterKind {
     /// Providers that reject oversized multipart uploads or time out on long
     /// audio. Recordings past either bound are split into one request per segment
     /// instead of failing at the provider.
-    pub fn batch_upload_limit(&self) -> Option<BatchUploadLimit> {
+    pub fn batch_upload_limit(&self, model: Option<&str>) -> Option<BatchUploadLimit> {
         let (max_bytes, max_duration) = match self {
             // OpenRouter's upstream providers time out after 60s per request, so
             // its segments stay well below the size cap.
@@ -541,9 +545,13 @@ impl AdapterKind {
                 OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
                 Duration::from_secs(10 * 60),
             ),
-            Self::OpenAI | Self::Groq | Self::Together | Self::Xai => (
+            Self::OpenAI => (
                 OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
-                Duration::from_secs(25 * 60),
+                openai_batch_max_duration(model),
+            ),
+            Self::Groq | Self::Together | Self::Xai => (
+                OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
+                OPENAI_COMPATIBLE_MAX_DURATION,
             ),
             Self::Zai => (OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES, Duration::from_secs(25)),
             Self::SiliconFlow => (50 * 1024 * 1024, Duration::from_secs(50 * 60)),
@@ -696,6 +704,19 @@ impl AdapterKind {
             Self::Deepgram => DeepgramAdapter::recommended_model_live(languages),
             _ => None,
         }
+    }
+}
+
+fn openai_batch_max_duration(model: Option<&str>) -> Duration {
+    match model.and_then(|value| {
+        value
+            .parse::<openai_transcription::batch::AudioModel>()
+            .ok()
+    }) {
+        Some(openai_transcription::batch::AudioModel::Gpt4oTranscribeDiarize) => {
+            OPENAI_DIARIZE_MAX_DURATION
+        }
+        _ => OPENAI_COMPATIBLE_MAX_DURATION,
     }
 }
 

--- a/crates/owhisper-client/src/adapter/tests.rs
+++ b/crates/owhisper-client/src/adapter/tests.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::*;
 
 #[test]
@@ -534,4 +536,31 @@ fn test_append_provider_param_no_existing_provider() {
     let url = append_provider_param("https://api.anarlog.so/stt", "anarlog");
     assert!(url.contains("provider=anarlog"));
     assert_eq!(url.matches("provider=").count(), 1);
+}
+
+#[test]
+fn openai_diarize_batch_limit_is_tighter_than_other_openai_models() {
+    let diarize = AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe-diarize"))
+        .expect("openai has an upload limit");
+    let transcribe = AdapterKind::OpenAI
+        .batch_upload_limit(Some("gpt-4o-transcribe"))
+        .expect("openai has an upload limit");
+    let default = AdapterKind::OpenAI
+        .batch_upload_limit(None)
+        .expect("openai has an upload limit");
+
+    assert_eq!(diarize.max_duration, Duration::from_secs(1390));
+    assert_eq!(transcribe.max_duration, Duration::from_secs(25 * 60));
+    assert_eq!(default.max_duration, Duration::from_secs(25 * 60));
+    assert!(diarize.max_duration < Duration::from_secs(1400));
+}
+
+#[test]
+fn groq_keeps_the_shared_openai_compatible_duration_for_any_model() {
+    let limit = AdapterKind::Groq
+        .batch_upload_limit(Some("gpt-4o-transcribe-diarize"))
+        .expect("groq has an upload limit");
+
+    assert_eq!(limit.max_duration, Duration::from_secs(25 * 60));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Re-transcribing a meeting with OpenAI `gpt-4o-transcribe-diarize` failed with `audio duration 1500.012 seconds is longer than 1400 seconds which is the maximum for this model`. Users then had to fall back to a local model. We already split oversized OpenAI uploads, but every OpenAI model used the shared 25-minute (1500s) bound, so a ~25-minute meeting was sent as one request that the diarize model rejects.

**Fix:** Make the OpenAI batch upload limit model-aware. `gpt-4o-transcribe-diarize` now splits at 1390s (10s under the 1400s API hard cap so MP3 re-encode padding cannot push a segment over). Other OpenAI models keep the 25-minute split. Existing segment merge already remaps speaker IDs across chunks.

## Verification

- `cargo test --locked -p owhisper-client --lib diarize`
- `cargo test --locked -p owhisper-client --lib groq_keeps_the_shared`
- `cargo test --locked -p listener2-core --lib openai_diarize_meetings`
- `cargo test --locked -p listener2-core --lib segments_only_when`
- `cargo check --locked -p owhisper-client -p listener2-core`
- `pnpm exec dprint check` on the changed Rust files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07932da0-4436-44a3-b9cd-6def625b6513?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07932da0-4436-44a3-b9cd-6def625b6513&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

