### PR TITLE
Remove the old floating live-caption overlay

### DIFF
--- a/apps/desktop/src/meeting-float/host.component.test.tsx
+++ b/apps/desktop/src/meeting-float/host.component.test.tsx
@@ -138,17 +138,35 @@ describe("FloatingMeetingWindowHost", () => {
     expect(mocks.floatingBarHide).not.toHaveBeenCalled();
   });
 
-  it("shows the floating bar on Windows and Linux", async () => {
-    mocks.platform.mockReturnValue("linux");
+  it.each(["windows", "linux"] as const)(
+    "uses the floating bar on %s like macOS, without the old caption overlay",
+    async (currentPlatform) => {
+      mocks.platform.mockReturnValue(currentPlatform);
 
-    render(<FloatingMeetingWindowHost />);
+      const view = render(<FloatingMeetingWindowHost />);
 
-    await waitFor(() => {
-      expect(mocks.floatingBarShow).toHaveBeenCalledOnce();
-      expect(mocks.floatingBarUpdate).toHaveBeenCalled();
-    });
-    expect(mocks.liveCaptionHide).toHaveBeenCalled();
-    expect(mocks.liveCaptionShow).not.toHaveBeenCalled();
-    expect(mocks.liveCaptionUpdate).not.toHaveBeenCalled();
-  });
+      await waitFor(() => {
+        expect(mocks.floatingBarShow).toHaveBeenCalledOnce();
+        expect(mocks.floatingBarUpdate).toHaveBeenLastCalledWith(
+          expect.objectContaining({ liveCaptionMinimized: true }),
+        );
+      });
+
+      mocks.settings.current = {
+        ...mocks.settings.current,
+        live_caption_minimized: false,
+      };
+      view.rerender(<FloatingMeetingWindowHost />);
+
+      await waitFor(() => {
+        expect(mocks.floatingBarUpdate).toHaveBeenLastCalledWith(
+          expect.objectContaining({ liveCaptionMinimized: false }),
+        );
+      });
+      expect(mocks.liveCaptionHide).toHaveBeenCalled();
+      expect(mocks.liveCaptionShow).not.toHaveBeenCalled();
+      expect(mocks.liveCaptionUpdate).not.toHaveBeenCalled();
+      expect(mocks.floatingBarHide).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/desktop/src/meeting-float/host.component.test.tsx
+++ b/apps/desktop/src/meeting-float/host.component.test.tsx
@@ -131,14 +131,9 @@ describe("FloatingMeetingWindowHost", () => {
           transcriptBubbles: null,
         }),
       );
-      expect(mocks.liveCaptionShow).toHaveBeenCalledOnce();
-      expect(mocks.liveCaptionUpdate).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          text: "we should ship this",
-          minimized: false,
-        }),
-      );
     });
+    expect(mocks.liveCaptionShow).not.toHaveBeenCalled();
+    expect(mocks.liveCaptionHide).toHaveBeenCalled();
     expect(mocks.floatingBarShow).toHaveBeenCalledOnce();
     expect(mocks.floatingBarHide).not.toHaveBeenCalled();
   });
@@ -154,5 +149,6 @@ describe("FloatingMeetingWindowHost", () => {
     });
     expect(mocks.liveCaptionHide).toHaveBeenCalled();
     expect(mocks.liveCaptionShow).not.toHaveBeenCalled();
+    expect(mocks.liveCaptionUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -15,9 +15,7 @@ import {
   getCurrentFloatingBarColorScheme,
   getFloatingLiveCaptionToggleVisible,
   getFloatingRouteState,
-  getLiveCaptionRouteState,
   isSameFloatingRouteState,
-  isSameLiveCaptionRouteState,
   type FloatingRouteState,
   type ListenerState,
 } from "./route-state";
@@ -31,7 +29,6 @@ import {
 import { isFloatingBarSupported } from "./support";
 import {
   createFloatingMeetingWindowSynchronizer,
-  createLiveCaptionWindowSynchronizer,
   hideFloatingMeetingPanel,
   hideLiveCaptionPanel,
   showFloatingMeetingWindow,
@@ -77,11 +74,7 @@ export function FloatingMeetingWindowHost() {
       ) : (
         <FloatingMeetingWindowDisabled />
       )}
-      {floatingOverlaySupported ? (
-        <LiveCaptionWindowSync settings={overlaySettings} />
-      ) : (
-        <LiveCaptionWindowDisabled />
-      )}
+      <LiveCaptionWindowDisabled />
     </>
   );
 }
