### PR TITLE
Keep the desktop update toast visible through download and install

### DIFF
--- a/apps/desktop/src/main/update-banner.test.tsx
+++ b/apps/desktop/src/main/update-banner.test.tsx
@@ -264,6 +264,38 @@ describe("useDesktopUpdateControl", () => {
     expect(screen.getByTestId("status").textContent).toBe("ready");
   });
 
+  it("keeps ready after late download events for the same version", async () => {
+    renderUpdateControl();
+
+    await waitFor(() =>
+      expect(eventHandlers.updateReady).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      eventHandlers.updateReady?.({ payload: { version: "1.0.34" } });
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("ready");
+
+    act(() => {
+      eventHandlers.updateDownloading?.({ payload: { version: "1.0.34" } });
+      eventHandlers.updateDownloadProgress?.({
+        payload: {
+          version: "1.0.34",
+          chunk_length: 10,
+          content_length: 100,
+        },
+      });
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("ready");
+    fireEvent.click(screen.getByRole("button", { name: "install" }));
+
+    await waitFor(() => {
+      expect(installAndRelaunchMock).toHaveBeenCalledWith("1.0.34");
+    });
+  });
+
   it("tracks download progress from updater events", async () => {
     renderUpdateControl();
 
@@ -442,6 +474,21 @@ describe("resolveUpdateState", () => {
         null,
       ),
     ).toEqual({ kind: "available", version: "1.0.34" });
+  });
+
+  it("upgrades a finished download to ready when the check says downloaded", () => {
+    expect(
+      resolveUpdateState(
+        {
+          kind: "downloading",
+          version: "1.0.34",
+          downloadedBytes: 100,
+          contentLength: 100,
+        },
+        { version: "1.0.34", ready: true },
+        null,
+      ),
+    ).toEqual({ kind: "ready", version: "1.0.34" });
   });
 
   it("keeps event precedence over the check for active and failed states", () => {

--- a/apps/desktop/src/main/update-banner.tsx
+++ b/apps/desktop/src/main/update-banner.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 
 import {
@@ -50,6 +50,13 @@ type UpdateCheckState = {
   ready: boolean;
 } | null;
 
+function isFinishedUpdate(event: UpdateEvent | null, version: string) {
+  return (
+    event?.version === version &&
+    (event.kind === "ready" || event.kind === "failed")
+  );
+}
+
 export function resolveUpdateState(
   event: UpdateEvent | null,
   check: UpdateCheckState,
@@ -59,7 +66,7 @@ export function resolveUpdateState(
 
   if (event) {
     if (
-      event.kind === "available" &&
+      (event.kind === "available" || event.kind === "downloading") &&
       checked?.version === event.version &&
       checked.ready
     ) {
@@ -92,6 +99,7 @@ const DISABLED_UPDATE_CONTROL: DesktopUpdateControl = {
 
 export function useDesktopUpdateControl(): DesktopUpdateControl {
   const updaterEnabled = !isAppStoreBuild();
+  const queryClient = useQueryClient();
   const [eventState, setEventState] = useState<UpdateEvent | null>(null);
   const [acknowledgedVersion, setAcknowledgedVersion] = useState<string | null>(
     null,
@@ -129,15 +137,23 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
           );
         }),
         updaterEvents.updateDownloadingEvent.listen(({ payload }) => {
-          setEventState({
-            kind: "downloading",
-            version: payload.version,
-            downloadedBytes: 0,
-            contentLength: null,
-          });
+          setEventState((current) =>
+            isFinishedUpdate(current, payload.version)
+              ? current
+              : {
+                  kind: "downloading",
+                  version: payload.version,
+                  downloadedBytes: 0,
+                  contentLength: null,
+                },
+          );
         }),
         updaterEvents.updateDownloadProgressEvent.listen(({ payload }) => {
           setEventState((current) => {
+            if (isFinishedUpdate(current, payload.version)) {
+              return current;
+            }
+
             const downloadedBytes =
               current?.kind === "downloading" &&
               current.version === payload.version
@@ -249,6 +265,13 @@ export function useDesktopUpdateControl(): DesktopUpdateControl {
     onSuccess: (_data, version) => {
       setEventState((current) =>
         current?.kind === "ready" ? current : { kind: "ready", version },
+      );
+      queryClient.setQueryData<UpdateCheckState>(
+        UPDATE_CHECK_QUERY_KEY,
+        (current) =>
+          !current || current.version === version
+            ? { version, ready: true }
+            : current,
       );
     },
   });

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -290,6 +290,36 @@ describe("ToastNotifications", () => {
     );
   });
 
+  it("updates download progress without dismissing the toast", () => {
+    mocks.update.status = "downloading";
+    mocks.update.version = "1.0.34";
+    mocks.update.progress = 0.1;
+
+    const view = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(mocks.loading).toHaveBeenCalledWith(
+      "Downloading Anarlog 1.0.34 (10%)",
+      expect.objectContaining({
+        id: "desktop-update:1.0.34:downloading",
+        duration: Infinity,
+      }),
+    );
+
+    mocks.loading.mockClear();
+    mocks.dismiss.mockClear();
+    mocks.update.progress = 0.58;
+    view.rerender(<ToastNotifications />);
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+    expect(mocks.loading).toHaveBeenCalledWith(
+      "Downloading Anarlog 1.0.34 (58%)",
+      expect.objectContaining({
+        id: "desktop-update:1.0.34:downloading",
+      }),
+    );
+  });
+
   it("uses the latest registry action while a toast remains visible", () => {
     mocks.dismissedToastIds.add("auth-promotion");
     mocks.config.current_llm_provider = null;

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -290,6 +290,37 @@ describe("ToastNotifications", () => {
     );
   });
 
+  it("offers Restart after the download finishes", () => {
+    mocks.update.status = "downloading";
+    mocks.update.version = "1.0.34";
+    mocks.update.progress = 1;
+    mocks.update.downloadStarting = true;
+
+    const view = render(<ToastNotifications />);
+    act(() => vi.advanceTimersByTime(500));
+
+    mocks.loading.mockClear();
+    mocks.dismiss.mockClear();
+    mocks.message.mockClear();
+    mocks.update.status = "ready";
+    mocks.update.progress = null;
+    mocks.update.downloadStarting = true;
+    view.rerender(<ToastNotifications />);
+
+    expect(mocks.message).toHaveBeenCalledWith(
+      "Anarlog 1.0.34 is ready to install",
+      expect.objectContaining({
+        id: "desktop-update:1.0.34:ready",
+        action: expect.objectContaining({ label: "Restart" }),
+      }),
+    );
+
+    const options =
+      mocks.message.mock.calls[mocks.message.mock.calls.length - 1][1];
+    options.action.onClick();
+    expect(mocks.update.installUpdate).toHaveBeenCalledOnce();
+  });
+
   it("updates download progress without dismissing the toast", () => {
     mocks.update.status = "downloading";
     mocks.update.version = "1.0.34";

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { sonnerToast, TOAST_DURATIONS } from "@anlg/ui/components/ui/toast";
 
@@ -273,14 +273,10 @@ export function ToastNotifications() {
     return null;
   }
 
-  const descriptionKey =
-    typeof displayToast.description === "string"
-      ? displayToast.description
-      : displayToast.id;
   const previewKey =
     devtoolsPreview && devtoolsToast
       ? `${devtoolsToast.id}:${devtoolsPreview.key}`
-      : `${displayToast.id}:${descriptionKey}`;
+      : displayToast.id;
 
   return (
     <SonnerNotification
@@ -293,6 +289,58 @@ export function ToastNotifications() {
   );
 }
 
+function toastPresentation(toast: ToastType) {
+  const description =
+    typeof toast.description === "string" ? toast.description : toast.id;
+  return [
+    toast.id,
+    description,
+    toast.variant ?? "default",
+    toast.loading ? "loading" : "idle",
+    toast.primaryAction?.label ?? "",
+  ].join(":");
+}
+
+function showSonnerNotification(
+  toast: ToastType,
+  toastRef: { current: ToastType },
+  onDismissRef: { current?: () => void },
+  dismissal: { persist: boolean },
+) {
+  const dismissible = toast.lifecycle.type === "persistent";
+  const options = {
+    id: toast.id,
+    duration: toast.variant === "error" ? TOAST_DURATIONS.error : Infinity,
+    closeButton: dismissible,
+    dismissible,
+    icon: toast.icon,
+    action: toast.primaryAction
+      ? {
+          label: toast.primaryAction.label,
+          onClick: () => {
+            dismissal.persist = false;
+            void toastRef.current.primaryAction?.onClick();
+          },
+        }
+      : undefined,
+    onDismiss: () => {
+      if (dismissal.persist) {
+        onDismissRef.current?.();
+      }
+    },
+  };
+
+  if (toast.loading) {
+    sonnerToast.loading(toast.description, options);
+  } else if (toast.variant === "error") {
+    sonnerToast.error(toast.description, options);
+  } else if (toast.variant === "warning") {
+    sonnerToast.warning(toast.description, options);
+  } else {
+    sonnerToast.message(toast.description, options);
+  }
+}
+
 function SonnerNotification({
   toast,
   onDismiss,
@@ -302,44 +350,25 @@ function SonnerNotification({
 }) {
   const toastRef = useLatestRef(toast);
   const onDismissRef = useLatestRef(onDismiss);
+  const dismissalRef = useRef({ persist: true });
+  const shownPresentationRef = useRef<string | null>(null);
+  const presentation = toastPresentation(toast);
+
+  if (
+    shownPresentationRef.current !== null &&
+    shownPresentationRef.current !== presentation
+  ) {
+    shownPresentationRef.current = presentation;
+    showSonnerNotification(toast, toastRef, onDismissRef, dismissalRef.current);
+  }
 
   useMountEffect(() => {
-    let shouldPersistDismissal = true;
-    const dismissible = toast.lifecycle.type === "persistent";
-    const options = {
-      id: toast.id,
-      duration: toast.variant === "error" ? TOAST_DURATIONS.error : Infinity,
-      closeButton: dismissible,
-      dismissible,
-      icon: toast.icon,
-      action: toast.primaryAction
-        ? {
-            label: toast.primaryAction.label,
-            onClick: () => {
-              shouldPersistDismissal = false;
-              void toastRef.current.primaryAction?.onClick();
-            },
-          }
-        : undefined,
-      onDismiss: () => {
-        if (shouldPersistDismissal) {
-          onDismissRef.current?.();
-        }
-      },
-    };
-
-    if (toast.loading) {
-      sonnerToast.loading(toast.description, options);
-    } else if (toast.variant === "error") {
-      sonnerToast.error(toast.description, options);
-    } else if (toast.variant === "warning") {
-      sonnerToast.warning(toast.description, options);
-    } else {
-      sonnerToast.message(toast.description, options);
-    }
+    dismissalRef.current.persist = true;
+    shownPresentationRef.current = toastPresentation(toast);
+    showSonnerNotification(toast, toastRef, onDismissRef, dismissalRef.current);
 
     return () => {
-      shouldPersistDismissal = false;
+      dismissalRef.current.persist = false;
       sonnerToast.dismiss(toast.id);
     };
   });

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -306,6 +306,32 @@ describe("sidebar toast registry", () => {
     expect(toast?.loading).toBeUndefined();
   });
 
+  it("keeps Restart available after the download finishes even if the mutation is still settling", () => {
+    const installUpdate = vi.fn();
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        update: {
+          ...baseParams.update,
+          status: "ready",
+          version: "1.0.34",
+          downloadStarting: true,
+          installUpdate,
+        },
+      }),
+      () => false,
+    );
+
+    expect(toast).toMatchObject({
+      id: "desktop-update:1.0.34:ready",
+      description: "Anarlog 1.0.34 is ready to install",
+      primaryAction: { label: "Restart" },
+    });
+
+    toast?.primaryAction?.onClick();
+    expect(installUpdate).toHaveBeenCalledOnce();
+  });
+
   it("creates devtools previews with app toast content", () => {
     const languageModelToast = createDevtoolsToastPreview({
       preview: "language-model",

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -222,7 +222,7 @@ export function createDesktopUpdateToast(
       // this update was downloading.
       id: `${id}:ready`,
       description: t`Anarlog ${update.version} is ready to install`,
-      primaryAction: busy
+      primaryAction: update.installing
         ? undefined
         : { label: t`Restart`, onClick: update.installUpdate },
       lifecycle: { type: "persistent", dismissal: "session" },


### PR DESCRIPTION
## Summary

**Problem:** The desktop update toast remounted on every progress tick, then after the download finished it dropped back to “available / Download” with no working Restart action.

**Fix:** Keep one Sonner toast for the in-progress download and update its copy in place. Once the update is ready, ignore leftover download events and keep Restart visible so install can proceed.

## Verification

- `pnpm -F desktop exec vitest run src/main/update-banner.test.tsx src/sidebar/toast/index.test.tsx src/sidebar/toast/registry.test.tsx`
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/main/update-banner.tsx apps/desktop/src/sidebar/toast/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to desktop update UI and local updater event ordering; no auth, data, or network contract changes beyond cache sync after download.
> 
> **Overview**
> Fixes desktop OTA UX where the update toast **remounted on every progress tick** and could **revert to “Download”** (with **Restart** missing) after the package was ready.
> 
> **Updater state (`update-banner`):** Late `downloading` / progress events for the same version no longer overwrite **ready** or **failed**. `resolveUpdateState` can promote an in-flight **downloading** event to **ready** when the periodic check reports the build is already downloaded. Successful download mutations also mark the update-check query as `ready: true`.
> 
> **Toasts:** `SonnerNotification` compares a presentation fingerprint and **updates the same Sonner toast in place** (e.g. percent text) instead of dismissing/remounting. The ready-update registry entry keeps **Restart** visible while `downloadStarting` is still true—only **installing** hides the action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d88fb92b36633682904628ede494a89c98e8ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->