### PR TITLE
Update the 1.4.14 changelog for unreleased desktop changes.

### DIFF
--- a/packages/changelog/content/1.4.14.md
+++ b/packages/changelog/content/1.4.14.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-08-27"
-summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, captures meeting chat more reliably, lets you pick local Whisper models and speaker devices, and makes sharing, sync, and speaker names more reliable."
+date: "2026-08-29"
+summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, captures meeting chat more reliably, lets you pick local Whisper models and speaker devices, connects Claude and Cursor to your notes with account sign-in, and makes sharing, sync, and Outlook reminders more reliable."
 ---
 
 ## Meetings and recording
@@ -16,6 +16,10 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
   Webex, including more Chromium and Firefox-based browsers, then search it
   in the session
 - Post a recording disclosure into the meeting chat when that setting is on
+- See live captions inside the recording floating bar when you expand it,
+  without a separate caption overlay
+- See **Record** instead of **Join & record** when Anarlog already detects the
+  meeting is in progress
 - Quit Completely from the tray or Dock confirmation without waiting for a
   background flush
 
@@ -25,6 +29,12 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
   instead of relying only on bundled downloads
 - Transcribe live with Google Gemini 3.5 Transcribe, then refine the recording
   with speaker labels and word timestamps using the same API key
+- Transcribe with AssemblyAI Universal 3.5 for live and batch, not the older
+  Universal 3 Pro IDs
+- See a Deprecated chip on superseded AssemblyAI, OpenAI, and Soniox models
+  that remain selectable
+- Transcribe meetings longer than about 23 minutes with GPT-4o Transcribe
+  Diarize instead of hitting OpenAI's length limit
 - Keep Mistral batch transcription speaker labels aligned with the words they
   belong to
 - Load ChatGPT subscription models from the current catalog instead of a
@@ -50,6 +60,11 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
 - Read a clear sync-failure message that your notes stay safe on this device,
   instead of a raw backend error
 
+## Calendars
+
+- Get Outlook meeting reminders and auto-start at the actual local time
+  instead of hours early in CEST and other UTC offsets
+
 ## Account and contacts
 
 - Find **Sign out** and **Sign out everywhere** on the Account tab, not under
@@ -64,6 +79,10 @@ summary: "Anarlog 1.4.14 keeps live meetings going through brief network drops, 
 
 ## Developers
 
+- Sign in to Anarlog Cloud MCP from Claude, Cursor, ChatGPT, or Copilot with
+  your Anarlog account instead of pasting an API key
+- Install one Anarlog plugin; Cloud is the default, and the local CLI fills in
+  meetings Cloud does not have
 - Propose a summary or memo replacement from the CLI or MCP, then apply or
   decline it in the desktop app
 


### PR DESCRIPTION
Cover Cloud MCP sign-in, Outlook reminder timing, AssemblyAI 3.5, long GPT-4o diarize, and floating-bar captions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or security impact.
> 
> **Overview**
> Updates the **1.4.14** changelog (`date` **2026-08-29**) and expands the front-matter **summary** to call out account-based MCP sign-in and Outlook reminder reliability.
> 
> **Meetings and recording** gains bullets for live captions in the expanded floating bar (no separate overlay) and showing **Record** when a meeting is already detected.
> 
> **Transcription and intelligence** documents AssemblyAI Universal 3.5 for live/batch, a **Deprecated** chip on older selectable models, and GPT-4o Transcribe Diarize for recordings past ~23 minutes.
> 
> A new **Calendars** section describes fixing Outlook reminders and auto-start firing at local time (e.g. CEST) instead of hours early.
> 
> **Developers** adds Cloud MCP sign-in via Anarlog account (replacing pasted API keys) and a single plugin model where Cloud is default and the local CLI backfills missing meetings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6221e47e3856946822f59bc4a270cbdb02088192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->