@@ -169,63 +162,6 @@ function LiveCaptionWindowDisabled() {
   });
 
   return null;
-}
-
-function LiveCaptionWindowSync({
-  settings,
-}: {
-  settings: FloatingOverlaySettings;
-}) {
-  const settingsRef = useLatestRef(settings);
-  const refreshSettingsRef = useRef<() => void>(() => {});
-
-  useMountEffect(() => {
-    let routeState = getLiveCaptionRouteState(
-      listenerStore.getState(),
-      settingsRef.current,
-    );
-    const windowSynchronizer = createLiveCaptionWindowSynchronizer();
-
-    const updateRouteState = (
-      nextRouteState: ReturnType<typeof getLiveCaptionRouteState>,
-    ) => {
-      if (isSameLiveCaptionRouteState(nextRouteState, routeState)) {
-        return;
-      }
-
-      routeState = nextRouteState;
-      windowSynchronizer.update(routeState);
-    };
-    const refreshCurrentRouteState = () => {
-      updateRouteState(
-        getLiveCaptionRouteState(listenerStore.getState(), settingsRef.current),
-      );
-    };
-    refreshSettingsRef.current = refreshCurrentRouteState;
-
-    windowSynchronizer.update(routeState);
-
-    const unsubscribe = listenerStore.subscribe((state, previousState) => {
-      if (!haveLiveCaptionRouteInputsChanged(state, previousState)) {
-        return;
-      }
-
-      refreshCurrentRouteState();
-    });
-
-    return () => {
-      refreshSettingsRef.current = () => {};
-      unsubscribe();
-      void windowSynchronizer.dispose();
-    };
-  });
-
-  return (
-    <FloatingMeetingWindowSettingsSync
-      key={JSON.stringify(settings)}
-      onSettingsChange={() => refreshSettingsRef.current()}
-    />
-  );
 }
 
 function FloatingMeetingWindowSync({
@@ -388,19 +324,6 @@ function getCurrentFloatingRouteState(
     speakerLabelContext: getFloatingSpeakerLabelContext(state, meetingData),
     transcriptBubbles,
   });
-}
-
-function haveLiveCaptionRouteInputsChanged(
-  state: ListenerState,
-  previousState: ListenerState,
-) {
-  return (
-    state.live.status !== previousState.live.status ||
-    state.live.sessionId !== previousState.live.sessionId ||
-    state.live.liveTranscriptionActive !==
-      previousState.live.liveTranscriptionActive ||
-    state.liveCaptionText !== previousState.liveCaptionText
-  );
 }
 
 function haveFloatingRouteInputsChanged(

--- a/plugins/windows/src/window/live_caption.rs
+++ b/plugins/windows/src/window/live_caption.rs
@@ -30,9 +30,11 @@ pub(crate) mod layout {
     use super::LiveCaptionPosition;
 
     pub const MIN_WIDTH: f64 = 260.0;
+    #[allow(dead_code)]
     pub const DEFAULT_WIDTH: f64 = 440.0;
     pub const MAX_WIDTH: f64 = 640.0;
     pub const MIN_LINE_COUNT: u32 = 1;
+    #[allow(dead_code)]
     pub const DEFAULT_LINE_COUNT: u32 = 1;
     pub const MAX_LINE_COUNT: u32 = 4;
     pub const LINE_HEIGHT: f64 = 22.0;
@@ -120,14 +122,12 @@ pub(crate) mod layout {
 
 #[cfg(target_os = "macos")]
 mod platform {
-    use swift_rs::{Bool, SRString, swift};
+    use swift_rs::{Bool, swift};
 
     use super::LiveCaptionState;
     use crate::Error;
 
-    swift!(fn _live_caption_show() -> Bool);
     swift!(fn _live_caption_hide() -> Bool);
-    swift!(fn _live_caption_update(json: &SRString) -> Bool);
 
     pub fn set_app_handle(_app: tauri::AppHandle<tauri::Wry>) {}
 
@@ -136,10 +136,7 @@ mod platform {
     }
 
     pub fn show() -> Result<(), Error> {
-        unsafe {
-            _live_caption_show();
-        }
-        Ok(())
+        hide()
     }
 
     pub fn hide() -> Result<(), Error> {
@@ -149,20 +146,8 @@ mod platform {
         Ok(())
     }
 
-    pub fn update(state: LiveCaptionState) -> Result<(), Error> {
-        let json = serde_json::to_string(&state).map_err(|error| {
-            Error::PanelError(format!("failed to serialize live caption state: {error}"))
-        })?;
-        let json = SRString::from(json.as_str());
-
-        let ok = unsafe { _live_caption_update(&json) };
-        if ok {
-            Ok(())
-        } else {
-            Err(Error::PanelError(
-                "failed to update native live caption".to_string(),
-            ))
-        }
+    pub fn update(_state: LiveCaptionState) -> Result<(), Error> {
+        hide()
     }
 }
 
@@ -170,14 +155,9 @@ mod platform {
 mod platform {
     use std::sync::{Mutex, OnceLock};
 
-    use tauri::{
-        LogicalPosition, LogicalSize, Manager, Position, Size, WebviewUrl, WebviewWindow,
-        WebviewWindowBuilder, window::Color,
-    };
-    use tauri_specta::Event;
+    use tauri::Manager;
 
-    use super::layout::{self, clamp_to_work_area, origin, window_size};
-    use super::{LiveCaptionPosition, LiveCaptionState, WINDOW_LABEL};
+    use super::{LiveCaptionState, WINDOW_LABEL};
     use crate::Error;
 
     static APP_HANDLE: OnceLock<tauri::AppHandle<tauri::Wry>> = OnceLock::new();
@@ -198,17 +178,7 @@ mod platform {
     }
 
     pub fn show() -> Result<(), Error> {
-        let app = app()?;
-        let window = ensure_window(app)?;
-        let state = current_state();
-        if state.as_ref().is_some_and(|value| value.minimized) {
-            window.hide()?;
-            return Ok(());
-        }
-        apply_layout(&window, state.as_ref(), true)?;
-        window.show()?;
-        crate::window::exclude_from_capture(&window);
-        Ok(())
+        hide()
     }
 
     pub fn hide() -> Result<(), Error> {
@@ -223,169 +193,8 @@ mod platform {
         Ok(())
     }
 
-    pub fn update(state: LiveCaptionState) -> Result<(), Error> {
-        let previous_position = current_state().map(|value| value.position);
-        if let Ok(mut last) = LAST_STATE.lock() {
-            *last = Some(state.clone());
-        }
-        let app = app()?;
-        let _ = crate::events::LiveCaptionOverlayState {
-            state: state.clone(),
-        }
-        .emit(app);
-        if state.minimized {
-            if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
-                window.hide()?;
-            }
-            return Ok(());
-        }
-        if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
-            let force_position = previous_position.is_some_and(|value| value != state.position);
-            apply_layout(&window, Some(&state), force_position)?;
-            if !window.is_visible().unwrap_or(false) {
-                window.show()?;
-                crate::window::exclude_from_capture(&window);
-            }
-        }
-        Ok(())
-    }
-
-    fn ensure_window(
-        app: &tauri::AppHandle<tauri::Wry>,
-    ) -> Result<WebviewWindow<tauri::Wry>, Error> {
-        if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
-            return Ok(window);
-        }
-
-        let (width, height) = window_size(layout::DEFAULT_WIDTH, layout::DEFAULT_LINE_COUNT);
-        let builder = WebviewWindowBuilder::new(
-            app,
-            WINDOW_LABEL,
-            WebviewUrl::App("app/live-caption".into()),
-        )
-        .title("Anarlog")
-        .inner_size(width, height)
-        .visible(false)
-        .focused(false)
-        .decorations(false);
-        #[cfg(any(not(target_os = "macos"), feature = "macos-private-api"))]
-        let builder = builder.transparent(true);
-        let window = builder
-            .shadow(false)
-            .resizable(false)
-            .maximizable(false)
-            .minimizable(false)
-            .closable(false)
-            .always_on_top(true)
-            .skip_taskbar(true)
-            .content_protected(true)
-            .background_color(Color(0, 0, 0, 0))
-            .disable_drag_drop_handler()
-            .build()?;
-
-        crate::window::exclude_from_capture(&window);
-
-        Ok(window)
-    }
-
-    fn apply_layout(
-        window: &WebviewWindow<tauri::Wry>,
-        state: Option<&LiveCaptionState>,
-        force_default_position: bool,
-    ) -> Result<(), Error> {
-        let width = state
-            .map(|value| value.width)
-            .unwrap_or(layout::DEFAULT_WIDTH);
-        let line_count = state
-            .map(|value| value.line_count)
-            .unwrap_or(layout::DEFAULT_LINE_COUNT);
-        let position = state
-            .map(|value| value.position)
-            .unwrap_or(LiveCaptionPosition::TopCenter);
-        let (width, height) = window_size(width, line_count);
-        let next_size = LogicalSize::new(width, height);
-        let scale = window.scale_factor()?;
-        let current_size = window.outer_size()?.to_logical::<f64>(scale);
-        let current_position = window.outer_position()?.to_logical::<f64>(scale);
-        let size_changed = (current_size.width - width).abs() >= 0.5
-            || (current_size.height - height).abs() >= 0.5;
-
-        if size_changed {
-            window.set_size(Size::Logical(next_size))?;
-        }
-
-        let (next_x, next_y) =
-            if force_default_position || current_position.x == 0.0 && current_position.y == 0.0 {
-                default_origin(window, position, width, height)?
-            } else if size_changed {
-                (current_position.x, current_position.y)
-            } else {
-                return Ok(());
-            };
-
-        let (clamped_x, clamped_y) = clamp_origin(window, next_x, next_y, width, height)?;
-        window.set_position(Position::Logical(LogicalPosition::new(
-            clamped_x, clamped_y,
-        )))?;
-        Ok(())
-    }
-
-    fn default_origin(
-        window: &WebviewWindow<tauri::Wry>,
-        position: LiveCaptionPosition,
-        width: f64,
-        height: f64,
-    ) -> Result<(f64, f64), Error> {
-        let monitor = window
-            .current_monitor()
-            .ok()
-            .flatten()
-            .or_else(|| window.app_handle().primary_monitor().ok().flatten())
-            .ok_or(Error::MonitorNotFound)?;
-        let scale = monitor.scale_factor();
-        let work_area = monitor.work_area();
-        let origin_point = work_area.position.to_logical::<f64>(scale);
-        let size = work_area.size.to_logical::<f64>(scale);
-        Ok(origin(
-            position,
-            origin_point.x,
-            origin_point.y,
-            size.width,
-            size.height,
-            width,
-            height,
-        ))
-    }
-
-    fn clamp_origin(
-        window: &WebviewWindow<tauri::Wry>,
-        x: f64,
-        y: f64,
-        width: f64,
-        height: f64,
-    ) -> Result<(f64, f64), Error> {
-        let monitor = window
-            .current_monitor()
-            .ok()
-            .flatten()
-            .or_else(|| window.app_handle().primary_monitor().ok().flatten());
-        let Some(monitor) = monitor else {
-            return Ok((x, y));
-        };
-        let scale = monitor.scale_factor();
-        let work_area = monitor.work_area();
-        let origin_point = work_area.position.to_logical::<f64>(scale);
-        let size = work_area.size.to_logical::<f64>(scale);
-        Ok(clamp_to_work_area(
-            x,
-            y,
-            width,
-            height,
-            origin_point.x,
-            origin_point.y,
-            size.width,
-            size.height,
-        ))
+    pub fn update(_state: LiveCaptionState) -> Result<(), Error> {
+        hide()
     }
 }
 

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -475,9 +475,6 @@ struct FloatingBarView: View {
   private func setExpanded(_ expanded: Bool) {
     model.isExpanded = expanded
     settings.setLiveCaptionMinimized(!expanded)
-    if !expanded {
-      LiveCaptionManager.shared.hide(clearText: false)
-    }
   }
 
   private func showsSpeakerLabel(at index: Int) -> Bool {

--- a/plugins/windows/swift-lib/src/FloatingOverlaySettingsPanel.swift
+++ b/plugins/windows/swift-lib/src/FloatingOverlaySettingsPanel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 enum FloatingOverlaySettingsPanelLayout {
   static let width: CGFloat = 276
-  static let height: CGFloat = 282
+  static let height: CGFloat = 148
   static let cornerRadius: CGFloat = 16
   static let margin: CGFloat = 10
 }
@@ -134,41 +134,6 @@ private struct FloatingOverlaySettingsPanelView: View {
         value: settings.floatingBarOpacity,
         onChange: settings.setFloatingBarOpacity)
 
-      Divider()
-
-      OpacitySlider(
-        title: "Transcript opacity",
-        value: settings.liveCaptionOpacity,
-        range: FloatingOverlayOpacity.minLiveCaption...FloatingOverlayOpacity.maxLiveCaption,
-        onChange: settings.setLiveCaptionOpacity)
-
-      VStack(alignment: .leading, spacing: 8) {
-        Text("Transcript position")
-          .font(.system(size: 12, weight: .medium))
-          .foregroundStyle(.secondary)
-
-        LazyVGrid(
-          columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 3),
-          spacing: 6
-        ) {
-          ForEach(LiveCaptionPosition.allCases, id: \.self) { position in
-            Button(action: { settings.setLiveCaptionPosition(position) }) {
-              Text(shortTitle(for: position))
-                .font(.system(size: 11, weight: .medium))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(
-                  position == settings.liveCaptionPosition ? Color.accentColor : Color.clear
-                )
-                .foregroundStyle(position == settings.liveCaptionPosition ? .white : .primary)
-                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(position.title)
-          }
-        }
-      }
-
       Button(
         action: { settings.setLiveCaptionMinimized(!settings.liveCaptionMinimized) }
       ) {
@@ -204,23 +169,6 @@ private struct FloatingOverlaySettingsPanelView: View {
       )
       .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
     )
-  }
-
-  private func shortTitle(for position: LiveCaptionPosition) -> String {
-    switch position {
-    case .topCenter:
-      return "Top"
-    case .topLeft:
-      return "TL"
-    case .topRight:
-      return "TR"
-    case .bottomLeft:
-      return "BL"
-    case .bottomRight:
-      return "BR"
-    case .bottomCenter:
-      return "Bottom"
-    }
   }
 }
 

--- a/plugins/windows/swift-lib/src/LiveCaptionManager.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionManager.swift
@@ -5,28 +5,13 @@ final class LiveCaptionManager {
 
   private init() {}
 
-  func show() {
-    hide(clearText: false)
-  }
+  func show() {}
 
   func hide(clearText: Bool = true) {
     _ = clearText
-    runOnMain {
-      FloatingOverlaySettingsPanelManager.shared.hide()
-    }
   }
 
   func update(state: LiveCaptionStatePayload) {
     _ = state
-    hide(clearText: false)
-  }
-
-  private func runOnMain(_ block: @escaping () -> Void) {
-    if Thread.isMainThread {
-      block()
-      return
-    }
-
-    DispatchQueue.main.sync(execute: block)
   }
 }

--- a/plugins/windows/swift-lib/src/LiveCaptionManager.swift
+++ b/plugins/windows/swift-lib/src/LiveCaptionManager.swift
@@ -1,139 +1,24 @@
-import Cocoa
-import SwiftUI
+import Foundation
 
 final class LiveCaptionManager {
   static let shared = LiveCaptionManager()
 
-  private var panel: NSPanel?
-  private let model = LiveCaptionViewModel()
-  private let settingsModel = FloatingOverlaySettingsModel.shared
-  private lazy var panelDelegate = LiveCaptionPanelDelegate(
-    model: model,
-    settings: settingsModel)
-  private var displayChangeObserver: Any?
-  private var followActiveScreenTimer: Timer?
-
   private init() {}
 
   func show() {
-    runOnMain { [weak self] in
-      guard let self else { return }
-      guard !self.settingsModel.liveCaptionMinimized else {
-        self.hidePanel(clearText: false)
-        return
-      }
-
-      if let panel = self.panel {
-        self.resize(panel)
-        self.position(panel, force: true)
-        self.startFollowingActiveScreen()
-        panel.orderFrontRegardless()
-        return
-      }
-
-      let panel = self.createPanel()
-      let hostingView = NSHostingView(
-        rootView: LiveCaptionView(
-          model: self.model,
-          settings: self.settingsModel,
-          onSetMinimized: { [weak self] minimized in
-            self?.setMinimized(minimized)
-          }))
-      hostingView.frame = NSRect(
-        x: 0,
-        y: 0,
-        width: self.initialSize.width,
-        height: self.initialSize.height)
-      hostingView.autoresizingMask = [.width, .height]
-
-      panel.contentView = hostingView
-      self.resize(panel)
-      self.position(panel, force: true)
-      panel.orderFrontRegardless()
-      self.panel = panel
-      self.startFollowingActiveScreen()
-    }
+    hide(clearText: false)
   }
 
   func hide(clearText: Bool = true) {
-    runOnMain { [weak self] in
-      guard let self else { return }
-      self.hidePanel(clearText: clearText)
+    _ = clearText
+    runOnMain {
+      FloatingOverlaySettingsPanelManager.shared.hide()
     }
-  }
-
-  private func hidePanel(clearText: Bool = true) {
-    guard let panel else {
-      if clearText {
-        model.text = ""
-      }
-      panelDelegate.resetActiveScreen()
-      return
-    }
-
-    stopFollowingActiveScreen()
-    FloatingOverlaySettingsPanelManager.shared.hide()
-    panel.orderOut(nil)
-    self.panel = nil
-    panelDelegate.resetActiveScreen()
-    if clearText {
-      model.text = ""
-    }
-    model.lineCount = LiveCaptionLayout.defaultLineCount
   }
 
   func update(state: LiveCaptionStatePayload) {
-    runOnMain { [weak self] in
-      guard let self else { return }
-      let placementChanged: Bool
-      if self.panel == nil {
-        placementChanged = self.settingsModel.apply(liveCaptionState: state)
-      } else {
-        placementChanged = self.settingsModel.applyLiveCaptionLayout(state)
-      }
-      if state.minimized {
-        self.hidePanel(clearText: false)
-        return
-      }
-
-      self.model.text = state.text
-      if let panel = self.panel {
-        self.resize(panel)
-        guard NSEvent.pressedMouseButtons == 0 else { return }
-        if placementChanged {
-          self.panelDelegate.clearPinnedPosition()
-        }
-        self.position(panel, force: true)
-      }
-    }
-  }
-
-  private func createPanel() -> NSPanel {
-    let initialSize = initialSize
-    let panel = NSPanel(
-      contentRect: NSRect(origin: .zero, size: initialSize),
-      styleMask: [.borderless, .nonactivatingPanel, .resizable],
-      backing: .buffered,
-      defer: false
-    )
-
-    panel.level = .floating
-    panel.isFloatingPanel = true
-    panel.hidesOnDeactivate = false
-    panel.isOpaque = false
-    panel.backgroundColor = .clear
-    panel.hasShadow = false
-    panel.sharingType = .none
-    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
-    panel.isMovableByWindowBackground = true
-    panel.minSize = NSSize(
-      width: LiveCaptionLayout.minWidth,
-      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.minLineCount))
-    panel.maxSize = NSSize(
-      width: LiveCaptionLayout.maxWidth,
-      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.maxLineCount))
-    panel.delegate = panelDelegate
-    return panel
+    _ = state
+    hide(clearText: false)
   }
 
   private func runOnMain(_ block: @escaping () -> Void) {
@@ -143,107 +28,5 @@ final class LiveCaptionManager {
     }
 
     DispatchQueue.main.sync(execute: block)
-  }
-
-  private func position(_ panel: NSPanel, force: Bool = false) {
-    panelDelegate.position(panel, force: force) { screen, size in
-      self.settingsModel.liveCaptionPosition.origin(in: screen.visibleFrame, size: size)
-    }
-  }
-
-  private var initialSize: NSSize {
-    return NSSize(
-      width: CGFloat(settingsModel.liveCaptionWidth),
-      height: LiveCaptionLayout.height(forLineCount: settingsModel.liveCaptionLineCount))
-  }
-
-  private func resize(_ panel: NSPanel) {
-    let targetSize = targetSize(for: panel)
-    updateSizeConstraints(panel, targetSize: targetSize)
-
-    guard panel.frame.size != targetSize else { return }
-
-    panelDelegate.setFrame(
-      panel,
-      to: NSRect(
-        x: panel.frame.minX,
-        y: panel.frame.maxY - targetSize.height,
-        width: targetSize.width,
-        height: targetSize.height),
-      display: true,
-      animate: false)
-  }
-
-  private func targetSize(for panel: NSPanel) -> NSSize {
-    let isResizing = NSEvent.pressedMouseButtons != 0
-    let requestedWidth = isResizing ? panel.frame.width : CGFloat(settingsModel.liveCaptionWidth)
-    let requestedLineCount = isResizing ? model.lineCount : settingsModel.liveCaptionLineCount
-    let width = min(max(requestedWidth, LiveCaptionLayout.minWidth), LiveCaptionLayout.maxWidth)
-    let lineCount = min(
-      max(requestedLineCount, LiveCaptionLayout.minLineCount),
-      LiveCaptionLayout.maxLineCount
-    )
-    model.lineCount = lineCount
-
-    return NSSize(
-      width: width,
-      height: LiveCaptionLayout.height(forLineCount: lineCount))
-  }
-
-  private func updateSizeConstraints(_ panel: NSPanel, targetSize: NSSize) {
-    panel.minSize = NSSize(
-      width: LiveCaptionLayout.minWidth,
-      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.minLineCount))
-    panel.maxSize = NSSize(
-      width: LiveCaptionLayout.maxWidth,
-      height: LiveCaptionLayout.height(forLineCount: LiveCaptionLayout.maxLineCount))
-  }
-
-  private func setMinimized(_ minimized: Bool) {
-    settingsModel.setLiveCaptionMinimized(minimized)
-    if minimized {
-      hidePanel(clearText: false)
-      return
-    }
-
-    if panel == nil {
-      show()
-      return
-    }
-
-    guard let panel else { return }
-    resize(panel)
-    panelDelegate.clearPinnedPosition()
-    position(panel, force: true)
-  }
-
-  private func startFollowingActiveScreen() {
-    guard followActiveScreenTimer == nil else { return }
-
-    let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-      guard let self, let panel = self.panel else { return }
-      self.position(panel)
-    }
-    RunLoop.main.add(timer, forMode: .common)
-    followActiveScreenTimer = timer
-
-    displayChangeObserver = NotificationCenter.default.addObserver(
-      forName: NSApplication.didChangeScreenParametersNotification,
-      object: nil,
-      queue: .main
-    ) { [weak self] _ in
-      guard let self, let panel = self.panel else { return }
-      self.position(panel, force: true)
-    }
-  }
-
-  private func stopFollowingActiveScreen() {
-    followActiveScreenTimer?.invalidate()
-    followActiveScreenTimer = nil
-
-    if let displayChangeObserver {
-      NotificationCenter.default.removeObserver(displayChangeObserver)
-      self.displayChangeObserver = nil
-    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Expanding the recording floating bar also brought back the old rolling live-caption window (opacity slider + Hide). That overlay was retired when the floating bar’s stop/expand transcript panel replaced it, then #6984 rewired it so both surfaces showed at once.

**Fix:** Windows and Linux keep the same recording UI as macOS: the floating bar with a stop button, and live transcript inside that bar when expanded. The old separate caption overlay is hidden on every desktop platform. Overlay-only settings (caption opacity/position) are removed from the floating-bar settings popover. Live-caption hide is a no-op, so collapsing the in-bar transcript or mounting the host no longer closes the floating-bar settings popover.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on changed non-Swift files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test` (3500 passed)
- `pnpm -F desktop exec vitest run src/meeting-float/host.component.test.tsx` after the Windows/Linux parity test
- `cargo test -p tauri-plugin-windows` could not run here: GTK 3 `gdk-3.0.pc` is not installed in this environment
- Swift formatter could not run here (macOS-only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5547100-91b9-42fa-8283-33b0a5faba52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5547100-91b9-42fa-8283-33b0a5faba52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

