### PR TITLE
Split footer links into Resources

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -9,6 +9,11 @@ const footerGroups = [
     links: [
       { label: "Download", to: "/download/" },
       { label: "Enterprise", to: "/enterprise/" },
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
       { label: "Blog", to: "/blog/" },
       { label: "Changelog", to: "/changelog/" },
       { label: "Docs", href: "https://docs.anarlog.so" },
@@ -71,7 +76,7 @@ export function SiteFooter() {
           </Link>
         )}
       </div>
-      <nav className="grid grid-cols-2 gap-x-12 gap-y-8 sm:grid-cols-3 sm:gap-x-16">
+      <nav className="grid grid-cols-2 gap-x-12 gap-y-8 sm:grid-cols-4 sm:gap-x-12">
         {footerGroups.map((group) => (
           <div key={group.title} className="flex flex-col gap-2.5">
             <span className="tracking-[0.04em] text-[#756b5d]">


### PR DESCRIPTION
- keep Download and Enterprise under Product
- move Blog, Changelog, Docs, and Status into Resources
- use four footer columns on desktop while retaining two on mobile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer link grouping and layout only; no auth, data, or API changes.
> 
> **Overview**
> Reorganizes **site footer** navigation by splitting what was a crowded **Product** column into **Product** (Download, Enterprise) and a new **Resources** column (Blog, Changelog, Docs, Status).
> 
> On `sm` breakpoints and up, the footer link grid goes from **three** to **four** columns (`sm:grid-cols-4`) with slightly tighter horizontal gap so all four groups (Product, Resources, Community, Legal) align on desktop; mobile stays at two columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cce4ea26eb13df1b77c3d04bc03eac65fa0b4fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->