### PR TITLE
Fix ChatGPT subscription summaries rejected as Bad Request

### DIFF
--- a/apps/desktop/src/settings/ai/llm/health.test.ts
+++ b/apps/desktop/src/settings/ai/llm/health.test.ts
@@ -21,6 +21,15 @@ describe("llmHealthErrorMessage", () => {
     ).toBe("invalid_model");
   });
 
+  test("reads Codex FastAPI detail payloads", () => {
+    expect(
+      llmHealthErrorMessage({
+        message: "Bad Request",
+        data: { detail: "Unsupported parameter: max_output_tokens" },
+      }),
+    ).toBe("Unsupported parameter: max_output_tokens");
+  });
+
   test("falls back to the first useful error line", () => {
     expect(
       llmHealthErrorMessage({

--- a/apps/desktop/src/settings/ai/llm/health.tsx
+++ b/apps/desktop/src/settings/ai/llm/health.tsx
@@ -96,6 +96,9 @@ function apiErrorFromUnknown(value: unknown): string | undefined {
   if (typeof record.message === "string" && record.message.trim()) {
     return firstUsefulLine(record.message);
   }
+  if (typeof record.detail === "string" && record.detail.trim()) {
+    return firstUsefulLine(record.detail);
+  }
 
   const nested = record.error;
   if (typeof nested === "string" && nested.trim()) {

--- a/apps/desktop/src/settings/ai/llm/subscriptions/fetch.test.ts
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/fetch.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  tauriFetch: vi.fn(),
+  resolveSubscriptionAccess: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: mocks.tauriFetch,
+}));
+
+vi.mock("./access", () => ({
+  resolveSubscriptionAccess: mocks.resolveSubscriptionAccess,
+}));
+
+import { createSubscriptionFetch } from "./fetch";
+
+describe("createSubscriptionFetch chatgpt", () => {
+  beforeEach(() => {
+    mocks.tauriFetch.mockReset();
+    mocks.resolveSubscriptionAccess.mockReset();
+    mocks.tauriFetch.mockResolvedValue(new Response("ok"));
+    mocks.resolveSubscriptionAccess.mockResolvedValue({
+      token: chatgptJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "acct_workspace",
+          chatgpt_compute_residency: "us",
+        },
+      }),
+      credential: { accountId: "acct_workspace" },
+    });
+  });
+
+  test("rewrites Responses calls onto the Codex backend contract", async () => {
+    const fetchImpl = createSubscriptionFetch("chatgpt", "stored-credential");
+
+    await fetchImpl("https://api.openai.com/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "gpt-5.4",
+        max_output_tokens: 8192,
+      }),
+    });
+
+    expect(mocks.tauriFetch).toHaveBeenCalledWith(
+      "https://chatgpt.com/backend-api/codex/responses",
+      expect.objectContaining({
+        body: '{"model":"gpt-5.4","store":false,"stream":true}',
+        headers: expect.any(Headers),
+      }),
+    );
+
+    const headers = mocks.tauriFetch.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get("ChatGPT-Account-ID")).toBe("acct_workspace");
+    expect(headers.get("originator")).toBe("codex_cli_rs");
+    expect(headers.get("session_id")).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(headers.get("x-openai-internal-codex-residency")).toBe("us");
+  });
+});
+
+function chatgptJwt(payload: Record<string, unknown>): string {
+  const json = JSON.stringify(payload);
+  const body = btoa(json)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  return `eyJhbGciOiJub25lIn0.${body}.sig`;
+}

