### PR TITLE
docs: align user docs with current desktop, CLI, and AI behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ anarlog keeps audio transcription separate from the language model used for summ
 
 | Stage | App setting | Anarlog Cloud | Local or bring your own |
 | --- | --- | --- | --- |
-| Audio → transcript | **Transcription** | A managed route chooses by language and live or batch mode. Current primary paths include Deepgram Nova and Soniox 5. | Soniqo or Apple Speech when available, or your selected transcription provider and model |
-| Transcript + memo → summary, title, or chat | **Intelligence** | Auto currently uses the latest Claude Sonnet alias through OpenRouter. | Your selected API, subscription, OpenAI-compatible server, or eligible Apple Intelligence |
+| Audio → transcript | **Transcription** | Managed **Pro (Cloud)** chooses by language and live or batch mode. Current primary paths include Deepgram Nova, Soniox 5, and AssemblyAI Universal 3.5. | Soniqo or Apple Speech when available, or your selected transcription provider and model |
+| Transcript + memo → summary, title, or chat | **Intelligence** | Managed **Auto** (also shown as Pro (Cloud)) currently uses the latest Claude Sonnet alias through OpenRouter. | Your selected API, subscription, OpenAI-compatible server, or eligible Apple Intelligence |
 
 The active provider and model are always visible under **Settings → Transcription** and **Settings → Intelligence**. Read [Models and providers](https://docs.anarlog.so/models-and-providers) for the current routes, local model list, and privacy boundaries.
 

--- a/agent-plugins/anarlog/skills/anarlog/references/cli.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/cli.md
@@ -2,7 +2,7 @@
 
 Use `--json` for agent-readable output.
 
-Linux desktop packages install this command as `anarlog-cli`; use that name instead of `anarlog` in the examples when necessary.
+Linux Flatpak installs this command as `anarlog-cli`; use that name instead of `anarlog` in the examples when that is the command on PATH.
 
 Account authentication works on headless systems:
 
@@ -14,7 +14,7 @@ anarlog auth logout
 
 For `auth login`, give the printed URL to the user. They may open it on another device, sign in, choose **Copy URL**, and paste the resulting `anarlog://auth/callback` link into the hidden prompt. Never ask the user to paste that callback link into chat or expose it in command arguments because it contains account tokens.
 
-On Linux, sessions use Secret Service when available and otherwise use the desktop-compatible local auth file with mode `0600`.
+On Linux, sessions use Secret Service when available and otherwise use the desktop-compatible local auth file with mode `0600`. With `--json`, `auth login` prints the URL to stderr and reads the callback from stdin.
 
 ```bash
 anarlog --json doctor

--- a/agent-plugins/anarlog/skills/anarlog/references/errors.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/errors.md
@@ -18,6 +18,6 @@ Choose a new path. Pass `--force` only when the user explicitly approves replaci
 
 ## MCP server exits
 
-Run `anarlog --json meetings list` to distinguish database access from client configuration. Confirm the MCP command is `anarlog` and its only required argument is `mcp`.
+Run `anarlog --json meetings list` to distinguish database access from client configuration. Confirm the MCP command is `anarlog` and its only required argument is `mcp`. Missing meetings and proposals are invalid parameters. Validation and conflict failures, including declining a non-pending proposal, are internal MCP errors.
 
 With `--json`, errors contain `schema_version` and an `error` object with `code`, `message`, and `exit_code`. CLI exit codes are `1` for an operation failure, `2` for missing data, `3` for a missing database, and `4` for an existing export target. Invalid CLI arguments use Clap's exit code and the `invalid_arguments` error code.

--- a/agent-plugins/anarlog/skills/anarlog/references/mcp.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/mcp.md
@@ -12,7 +12,7 @@ Read tools are idempotent. Proposal tools insert or decline staged edits; they n
 | `propose_memo_edit`             | Stage a complete memo replacement.                                                                      |
 | `list_proposals`                | List staged proposals. Defaults to `status: pending`.                                                   |
 | `get_proposal`                  | Read one proposal and its unified `diff`.                                                               |
-| `decline_proposal`              | Discard a pending proposal without changing the meeting.                                                |
+| `decline_proposal`              | Discard a pending proposal without changing the meeting. Applied proposals cannot be declined.          |
 
 Transcript limits are measured in words. The default is 200 and the maximum is 500.
 
@@ -22,4 +22,4 @@ Available resources:
 - `anarlog://meetings/{meeting_id}/transcript{?offset,limit}`
 - `anarlog://series/{series_id}`
 
-Prefer tools when the workflow needs structured JSON. Use resources when the client needs concise Markdown or plain-text context.
+Prefer tools when the workflow needs structured JSON. Use resources when the client needs concise Markdown or plain-text context. Transcript resources default to 200 words (cap 500) and return plain text only.

--- a/agent-plugins/anarlog/skills/anarlog/references/setup.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/setup.md
@@ -25,7 +25,12 @@ Restart the client after changing its MCP configuration.
 
 ## CLI
 
-On macOS, open **Anarlog → Settings → Developers** and select **Install**. Anarlog installs the bundled command at `~/.local/bin/anarlog`.
+Open **Anarlog → Settings → Developers** and select **Install**. Direct-download builds install:
+
+- macOS and Linux (DEB / AppImage): `~/.local/bin/anarlog`
+- Windows: `%LOCALAPPDATA%\Anarlog\bin\anarlog.exe`
+
+The Mac App Store build does not bundle CLI installation. Build from source instead.
 
 To build from source instead:
 
@@ -38,10 +43,10 @@ anarlog --version
 
 Run the Anarlog desktop app once so its local database exists. The CLI and local MCP server work while the app is closed after that.
 
-Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`.
+Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`. With `--json`, the login URL is printed to stderr and the callback is read from stdin.
 
-The Linux desktop package names the bundled command `anarlog-cli`, so use `anarlog-cli auth login` and `anarlog-cli auth status` there.
+On Flatpak, the host command is `anarlog-cli`. On DEB, AppImage, macOS, Windows, and Settings-installed builds, the command is `anarlog`.
 
-Homebrew, standalone release binaries, Windows package-manager distribution, and bundled CLI installation on platforms other than macOS are not yet available.
+Homebrew, standalone release binaries, and Windows package-manager distribution are not yet available.
 
 Use `--db-path FILE` or `ANARLOG_DB_PATH` only when the database is outside Anarlog's default application-data location.

--- a/docs/agents/cli.mdx
+++ b/docs/agents/cli.mdx
@@ -32,9 +32,10 @@ Use `meetings get` when participants or action items matter. Use `meetings note`
 anarlog --json proposals create --meeting MEETING_ID --kind summary --content "Replacement markdown"
 anarlog --json proposals list --meeting MEETING_ID
 anarlog --json proposals show PROPOSAL_ID
+anarlog --json proposals decline PROPOSAL_ID
 ```
 
-The create command returns a pending proposal. Do not claim the meeting changed. Open the meeting in the desktop app to apply or decline it.
+The create command returns a pending proposal. Do not claim the meeting changed. Open the meeting in the desktop app to apply it, or decline it from the CLI or desktop app. Only pending proposals can be declined.
 
 ## Transcripts
 

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -22,7 +22,7 @@ Use this generic MCP configuration:
 }
 ```
 
-If `anarlog` is not on the client's `PATH`, use the executable's absolute path as `command`. Restart the client after changing its configuration.
+If `anarlog` is not on the client's `PATH`, use the executable's absolute path as `command`. On Flatpak, substitute `anarlog-cli` for `anarlog`. Restart the client after changing its configuration.
 
 For a custom database path:
 
@@ -45,7 +45,9 @@ Transcript pages default to 200 words and cap at 500. Follow `pagination.next_of
 
 Use `get_recurring_meeting_history` with a known meeting ID when a task depends on earlier meetings in the same series.
 
-To persist an edit, call `propose_summary_edit` or `propose_memo_edit`. The tool returns a pending proposal. Do not claim the meeting changed. Use `list_proposals` and `get_proposal` to inspect staged work. `decline_proposal` discards a pending proposal.
+To persist an edit, call `propose_summary_edit` or `propose_memo_edit`. The tool returns a pending proposal. Do not claim the meeting changed. Use `list_proposals` and `get_proposal` to inspect staged work. `decline_proposal` discards a pending proposal; applied or already-declined proposals cannot be declined.
+
+The server also exposes MCP resources (`anarlog://meetings/...`) for Markdown or plain-text context when the client prefers resources over tools.
 
 See the [MCP reference](/reference/mcp) for exact parameters and resources.
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -3,7 +3,7 @@ title: "Agent overview"
 description: "Give an agent useful Anarlog context without exposing storage internals or unbounded transcripts."
 ---
 
-Anarlog gives agents three read-only ways to access meeting context. Choose based on where the agent runs.
+Anarlog gives agents three ways to access meeting context. Local CLI and MCP reads are bounded; both can also stage proposals for human review. Hosted Cloud API and remote MCP are read-only. Choose based on where the agent runs.
 
 | Transport | Choose it when | Output |
 | --- | --- | --- |

--- a/docs/ai-setup.mdx
+++ b/docs/ai-setup.mdx
@@ -16,7 +16,7 @@ Open **Settings → Transcription** or **Settings → Intelligence** to choose a
 
 <CardGroup cols={2}>
   <Card title="Anarlog Cloud" icon="cloud">
-    Sign in and choose Anarlog for the quickest setup. Hosted models require Pro.
+    Sign in and choose Anarlog for the quickest setup. Hosted models require a paid Anarlog plan.
   </Card>
   <Card title="On-device transcription" icon="laptop">
     Download Soniqo on a supported Apple Silicon Mac, or use Apple Speech when macOS 26 reports it available.
@@ -32,6 +32,10 @@ Open **Settings → Transcription** or **Settings → Intelligence** to choose a
 Models labeled **Live** show text during the meeting. Models labeled **After recording** transcribe after you stop.
 
 To keep transcription, summaries, and chat on your computer, follow [Use Anarlog offline](/offline).
+
+## Subscription providers
+
+You can use an existing paid plan for Intelligence without a separate API key. Open **Settings → Intelligence → Configure Providers** and connect **Claude**, **ChatGPT**, **Grok**, **GitHub Copilot**, or **Kimi Code**. After the connection finishes, select that provider under **Model being used**.
 
 ## Apple Intelligence
 

--- a/docs/automatic-capture.mdx
+++ b/docs/automatic-capture.mdx
@@ -11,6 +11,8 @@ Open **Settings → Meetings** and enable **Start when meeting begins**.
 
 When a calendar-backed note reaches its scheduled start time, Anarlog starts listening. This setting does not apply to ordinary notes without a calendar event.
 
+Enable **Join scheduled meetings** on the same page to open the meeting link when listening starts. That toggle stays disabled until **Start when meeting begins** is on.
+
 Keep Anarlog running and make sure microphone and system-audio access are allowed. See [Connect a calendar](/calendar) if your events are not visible.
 
 ## Detect unscheduled calls
@@ -19,13 +21,22 @@ Open **Settings → Notifications** and enable **Microphone detection**. Anarlog
 
 Microphone detection is a reminder; it does not start recording by itself. Choose a detection delay from 5 seconds to 2 minutes, and exclude apps that should not trigger a meeting prompt.
 
-Accessibility permission is required to detect meeting apps and synchronize mute state. You can manage it under **Settings → Permissions**.
+Microphone detection is available on macOS and Linux. On macOS, Accessibility permission is required to detect meeting apps and synchronize mute state; manage it under **Settings → Permissions**. On Linux, enable the meeting toggles under **Settings → Meetings** and allow assistive-technology access for the desktop session when prompted.
 
 ## Stop when the call ends
 
 Under **Settings → Meetings**, enable **Stop when meeting ends**. Anarlog stops listening when the meeting app releases the microphone.
 
-If you switch audio devices or use an app with unusual microphone behavior, check that the recording is still active before closing the meeting.
+This control is available on macOS and Linux. If you switch audio devices or use an app with unusual microphone behavior, check that the recording is still active before closing the meeting.
+
+## Capture meeting chat
+
+On macOS and Linux, **Settings → Meetings** also includes:
+
+- **Post recording disclosure in meeting chat**, which tells participants when listening starts. This does not confirm consent.
+- **Capture meeting chat in Memos**, which saves visible chat from supported meetings. On macOS this uses Accessibility; on Linux it uses assistive-technology access.
+
+These features are not available on Windows.
 
 ## Keep controls nearby
 

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -54,6 +54,8 @@ Deleting retained audio does not remove the meeting note or transcript. If you n
 
 Open **Settings → Privacy** and disable **Share usage data (PostHog)**. This controls product analytics and desktop session replay, not the meeting content sent to a provider you selected.
 
+Disable **Sentry** on the same page to stop sending sanitized crash and error reports.
+
 <Warning>
   Recording-consent rules depend on where you and the other participants are located. Make sure you have permission before recording.
 </Warning>

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -11,7 +11,7 @@ No. Anarlog captures your microphone and computer audio from the desktop without
 
 ### Can recording start automatically?
 
-Yes. Anarlog can start calendar-backed meetings on schedule and prompt you when it detects an unscheduled call. Manage scheduled meeting controls under **Settings → Meetings** and microphone detection under **Settings → Notifications**. See [Automatic capture](/automatic-capture).
+Yes. Anarlog can start calendar-backed meetings on schedule and prompt you when it detects an unscheduled call. Manage scheduled meeting controls under **Settings → Meetings** and microphone detection under **Settings → Notifications**. Microphone detection, auto-stop, and meeting-chat capture are available on macOS and Linux, not Windows. See [Automatic capture](/automatic-capture).
 
 ### Can I edit a transcript or fix a speaker?
 
@@ -77,6 +77,6 @@ Not yet. Anarlog currently ships as a desktop app.
 
 ### Can agents reach my meetings while Anarlog is closed?
 
-The CLI and local MCP server read the local database, so they work while the app is closed. Webhooks only deliver while the app is open. For hosted access from anywhere, explicitly enable [Cloud API & Connectors](/reference/api-cloud).
+The CLI and local MCP server read the local database, so they work while the app is closed. They can also stage a memo or summary proposal; review the **pending edit** banner in the desktop meeting note before applying it. Webhooks only deliver while the app is open. For hosted access from anywhere, explicitly enable [Cloud API & Connectors](/reference/api-cloud).
 
 If something is not working, go to [Troubleshooting](/troubleshooting). For a question not covered here, email [founders@anarlog.so](mailto:founders@anarlog.so) or [join Discord](https://anarlog.so/discord).

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -13,13 +13,26 @@ The `anarlog` executable includes both the CLI and the local MCP server.
 
 ## Install from the desktop app
 
-On macOS, open **Settings → Developers** and select **Install**. Anarlog copies its bundled CLI to `~/.local/bin/anarlog`.
+Open **Settings → Developers** and select **Install** (or **Reinstall**). Direct-download desktop builds copy the bundled CLI onto your PATH.
 
-If your shell cannot find `anarlog`, add `~/.local/bin` to `PATH`:
+| Platform | Installed command | Path |
+| --- | --- | --- |
+| macOS | `anarlog` | `~/.local/bin/anarlog` |
+| Linux (DEB / AppImage) | `anarlog` | `~/.local/bin/anarlog` |
+| Linux (Flatpak) | `anarlog-cli` | Preinstalled host wrapper; Settings install is optional |
+| Windows | `anarlog` | `%LOCALAPPDATA%\Anarlog\bin\anarlog.exe` (added to your user PATH) |
+
+On macOS and Linux, add `~/.local/bin` to `PATH` if your shell cannot find `anarlog`:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 ```
+
+On Windows, open a new terminal after installing so the PATH update applies.
+
+<Note>
+  The Mac App Store build does not include bundled CLI installation. Use [build from source](#build-from-source) instead.
+</Note>
 
 ## Build from source
 

--- a/docs/languages.mdx
+++ b/docs/languages.mdx
@@ -19,6 +19,8 @@ Under **Additional spoken languages**, add other languages people may use in the
 
 The selected Transcription provider and model must support those languages. If a language is missing or performs poorly, try another model under **Settings → Transcription**.
 
+Apple Speech live transcription uses one supported language at a time: German, English, Spanish, French, Italian, Japanese, Korean, Portuguese, Cantonese, or Chinese. Add that language in macOS System Settings before selecting Apple Speech.
+
 ## Improve names and jargon
 
 Language selection does not teach the model company-specific terminology. Add names, acronyms, and product terms under **Settings → Dictionary**.

--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -8,7 +8,7 @@ Anarlog does not hide one model behind the whole app. It keeps two independent s
 - **Transcription** turns meeting audio into text.
 - **Intelligence** turns text into summaries, titles, and chat responses.
 
-Open **Settings → Transcription** and **Settings → Intelligence** to see the selection active on your computer. Changing one selection does not change the other. For managed **Cloud** and **Auto** selections, this page explains the current upstream route.
+Open **Settings → Transcription** and **Settings → Intelligence** to see the selection active on your computer. Changing one selection does not change the other. For managed **Pro (Cloud)** and **Auto** selections, this page explains the current upstream route.
 
 ## How a meeting moves through AI
 
@@ -22,7 +22,7 @@ Recording, editing, and local storage do not require an AI model. A hosted Trans
 
 ## Anarlog Cloud
 
-Anarlog Cloud uses managed routes. The **Cloud** and **Auto** labels let Anarlog choose a suitable upstream model and retry a compatible provider when needed.
+Anarlog Cloud uses managed routes. Settings displays the managed selection as **Pro (Cloud)**. Transcription uses that Cloud route. Intelligence uses **Auto**, which Settings also displays as Pro (Cloud). Either selection lets Anarlog choose a suitable upstream model and retry a compatible provider when needed.
 
 <Note>
   The routes below describe the current implementation, not a permanently pinned model contract. Anarlog may update a managed route to improve quality, language coverage, latency, or availability. Select your own provider and model when you need a fixed model ID.
@@ -34,8 +34,9 @@ The managed Transcription route chooses a provider from the meeting's languages 
 
 - Deepgram currently resolves the route to **Nova 3** or **Nova 2**, depending on language support.
 - Soniox currently resolves it to **Soniox 5**: `stt-rt-v5` for live transcription and `stt-async-v5` after recording.
+- AssemblyAI currently resolves it to **Universal 3.5 Pro** (`universal-3-5-pro`) for live and after-recording transcription.
 - After-recording transcription prefers Soniox when it supports the selected languages.
-- The eligible fallback pool also includes configured routes for AssemblyAI, Gladia, ElevenLabs, Fireworks, OpenAI, Mistral, and Alibaba Cloud Model Studio.
+- The eligible fallback pool also includes configured routes for Gladia (currently **Solaria 1**), ElevenLabs, Fireworks, OpenAI, Mistral, and Alibaba Cloud Model Studio.
 
 Only configured providers that support the requested mode and languages enter the route. If one returns a retryable error, Anarlog can try the next eligible provider.
 
@@ -61,7 +62,7 @@ Anarlog currently offers two built-in on-device Transcription providers. Setting
 | --- | --- | --- | --- |
 | Soniqo | Parakeet Streaming | During the meeting | Apple Silicon; live transcription for 25 European languages |
 | Soniqo | Parakeet Batch | After recording | Apple Silicon; speaker-labeled transcription for 25 European languages |
-| Apple Speech | Apple Speech | During the meeting | macOS 26 with a supported language added in System Settings |
+| Apple Speech | Apple Speech | During the meeting | macOS 26 with a supported language added in System Settings. Live transcription uses one language at a time from German, English, Spanish, French, Italian, Japanese, Korean, Portuguese, Cantonese, or Chinese. |
 
 <Note>
   Compatibility code still recognizes some older local model IDs, but they are not offered as new choices. The table above is the current user-facing model list.
@@ -95,6 +96,15 @@ When you configure a provider with your own API key:
 - The provider's pricing, retention, and training policies apply.
 
 Anarlog supports dedicated provider integrations and OpenAI-compatible endpoints. Intelligence model lists are loaded from the provider when its API supports discovery, so **Settings → Intelligence** is the current source of truth for available model IDs.
+
+You can also connect a subscription for Intelligence instead of an API key: **Claude**, **ChatGPT**, **Grok**, **GitHub Copilot**, or **Kimi Code**. Open **Settings → Intelligence → Configure Providers** and use **Connect**.
+
+Recent bring-your-own Transcription models in Settings include:
+
+- **Google Gemini 3.5 Transcribe** (`gemini-3.5-transcribe-live` during the meeting, `gemini-3.5-transcribe` after recording)
+- **AssemblyAI Universal 3.5 Pro** (`universal-3-5-pro-realtime` during the meeting, `universal-3-5-pro` after recording)
+
+Settings may still show older model IDs for compatibility. Prefer the current Gemini 3.5, Universal 3.5, Soniox 5, and GPT Transcribe models when you configure a provider yourself.
 
 ## Choose a setup
 

--- a/docs/notes.mdx
+++ b/docs/notes.mdx
@@ -11,6 +11,8 @@ Every meeting note has up to three views:
 
 You can edit memos and summaries like regular notes. In a transcript, select a speaker label to assign a participant and use **Apply to all** when the same speaker appears again.
 
+When CLI, MCP, or Chat stages a memo or summary replacement, the meeting shows a **pending edit** banner. Open **Review memo** or **Review summary** to inspect the unified diff, then apply or decline it. A proposal does not change the meeting until you apply it.
+
 ## Correct a transcript
 
 - Click **Write** above the transcript to edit its text. Click **Done writing** when you finish.

--- a/docs/offline.mdx
+++ b/docs/offline.mdx
@@ -18,7 +18,7 @@ Hosted models, Google and Outlook calendar sync, cloud sync, and share links nee
 ## Prepare offline transcription
 
 1. Open **Settings → Transcription**.
-2. Choose Soniqo, or choose Apple Speech if it appears.
+2. Choose Soniqo, or choose Apple Speech if it appears. You can also choose **Local file** for after-recording transcription from a downloaded GGUF model.
 3. Download the Soniqo model. For Apple Speech, add the supported language in macOS System Settings.
 4. Select the model under **Model being used**.
 5. Run a short test recording before going offline.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -17,7 +17,7 @@ anarlog [--base DIR] [--db-path FILE] [--json] <command>
 
 `--db-path` takes precedence over `--base`. Without either option, the CLI uses Anarlog's platform application-data directory and recognized legacy locations.
 
-The Linux desktop package exposes the bundled command as `anarlog-cli`. Substitute `anarlog-cli` for `anarlog` in the examples below when using that package.
+On Flatpak, the host command is `anarlog-cli`. On DEB, AppImage, macOS, Windows, and Settings-installed builds, the command is `anarlog`. Substitute `anarlog-cli` only when that is the command on your PATH.
 
 ## Account commands
 
@@ -29,7 +29,9 @@ anarlog auth logout
 
 `auth login` prints a URL that can be opened in any browser, including one on another device. Sign in, choose **Copy URL** on the completion page, then paste the `anarlog://auth/callback` link into the hidden CLI prompt. The CLI verifies the session with Anarlog before saving it in the same local auth store as the desktop app.
 
-On Linux, the CLI uses Secret Service when it is available. Headless systems without Secret Service fall back to `auth.cli.json` in Anarlog's local application-data directory with permissions limited to the current user. The desktop app reconciles that file into Secret Service when it becomes available. `auth logout` removes the local session; it does not delete the Anarlog account.
+With `--json`, the login URL and instructions are printed to stderr. The callback URL is read from stdin. JSON appears on stdout only after login completes.
+
+On Linux, the CLI uses Secret Service when it is available. Headless systems without Secret Service fall back to `auth.cli.json` in Anarlog's local application-data directory with permissions limited to the current user. The desktop app reconciles that file into Secret Service when it becomes available. On Windows, the CLI stores sessions with DPAPI in the desktop app's secure auth file. `auth logout` removes the local session; it does not delete the Anarlog account.
 
 `auth status` reports the signed-in account and whether the current access token has expired. The stored refresh token lets the desktop app refresh an expired access token when it starts.
 
@@ -82,7 +84,7 @@ Checks the resolved database path, read-only access, and required schema without
 anarlog mcp
 ```
 
-Starts the read-only MCP server over stdio. Do not write other output to the server's stdout.
+Starts the local MCP server over stdio. Meeting reads are idempotent. Proposal tools stage or decline pending edits without applying them to the meeting. Do not write other output to the server's stdout.
 
 ## Help and version
 

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -15,6 +15,6 @@ Without `--json`, CLI errors are written to standard error as human-readable tex
 
 Invalid arguments use the `invalid_arguments` error code with Clap's nonzero exit code.
 
-MCP reports missing meetings as invalid parameters. Database and serialization failures are internal MCP errors.
+MCP maps missing meetings and proposals to invalid parameters. Validation and conflict failures—such as empty proposal content, multiple summaries without `target_id`, or declining a non-pending proposal—are reported as internal MCP errors. Database and serialization failures are also internal errors.
 
 Do not recover by creating tables, running migrations, or issuing SQL. The desktop app owns schema initialization and migrations.

--- a/docs/reference/mcp.mdx
+++ b/docs/reference/mcp.mdx
@@ -32,7 +32,7 @@ The result includes `meeting_id`, `text`, `words`, and a `pagination` object. Pa
 
 ### `get_recurring_meeting_history`
 
-Accepts required string `meeting_id` plus optional integer `limit` and `offset`. The limit defaults to 20 and is clamped to `1..200`; the offset defaults to 0.
+Accepts required string `meeting_id` plus optional integer `limit` and `offset`. The limit defaults to 20 and is clamped to `1..200`; the offset defaults to 0. Results are newest first. When the meeting has no recurring series, `meetings` is empty.
 
 ### `propose_summary_edit`
 
@@ -51,7 +51,7 @@ The result is a pending proposal. It does not change the meeting until a human a
 | `meeting_id` | string | required | A returned Anarlog meeting ID. |
 | `content` | string | required | Complete replacement memo in markdown. |
 
-The result is a pending proposal. It does not change the meeting until a human applies it in the desktop app.
+The result is a pending proposal. It does not change the meeting until a human applies it in the desktop app. `content` replaces the canonical meeting memo.
 
 ### `list_proposals`
 
@@ -68,14 +68,14 @@ Accepts required string `proposal_id`. Returns metadata and a unified `diff`.
 
 ### `decline_proposal`
 
-Accepts required string `proposal_id`. Marks a pending proposal declined without changing the meeting.
+Accepts required string `proposal_id`. Marks a pending proposal declined without changing the meeting. Applied or already-declined proposals cannot be declined.
 
 ## Resources
 
 | URI | MIME type | Content |
 | --- | --- | --- |
 | `anarlog://meetings/{meeting_id}` | `text/markdown` | Meeting detail without transcript text. |
-| `anarlog://meetings/{meeting_id}/transcript{?offset,limit}` | `text/plain` | A bounded transcript page. |
+| `anarlog://meetings/{meeting_id}/transcript{?offset,limit}` | `text/plain` | A bounded transcript page. `offset` defaults to 0 and `limit` defaults to 200 (clamped to 500 words). Returns plain text only; use `get_meeting_transcript` for structured `words`. |
 | `anarlog://series/{series_id}` | `text/markdown` | Up to 100 meetings in a recurring series. |
 
 Resource listing returns recent meeting resources in pages of 20. Its cursor is a numeric result offset.

--- a/docs/sync.mdx
+++ b/docs/sync.mdx
@@ -84,7 +84,7 @@ Anarlog does not currently expose a control for changing a storage location sele
 2. Leave the existing folder in place. Do not move or delete it manually.
 3. Email [founders@anarlog.so](mailto:founders@anarlog.so) with your operating system and the cloud-storage service named in the warning.
 
-Notes and transcripts migrated to the local SQLite database, but saved recordings and attachments may still depend on the existing folder.
+Notes and transcripts migrated to the local app data store, but saved recordings and attachments may still depend on the existing folder.
 
 ## Fix a blocked sync
 

--- a/skills/anarlog/references/cli.md
+++ b/skills/anarlog/references/cli.md
@@ -2,7 +2,7 @@
 
 Use `--json` for agent-readable output.
 
-Linux desktop packages install this command as `anarlog-cli`; use that name instead of `anarlog` in the examples when necessary.
+Linux Flatpak installs this command as `anarlog-cli`; use that name instead of `anarlog` in the examples when that is the command on PATH.
 
 Account authentication works on headless systems:
 
@@ -14,7 +14,7 @@ anarlog auth logout
 
 For `auth login`, give the printed URL to the user. They may open it on another device, sign in, choose **Copy URL**, and paste the resulting `anarlog://auth/callback` link into the hidden prompt. Never ask the user to paste that callback link into chat or expose it in command arguments because it contains account tokens.
 
-On Linux, sessions use Secret Service when available and otherwise use the desktop-compatible local auth file with mode `0600`.
+On Linux, sessions use Secret Service when available and otherwise use the desktop-compatible local auth file with mode `0600`. With `--json`, `auth login` prints the URL to stderr and reads the callback from stdin.
 
 ```bash
 anarlog --json doctor

--- a/skills/anarlog/references/errors.md
+++ b/skills/anarlog/references/errors.md
@@ -18,6 +18,6 @@ Choose a new path. Pass `--force` only when the user explicitly approves replaci
 
 ## MCP server exits
 
-Run `anarlog --json meetings list` to distinguish database access from client configuration. Confirm the MCP command is `anarlog` and its only required argument is `mcp`.
+Run `anarlog --json meetings list` to distinguish database access from client configuration. Confirm the MCP command is `anarlog` and its only required argument is `mcp`. Missing meetings and proposals are invalid parameters. Validation and conflict failures, including declining a non-pending proposal, are internal MCP errors.
 
 With `--json`, errors contain `schema_version` and an `error` object with `code`, `message`, and `exit_code`. CLI exit codes are `1` for an operation failure, `2` for missing data, `3` for a missing database, and `4` for an existing export target. Invalid CLI arguments use Clap's exit code and the `invalid_arguments` error code.

--- a/skills/anarlog/references/mcp.md
+++ b/skills/anarlog/references/mcp.md
@@ -12,7 +12,7 @@ Read tools are idempotent. Proposal tools insert or decline staged edits; they n
 | `propose_memo_edit`             | Stage a complete memo replacement.                                                                      |
 | `list_proposals`                | List staged proposals. Defaults to `status: pending`.                                                   |
 | `get_proposal`                  | Read one proposal and its unified `diff`.                                                               |
-| `decline_proposal`              | Discard a pending proposal without changing the meeting.                                                |
+| `decline_proposal`              | Discard a pending proposal without changing the meeting. Applied proposals cannot be declined.          |
 
 Transcript limits are measured in words. The default is 200 and the maximum is 500.
 
@@ -22,4 +22,4 @@ Available resources:
 - `anarlog://meetings/{meeting_id}/transcript{?offset,limit}`
 - `anarlog://series/{series_id}`
 
-Prefer tools when the workflow needs structured JSON. Use resources when the client needs concise Markdown or plain-text context.
+Prefer tools when the workflow needs structured JSON. Use resources when the client needs concise Markdown or plain-text context. Transcript resources default to 200 words (cap 500) and return plain text only.

--- a/skills/anarlog/references/setup.md
+++ b/skills/anarlog/references/setup.md
@@ -25,7 +25,12 @@ Restart the client after changing its MCP configuration.
 
 ## CLI
 
-On macOS, open **Anarlog → Settings → Developers** and select **Install**. Anarlog installs the bundled command at `~/.local/bin/anarlog`.
+Open **Anarlog → Settings → Developers** and select **Install**. Direct-download builds install:
+
+- macOS and Linux (DEB / AppImage): `~/.local/bin/anarlog`
+- Windows: `%LOCALAPPDATA%\Anarlog\bin\anarlog.exe`
+
+The Mac App Store build does not bundle CLI installation. Build from source instead.
 
 To build from source instead:
 
@@ -38,10 +43,10 @@ anarlog --version
 
 Run the Anarlog desktop app once so its local database exists. The CLI and local MCP server work while the app is closed after that.
 
-Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`.
+Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`. With `--json`, the login URL is printed to stderr and the callback is read from stdin.
 
-The Linux desktop package names the bundled command `anarlog-cli`, so use `anarlog-cli auth login` and `anarlog-cli auth status` there.
+On Flatpak, the host command is `anarlog-cli`. On DEB, AppImage, macOS, Windows, and Settings-installed builds, the command is `anarlog`.
 
-Homebrew, standalone release binaries, Windows package-manager distribution, and bundled CLI installation on platforms other than macOS are not yet available.
+Homebrew, standalone release binaries, and Windows package-manager distribution are not yet available.
 
 Use `--db-path FILE` or `ANARLOG_DB_PATH` only when the database is outside Anarlog's default application-data location.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** User-facing docs drifted from the current desktop, CLI, and MCP sources: CLI install was documented as macOS-only, local MCP was called read-only, Cloud vs Auto model labels were mixed, and several shipped settings (Gemini 3.5 Transcribe, AssemblyAI Universal 3.5, subscription Intelligence providers, meeting-chat capture, pending-edit review) were missing.

**Fix:** Audit the published Mintlify docs and agent skill against `apps/cli`, `apps/desktop`, and routing crates, then update the pages so they match current behavior without documenting unpublished install channels or telling users to touch storage internals.

## Verification

- `pnpm exec dprint fmt 'docs/**/*' 'skills/**/*' 'README.md' 'agent-plugins/**/*'`
- `pnpm exec dprint check 'docs/**/*' 'skills/**/*' 'README.md' 'agent-plugins/anarlog/**/*'`
- `node scripts/publish-anarlog-skill.mjs --check`
- `node --test scripts/publish-anarlog-skill.test.mjs`
- `cargo test --locked -p anarlog-cli --lib` (includes CLI/MCP docs contract tests)
- `npx mint@4.2.687 validate` and `npx mint@4.2.687 broken-links` from `docs/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-460a2274-914f-412d-8053-f7e2d7b88d5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-460a2274-914f-412d-8053-f7e2d7b88d5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

