### PR TITLE
Add the 1.4.15 desktop changelog

### DIFF
--- a/packages/changelog/content/1.4.15.md
+++ b/packages/changelog/content/1.4.15.md
@@ -1,0 +1,11 @@
+---
+date: "2026-08-29"
+summary: "Anarlog 1.4.15 generates summaries and enhancements with a connected ChatGPT subscription instead of failing with Bad Request."
+---
+
+## Intelligence
+
+- Generate summaries and enhancements with a connected ChatGPT Plus or Pro
+  subscription instead of seeing a generic Bad Request
+- See the actual ChatGPT error in Intelligence settings when a request is
+  rejected, instead of only Bad Request


### PR DESCRIPTION
Cover the ChatGPT subscription summary fix for the next stable desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog entry with no runtime or security impact.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.15.md`** for the next stable desktop release, following the same frontmatter + section layout as prior versions (e.g. 1.4.14).
> 
> The **Intelligence** section documents user-facing fixes already slated for 1.4.15: summaries and enhancements work with a connected **ChatGPT Plus or Pro** subscription instead of a generic **Bad Request**, and rejected requests show the **real ChatGPT error** in Intelligence settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef650aba7b73e3f4a9feb4a58a97c1b0e5ee75b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->