### PR TITLE
Keep Nango error bodies so expired Outlook tokens reconnect

### DIFF
--- a/crates/api-calendar/src/google/routes.rs
+++ b/crates/api-calendar/src/google/routes.rs
@@ -57,7 +57,8 @@ pub async fn list_calendars(
             GoogleCalendar::ID,
             &req.connection_id,
         )
-        .await?;
+        .await?
+        .with_retries(0);
 
     let client = GoogleCalendarClient::new(http);
 
@@ -102,7 +103,8 @@ pub async fn list_events(
             GoogleCalendar::ID,
             &req.connection_id,
         )
-        .await?;
+        .await?
+        .with_retries(0);
 
     let client = GoogleCalendarClient::new(http);
 

--- a/crates/api-calendar/src/outlook/routes.rs
+++ b/crates/api-calendar/src/outlook/routes.rs
@@ -52,6 +52,7 @@ pub async fn list_calendars(
             &req.connection_id,
         )
         .await?
+        .with_retries(0)
         .with_base_url_override("https://graph.microsoft.com/v1.0");
 
     let client = OutlookCalendarClient::new(http);
@@ -92,6 +93,7 @@ pub async fn list_events(
             &req.connection_id,
         )
         .await?
+        .with_retries(0)
         .with_base_url_override("https://graph.microsoft.com/v1.0");
 
     let client = OutlookCalendarClient::new(http);

--- a/crates/api-nango/src/extractor.rs
+++ b/crates/api-nango/src/extractor.rs
@@ -273,10 +273,14 @@ impl std::error::Error for NangoConnectionError {}
 pub fn is_provider_auth_failure(message: &str) -> bool {
     let lower = message.to_lowercase();
     lower.contains("(401")
+        || lower.contains("status 401")
         || lower.contains("invalidauthenticationtoken")
+        || lower.contains("invalid_credentials")
         || lower.contains("token is expired")
         || lower.contains("lifetime validation failed")
         || lower.contains("invalid_grant")
+        || lower.contains("could not refresh")
+        || lower.contains("refresh access token")
 }
 
 impl<S: Send + Sync, I: NangoIntegrationId> FromRequestParts<S> for NangoConnection<I> {
@@ -323,8 +327,17 @@ mod tests {
             r#"{"error":{"code":"InvalidAuthenticationToken","message":"Lifetime validation failed, the token is expired."}}"#
         ));
         assert!(is_provider_auth_failure("invalid_grant"));