--- a/apps/desktop/src/settings/ai/llm/subscriptions/fetch.ts
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/fetch.ts
@@ -9,6 +9,7 @@ import {
   claudeMessagesUrl,
   COPILOT_REQUEST_HEADERS,
   parseChatgptAccountId,
+  parseChatgptResidency,
 } from "./oauth";
 
 export function createSubscriptionFetch(
@@ -48,6 +49,13 @@ export function createSubscriptionFetch(
       const accountId = credential?.accountId ?? parseChatgptAccountId(token);
       if (accountId) {
         headers.set("ChatGPT-Account-ID", accountId);
+      }
+      const residency = parseChatgptResidency(token);
+      if (residency) {
+        headers.set("x-openai-internal-codex-residency", residency);
+      }
+      if (!headers.has("session_id") && !headers.has("session-id")) {
+        headers.set("session_id", crypto.randomUUID());
       }
       const url = chatgptCodexUrl(requestUrl(input));
       const body = url.includes("/responses")

--- a/apps/desktop/src/settings/ai/llm/subscriptions/oauth.test.ts
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/oauth.test.ts
@@ -14,6 +14,7 @@ import {
   looksLikeAuthorizationInput,
   parseAuthorizationInput,
   parseChatgptAccountId,
+  parseChatgptResidency,
   subscriptionAuthFromCallback,
   usesSubscriptionFetch,
 } from "./oauth";
@@ -196,7 +197,29 @@ describe("subscription OAuth helpers", () => {
       "https://api.openai.com/auth": { chatgpt_account_id: "acct_workspace" },
     });
     expect(parseChatgptAccountId(token)).toBe("acct_workspace");
+    expect(
+      parseChatgptAccountId(chatgptJwt({ organizations: [{ id: "org_1" }] })),
+    ).toBe("org_1");
     expect(parseChatgptAccountId("sk-not-a-jwt")).toBeUndefined();
+  });
+
+  test("reads ChatGPT compute residency from token claims", () => {
+    expect(
+      parseChatgptResidency(
+        chatgptJwt({
+          "https://api.openai.com/auth": { chatgpt_compute_residency: "us" },
+        }),
+      ),
+    ).toBe("us");
+    expect(
+      parseChatgptResidency(
+        chatgptJwt({
+          "https://api.openai.com/auth": {
+            chatgpt_compute_residency: "no_constraint",
+          },
+        }),
+      ),
+    ).toBeUndefined();
   });
 
   test("rewrites platform OpenAI URLs onto the Codex backend", () => {
@@ -211,13 +234,18 @@ describe("subscription OAuth helpers", () => {
     ).toBe("https://chatgpt.com/backend-api/codex/responses");
   });
 
-  test("forces store=false on Codex Responses bodies", () => {
+  test("rewrites Codex Responses bodies to the ChatGPT backend contract", () => {
     expect(chatgptResponsesBody('{"model":"gpt-5.4","store":true}')).toBe(
-      '{"model":"gpt-5.4","store":false}',
+      '{"model":"gpt-5.4","store":false,"stream":true}',
     );
     expect(chatgptResponsesBody('{"model":"gpt-5.4"}')).toBe(
-      '{"model":"gpt-5.4","store":false}',
+      '{"model":"gpt-5.4","store":false,"stream":true}',
     );
+    expect(
+      chatgptResponsesBody(
+        '{"model":"gpt-5.4","store":false,"max_output_tokens":8192}',
+      ),
+    ).toBe('{"model":"gpt-5.4","store":false,"stream":true}');
   });
 });
 

--- a/apps/desktop/src/settings/ai/llm/subscriptions/oauth.ts
+++ b/apps/desktop/src/settings/ai/llm/subscriptions/oauth.ts
@@ -626,7 +626,51 @@ export function parseChatgptAccountId(jwt?: string): string | undefined {
   }
 
   const direct = payload.chatgpt_account_id;
-  return typeof direct === "string" && direct.length > 0 ? direct : undefined;
+  if (typeof direct === "string" && direct.length > 0) {
+    return direct;
+  }
+
+  const organizations = payload.organizations;
+  if (Array.isArray(organizations)) {
+    const first = organizations[0];
+    if (first && typeof first === "object") {
+      const id = (first as Record<string, unknown>).id;
+      if (typeof id === "string" && id.length > 0) {
+        return id;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function parseChatgptResidency(jwt?: string): string | undefined {
+  if (!jwt) {
+    return undefined;
+  }
+
+  const payload = decodeJwtPayload(jwt);
+  if (!payload) {
+    return undefined;
+  }
+
+  const auth = payload["https://api.openai.com/auth"];
+  const nested =
+    auth && typeof auth === "object"
+      ? (auth as Record<string, unknown>).chatgpt_compute_residency
+      : undefined;
+  const residency =
+    (typeof nested === "string" && nested.length > 0 ? nested : undefined) ??
+    (typeof payload.chatgpt_compute_residency === "string" &&
+    payload.chatgpt_compute_residency.length > 0
+      ? payload.chatgpt_compute_residency
+      : undefined);
+
+  if (!residency || residency === "no_constraint") {
+    return undefined;
+  }
+
+  return residency;
 }
 
 function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
@@ -665,10 +709,10 @@ export function chatgptResponsesBody(body: BodyInit | null | undefined) {
 
   try {
     const parsed = JSON.parse(body) as Record<string, unknown>;
-    if (parsed.store === false) {
-      return body;
-    }
-    return JSON.stringify({ ...parsed, store: false });
+    const { max_output_tokens: _omitted, ...rest } = parsed;
+    // Codex rejects platform Responses defaults: store must be false, stream
+    // must be true, and max_output_tokens is unsupported.
+    return JSON.stringify({ ...rest, store: false, stream: true });
   } catch {
     return body;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Summary generation fails with a generic `Bad Request` when Intelligence is a connected ChatGPT Plus/Pro subscription. The enhancer always sends `maxOutputTokens: 8192`, and `@ai-sdk/openai` forwards that as `max_output_tokens` with `store: true` — both rejected by `chatgpt.com/backend-api/codex/responses`.

**Fix:** Match OpenCode's ChatGPT subscription / Codex request contract on the fetch rewrite path:

- Force `store: false` and `stream: true`
- Drop unsupported `max_output_tokens`
- Send `session_id` plus compute-residency when the token carries it
- Surface Codex `{ "detail": "..." }` payloads in the settings health check instead of just "Bad Request"

**Other subscriptions:** This rewrite is ChatGPT-only. Claude, Grok, Copilot, and Kimi talk to their public APIs (`api.anthropic.com`, `api.x.ai`, `api.githubcopilot.com`, `api.kimi.com/coding`), which accept the SDK's normal `max_tokens` / Messages bodies. OpenCode's Claude/Grok/Copilot plugins only swap auth headers for those providers — they do not rewrite the request body. Applying the Codex `store`/`stream`/`max_output_tokens` contract there would be wrong.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/settings/ai/llm/`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test src/settings/ai/llm/subscriptions/oauth.test.ts src/settings/ai/llm/subscriptions/fetch.test.ts src/settings/ai/llm/health.test.ts`

Manual ChatGPT Plus/Pro summary generation was not run here (needs a live subscription). After merge, connect ChatGPT in Settings → Intelligence and retry Enhance on a note.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b6063ed-17b8-4d47-8785-828f73901154?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b6063ed-17b8-4d47-8785-828f73901154&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

