### PR TITLE
Map expired Outlook Graph tokens to reconnect instead of 500

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "outlook-calendar",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
  "utoipa",
 ]
 

--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -39,6 +39,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "424": {
+            "description": "Calendar connection requires reconnect"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -79,6 +82,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "424": {
+            "description": "Calendar connection requires reconnect"
           },
           "500": {
             "description": "Internal server error"
@@ -121,6 +127,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "424": {
+            "description": "Calendar connection requires reconnect"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -161,6 +170,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "424": {
+            "description": "Calendar connection requires reconnect"
           },
           "500": {
             "description": "Internal server error"

--- a/crates/api-calendar/Cargo.toml
+++ b/crates/api-calendar/Cargo.toml
@@ -14,6 +14,7 @@ anlg-outlook-calendar = { workspace = true, features = ["utoipa"] }
 chrono = { workspace = true, features = ["serde"] }
 
 axum = { workspace = true }
+tracing = { workspace = true }
 utoipa = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }

--- a/crates/api-calendar/src/error.rs
+++ b/crates/api-calendar/src/error.rs
@@ -1,3 +1,4 @@
+use anlg_api_nango::{NangoConnectionError, NangoConnectionState, is_provider_auth_failure};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -5,6 +6,34 @@ use axum::{
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, CalendarError>;
+
+pub async fn map_provider_error(
+    nango_state: &NangoConnectionState,
+    integration_id: &str,
+    connection_id: &str,
+    err: impl std::fmt::Display,
+) -> CalendarError {
+    let message = err.to_string();
+    if !is_provider_auth_failure(&message) {
+        return CalendarError::Internal(message);
+    }
+
+    if let Err(mark_err) = nango_state
+        .mark_reconnect_required(integration_id, connection_id, &message)
+        .await
+    {
+        tracing::warn!(
+            error = %mark_err,
+            integration_id,
+            connection_id,
+            "failed to persist calendar reconnect_required"
+        );
+    }
+
+    CalendarError::NangoConnection(NangoConnectionError::ReconnectRequired(
+        integration_id.to_string(),
+    ))
+}
 
 #[derive(Debug, Error)]
 pub enum CalendarError {

--- a/crates/api-calendar/src/google/routes.rs
+++ b/crates/api-calendar/src/google/routes.rs
@@ -7,7 +7,7 @@ use axum::{Extension, Json};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
-use crate::error::{CalendarError, Result};
+use crate::error::{CalendarError, Result, map_provider_error};
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GoogleListCalendarsRequest {
@@ -40,6 +40,7 @@ pub struct GoogleListEventsRequest {
     responses(
         (status = 200, description = "Google calendars fetched", body = ListCalendarsResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 424, description = "Calendar connection requires reconnect"),
         (status = 500, description = "Internal server error"),
     ),
     tag = "calendar",
@@ -60,10 +61,18 @@ pub async fn list_calendars(
 
     let client = GoogleCalendarClient::new(http);
 
-    let response = client
-        .list_calendars()
-        .await
-        .map_err(|e| CalendarError::Internal(e.to_string()))?;
+    let response = match client.list_calendars().await {
+        Ok(response) => response,
+        Err(e) => {
+            return Err(map_provider_error(
+                &nango_state,
+                GoogleCalendar::ID,
+                &req.connection_id,
+                e,
+            )
+            .await);
+        }
+    };
 
     Ok(Json(response))
 }
@@ -76,6 +85,7 @@ pub async fn list_calendars(
     responses(
         (status = 200, description = "Google events fetched", body = ListEventsResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 424, description = "Calendar connection requires reconnect"),
         (status = 500, description = "Internal server error"),
     ),
     tag = "calendar",
@@ -140,10 +150,18 @@ pub async fn list_events(
         ..Default::default()
     };
 
-    let response = client
-        .list_events(google_req)
-        .await
-        .map_err(|e| CalendarError::Internal(e.to_string()))?;
+    let response = match client.list_events(google_req).await {
+        Ok(response) => response,
+        Err(e) => {
+            return Err(map_provider_error(
+                &nango_state,
+                GoogleCalendar::ID,
+                &req.connection_id,
+                e,
+            )
+            .await);
+        }
+    };
 
     Ok(Json(response))
 }

--- a/crates/api-calendar/src/outlook/routes.rs
+++ b/crates/api-calendar/src/outlook/routes.rs
@@ -5,7 +5,7 @@ use axum::{Extension, Json};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
-use crate::error::{CalendarError, Result};
+use crate::error::{CalendarError, Result, map_provider_error};
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct OutlookListCalendarsRequest {
@@ -34,6 +34,7 @@ pub struct OutlookListEventsRequest {
     responses(
         (status = 200, description = "Outlook calendars fetched", body = ListCalendarsResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 424, description = "Calendar connection requires reconnect"),
         (status = 500, description = "Internal server error"),
     ),
     tag = "calendar",
@@ -55,10 +56,12 @@ pub async fn list_calendars(
 
     let client = OutlookCalendarClient::new(http);
 
-    let response = client
-        .list_calendars()
-        .await
-        .map_err(|e| CalendarError::Internal(e.to_string()))?;
+    let response = match client.list_calendars().await {
+        Ok(response) => response,
+        Err(e) => {
+            return Err(map_provider_error(&nango_state, Outlook::ID, &req.connection_id, e).await);
+        }
+    };
 
     Ok(Json(response))
 }
@@ -71,6 +74,7 @@ pub async fn list_calendars(
     responses(
         (status = 200, description = "Outlook events fetched", body = ListEventsResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 424, description = "Calendar connection requires reconnect"),
         (status = 500, description = "Internal server error"),
     ),
     tag = "calendar",
@@ -127,10 +131,12 @@ pub async fn list_events(
         ..Default::default()
     };
 
-    let response = client
-        .list_events(outlook_req)
-        .await
-        .map_err(|e| CalendarError::Internal(e.to_string()))?;
+    let response = match client.list_events(outlook_req).await {
+        Ok(response) => response,
+        Err(e) => {
+            return Err(map_provider_error(&nango_state, Outlook::ID, &req.connection_id, e).await);
+        }
+    };
 
     Ok(Json(response))
 }

--- a/crates/api-nango/src/extractor.rs
+++ b/crates/api-nango/src/extractor.rs
@@ -9,6 +9,7 @@ use axum::{
 };
 
 use crate::integrations::NangoIntegrationId;
+use crate::supabase::SupabaseClient;
 
 #[derive(Clone)]
 pub struct NangoConnectionState {
@@ -16,6 +17,7 @@ pub struct NangoConnectionState {
     http_client: reqwest::Client,
     supabase_url: String,
     supabase_anon_key: String,
+    supabase: SupabaseClient,
 }
 
 impl NangoConnectionState {
@@ -24,18 +26,56 @@ impl NangoConnectionState {
         supabase_url: impl Into<String>,
         supabase_anon_key: impl Into<String>,
     ) -> Self {
-        Self {
-            nango,
-            http_client: reqwest::Client::new(),
-            supabase_url: supabase_url.into().trim_end_matches('/').to_string(),
-            supabase_anon_key: supabase_anon_key.into(),
-        }
+        Self::with_service_role(nango, supabase_url, supabase_anon_key, None)
     }
 
     pub fn from_config(config: &crate::config::NangoConfig) -> Self {
         let nango = crate::config::build_nango_client(config).expect("failed to build NangoClient");
 
-        Self::new(nango, &config.supabase_url, &config.supabase_anon_key)
+        Self::with_service_role(
+            nango,
+            &config.supabase_url,
+            &config.supabase_anon_key,
+            config.supabase_service_role_key.clone(),
+        )
+    }
+
+    fn with_service_role(
+        nango: NangoClient,
+        supabase_url: impl Into<String>,
+        supabase_anon_key: impl Into<String>,
+        supabase_service_role_key: Option<String>,
+    ) -> Self {
+        let supabase_url = supabase_url.into();
+        let supabase_anon_key = supabase_anon_key.into();
+        Self {
+            nango,
+            http_client: reqwest::Client::new(),
+            supabase_url: supabase_url.trim_end_matches('/').to_string(),
+            supabase_anon_key: supabase_anon_key.clone(),
+            supabase: SupabaseClient::new(
+                supabase_url,
+                supabase_anon_key,
+                supabase_service_role_key,
+            ),
+        }
+    }
+
+    pub async fn mark_reconnect_required(
+        &self,
+        integration_id: &str,
+        connection_id: &str,
+        error_description: &str,
+    ) -> Result<(), NangoConnectionError> {
+        self.supabase
+            .mark_connection_refresh_failed(
+                integration_id,
+                connection_id,
+                Some("provider_auth"),
+                Some(error_description),
+            )
+            .await
+            .map_err(|e| NangoConnectionError::Database(e.to_string()))
     }
 
     pub async fn build_http_client(
@@ -230,6 +270,15 @@ impl std::fmt::Display for NangoConnectionError {
 
 impl std::error::Error for NangoConnectionError {}
 
+pub fn is_provider_auth_failure(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("(401")
+        || lower.contains("invalidauthenticationtoken")
+        || lower.contains("token is expired")
+        || lower.contains("lifetime validation failed")
+        || lower.contains("invalid_grant")
+}
+
 impl<S: Send + Sync, I: NangoIntegrationId> FromRequestParts<S> for NangoConnection<I> {
     type Rejection = NangoConnectionError;
 
@@ -255,5 +304,54 @@ impl<S: Send + Sync, I: NangoIntegrationId> FromRequestParts<S> for NangoConnect
             http,
             _marker: PhantomData,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::NangoConfig;
+    use wiremock::matchers::{method, path_regex, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn detects_graph_expired_token() {
+        assert!(is_provider_auth_failure(
+            "HTTP status client error (401 Unauthorized) for url (https://api.nango.dev/proxy/me/calendars)"
+        ));
+        assert!(is_provider_auth_failure(
+            r#"{"error":{"code":"InvalidAuthenticationToken","message":"Lifetime validation failed, the token is expired."}}"#
+        ));
+        assert!(is_provider_auth_failure("invalid_grant"));
+        assert!(!is_provider_auth_failure(
+            "HTTP status server error (500 Internal Server Error) for url (https://api.nango.dev/proxy/me/calendars)"
+        ));
+        assert!(!is_provider_auth_failure(
+            "HTTP status client error (403 Forbidden) for url (https://api.nango.dev/proxy/me/calendars/AAMk)"
+        ));
+    }
+
+    #[tokio::test]
+    async fn mark_reconnect_required_patches_connection() {
+        let nango_mock = MockServer::start().await;
+        let supabase_mock = MockServer::start().await;
+        let config = NangoConfig::for_test(&nango_mock.uri(), &supabase_mock.uri());
+        let state = NangoConnectionState::from_config(&config);
+
+        Mock::given(method("PATCH"))
+            .and(path_regex("/rest/v1/nango_connections"))
+            .and(query_param("integration_id", "eq.outlook"))
+            .and(query_param("connection_id", "eq.conn-123"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&supabase_mock)
+            .await;
+
+        state
+            .mark_reconnect_required("outlook", "conn-123", "token is expired")
+            .await
+            .unwrap();
+
+        supabase_mock.verify().await;
     }
 }

--- a/crates/api-nango/src/integrations.rs
+++ b/crates/api-nango/src/integrations.rs
@@ -171,6 +171,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(scopes, OUTLOOK_OAUTH_SCOPES);
+        assert!(scopes.contains("offline_access"));
         assert!(scopes.contains("Calendars.Read"));
         assert!(!scopes.contains("Calendars.ReadWrite"));
     }

--- a/crates/api-nango/src/lib.rs
+++ b/crates/api-nango/src/lib.rs
@@ -8,7 +8,9 @@ mod state;
 mod supabase;
 
 pub use config::NangoConfig;
-pub use extractor::{NangoConnection, NangoConnectionError, NangoConnectionState};
+pub use extractor::{
+    NangoConnection, NangoConnectionError, NangoConnectionState, is_provider_auth_failure,
+};
 pub use integrations::{
     Discord, Fathom, GitHub, GoogleCalendar, GoogleDrive, GoogleMail, GoogleMeet, Linear,
     MicrosoftTeams, NangoIntegrationId, Notion, Outlook, Slack, Webex, Zoom,


### PR DESCRIPTION
## Summary

**Problem:** Outlook list-calendars/list-events mapped Graph 401s (expired tokens, no refresh) to CalendarError::Internal. That produced ~5k API 500s/day. Nango prod Outlook was also missing `offline_access`, so new connections died after ~1 hour and never got marked reconnect_required.

**Fix:** Detect Graph 401 / InvalidAuthenticationToken / expired-token failures, persist `reconnect_required`, and return 424 so the client prompts reconnect. Added `offline_access` on Nango prod Outlook so new connections can refresh. Existing connections still need a one-time reconnect.

## Verification

- `cargo test -p api-nango --lib`
- `cargo test -p api-calendar --lib`
- `cargo check -p api-calendar -p api`
- `cargo test -p api gen_openapi_json`
- Confirmed Nango prod Outlook scopes now include `offline_access`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes calendar error handling and writes connection state to Supabase on auth failures, which affects client-visible status codes and integration reconnect flows.
> 
> **Overview**
> Calendar Google/Outlook list endpoints no longer treat expired or invalid provider tokens as generic **500** errors. Provider failures are classified with **`is_provider_auth_failure`**, **`mark_reconnect_required`** updates the Nango connection in Supabase (`provider_auth`), and clients get **424** (`reconnect_required`) instead of an internal error.
> 
> **`NangoConnectionState`** now builds a **`SupabaseClient`** (including optional service role from config) and exposes **`mark_reconnect_required`** for that persistence path. OpenAPI and utoipa docs for all four calendar routes document the new **424** response. Tests cover auth-failure heuristics and the Supabase PATCH on reconnect marking; Outlook integration tests assert **`offline_access`** is in the configured OAuth scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d379e3599c33f28e82ebbf5c96f2a3499d7c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->