+        assert!(is_provider_auth_failure(
+            r#"API error (status 500): {"error":{"code":"InvalidAuthenticationToken","message":"Lifetime validation failed, the token is expired."}}"#
+        ));
+        assert!(is_provider_auth_failure(
+            r#"API error (status 500): {"error":{"code":"invalid_credentials","message":"Could not refresh access token for connection"}}"#
+        ));
         assert!(!is_provider_auth_failure(
             "HTTP status server error (500 Internal Server Error) for url (https://api.nango.dev/proxy/me/calendars)"
+        ));
+        assert!(!is_provider_auth_failure(
+            "API error (status 500): Internal Server Error"
         ));
         assert!(!is_provider_auth_failure(
             "HTTP status client error (403 Forbidden) for url (https://api.nango.dev/proxy/me/calendars/AAMk)"

--- a/crates/nango/src/client.rs
+++ b/crates/nango/src/client.rs
@@ -74,6 +74,17 @@ pub(crate) async fn check_response(
     }
 }
 
+pub(crate) async fn response_bytes(response: reqwest::Response) -> Result<Vec<u8>, crate::Error> {
+    let status = response.status();
+    let bytes = response.bytes().await?;
+    if status.is_success() {
+        Ok(bytes.to_vec())
+    } else {
+        let body = String::from_utf8_lossy(&bytes).into_owned();
+        Err(crate::Error::Api(status.as_u16(), body))
+    }
+}
+
 pub(crate) async fn parse_response<T: DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T, crate::Error> {

--- a/crates/nango/src/error.rs
+++ b/crates/nango/src/error.rs
@@ -26,3 +26,21 @@ impl Serialize for Error {
         serializer.serialize_str(self.to_string().as_ref())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn api_error_keeps_status_and_body() {
+        let err = Error::Api(
+            500,
+            r#"{"error":{"code":"InvalidAuthenticationToken","message":"the token is expired."}}"#
+                .to_string(),
+        );
+        let message = err.to_string();
+        assert!(message.contains("status 500"));
+        assert!(message.contains("InvalidAuthenticationToken"));
+        assert!(message.contains("the token is expired"));
+    }
+}

--- a/crates/nango/src/http.rs
+++ b/crates/nango/src/http.rs
@@ -10,11 +10,16 @@ impl<'a> NangoHttpClient<'a> {
     }
 }
 
+async fn proxy_bytes(
+    response: reqwest::Response,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    Ok(crate::client::response_bytes(response).await?)
+}
+
 impl<'a> anlg_http::HttpClient for NangoHttpClient<'a> {
     async fn get(&self, path: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.proxy.get(path)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn post(
@@ -24,8 +29,7 @@ impl<'a> anlg_http::HttpClient for NangoHttpClient<'a> {
         content_type: &str,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.proxy.post(path, body, content_type)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn put(
@@ -35,8 +39,7 @@ impl<'a> anlg_http::HttpClient for NangoHttpClient<'a> {
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let json_value: serde_json::Value = serde_json::from_slice(&body)?;
         let response = self.proxy.put(path, &json_value)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn patch(
@@ -46,8 +49,7 @@ impl<'a> anlg_http::HttpClient for NangoHttpClient<'a> {
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let json_value: serde_json::Value = serde_json::from_slice(&body)?;
         let response = self.proxy.patch(path, &json_value)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn delete(
@@ -55,8 +57,7 @@ impl<'a> anlg_http::HttpClient for NangoHttpClient<'a> {
         path: &str,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.proxy.delete(path)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 }
 
@@ -85,8 +86,7 @@ impl OwnedNangoHttpClient {
 impl anlg_http::HttpClient for OwnedNangoHttpClient {
     async fn get(&self, path: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.proxy.get(path)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn post(
@@ -96,8 +96,7 @@ impl anlg_http::HttpClient for OwnedNangoHttpClient {
         content_type: &str,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.proxy.post(path, body, content_type)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn put(
@@ -107,8 +106,7 @@ impl anlg_http::HttpClient for OwnedNangoHttpClient {
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let json_value: serde_json::Value = serde_json::from_slice(&body)?;
         let response = self.proxy.put(path, &json_value)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn patch(
@@ -118,8 +116,7 @@ impl anlg_http::HttpClient for OwnedNangoHttpClient {
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let json_value: serde_json::Value = serde_json::from_slice(&body)?;
         let response = self.proxy.patch(path, &json_value)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 
     async fn delete(
@@ -127,7 +124,6 @@ impl anlg_http::HttpClient for OwnedNangoHttpClient {
         path: &str,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         let response = self.proxy.delete(path)?.send().await?;
-        let bytes = response.error_for_status()?.bytes().await?;
-        Ok(bytes.to_vec())
+        proxy_bytes(response).await
     }
 }

--- a/crates/nango/src/http.rs
+++ b/crates/nango/src/http.rs
@@ -71,6 +71,11 @@ impl OwnedNangoHttpClient {
         Self { proxy }
     }
 
+    pub fn with_retries(mut self, retries: u32) -> Self {
+        self.proxy = self.proxy.retries(retries);
+        self
+    }
+
     pub fn with_base_url_override(mut self, base_url: impl Into<String>) -> Self {
         self.proxy = self.proxy.base_url_override(base_url);
         self

--- a/crates/nango/src/proxy.rs
+++ b/crates/nango/src/proxy.rs
@@ -149,6 +149,11 @@ impl OwnedNangoProxy {
         }
     }
 
+    pub fn retries(mut self, retries: u32) -> Self {
+        self.retries = Some(retries);
+        self
+    }
+
     pub fn base_url_override(mut self, base_url: impl Into<String>) -> Self {
         self.base_url_override = Some(base_url.into());
         self


### PR DESCRIPTION
## Summary

**Problem:** 0.0.78 still returned 500 on Outlook list-events (~21s). Nango exhausts 401 retries and responds 500; `error_for_status` discarded the body, so we never saw `InvalidAuthenticationToken` / `invalid_credentials` and never marked reconnect.

**Fix:** Proxy errors now include status + body. Auth detection also matches Nango refresh failures (`invalid_credentials`, could not refresh). Generic 500s stay 500s.

## Verification

- `cargo test -p nango --lib`
- `cargo test -p api-nango --lib detects_graph_expired_token`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Nango proxy error handling and calendar auth-failure detection for all Google/Outlook list routes; misclassification could wrongly trigger reconnect or still return 500, but scope is limited to integration HTTP clients with added tests.
> 
> **Overview**
> Fixes calendar list endpoints returning slow **500** responses instead of **424 reconnect** when Nango/Graph auth fails after retries.
> 
> **Nango HTTP layer:** Proxy responses no longer use `error_for_status()`, which dropped error bodies. Failed responses are read via `response_bytes` and surfaced as `Error::Api(status, body)` so downstream code can inspect provider/Nango payloads (including **500** responses that still carry auth JSON).
> 
> **Auth classification:** `is_provider_auth_failure` now matches additional message shapes (`status 401`, `invalid_credentials`, refresh-token failures) so `map_provider_error` can mark connections reconnect-required instead of treating them as generic internal errors.
> 
> **Calendar routes:** Google and Outlook list-calendars/list-events HTTP clients call **`with_retries(0)`** to avoid long Nango retry loops on bad tokens (~21s) while still benefiting from preserved error bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b91f2bd140d29f76829127ec242e9a784fc1b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->