### PR TITLE
Add Gemini 3.5 Transcribe as a desktop STT provider

### DIFF
--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -91,19 +91,21 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                               ? `Use [Mistral](https://mistral.ai) for transcriptions. Keep the Base URL as \`https://api.mistral.ai/v1\` (Reset under Advanced if you pasted a transcriptions endpoint). **Voxtral Mini Transcribe 2** transcribes after recording; the realtime model is for live captions.`
                               : providerId === "cohere"
                                 ? `Use [Cohere Transcribe](https://docs.cohere.com/docs/transcribe) for batch transcription. Files must be 25 MB or smaller and use one selected language. Cohere does not return timestamps or speaker labels, so Anarlog estimates word timing.`
-                                : providerId === "google_cloud"
-                                  ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) synchronous recognition for recordings up to one minute and 10 MB. Paste an OAuth access token in the API key field; refresh it when it expires.`
-                                  : providerId === "azure_speech"
-                                    ? `Use [Azure AI Speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text) fast transcription. Enter the regional Speech resource endpoint as the Base URL and its subscription key as the API key.`
-                                    : providerId === "aws_transcribe"
-                                      ? `Amazon Transcribe's native file API requires SigV4 plus an S3 object. Enter an OpenAI-compatible gateway URL that performs that AWS authentication and upload, then paste the gateway token as the API key.`
-                                      : providerId === "speechmatics"
-                                        ? `Use [Speechmatics](https://docs.speechmatics.com/speech-to-text/batch/quickstart) enhanced batch transcription. The default endpoint uses the EU region and can be changed under Advanced.`
-                                        : providerId === "revai"
-                                          ? `Use [Rev AI](https://docs.rev.ai/api/asynchronous/get-started) asynchronous transcription. Anarlog uploads the recording, waits for the job, and retrieves word timestamps and speaker labels.`
-                                          : providerId === "custom"
-                                            ? `We only support **Deepgram compatible** endpoints for now.`
-                                            : "";
+                                : providerId === "google_generative_ai"
+                                  ? `Use [Gemini 3.5 Transcribe](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5-transcribe/) with a Google AI Studio API key. **3.5 Transcribe Live** captions during recording (preview sessions last up to 10 minutes). **3.5 Transcribe** runs after recording with speaker labels and word timestamps; Anarlog splits files past 15 minutes.`
+                                  : providerId === "google_cloud"
+                                    ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) synchronous recognition for recordings up to one minute and 10 MB. Paste an OAuth access token in the API key field; refresh it when it expires.`
+                                    : providerId === "azure_speech"
+                                      ? `Use [Azure AI Speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text) fast transcription. Enter the regional Speech resource endpoint as the Base URL and its subscription key as the API key.`
+                                      : providerId === "aws_transcribe"
+                                        ? `Amazon Transcribe's native file API requires SigV4 plus an S3 object. Enter an OpenAI-compatible gateway URL that performs that AWS authentication and upload, then paste the gateway token as the API key.`
+                                        : providerId === "speechmatics"
+                                          ? `Use [Speechmatics](https://docs.speechmatics.com/speech-to-text/batch/quickstart) enhanced batch transcription. The default endpoint uses the EU region and can be changed under Advanced.`
+                                          : providerId === "revai"
+                                            ? `Use [Rev AI](https://docs.rev.ai/api/asynchronous/get-started) asynchronous transcription. Anarlog uploads the recording, waits for the job, and retrieves word timestamps and speaker labels.`
+                                            : providerId === "custom"
+                                              ? `We only support **Deepgram compatible** endpoints for now.`
+                                              : "";
 
   if (!content.trim()) {
     return null;

--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -22,6 +22,9 @@ describe("getDefaultSttModel", () => {
     expect(getDefaultSttModel("speechmatics")).toBe("enhanced");
     expect(getDefaultSttModel("azure_speech")).toBe("fast-transcription");
     expect(getDefaultSttModel("google_cloud")).toBe("latest_long");
+    expect(getDefaultSttModel("google_generative_ai")).toBe(
+      "gemini-3.5-transcribe-live",
+    );
     expect(getDefaultSttModel("aws_transcribe")).toBe("amazon-transcribe");
     expect(getDefaultSttModel("revai")).toBe("machine");
     expect(getDefaultSttModel("fireworks")).toBe("whisper-v3-turbo");

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -22,6 +22,7 @@ describe("STT providers", () => {
       "dashscope",
       "zai",
       "siliconflow",
+      "google_generative_ai",
       "google_cloud",
       "aws_transcribe",
       "azure_speech",
@@ -81,6 +82,10 @@ describe("STT model display labels", () => {
       "Whisper Large V3 Turbo",
     );
     expect(displayModelLabel("xai-stt")).toBe("xAI Speech to Text");
+    expect(displayModelLabel("gemini-3.5-transcribe-live")).toBe(
+      "3.5 Transcribe Live",
+    );
+    expect(displayModelLabel("gemini-3.5-transcribe")).toBe("3.5 Transcribe");
     expect(displayModelLabel("local-file")).toBe("Local model file");
     expect(displayModelLabel("fast-transcription")).toBe("Fast Transcription");
     expect(displayModelLabel("openai/gpt-4o-mini-transcribe")).toBe(
@@ -106,6 +111,11 @@ describe("STT model display labels", () => {
     expect(providers.fireworks.disabled).toBe(false);
     expect(providers.fireworks.models).toEqual(["whisper-v3-turbo"]);
     expect(providers.xai.badge).toBeNull();
+    expect(providers.google_generative_ai.badge).toBeNull();
+    expect(providers.google_generative_ai.models).toEqual([
+      "gemini-3.5-transcribe-live",
+      "gemini-3.5-transcribe",
+    ]);
     for (const provider of [
       "groq",
       "openrouter",

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -9,6 +9,7 @@ import {
   ElevenLabs,
   Fireworks,
   GoogleCloud,
+  Gemini,
   Groq,
   Mistral,
   OpenAI,
@@ -213,6 +214,20 @@ export const displayModelId = (model: string): string => {
 
   if (model === "xai-stt") {
     return "xAI Speech to Text";
+  }
+
+  if (
+    model === "gemini-3.5-transcribe-live" ||
+    model === "gemini-3.5-transcribe-live-preview"
+  ) {
+    return "3.5 Transcribe Live";
+  }
+
+  if (
+    model === "gemini-3.5-transcribe" ||
+    model === "gemini-3.5-transcribe-preview"
+  ) {
+    return "3.5 Transcribe";
   }
 
   if (model === "enhanced") {
@@ -669,6 +684,26 @@ const _PROVIDERS = [
   },
   {
     disabled: false,
+    id: "google_generative_ai",
+    displayName: "Google Gemini",
+    badge: null,
+    icon: <ProviderLobeIcon icon={Gemini} />,
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    models: ["gemini-3.5-transcribe-live", "gemini-3.5-transcribe"],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Available models",
+        url: "https://ai.google.dev/gemini-api/docs/models",
+      },
+      setup: {
+        label: "API setup",
+        url: "https://aistudio.google.com/api-keys",
+      },
+    },
+  },
+  {
+    disabled: false,
     id: "aws_transcribe",
     displayName: "Amazon Transcribe",
     badge: "Gateway",
@@ -953,6 +988,7 @@ const PROVIDER_ORDER = [
   "dashscope",
   "zai",
   "siliconflow",
+  "google_generative_ai",
   "google_cloud",
   "aws_transcribe",
   "azure_speech",

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -106,6 +106,18 @@ describe("getSttModelTranscriptionMode", () => {
     );
     expect(getSttModelTranscriptionMode("gladia", "solaria-3")).toBe("batch");
     expect(
+      getSttModelTranscriptionMode(
+        "google_generative_ai",
+        "gemini-3.5-transcribe-live",
+      ),
+    ).toBe("live");
+    expect(
+      getSttModelTranscriptionMode(
+        "google_generative_ai",
+        "gemini-3.5-transcribe",
+      ),
+    ).toBe("batch");
+    expect(
       getSttModelTranscriptionMode("cohere", "cohere-transcribe-03-2026"),
     ).toBe("batch");
     for (const [provider, model] of [

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -195,6 +195,15 @@ export function getSttModelTranscriptionMode(
     return "batch";
   }
 
+  if (provider === "google_generative_ai") {
+    if (model?.includes("transcribe-live")) {
+      return "live";
+    }
+    if (model) {
+      return "batch";
+    }
+  }
+
   if (provider === "openai") {
     if (model === "gpt-live-transcribe") return "live";
     if (

--- a/apps/desktop/src/stt/model-selection.ts
+++ b/apps/desktop/src/stt/model-selection.ts
@@ -30,6 +30,7 @@ const DEFAULT_EXTERNAL_STT_MODELS: Record<string, string> = {
   speechmatics: "enhanced",
   azure_speech: "fast-transcription",
   google_cloud: "latest_long",
+  google_generative_ai: "gemini-3.5-transcribe-live",
   aws_transcribe: "amazon-transcribe",
   revai: "machine",
 };

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -202,6 +202,7 @@ describe("getBatchProvider", () => {
     ["aws_transcribe", "amazon-transcribe"],
     ["azure_speech", "fast-transcription"],
     ["google_cloud", "latest_long"],
+    ["google_generative_ai", "gemini-3.5-transcribe"],
     ["groq", "whisper-large-v3-turbo"],
     ["openrouter", "openai/gpt-4o-mini-transcribe"],
     ["siliconflow", "FunAudioLLM/SenseVoiceSmall"],

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -88,6 +88,7 @@ const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
   "aws_transcribe",
   "azure_speech",
   "google_cloud",
+  "google_generative_ai",
   "groq",
   "revai",
   "speechmatics",

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -7,8 +7,8 @@ use ractor::{ActorProcessingErr, ActorRef};
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, ArgmaxAdapter, AssemblyAIAdapter, CartesiaAdapter,
     DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter,
-    GladiaAdapter, MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SonioxAdapter, XaiAdapter,
-    anlg_ws_client,
+    GladiaAdapter, GoogleGenerativeAiAdapter, MistralAdapter, OpenAIAdapter, RealtimeSttAdapter,
+    SonioxAdapter, XaiAdapter, anlg_ws_client,
 };
 use owhisper_interface::stream::{Extra, StreamResponse};
 use owhisper_interface::{ControlMessage, MixedMessage};
@@ -193,6 +193,7 @@ pub(super) async fn spawn_rx_task(
         DashScope => DashScopeAdapter,
         Mistral => MistralAdapter,
         Xai => XaiAdapter,
+        GoogleGenerativeAi => GoogleGenerativeAiAdapter,
         Anarlog => AnarlogAdapter,
     }, batch_only: [
         AquaVoice,

--- a/crates/listener-core/src/actors/session/types.rs
+++ b/crates/listener-core/src/actors/session/types.rs
@@ -91,6 +91,12 @@ pub fn resolve_transcription_mode(
         return TranscriptionMode::Batch;
     }
 
+    if adapter_kind == AdapterKind::GoogleGenerativeAi
+        && !owhisper_client::GoogleGenerativeAiAdapter::is_live_model(model)
+    {
+        return TranscriptionMode::Batch;
+    }
+
     if !adapter_kind.has_live_mode() {
         return TranscriptionMode::Batch;
     }
@@ -237,6 +243,34 @@ mod tests {
         let params = session_params(
             "https://api.openai.com/v1",
             "whisper-1",
+            TranscriptionMode::Live,
+        );
+
+        assert_eq!(
+            params.effective_transcription_mode(),
+            TranscriptionMode::Batch
+        );
+    }
+
+    #[test]
+    fn effective_mode_uses_live_for_gemini_transcribe_live() {
+        let params = session_params(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini-3.5-transcribe-live",
+            TranscriptionMode::Live,
+        );
+
+        assert_eq!(
+            params.effective_transcription_mode(),
+            TranscriptionMode::Live
+        );
+    }
+
+    #[test]
+    fn effective_mode_forces_gemini_file_model_to_batch() {
+        let params = session_params(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini-3.5-transcribe",
             TranscriptionMode::Live,
         );
 

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -51,6 +51,9 @@ pub enum BatchProvider {
     #[serde(rename = "google_cloud")]
     #[strum(serialize = "google_cloud")]
     GoogleCloud,
+    #[serde(rename = "google_generative_ai")]
+    #[strum(serialize = "google_generative_ai")]
+    GoogleGenerativeAi,
     Groq,
     RevAi,
     Speechmatics,
@@ -81,6 +84,7 @@ impl BatchProvider {
             Self::AwsTranscribe => Some(AdapterKind::AwsTranscribe),
             Self::AzureSpeech => Some(AdapterKind::AzureSpeech),
             Self::GoogleCloud => Some(AdapterKind::GoogleCloud),
+            Self::GoogleGenerativeAi => Some(AdapterKind::GoogleGenerativeAi),
             Self::Groq => Some(AdapterKind::Groq),
             Self::RevAi => Some(AdapterKind::RevAi),
             Self::Speechmatics => Some(AdapterKind::Speechmatics),

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -5,9 +5,9 @@ use owhisper_client::{
     AdapterKind, AnarlogAdapter, AquaVoiceAdapter, ArgmaxAdapter, AssemblyAIAdapter,
     AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, BatchUploadLimit, CartesiaAdapter,
     CohereAdapter, DeepgramAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter,
-    GoogleCloudAdapter, GroqAdapter, MistralAdapter, OpenAIAdapter, OpenRouterAdapter,
-    PyannoteAdapter, RevAiAdapter, SiliconFlowAdapter, SonioxAdapter, SpeechmaticsAdapter,
-    TogetherAdapter, XaiAdapter, ZaiAdapter,
+    GoogleCloudAdapter, GoogleGenerativeAiAdapter, GroqAdapter, MistralAdapter, OpenAIAdapter,
+    OpenRouterAdapter, PyannoteAdapter, RevAiAdapter, SiliconFlowAdapter, SonioxAdapter,
+    SpeechmaticsAdapter, TogetherAdapter, XaiAdapter, ZaiAdapter,
 };
 use owhisper_interface::batch::{Alternatives, Channel, Response, Results};
 use tracing::Instrument;
@@ -90,6 +90,7 @@ pub(in crate::batch) async fn run_direct_batch_for_adapter_kind(
         AwsTranscribe => AwsTranscribeAdapter,
         AzureSpeech => AzureSpeechAdapter,
         GoogleCloud => GoogleCloudAdapter,
+        GoogleGenerativeAi => GoogleGenerativeAiAdapter,
         Groq => GroqAdapter,
         RevAi => RevAiAdapter,
         Speechmatics => SpeechmaticsAdapter,

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -151,6 +151,7 @@ pub fn suggest_providers_for_languages_batch(languages: &[anlg_language::Languag
         AdapterKind::AwsTranscribe,
         AdapterKind::AzureSpeech,
         AdapterKind::GoogleCloud,
+        AdapterKind::GoogleGenerativeAi,
         AdapterKind::Groq,
         AdapterKind::RevAi,
         AdapterKind::Speechmatics,

--- a/crates/owhisper-client/src/adapter/google_generative_ai/batch.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/batch.rs
@@ -1,0 +1,315 @@
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use owhisper_interface::ListenParams;
+use owhisper_interface::batch::{Alternatives, Channel, Response, Results, Word};
+
+use super::{GoogleGenerativeAiAdapter, parse_duration_secs};
+use crate::adapter::http::{ensure_success, mime_type_from_extension};
+use crate::adapter::parsing::parse_speaker_id;
+use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware};
+use crate::error::Error;
+use crate::providers::Provider;
+
+const INLINE_AUDIO_LIMIT_BYTES: u64 = 20 * 1024 * 1024;
+
+impl BatchSttAdapter for GoogleGenerativeAiAdapter {
+    fn provider_name(&self) -> &'static str {
+        "google_generative_ai"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_batch(languages).is_supported()
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        client: &'a ClientWithMiddleware,
+        api_base: &'a str,
+        api_key: &'a str,
+        params: &'a ListenParams,
+        file_path: P,
+    ) -> BatchFuture<'a> {
+        let path = file_path.as_ref().to_path_buf();
+        Box::pin(do_transcribe_file(client, api_base, api_key, params, path))
+    }
+}
+
+async fn do_transcribe_file(
+    client: &ClientWithMiddleware,
+    api_base: &str,
+    api_key: &str,
+    params: &ListenParams,
+    file_path: PathBuf,
+) -> Result<Response, Error> {
+    let metadata = tokio::fs::metadata(&file_path)
+        .await
+        .map_err(|error| Error::AudioProcessing(error.to_string()))?;
+    if metadata.len() > INLINE_AUDIO_LIMIT_BYTES {
+        return Err(Error::AudioProcessing(
+            "Gemini 3.5 Transcribe accepts inline audio up to 20 MB; longer recordings are split automatically"
+                .to_string(),
+        ));
+    }
+
+    let audio = tokio::fs::read(&file_path)
+        .await
+        .map_err(|error| Error::AudioProcessing(error.to_string()))?;
+    let model = GoogleGenerativeAiAdapter::resolve_batch_model(params.model.as_deref());
+    let language_codes = GoogleGenerativeAiAdapter::language_codes(params);
+    let language_hints = if language_codes.is_empty() {
+        vec!["auto".to_string()]
+    } else {
+        language_codes.clone()
+    };
+
+    // Word timestamps require verbatim mode. Google rejects custom vocabulary
+    // when timestamp_granularities is set, so keywords stay on the live path.
+    let mut transcription_config = serde_json::json!({
+        "language_hints": language_hints,
+        "mode": {
+            "type": "verbatim",
+            "diarization_mode": "speaker",
+            "timestamp_granularities": ["word"],
+        }
+    });
+    if !language_codes.is_empty() {
+        transcription_config["language_codes"] = serde_json::Value::Array(
+            language_codes
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        );
+    }
+
+    let request = serde_json::json!({
+        "model": model,
+        "input": [{
+            "type": "audio",
+            "data": base64::engine::general_purpose::STANDARD.encode(audio),
+            "mime_type": mime_type_from_extension(&file_path),
+        }],
+        "generation_config": {
+            "transcription_config": transcription_config,
+        }
+    });
+
+    let url = interactions_url(api_base)?;
+    let response = client
+        .post(url)
+        .header("x-goog-api-key", api_key)
+        .json(&request)
+        .send()
+        .await?;
+    let payload: serde_json::Value = ensure_success(response).await?.json().await?;
+
+    Ok(convert_response(&payload))
+}
+
+fn interactions_url(api_base: &str) -> Result<String, Error> {
+    let mut url: url::Url = if api_base.is_empty() {
+        Provider::GoogleGenerativeAi
+            .default_api_base()
+            .parse()
+            .expect("invalid_default_google_generative_ai_api_base")
+    } else {
+        api_base.parse().map_err(|error: url::ParseError| {
+            Error::AudioProcessing(format!("invalid api_base: {error}"))
+        })?
+    };
+    let path = url.path().trim_end_matches('/').to_string();
+    if !path.ends_with("/interactions") {
+        url.set_path(&format!("{path}/interactions"));
+    }
+    url.set_query(None);
+    Ok(url.to_string())
+}
+
+fn convert_response(payload: &serde_json::Value) -> Response {
+    let mut transcript_parts = Vec::new();
+    let mut words = Vec::new();
+
+    for content in content_blocks(payload) {
+        let text = content
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .trim();
+        if !text.is_empty() {
+            transcript_parts.push(text.to_string());
+        }
+
+        let annotations = content
+            .get("annotations")
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mut found_words = false;
+        for annotation in annotations {
+            if annotation.get("type").and_then(serde_json::Value::as_str) != Some("word_info") {
+                continue;
+            }
+            let token = annotation
+                .get("text")
+                .or_else(|| annotation.get("word"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if token.is_empty() {
+                continue;
+            }
+            found_words = true;
+            let speaker = annotation
+                .get("speaker")
+                .or_else(|| annotation.get("speakerLabel"))
+                .or_else(|| annotation.get("speaker_label"))
+                .and_then(serde_json::Value::as_str)
+                .and_then(parse_speaker_id);
+            let start = annotation
+                .get("start_offset")
+                .or_else(|| annotation.get("startOffset"))
+                .map(parse_duration_secs)
+                .unwrap_or_default();
+            let end = annotation
+                .get("end_offset")
+                .or_else(|| annotation.get("endOffset"))
+                .map(parse_duration_secs)
+                .unwrap_or(start);
+            words.push(Word {
+                punctuated_word: Some(token.clone()),
+                word: token,
+                start,
+                end,
+                confidence: 1.0,
+                channel: 0,
+                speaker,
+            });
+        }
+
+        if !found_words && !text.is_empty() {
+            let speaker = content
+                .get("audioTranscription")
+                .or_else(|| content.get("audio_transcription"))
+                .and_then(|value| {
+                    value
+                        .get("speakerLabel")
+                        .or_else(|| value.get("speaker_label"))
+                })
+                .and_then(serde_json::Value::as_str)
+                .and_then(parse_speaker_id);
+            words.push(Word {
+                punctuated_word: Some(text.to_string()),
+                word: text.to_string(),
+                start: 0.0,
+                end: 0.0,
+                confidence: 1.0,
+                channel: 0,
+                speaker,
+            });
+        }
+    }
+
+    Response {
+        metadata: serde_json::json!({ "provider": "google_generative_ai" }),
+        results: Results {
+            channels: vec![Channel {
+                alternatives: vec![Alternatives {
+                    transcript: transcript_parts.join(" "),
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
+}
+
+fn content_blocks(payload: &serde_json::Value) -> Vec<serde_json::Value> {
+    let mut blocks = Vec::new();
+    for key in ["steps", "outputs"] {
+        let Some(items) = payload.get(key).and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        for item in items {
+            if let Some(content) = item.get("content").and_then(serde_json::Value::as_array) {
+                blocks.extend(content.iter().cloned());
+            } else if item.get("text").is_some() || item.get("type").is_some() {
+                blocks.push(item.clone());
+            }
+        }
+    }
+    if blocks.is_empty() {
+        if let Some(parts) = payload
+            .pointer("/candidates/0/content/parts")
+            .and_then(serde_json::Value::as_array)
+        {
+            blocks.extend(parts.iter().cloned());
+        }
+    }
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_interactions_url() {
+        assert_eq!(
+            interactions_url("https://generativelanguage.googleapis.com/v1beta").unwrap(),
+            "https://generativelanguage.googleapis.com/v1beta/interactions"
+        );
+        assert_eq!(
+            interactions_url("https://generativelanguage.googleapis.com/v1beta/interactions")
+                .unwrap(),
+            "https://generativelanguage.googleapis.com/v1beta/interactions"
+        );
+    }
+
+    #[test]
+    fn converts_word_info_annotations() {
+        let payload = serde_json::json!({
+            "steps": [{
+                "content": [{
+                    "type": "text",
+                    "text": "Hello there. Hi.",
+                    "annotations": [
+                        {
+                            "type": "word_info",
+                            "text": "Hello",
+                            "speaker": "spk_2",
+                            "start_offset": "0.10s",
+                            "end_offset": "0.40s"
+                        },
+                        {
+                            "type": "word_info",
+                            "text": "there.",
+                            "speaker": "spk_2",
+                            "start_offset": "0.40s",
+                            "end_offset": "0.90s"
+                        },
+                        {
+                            "type": "word_info",
+                            "text": "Hi.",
+                            "speaker": "spk_1",
+                            "start_offset": "1.00s",
+                            "end_offset": "1.20s"
+                        }
+                    ]
+                }]
+            }]
+        });
+
+        let response = convert_response(&payload);
+        let alternative = &response.results.channels[0].alternatives[0];
+
+        assert_eq!(alternative.transcript, "Hello there. Hi.");
+        assert_eq!(alternative.words[0].speaker, Some(2));
+        assert_eq!(alternative.words[0].start, 0.1);
+        assert_eq!(alternative.words[2].speaker, Some(1));
+        assert_eq!(response.metadata["provider"], "google_generative_ai");
+    }
+}

--- a/crates/owhisper-client/src/adapter/google_generative_ai/batch.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/batch.rs
@@ -60,31 +60,6 @@ async fn do_transcribe_file(
         .await
         .map_err(|error| Error::AudioProcessing(error.to_string()))?;
     let model = GoogleGenerativeAiAdapter::resolve_batch_model(params.model.as_deref());
-    let language_codes = GoogleGenerativeAiAdapter::language_codes(params);
-    let language_hints = if language_codes.is_empty() {
-        vec!["auto".to_string()]
-    } else {
-        language_codes.clone()
-    };
-
-    // Word timestamps require verbatim mode. Google rejects custom vocabulary
-    // when timestamp_granularities is set, so keywords stay on the live path.
-    let mut transcription_config = serde_json::json!({
-        "language_hints": language_hints,
-        "mode": {
-            "type": "verbatim",
-            "diarization_mode": "speaker",
-            "timestamp_granularities": ["word"],
-        }
-    });
-    if !language_codes.is_empty() {
-        transcription_config["language_codes"] = serde_json::Value::Array(
-            language_codes
-                .into_iter()
-                .map(serde_json::Value::String)
-                .collect(),
-        );
-    }
 
     let request = serde_json::json!({
         "model": model,
@@ -94,7 +69,7 @@ async fn do_transcribe_file(
             "mime_type": mime_type_from_extension(&file_path),
         }],
         "generation_config": {
-            "transcription_config": transcription_config,
+            "transcription_config": transcription_config(params),
         }
     });
 
@@ -108,6 +83,30 @@ async fn do_transcribe_file(
     let payload: serde_json::Value = ensure_success(response).await?.json().await?;
 
     Ok(convert_response(&payload))
+}
+
+fn transcription_config(params: &ListenParams) -> serde_json::Value {
+    // Word timestamps require verbatim mode. Google rejects custom vocabulary
+    // when timestamp_granularities is set, so keywords stay on the live path.
+    let mut config = serde_json::json!({
+        "mode": {
+            "type": "verbatim",
+            "diarization_mode": "speaker",
+            "timestamp_granularities": ["word"],
+        }
+    });
+    let language_codes = GoogleGenerativeAiAdapter::language_codes(params);
+    if !language_codes.is_empty() {
+        let codes = serde_json::Value::Array(
+            language_codes
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        );
+        config["language_hints"] = codes.clone();
+        config["language_codes"] = codes;
+    }
+    config
 }
 
 fn interactions_url(api_base: &str) -> Result<String, Error> {
@@ -255,6 +254,24 @@ fn content_blocks(payload: &serde_json::Value) -> Vec<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn omits_language_hints_when_none_are_selected() {
+        let config = transcription_config(&ListenParams::default());
+        assert!(config.get("language_hints").is_none());
+        assert!(config.get("language_codes").is_none());
+        assert_eq!(config["mode"]["type"], "verbatim");
+    }
+
+    #[test]
+    fn includes_language_hints_when_selected() {
+        let config = transcription_config(&ListenParams {
+            languages: vec!["en-US".parse().unwrap()],
+            ..Default::default()
+        });
+        assert_eq!(config["language_hints"][0], "en-US");
+        assert_eq!(config["language_codes"][0], "en-US");
+    }
 
     #[test]
     fn builds_interactions_url() {

--- a/crates/owhisper-client/src/adapter/google_generative_ai/language.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/language.rs
@@ -1,0 +1,129 @@
+use crate::adapter::{LanguageQuality, LanguageSupport};
+
+// https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-5-transcribe
+pub const DOCUMENTED_BCP47_CODES: &[&str] = &[
+    "af-ZA",
+    "am-ET",
+    "ar-EG",
+    "hy-AM",
+    "as-IN",
+    "az-AZ",
+    "be-BY",
+    "bn-BD",
+    "bn-IN",
+    "bs-BA",
+    "bg-BG",
+    "rup-BG",
+    "my-MM",
+    "yue-Hant-HK",
+    "ca-ES",
+    "ceb",
+    "km-KH",
+    "hr-HR",
+    "cs-CZ",
+    "da-DK",
+    "nl-NL",
+    "en-AU",
+    "en-GB",
+    "en-IN",
+    "en-US",
+    "et-EE",
+    "fa-IR",
+    "fil-PH",
+    "fi-FI",
+    "fr-FR",
+    "fr-CA",
+    "gl-ES",
+    "ka-GE",
+    "de-DE",
+    "el-GR",
+    "gu-IN",
+    "ha-NG",
+    "he-IL",
+    "hi-IN",
+    "hu-HU",
+    "is-IS",
+    "id-ID",
+    "it-IT",
+    "ja-JP",
+    "jv-ID",
+    "kn-IN",
+    "kk-KZ",
+    "ko-KR",
+    "ky-KG",
+    "lv-LV",
+    "ln-CD",
+    "lt-LT",
+    "mk-MK",
+    "ms-MY",
+    "ml-IN",
+    "mt-MT",
+    "cmn-Hans-CN",
+    "mr-IN",
+    "mn-MN",
+    "ne-NP",
+    "nb-NO",
+    "or-IN",
+    "pl-PL",
+    "pt-BR",
+    "pt-PT",
+    "pa-IN",
+    "pa-Guru-IN",
+    "ro-RO",
+    "ru-RU",
+    "sr-RS",
+    "sd-Arab-IN",
+    "sk-SK",
+    "sl-SI",
+    "kea-CV",
+    "es-419",
+    "es-ES",
+    "es-US",
+    "sw-KE",
+    "sv-SE",
+    "tg-TJ",
+    "te-IN",
+    "th-TH",
+    "tr-TR",
+    "uk-UA",
+    "uz-UZ",
+    "vi-VN",
+];
+
+const HIGH_QUALITY: &[&str] = &[
+    "ca", "hr", "da", "nl", "en", "fi", "fr", "de", "el", "hi", "it", "ja", "ko", "zh", "pl", "pt",
+    "ro", "ru", "es", "sv", "tr", "uk", "vi",
+];
+
+const DOCUMENTED_ISO: &[&str] = &[
+    "af", "am", "ar", "hy", "as", "az", "be", "bn", "bs", "bg", "my", "yue", "ca", "ceb", "km",
+    "hr", "cs", "da", "nl", "en", "et", "fa", "tl", "fi", "fr", "gl", "ka", "de", "el", "gu", "ha",
+    "he", "hi", "hu", "is", "id", "it", "ja", "jv", "kn", "kk", "ko", "ky", "lv", "ln", "lt", "mk",
+    "ms", "ml", "mt", "zh", "mr", "mn", "ne", "no", "or", "pl", "pt", "pa", "ro", "ru", "sr", "sk",
+    "sl", "es", "sw", "sv", "tg", "te", "th", "tr", "uk", "uz", "vi",
+];
+
+pub fn language_support(languages: &[anlg_language::Language]) -> LanguageSupport {
+    if languages.is_empty() {
+        return LanguageSupport::Supported {
+            quality: LanguageQuality::High,
+        };
+    }
+
+    LanguageSupport::min(languages.iter().map(|language| {
+        let code = language.iso639().code();
+        if HIGH_QUALITY.contains(&code) {
+            LanguageSupport::Supported {
+                quality: LanguageQuality::High,
+            }
+        } else if DOCUMENTED_ISO.contains(&code) {
+            LanguageSupport::Supported {
+                quality: LanguageQuality::Moderate,
+            }
+        } else {
+            LanguageSupport::Supported {
+                quality: LanguageQuality::NoData,
+            }
+        }
+    }))
+}

--- a/crates/owhisper-client/src/adapter/google_generative_ai/live.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/live.rs
@@ -259,7 +259,7 @@ fn transcription_response(
         duration: (end - start).max(0.0),
         is_final,
         speech_final: is_final,
-        from_finalize: is_final,
+        from_finalize: false,
         channel: Channel {
             alternatives: vec![Alternatives {
                 transcript: text.to_string(),
@@ -347,6 +347,22 @@ mod tests {
     }
 
     #[test]
+    fn initial_message_omits_languages_when_unset() {
+        let Message::Text(payload) = GoogleGenerativeAiAdapter
+            .initial_message(None, &ListenParams::default(), 1)
+            .expect("setup message")
+        else {
+            panic!("expected text setup message");
+        };
+        let json: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert!(
+            json["setup"]["inputAudioTranscription"]
+                .get("languageCodes")
+                .is_none()
+        );
+    }
+
+    #[test]
     fn parses_interim_and_final_transcriptions() {
         let adapter = GoogleGenerativeAiAdapter;
         let interim = adapter
@@ -358,6 +374,7 @@ mod tests {
         let StreamResponse::TranscriptResponse {
             is_final,
             speech_final,
+            from_finalize,
             channel,
             ..
         } = &interim[0]
@@ -366,11 +383,13 @@ mod tests {
         };
         assert!(!*is_final);
         assert!(!*speech_final);
+        assert!(!*from_finalize);
         assert_eq!(channel.alternatives[0].transcript, "hel");
 
         let StreamResponse::TranscriptResponse {
             is_final,
             speech_final,
+            from_finalize,
             channel,
             start,
             duration,
@@ -381,6 +400,7 @@ mod tests {
         };
         assert!(*is_final);
         assert!(*speech_final);
+        assert!(!*from_finalize);
         assert_eq!(channel.alternatives[0].transcript, "hello there");
         assert_eq!(channel.alternatives[0].words[0].speaker, Some(2));
         assert_eq!(*start, 0.1);

--- a/crates/owhisper-client/src/adapter/google_generative_ai/live.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/live.rs
@@ -1,0 +1,405 @@
+use anlg_ws_client::client::Message;
+use owhisper_interface::ListenParams;
+use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse};
+
+use super::{GoogleGenerativeAiAdapter, WS_PATH, parse_duration_secs};
+use crate::adapter::parsing::{WordBuilder, parse_speaker_id};
+use crate::adapter::{
+    RealtimeSttAdapter, build_proxy_ws_url, build_url_with_scheme, is_anarlog_proxy,
+};
+use crate::providers::Provider;
+
+impl RealtimeSttAdapter for GoogleGenerativeAiAdapter {
+    fn provider_name(&self) -> &'static str {
+        "google_generative_ai"
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        Self::language_support_live(languages).is_supported()
+    }
+
+    fn supports_native_multichannel(&self) -> bool {
+        false
+    }
+
+    fn build_ws_url(&self, api_base: &str, params: &ListenParams, _channels: u8) -> url::Url {
+        self.build_ws_url_inner(api_base, params, None)
+    }
+
+    fn build_ws_url_with_api_key(
+        &self,
+        api_base: &str,
+        params: &ListenParams,
+        _channels: u8,
+        api_key: Option<&str>,
+    ) -> impl std::future::Future<Output = Option<url::Url>> + Send {
+        let url = self.build_ws_url_inner(api_base, params, api_key);
+        async move { Some(url) }
+    }
+
+    fn build_auth_header(&self, api_key: Option<&str>) -> Option<(&'static str, String)> {
+        api_key.and_then(|key| Provider::GoogleGenerativeAi.build_auth_header(key))
+    }
+
+    fn keep_alive_message(&self) -> Option<Message> {
+        None
+    }
+
+    fn audio_to_message(&self, audio: bytes::Bytes) -> Message {
+        use base64::Engine;
+        let event = serde_json::json!({
+            "realtimeInput": {
+                "audio": {
+                    "mimeType": "audio/pcm;rate=16000",
+                    "data": base64::engine::general_purpose::STANDARD.encode(audio),
+                }
+            }
+        });
+        Message::Text(event.to_string().into())
+    }
+
+    fn initial_message(
+        &self,
+        _api_key: Option<&str>,
+        params: &ListenParams,
+        _channels: u8,
+    ) -> Option<Message> {
+        let model = Self::setup_model_name(&Self::resolve_live_model(params.model.as_deref()));
+        let language_codes = Self::language_codes(params);
+        let mut input_audio_transcription = serde_json::Map::new();
+        if !language_codes.is_empty() {
+            input_audio_transcription.insert(
+                "languageCodes".to_string(),
+                serde_json::Value::Array(
+                    language_codes
+                        .into_iter()
+                        .map(serde_json::Value::String)
+                        .collect(),
+                ),
+            );
+        }
+        if !params.keywords.is_empty() {
+            input_audio_transcription.insert(
+                "customVocabulary".to_string(),
+                serde_json::Value::Array(
+                    params
+                        .keywords
+                        .iter()
+                        .cloned()
+                        .map(serde_json::Value::String)
+                        .collect(),
+                ),
+            );
+        }
+
+        // Omitting generationConfig.responseModalities: on the current Live
+        // endpoint that field suppresses final inputTranscription segments.
+        let setup = serde_json::json!({
+            "setup": {
+                "model": model,
+                "inputAudioTranscription": input_audio_transcription,
+            }
+        });
+        Some(Message::Text(setup.to_string().into()))
+    }
+
+    fn finalize_message(&self) -> Message {
+        Message::Text(r#"{"realtimeInput":{"audioStreamEnd":true}}"#.into())
+    }
+
+    fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
+        let event: serde_json::Value = match serde_json::from_str(raw) {
+            Ok(event) => event,
+            Err(error) => {
+                tracing::warn!(
+                    error = ?error,
+                    anarlog.payload.size_bytes = raw.len() as u64,
+                    "google_generative_ai_json_parse_failed"
+                );
+                return Vec::new();
+            }
+        };
+
+        if let Some(message) = event
+            .pointer("/error/message")
+            .and_then(serde_json::Value::as_str)
+        {
+            return vec![StreamResponse::ErrorResponse {
+                error_code: event
+                    .pointer("/error/code")
+                    .and_then(|value| value.as_i64().and_then(|code| i32::try_from(code).ok())),
+                error_message: message.to_string(),
+                provider: "google_generative_ai".to_string(),
+            }];
+        }
+
+        let server_content = event
+            .get("serverContent")
+            .or_else(|| event.get("server_content"));
+        let Some(server_content) = server_content else {
+            return Vec::new();
+        };
+
+        if let Some(response) = transcription_response(
+            server_content
+                .get("inputTranscription")
+                .or_else(|| server_content.get("input_transcription")),
+            true,
+        ) {
+            return vec![response];
+        }
+
+        if let Some(response) = transcription_response(
+            server_content
+                .get("interimInputTranscription")
+                .or_else(|| server_content.get("interim_input_transcription")),
+            false,
+        ) {
+            return vec![response];
+        }
+
+        Vec::new()
+    }
+}
+
+impl GoogleGenerativeAiAdapter {
+    fn build_ws_url_inner(
+        &self,
+        api_base: &str,
+        _params: &ListenParams,
+        api_key: Option<&str>,
+    ) -> url::Url {
+        let (mut url, existing_params) = if let Some(result) = build_proxy_ws_url(api_base) {
+            result
+        } else {
+            let parsed: url::Url = if api_base.is_empty() {
+                Provider::GoogleGenerativeAi
+                    .default_api_base()
+                    .parse()
+                    .expect("invalid_default_google_generative_ai_api_base")
+            } else {
+                api_base.parse().unwrap_or_else(|_| {
+                    Provider::GoogleGenerativeAi
+                        .default_api_base()
+                        .parse()
+                        .expect("invalid_default_google_generative_ai_api_base")
+                })
+            };
+            (
+                build_url_with_scheme(
+                    &parsed,
+                    Provider::GoogleGenerativeAi.default_ws_host(),
+                    WS_PATH,
+                    true,
+                ),
+                Vec::new(),
+            )
+        };
+
+        {
+            let mut query = url.query_pairs_mut();
+            if is_anarlog_proxy(api_base) {
+                query.extend_pairs(&existing_params);
+            } else if let Some(api_key) = api_key.filter(|key| !key.is_empty()) {
+                query.append_pair("key", api_key);
+            }
+        }
+
+        url
+    }
+}
+
+fn transcription_response(
+    value: Option<&serde_json::Value>,
+    is_final: bool,
+) -> Option<StreamResponse> {
+    let value = value?;
+    let text = value
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    let speaker = value
+        .get("speakerLabel")
+        .or_else(|| value.get("speaker_label"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(parse_speaker_id)
+        .and_then(|speaker| i32::try_from(speaker).ok());
+    let start = value
+        .get("startOffset")
+        .or_else(|| value.get("start_offset"))
+        .map(parse_duration_secs)
+        .unwrap_or_default();
+    let end = value
+        .get("endOffset")
+        .or_else(|| value.get("end_offset"))
+        .map(parse_duration_secs)
+        .unwrap_or(start);
+    let words = text
+        .split_whitespace()
+        .map(|word| {
+            WordBuilder::new(word)
+                .start(start)
+                .end(end)
+                .speaker(speaker)
+                .build()
+        })
+        .collect();
+
+    Some(StreamResponse::TranscriptResponse {
+        start,
+        duration: (end - start).max(0.0),
+        is_final,
+        speech_final: is_final,
+        from_finalize: is_final,
+        channel: Channel {
+            alternatives: vec![Alternatives {
+                transcript: text.to_string(),
+                words,
+                confidence: 1.0,
+                languages: Vec::new(),
+            }],
+        },
+        metadata: Metadata::default(),
+        channel_index: vec![0, 1],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_direct_and_proxy_urls() {
+        let params = ListenParams {
+            sample_rate: 16_000,
+            languages: vec![anlg_language::ISO639::En.into()],
+            ..Default::default()
+        };
+        let adapter = GoogleGenerativeAiAdapter;
+
+        let direct = adapter.build_ws_url(
+            "https://generativelanguage.googleapis.com/v1beta",
+            &params,
+            1,
+        );
+        let keyed = adapter.build_ws_url_inner(
+            "https://generativelanguage.googleapis.com/v1beta",
+            &params,
+            Some("test-key"),
+        );
+        let proxy = adapter.build_ws_url(
+            "https://api.anarlog.so/stt?provider=google_generative_ai",
+            &params,
+            1,
+        );
+
+        assert_eq!(direct.scheme(), "wss");
+        assert_eq!(direct.host_str(), Some("generativelanguage.googleapis.com"));
+        assert_eq!(direct.path(), WS_PATH);
+        assert!(keyed.query().unwrap().contains("key=test-key"));
+        assert_eq!(
+            proxy.as_str().split('?').next().unwrap(),
+            "wss://api.anarlog.so/stt/listen"
+        );
+        assert!(
+            proxy
+                .query()
+                .unwrap()
+                .contains("provider=google_generative_ai")
+        );
+    }
+
+    #[test]
+    fn initial_message_includes_languages_and_keywords() {
+        let params = ListenParams {
+            languages: vec!["en-US".parse().unwrap()],
+            keywords: vec!["Anarlog".to_string()],
+            model: Some("gemini-3.5-transcribe-live".to_string()),
+            ..Default::default()
+        };
+        let Message::Text(payload) = GoogleGenerativeAiAdapter
+            .initial_message(None, &params, 1)
+            .expect("setup message")
+        else {
+            panic!("expected text setup message");
+        };
+        let json: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+        assert_eq!(json["setup"]["model"], "models/gemini-3.5-transcribe-live");
+        assert!(json["setup"].get("generationConfig").is_none());
+        assert_eq!(
+            json["setup"]["inputAudioTranscription"]["languageCodes"][0],
+            "en-US"
+        );
+        assert_eq!(
+            json["setup"]["inputAudioTranscription"]["customVocabulary"][0],
+            "Anarlog"
+        );
+    }
+
+    #[test]
+    fn parses_interim_and_final_transcriptions() {
+        let adapter = GoogleGenerativeAiAdapter;
+        let interim = adapter
+            .parse_response(r#"{"serverContent":{"interimInputTranscription":{"text":"hel"}}}"#);
+        let final_event = adapter.parse_response(
+            r#"{"serverContent":{"inputTranscription":{"text":"hello there","speakerLabel":"Speaker 2","startOffset":"0.10s","endOffset":"0.80s"}}}"#,
+        );
+
+        let StreamResponse::TranscriptResponse {
+            is_final,
+            speech_final,
+            channel,
+            ..
+        } = &interim[0]
+        else {
+            panic!("expected interim transcript");
+        };
+        assert!(!*is_final);
+        assert!(!*speech_final);
+        assert_eq!(channel.alternatives[0].transcript, "hel");
+
+        let StreamResponse::TranscriptResponse {
+            is_final,
+            speech_final,
+            channel,
+            start,
+            duration,
+            ..
+        } = &final_event[0]
+        else {
+            panic!("expected final transcript");
+        };
+        assert!(*is_final);
+        assert!(*speech_final);
+        assert_eq!(channel.alternatives[0].transcript, "hello there");
+        assert_eq!(channel.alternatives[0].words[0].speaker, Some(2));
+        assert_eq!(*start, 0.1);
+        assert!((*duration - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn reports_provider_errors() {
+        let responses = GoogleGenerativeAiAdapter
+            .parse_response(r#"{"error":{"code":13,"message":"quota exceeded"}}"#);
+        let StreamResponse::ErrorResponse {
+            error_message,
+            provider,
+            ..
+        } = &responses[0]
+        else {
+            panic!("expected error response");
+        };
+        assert_eq!(error_message, "quota exceeded");
+        assert_eq!(provider, "google_generative_ai");
+    }
+}

--- a/crates/owhisper-client/src/adapter/google_generative_ai/mod.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/mod.rs
@@ -1,0 +1,174 @@
+mod batch;
+mod language;
+mod live;
+
+use crate::adapter::LanguageSupport;
+use crate::providers;
+
+pub const DEFAULT_LIVE_MODEL: &str = "gemini-3.5-transcribe-live";
+pub const DEFAULT_BATCH_MODEL: &str = "gemini-3.5-transcribe";
+pub const WS_PATH: &str =
+    "/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
+
+#[derive(Clone, Default)]
+pub struct GoogleGenerativeAiAdapter;
+
+impl GoogleGenerativeAiAdapter {
+    pub fn language_support_live(languages: &[anlg_language::Language]) -> LanguageSupport {
+        language::language_support(languages)
+    }
+
+    pub fn language_support_batch(languages: &[anlg_language::Language]) -> LanguageSupport {
+        language::language_support(languages)
+    }
+
+    pub fn documented_language_codes() -> &'static [&'static str] {
+        language::DOCUMENTED_BCP47_CODES
+    }
+
+    pub fn is_live_model(model: &str) -> bool {
+        model_id(model).contains("transcribe-live")
+    }
+
+    pub fn resolve_live_model(model: Option<&str>) -> String {
+        match model {
+            Some(model) if providers::is_meta_model(model) || model.is_empty() => {
+                DEFAULT_LIVE_MODEL.to_string()
+            }
+            Some(model) if Self::is_live_model(model) => model_id(model).to_string(),
+            _ => DEFAULT_LIVE_MODEL.to_string(),
+        }
+    }
+
+    pub fn resolve_batch_model(model: Option<&str>) -> String {
+        match model {
+            Some(model) if providers::is_meta_model(model) || model.is_empty() => {
+                DEFAULT_BATCH_MODEL.to_string()
+            }
+            Some(model) if Self::is_live_model(model) => DEFAULT_BATCH_MODEL.to_string(),
+            Some(model) => model_id(model).to_string(),
+            None => DEFAULT_BATCH_MODEL.to_string(),
+        }
+    }
+
+    fn setup_model_name(model: &str) -> String {
+        let model = model_id(model);
+        if model.starts_with("models/") {
+            model.to_string()
+        } else {
+            format!("models/{model}")
+        }
+    }
+
+    fn language_codes(params: &owhisper_interface::ListenParams) -> Vec<String> {
+        params
+            .languages
+            .iter()
+            .map(anlg_language::Language::bcp47_code)
+            .filter(|code| !code.is_empty())
+            .collect()
+    }
+}
+
+fn model_id(model: &str) -> &str {
+    model.strip_prefix("models/").unwrap_or(model)
+}
+
+pub(crate) fn parse_duration_secs(value: &serde_json::Value) -> f64 {
+    match value {
+        serde_json::Value::Number(number) => number.as_f64().unwrap_or_default(),
+        serde_json::Value::String(text) => parse_duration_str(text),
+        serde_json::Value::Object(object) => {
+            let seconds = object
+                .get("seconds")
+                .and_then(|value| value.as_f64().or_else(|| value.as_i64().map(|n| n as f64)))
+                .unwrap_or_default();
+            let nanos = object
+                .get("nanos")
+                .and_then(|value| value.as_f64().or_else(|| value.as_i64().map(|n| n as f64)))
+                .unwrap_or_default();
+            seconds + nanos / 1_000_000_000.0
+        }
+        _ => 0.0,
+    }
+}
+
+fn parse_duration_str(value: &str) -> f64 {
+    value
+        .strip_suffix('s')
+        .unwrap_or(value)
+        .parse()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::LanguageQuality;
+
+    #[test]
+    fn classifies_live_and_batch_model_ids() {
+        assert!(GoogleGenerativeAiAdapter::is_live_model(
+            "gemini-3.5-transcribe-live"
+        ));
+        assert!(GoogleGenerativeAiAdapter::is_live_model(
+            "models/gemini-3.5-transcribe-live-preview"
+        ));
+        assert!(!GoogleGenerativeAiAdapter::is_live_model(
+            "gemini-3.5-transcribe"
+        ));
+        assert!(!GoogleGenerativeAiAdapter::is_live_model(
+            "gemini-3.5-transcribe-preview"
+        ));
+    }
+
+    #[test]
+    fn maps_live_selection_to_file_model_for_batch() {
+        assert_eq!(
+            GoogleGenerativeAiAdapter::resolve_batch_model(Some("gemini-3.5-transcribe-live")),
+            DEFAULT_BATCH_MODEL
+        );
+        assert_eq!(
+            GoogleGenerativeAiAdapter::resolve_batch_model(Some("gemini-3.5-transcribe-preview")),
+            "gemini-3.5-transcribe-preview"
+        );
+    }
+
+    #[test]
+    fn maps_file_selection_to_live_model_for_streaming() {
+        assert_eq!(
+            GoogleGenerativeAiAdapter::resolve_live_model(Some("gemini-3.5-transcribe")),
+            DEFAULT_LIVE_MODEL
+        );
+        assert_eq!(
+            GoogleGenerativeAiAdapter::resolve_live_model(Some(
+                "gemini-3.5-transcribe-live-preview"
+            )),
+            "gemini-3.5-transcribe-live-preview"
+        );
+    }
+
+    #[test]
+    fn parses_protobuf_durations() {
+        assert_eq!(parse_duration_secs(&serde_json::json!("0.250s")), 0.25);
+        assert_eq!(
+            parse_duration_secs(&serde_json::json!({ "seconds": 1, "nanos": 500_000_000 })),
+            1.5
+        );
+        assert_eq!(parse_duration_secs(&serde_json::json!(2.5)), 2.5);
+    }
+
+    #[test]
+    fn language_support_covers_documented_and_unknown_codes() {
+        let english = vec![anlg_language::ISO639::En.into()];
+        let korean = vec![anlg_language::ISO639::Ko.into()];
+
+        assert!(GoogleGenerativeAiAdapter::language_support_live(&english).is_supported());
+        assert!(GoogleGenerativeAiAdapter::language_support_batch(&korean).is_supported());
+        assert!(GoogleGenerativeAiAdapter::language_support_live(&[]).is_supported());
+        assert_eq!(
+            GoogleGenerativeAiAdapter::language_support_live(&english).quality(),
+            Some(LanguageQuality::High)
+        );
+    }
+}

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod elevenlabs;
 mod fireworks;
 mod gladia;
 mod google_cloud;
+pub(crate) mod google_generative_ai;
 mod groq;
 pub mod http;
 mod language;
@@ -49,6 +50,7 @@ pub use elevenlabs::*;
 pub use fireworks::*;
 pub use gladia::*;
 pub use google_cloud::*;
+pub use google_generative_ai::*;
 pub use groq::*;
 pub use language::{LanguageQuality, LanguageSupport};
 pub use mistral::*;
@@ -126,6 +128,7 @@ pub fn documented_language_codes_live() -> Vec<String> {
     codes.extend(assemblyai::documented_language_codes_live().iter().copied());
     codes.extend(elevenlabs::documented_language_codes());
     codes.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
+    codes.extend(google_generative_ai::GoogleGenerativeAiAdapter::documented_language_codes());
 
     simple_documented_language_codes(codes)
 }
@@ -146,6 +149,7 @@ pub fn documented_language_codes_batch() -> Vec<String> {
     codes.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
     codes.extend(pyannote::documented_language_codes());
     codes.extend(cohere::documented_language_codes().iter().copied());
+    codes.extend(google_generative_ai::GoogleGenerativeAiAdapter::documented_language_codes());
 
     simple_documented_language_codes(codes)
 }
@@ -476,6 +480,8 @@ pub enum AdapterKind {
     AzureSpeech,
     #[strum(serialize = "google_cloud")]
     GoogleCloud,
+    #[strum(serialize = "google_generative_ai")]
+    GoogleGenerativeAi,
     #[strum(serialize = "groq")]
     Groq,
     #[strum(serialize = "revai")]
@@ -525,6 +531,13 @@ impl AdapterKind {
             return Self::Zai;
         }
 
+        if host_matches(base_url, |host| {
+            host == "generativelanguage.googleapis.com"
+                || host.ends_with(".generativelanguage.googleapis.com")
+        }) {
+            return Self::GoogleGenerativeAi;
+        }
+
         Provider::from_url(base_url)
             .map(Self::from)
             .unwrap_or(Self::Deepgram)
@@ -545,6 +558,7 @@ impl AdapterKind {
                 OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES,
                 Duration::from_secs(25 * 60),
             ),
+            Self::GoogleGenerativeAi => (20 * 1024 * 1024, Duration::from_secs(15 * 60)),
             Self::Zai => (OPENAI_COMPATIBLE_MAX_UPLOAD_BYTES, Duration::from_secs(25)),
             Self::SiliconFlow => (50 * 1024 * 1024, Duration::from_secs(50 * 60)),
             _ => return None,
@@ -583,6 +597,7 @@ impl AdapterKind {
             | Self::DashScope
             | Self::Mistral
             | Self::Xai
+            | Self::GoogleGenerativeAi
             | Self::Anarlog => true,
         }
     }
@@ -620,6 +635,7 @@ impl AdapterKind {
             | Self::Speechmatics
             | Self::Together => LanguageSupport::NotSupported,
             Self::Xai => XaiAdapter::language_support_live(languages),
+            Self::GoogleGenerativeAi => GoogleGenerativeAiAdapter::language_support_live(languages),
             Self::Anarlog => AnarlogAdapter::language_support_live(languages, model),
         }
     }
@@ -658,6 +674,9 @@ impl AdapterKind {
             Self::Speechmatics => SpeechmaticsAdapter::language_support_batch(languages),
             Self::Together => TogetherAdapter::language_support_batch(languages),
             Self::Xai => XaiAdapter::language_support_batch(languages),
+            Self::GoogleGenerativeAi => {
+                GoogleGenerativeAiAdapter::language_support_batch(languages)
+            }
             Self::Anarlog => AnarlogAdapter::language_support_batch(languages, model),
         }
     }
@@ -719,6 +738,7 @@ impl From<crate::providers::Provider> for AdapterKind {
             Provider::AwsTranscribe => Self::AwsTranscribe,
             Provider::AzureSpeech => Self::AzureSpeech,
             Provider::GoogleCloud => Self::GoogleCloud,
+            Provider::GoogleGenerativeAi => Self::GoogleGenerativeAi,
             Provider::Groq => Self::Groq,
             Provider::RevAi => Self::RevAi,
             Provider::Speechmatics => Self::Speechmatics,

--- a/crates/owhisper-client/src/adapter/tests.rs
+++ b/crates/owhisper-client/src/adapter/tests.rs
@@ -240,6 +240,7 @@ fn test_has_live_mode() {
         AdapterKind::DashScope,
         AdapterKind::Mistral,
         AdapterKind::Xai,
+        AdapterKind::GoogleGenerativeAi,
         AdapterKind::Anarlog,
     ];
     for kind in live {
@@ -486,6 +487,14 @@ fn test_direct_provider_urls_not_affected() {
     assert_eq!(
         AdapterKind::from_url_and_languages("https://api.x.ai/v1", &en, None),
         AdapterKind::Xai,
+    );
+    assert_eq!(
+        AdapterKind::from_url_and_languages(
+            "https://generativelanguage.googleapis.com/v1beta",
+            &en,
+            None,
+        ),
+        AdapterKind::GoogleGenerativeAi,
     );
     assert_eq!(
         AdapterKind::from_url_and_languages("http://localhost:50060/v1", &en, None),

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -26,11 +26,12 @@ pub use adapter::{
     AwsTranscribeAdapter, AzureSpeechAdapter, BatchSttAdapter, BatchUploadLimit, CallbackResult,
     CallbackSttAdapter, CartesiaAdapter, CohereAdapter, DashScopeAdapter, DeepgramAdapter,
     DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter,
-    GroqAdapter, LanguageQuality, LanguageSupport, MistralAdapter, OpenAIAdapter,
-    OpenRouterAdapter, PyannoteAdapter, RealtimeSttAdapter, RevAiAdapter, SiliconFlowAdapter,
-    SmallestAIAdapter, SonioxAdapter, SpeechmaticsAdapter, TogetherAdapter, WhisperCppAdapter,
-    XaiAdapter, ZaiAdapter, append_provider_param, documented_language_codes_batch,
-    documented_language_codes_live, is_anarlog_proxy, is_local_host, normalize_languages,
+    GoogleGenerativeAiAdapter, GroqAdapter, LanguageQuality, LanguageSupport, MistralAdapter,
+    OpenAIAdapter, OpenRouterAdapter, PyannoteAdapter, RealtimeSttAdapter, RevAiAdapter,
+    SiliconFlowAdapter, SmallestAIAdapter, SonioxAdapter, SpeechmaticsAdapter, TogetherAdapter,
+    WhisperCppAdapter, XaiAdapter, ZaiAdapter, append_provider_param,
+    documented_language_codes_batch, documented_language_codes_live, is_anarlog_proxy,
+    is_local_host, normalize_languages,
 };
 pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -99,6 +99,8 @@ pub enum Provider {
     AzureSpeech,
     #[strum(serialize = "google_cloud")]
     GoogleCloud,
+    #[strum(serialize = "google_generative_ai")]
+    GoogleGenerativeAi,
     #[strum(serialize = "groq")]
     Groq,
     #[strum(serialize = "revai")]
@@ -112,7 +114,7 @@ pub enum Provider {
 }
 
 impl Provider {
-    const ALL: [Provider; 21] = [
+    const ALL: [Provider; 22] = [
         Self::AquaVoice,
         Self::Cartesia,
         Self::Deepgram,
@@ -129,6 +131,7 @@ impl Provider {
         Self::AwsTranscribe,
         Self::AzureSpeech,
         Self::GoogleCloud,
+        Self::GoogleGenerativeAi,
         Self::Groq,
         Self::RevAi,
         Self::Speechmatics,
@@ -196,8 +199,15 @@ impl Provider {
                 name: "Ocp-Apim-Subscription-Key",
                 prefix: None,
             },
+            Self::GoogleCloud => Auth::Header {
+                name: "Authorization",
+                prefix: Some("Bearer "),
+            },
+            Self::GoogleGenerativeAi => Auth::Header {
+                name: "x-goog-api-key",
+                prefix: None,
+            },
             Self::AwsTranscribe
-            | Self::GoogleCloud
             | Self::Groq
             | Self::RevAi
             | Self::Speechmatics
@@ -235,6 +245,7 @@ impl Provider {
             Self::AwsTranscribe => "transcribe.us-east-1.amazonaws.com",
             Self::AzureSpeech => "api.cognitive.microsoft.com",
             Self::GoogleCloud => "speech.googleapis.com",
+            Self::GoogleGenerativeAi => "generativelanguage.googleapis.com",
             Self::Groq => "api.groq.com",
             Self::RevAi => "api.rev.ai",
             Self::Speechmatics => "eu1.asr.api.speechmatics.com",
@@ -261,6 +272,7 @@ impl Provider {
             Self::AwsTranscribe => "transcribestreaming.us-east-1.amazonaws.com",
             Self::AzureSpeech => "api.cognitive.microsoft.com",
             Self::GoogleCloud => "speech.googleapis.com",
+            Self::GoogleGenerativeAi => "generativelanguage.googleapis.com",
             Self::Groq => "api.groq.com",
             Self::RevAi => "api.rev.ai",
             Self::Speechmatics => "eu2.rt.speechmatics.com",
@@ -285,6 +297,7 @@ impl Provider {
             Self::Pyannote => "/v1/diarize",
             Self::Cohere => "",
             Self::Xai => "/v1/stt",
+            Self::GoogleGenerativeAi => crate::adapter::google_generative_ai::WS_PATH,
             Self::AwsTranscribe
             | Self::AzureSpeech
             | Self::GoogleCloud
@@ -317,6 +330,7 @@ impl Provider {
             | Self::RevAi
             | Self::Speechmatics
             | Self::Together
+            | Self::GoogleGenerativeAi
             | Self::Xai => None,
         }
     }
@@ -339,6 +353,7 @@ impl Provider {
             Self::AwsTranscribe => "https://transcribe.us-east-1.amazonaws.com",
             Self::AzureSpeech => "https://api.cognitive.microsoft.com",
             Self::GoogleCloud => "https://speech.googleapis.com/v1",
+            Self::GoogleGenerativeAi => "https://generativelanguage.googleapis.com/v1beta",
             Self::Groq => "https://api.groq.com/openai/v1",
             Self::RevAi => "https://api.rev.ai/speechtotext/v1",
             Self::Speechmatics => "https://eu1.asr.api.speechmatics.com/v2",
@@ -364,7 +379,8 @@ impl Provider {
             Self::Cohere => "cohere.com",
             Self::AwsTranscribe => "amazonaws.com",
             Self::AzureSpeech => "cognitive.microsoft.com",
-            Self::GoogleCloud => "googleapis.com",
+            Self::GoogleCloud => "speech.googleapis.com",
+            Self::GoogleGenerativeAi => "generativelanguage.googleapis.com",
             Self::Groq => "groq.com",
             Self::RevAi => "rev.ai",
             Self::Speechmatics => "speechmatics.com",
@@ -415,6 +431,7 @@ impl Provider {
             Self::AwsTranscribe => "AWS_TRANSCRIBE_API_KEY",
             Self::AzureSpeech => "AZURE_SPEECH_API_KEY",
             Self::GoogleCloud => "GOOGLE_CLOUD_ACCESS_TOKEN",
+            Self::GoogleGenerativeAi => "GEMINI_API_KEY",
             Self::Groq => "GROQ_API_KEY",
             Self::RevAi => "REVAI_ACCESS_TOKEN",
             Self::Speechmatics => "SPEECHMATICS_API_KEY",
@@ -441,6 +458,7 @@ impl Provider {
             Self::AwsTranscribe => "amazon-transcribe",
             Self::AzureSpeech => "fast-transcription",
             Self::GoogleCloud => "latest_long",
+            Self::GoogleGenerativeAi => "gemini-3.5-transcribe-live",
             Self::Groq => "whisper-large-v3-turbo",
             Self::RevAi => "machine",
             Self::Speechmatics => "enhanced",
@@ -488,6 +506,7 @@ impl Provider {
             Self::AwsTranscribe => "amazon-transcribe",
             Self::AzureSpeech => "fast-transcription",
             Self::GoogleCloud => "latest_long",
+            Self::GoogleGenerativeAi => "gemini-3.5-transcribe",
             Self::Groq => "whisper-large-v3-turbo",
             Self::RevAi => "machine",
             Self::Speechmatics => "enhanced",
@@ -534,6 +553,7 @@ impl Provider {
             | Self::AwsTranscribe
             | Self::AzureSpeech
             | Self::GoogleCloud
+            | Self::GoogleGenerativeAi
             | Self::Groq
             | Self::RevAi
             | Self::Speechmatics
@@ -563,6 +583,7 @@ impl Provider {
             | Self::AwsTranscribe
             | Self::AzureSpeech
             | Self::GoogleCloud
+            | Self::GoogleGenerativeAi
             | Self::Groq
             | Self::RevAi
             | Self::Speechmatics
@@ -641,6 +662,9 @@ impl Provider {
             Self::Pyannote => None,
             Self::Cohere => None,
             Self::Xai => from_adapter(&crate::adapter::XaiAdapter::default(), msg),
+            Self::GoogleGenerativeAi => {
+                from_adapter(&crate::adapter::GoogleGenerativeAiAdapter, msg)
+            }
             Self::AwsTranscribe
             | Self::AzureSpeech
             | Self::GoogleCloud
@@ -669,6 +693,7 @@ impl Provider {
             | Self::AwsTranscribe
             | Self::AzureSpeech
             | Self::GoogleCloud
+            | Self::GoogleGenerativeAi
             | Self::Groq
             | Self::RevAi
             | Self::Speechmatics

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -315,7 +315,8 @@ pub(super) async fn transcribe_with_provider(
         | Provider::RevAi
         | Provider::Speechmatics
         | Provider::Together
-        | Provider::Xai => {
+        | Provider::Xai
+        | Provider::GoogleGenerativeAi => {
             return Err(BatchAttemptError::Unsupported(format!(
                 "{provider:?} is a direct BYOK provider",
             )));

--- a/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
@@ -70,7 +70,10 @@ fn build_upstream_url_with_adapter(
         | Provider::RevAi
         | Provider::Speechmatics
         | Provider::Together
-        | Provider::Xai => unreachable!("direct BYOK provider is not configured in the proxy"),
+        | Provider::Xai
+        | Provider::GoogleGenerativeAi => {
+            unreachable!("direct BYOK provider is not configured in the proxy")
+        }
     }
 }
 
@@ -109,7 +112,10 @@ fn build_initial_message_with_adapter(
         | Provider::RevAi
         | Provider::Speechmatics
         | Provider::Together
-        | Provider::Xai => unreachable!("direct BYOK provider is not configured in the proxy"),
+        | Provider::Xai
+        | Provider::GoogleGenerativeAi => {
+            unreachable!("direct BYOK provider is not configured in the proxy")
+        }
     };
 
     msg.and_then(|m| match m {
@@ -151,7 +157,10 @@ fn build_response_transformer(
             | Provider::RevAi
             | Provider::Speechmatics
             | Provider::Together
-            | Provider::Xai => unreachable!("direct BYOK provider is not configured in the proxy"),
+            | Provider::Xai
+            | Provider::GoogleGenerativeAi => {
+                unreachable!("direct BYOK provider is not configured in the proxy")
+            }
         };
 
         if provider == Provider::Soniox && proxy_debug_enabled() {

--- a/crates/transcribe-proxy/tests/common/mod.rs
+++ b/crates/transcribe-proxy/tests/common/mod.rs
@@ -125,7 +125,8 @@ pub fn env_with_provider(provider: Provider, api_key: String) -> transcribe_prox
         | Provider::RevAi
         | Provider::Speechmatics
         | Provider::Together
-        | Provider::Xai => panic!("{provider} is not configured in the Pro proxy"),
+        | Provider::Xai
+        | Provider::GoogleGenerativeAi => panic!("{provider} is not configured in the Pro proxy"),
     }
     env
 }

--- a/plugins/transcription/js/bindings.gen.ts
+++ b/plugins/transcription/js/bindings.gen.ts
@@ -234,7 +234,7 @@ transcriptionEvent: "plugin:transcription:transcription-event"
 export type BatchAlternatives = { transcript: string; confidence: number; words?: BatchWord[] }
 export type BatchChannel = { alternatives: BatchAlternatives[] }
 export type BatchErrorCode = "unknown" | "timed_out" | "audio_metadata_join_failed" | "audio_metadata_read_failed" | "batch_capability_unsupported" | "direct_batch_unsupported" | "progressive_batch_unsupported" | "direct_request_failed" | "progressive_actor_spawn_failed" | "progressive_start_cancelled" | "progressive_stopped_without_completion_signal" | "progressive_finished_without_status" | "progressive_start_failed" | "progressive_stream_error" | "progressive_stream_timeout"
-export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "openrouter" | "siliconflow" | "zai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "anarlog" | "am" | "soniqo" | "applespeech" | "aquavoice" | "cartesia" | "cohere" | "aws_transcribe" | "azure_speech" | "google_cloud" | "groq" | "revai" | "speechmatics" | "together" | "xai"
+export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "openrouter" | "siliconflow" | "zai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "anarlog" | "am" | "soniqo" | "applespeech" | "aquavoice" | "cartesia" | "cohere" | "aws_transcribe" | "azure_speech" | "google_cloud" | "google_generative_ai" | "groq" | "revai" | "speechmatics" | "together" | "xai"
 export type BatchResponse = { metadata: JsonValue; results: BatchResults }
 export type BatchResults = { channels: BatchChannel[] }
 export type BatchRunMode = "direct" | "streamed"

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -468,6 +468,26 @@ mod tests {
     }
 
     #[test]
+    fn defaults_gemini_live_capture_to_live_mode() {
+        let params = capture_params(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini-3.5-transcribe-live",
+        );
+
+        assert_eq!(resolved(&params), TranscriptionMode::Live);
+    }
+
+    #[test]
+    fn defaults_gemini_file_capture_to_batch_mode() {
+        let params = capture_params(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "gemini-3.5-transcribe",
+        );
+
+        assert_eq!(resolved(&params), TranscriptionMode::Batch);
+    }
+
+    #[test]
     fn defaults_pyannote_capture_to_batch_mode() {
         let params = capture_params("https://api.pyannote.ai", "parakeet-tdt-0.6b-v3");
 

--- a/plugins/transcription/src/listener/commands.rs
+++ b/plugins/transcription/src/listener/commands.rs
@@ -148,6 +148,7 @@ pub async fn suggest_providers_for_languages_live<R: tauri::Runtime>(
         AdapterKind::DashScope,
         AdapterKind::Mistral,
         AdapterKind::Xai,
+        AdapterKind::GoogleGenerativeAi,
     ];
 
     let mut with_support: Vec<_> = all_providers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Gemini 3.5 Transcribe is now available in Google AI Studio, with a live model for captions during recording and a file model for speaker labels and word timestamps. Settings only offered Google Cloud Speech-to-Text, which uses a different API, auth, and host.

**Fix:** Add a **Google Gemini** STT provider (`google_generative_ai`) that uses an AI Studio API key. Live captions use `gemini-3.5-transcribe-live` over the Live API; after recording, `gemini-3.5-transcribe` goes through the Interactions API with speaker diarization and word timestamps. Selecting the file model forces batch mode so live is not called with the wrong model ID. This stays BYOK and is not added to the Anarlog Pro proxy.

Batch requests omit language hints when none are selected (auto-detect), matching the live path. Live `inputTranscription` events stay normal committed captions (`from_finalize: false`) rather than looking like an end-of-stream flush.

## Verification

- `cargo test -p owhisper-client --lib`
- `cargo test -p owhisper-client --lib adapter::google_generative_ai`
- `cargo test -p listener-core --lib`
- `cargo test -p listener2-core --lib`
- `cargo test -p transcribe-proxy --lib`
- `pnpm exec dprint check` on changed non-Swift files
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`

Skipped `cargo test -p tauri-plugin-transcription` here because this environment is missing GTK/WebKit for the Tauri/specta export test. `plugins/transcription/js/bindings.gen.ts` includes `google_generative_ai` on `BatchProvider`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b25d11e9-61a6-4906-8e0e-2b8bd02ccd6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b25d11e9-61a6-4906-8e0e-2b8bd02ccd6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

