### PR TITLE
Make /enterprise a forwardable security-review page

### DIFF
--- a/apps/web/src/components/book-founder-call.tsx
+++ b/apps/web/src/components/book-founder-call.tsx
@@ -1,0 +1,35 @@
+import { useAnalytics } from "@/hooks/use-posthog";
+import {
+  BOOK_CALL_URL,
+  ENTERPRISE_EVENTS,
+  type EnterpriseCtaLocation,
+  type EnterpriseSurface,
+} from "@/lib/enterprise";
+
+export function BookFounderCall({
+  location,
+  page,
+}: {
+  location: EnterpriseCtaLocation;
+  page: EnterpriseSurface;
+}) {
+  const { track } = useAnalytics();
+
+  return (
+    <a
+      href={BOOK_CALL_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() =>
+        track(ENTERPRISE_EVENTS.ctaClicked, {
+          cta: "book_call",
+          location,
+          page,
+        })
+      }
+      className="inline-flex h-11 items-center justify-center rounded-full bg-[#181613] px-6 text-sm font-medium text-white transition-all hover:scale-[102%] hover:bg-[#4f4940] active:scale-[98%]"
+    >
+      Book a call with the founder
+    </a>
+  );
+}

--- a/apps/web/src/components/enterprise-callout.tsx
+++ b/apps/web/src/components/enterprise-callout.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 
 const heading = "Rolling Anarlog out to a team?";
 const body =
-  "Workspace admin, SSO, and a self-hosted server for regulated environments — shaped with early partners.";
+  "Forward the enterprise page to IT: encryption, retention, training, and subprocessors, then a founder-led pilot.";
 const ctaClassName =
   "inline-flex h-11 shrink-0 items-center justify-center rounded-full bg-[#181613] px-6 text-sm font-medium text-white transition-all hover:scale-[102%] hover:bg-[#4f4940] active:scale-[98%]";
 

--- a/apps/web/src/components/enterprise-cta-link.tsx
+++ b/apps/web/src/components/enterprise-cta-link.tsx
@@ -1,0 +1,59 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+import { cn } from "@anlg/utils";
+
+import { useAnalytics } from "@/hooks/use-posthog";
+import {
+  ENTERPRISE_EVENTS,
+  type EnterpriseCta,
+  type EnterpriseCtaLocation,
+  type EnterpriseSurface,
+} from "@/lib/enterprise";
+
+export function EnterpriseCtaLink({
+  to,
+  href,
+  cta,
+  location,
+  page,
+  children,
+  className,
+}: {
+  to?: "/security/" | "/privacy/" | "/terms/" | "/pricing/" | "/enterprise/";
+  href?: string;
+  cta: EnterpriseCta;
+  location: EnterpriseCtaLocation;
+  page: EnterpriseSurface;
+  children: ReactNode;
+  className?: string;
+}) {
+  const { track } = useAnalytics();
+  const classes = cn([
+    "text-sm text-[#756b5d] underline decoration-[#d9cdb8] underline-offset-4 transition-colors hover:text-[#181613]",
+    className,
+  ]);
+  const onClick = () =>
+    track(ENTERPRISE_EVENTS.ctaClicked, { cta, location, page });
+
+  if (to) {
+    return (
+      <Link to={to} onClick={onClick} className={classes}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      onClick={onClick}
+      className={classes}
+      {...(href?.startsWith("http")
+        ? { target: "_blank", rel: "noopener noreferrer" }
+        : {})}
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/web/src/components/pilot-path.tsx
+++ b/apps/web/src/components/pilot-path.tsx
@@ -1,0 +1,21 @@
+import { pilotSteps } from "@/lib/trust-center";
+
+export function PilotPath() {
+  return (
+    <ol className="mx-auto mt-8 flex max-w-2xl flex-col gap-6 text-left">
+      {pilotSteps.map((step, index) => (
+        <li key={step.title} className="flex gap-4">
+          <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#181613] text-xs font-medium text-white">
+            {index + 1}
+          </span>
+          <div>
+            <h3 className="text-base font-medium text-[#181613]">
+              {step.title}
+            </h3>
+            <p className="mt-1 text-sm leading-6 text-[#4f4940]">{step.body}</p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/web/src/components/security-review-list.tsx
+++ b/apps/web/src/components/security-review-list.tsx
@@ -1,0 +1,18 @@
+import { securityReviewAnswers } from "@/lib/trust-center";
+
+export function SecurityReviewList({ detail = false }: { detail?: boolean }) {
+  return (
+    <dl className="mx-auto mt-8 max-w-2xl divide-y divide-[#eadfce] text-left">
+      {securityReviewAnswers.map((item) => (
+        <div key={item.question} className="py-5 first:pt-0 last:pb-0">
+          <dt className="text-base font-medium text-[#181613]">
+            {item.question}
+          </dt>
+          <dd className="mt-2 text-sm leading-6 text-[#4f4940]">
+            {detail ? item.detail : item.summary}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -32,6 +32,7 @@ const footerGroups = [
   {
     title: "Legal",
     links: [
+      { label: "Security", to: "/security/" },
       { label: "Privacy", to: "/privacy/" },
       { label: "Terms", to: "/terms/" },
     ],

--- a/apps/web/src/lib/enterprise.ts
+++ b/apps/web/src/lib/enterprise.ts
@@ -12,7 +12,7 @@ export const ENTERPRISE_EVENTS = {
 
 export type EnterpriseCta =
   | "book_call"
-  | "trust_center"
+  | "security"
   | "enterprise"
   | "privacy"
   | "terms"

--- a/apps/web/src/lib/enterprise.ts
+++ b/apps/web/src/lib/enterprise.ts
@@ -1,1 +1,32 @@
 export const BOOK_CALL_URL = "https://cal.com/team/fastrepl/hi";
+export const SECURITY_REPORT_EMAIL = "founders@fastrepl.com";
+export const SECURITY_ADVISORY_URL =
+  "https://github.com/fastrepl/anarlog/security/advisories/new";
+export const PROCUREMENT_EMAIL = "founders@anarlog.so";
+
+export const ENTERPRISE_EVENTS = {
+  pageViewed: "enterprise_page_viewed",
+  securityPageViewed: "security_page_viewed",
+  ctaClicked: "enterprise_cta_clicked",
+} as const;
+
+export type EnterpriseCta =
+  | "book_call"
+  | "trust_center"
+  | "enterprise"
+  | "privacy"
+  | "terms"
+  | "pricing"
+  | "docs"
+  | "dpa"
+  | "security_report";
+
+export type EnterpriseCtaLocation =
+  | "hero"
+  | "security_review"
+  | "pilot"
+  | "talk"
+  | "footer"
+  | "packet";
+
+export type EnterpriseSurface = "enterprise" | "security";

--- a/apps/web/src/lib/trust-center.test.ts
+++ b/apps/web/src/lib/trust-center.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ENTERPRISE_EVENTS } from "./enterprise.ts";
+import {
+  architectureLayers,
+  certificationStatus,
+  contractualDocs,
+  pilotSteps,
+  proofStatus,
+  securityReviewAnswers,
+  shipsToday,
+  shipsWithPartners,
+  subprocessors,
+} from "./trust-center.ts";
+
+test("answers the security-review questions buyers forward to IT", () => {
+  const questions = securityReviewAnswers.map((item) => item.question);
+
+  assert.deepEqual(questions, [
+    "How is meeting content encrypted?",
+    "Where does data live, and which jurisdiction applies?",
+    "How long do you keep data?",
+    "Do you train models on our meetings?",
+    "Who are your subprocessors?",
+    "Does a bot join our calls?",
+  ]);
+
+  for (const item of securityReviewAnswers) {
+    assert.ok(item.summary.length > 40);
+    assert.ok(item.detail.length > item.summary.length);
+  }
+});
+
+test("lists processors without claiming they can read Cloud Sync content", () => {
+  const names = subprocessors.map((item) => item.name).join(" ");
+
+  assert.match(names, /SQLite Cloud/);
+  assert.match(names, /Stripe/);
+  assert.match(names, /Deepgram/);
+  assert.match(names, /OpenRouter/);
+  assert.match(names, /Nango/);
+
+  const sync = subprocessors.find((item) => item.name === "SQLite Cloud");
+  assert.match(sync?.receives ?? "", /encrypted/i);
+});
+
+test("does not claim certifications that are not complete", () => {
+  assert.deepEqual(certificationStatus.claimed, []);
+  assert.match(certificationStatus.planned, /does not claim/);
+  assert.doesNotMatch(certificationStatus.planned, /we are SOC 2/i);
+  assert.doesNotMatch(certificationStatus.planned, /HIPAA compliant/i);
+});
+
+test("keeps the DPA as a request, not a published legal invention", () => {
+  const dpa = contractualDocs.find((doc) => doc.label.includes("Processing"));
+  assert.ok(dpa?.href.startsWith("mailto:"));
+  assert.match(dpa?.note ?? "", /on request/i);
+});
+
+test("describes a founder-led rollout without inventing customer proof", () => {
+  assert.equal(pilotSteps.length, 3);
+  assert.equal(pilotSteps[0]?.title, "Security review");
+  assert.equal(pilotSteps[1]?.title, "Scoped pilot");
+  assert.equal(pilotSteps[2]?.title, "Rollout");
+  assert.match(proofStatus.body, /does not invent/);
+  assert.ok(shipsToday.length >= 4);
+  assert.ok(shipsWithPartners.length >= 2);
+  assert.equal(architectureLayers.length, 4);
+});
+
+test("uses stable funnel event names", () => {
+  assert.deepEqual(ENTERPRISE_EVENTS, {
+    pageViewed: "enterprise_page_viewed",
+    securityPageViewed: "security_page_viewed",
+    ctaClicked: "enterprise_cta_clicked",
+  });
+});

--- a/apps/web/src/lib/trust-center.test.ts
+++ b/apps/web/src/lib/trust-center.test.ts
@@ -50,6 +50,11 @@ test("does not claim certifications that are not complete", () => {
   assert.match(certificationStatus.planned, /does not claim/);
   assert.doesNotMatch(certificationStatus.planned, /we are SOC 2/i);
   assert.doesNotMatch(certificationStatus.planned, /HIPAA compliant/i);
+  assert.match(certificationStatus.hostedTrustCenter, /separate site/);
+  assert.doesNotMatch(
+    `${certificationStatus.planned} ${certificationStatus.hostedTrustCenter}`,
+    /this page is (the|our) trust center/i,
+  );
 });
 
 test("keeps the DPA as a request, not a published legal invention", () => {

--- a/apps/web/src/lib/trust-center.ts
+++ b/apps/web/src/lib/trust-center.ts
@@ -153,6 +153,8 @@ export const certificationStatus = {
   claimed: [] as string[],
   planned:
     "SOC 2, ISO 27001, AIUC-1, and HIPAA/BAA programs are planned after we have operational evidence. This page does not claim any of them.",
+  hostedTrustCenter:
+    "A hosted trust center — the Vanta or Oneleet surface buyers expect — comes after those programs start. It will be a separate site, not this page.",
 };
 
 export const contractualDocs = [
@@ -191,7 +193,7 @@ export const shipsWithPartners = [
 export const pilotSteps = [
   {
     title: "Security review",
-    body: "Forward this site to IT, security, and legal. The trust center, privacy policy, and source-visible client are the packet. We answer questionnaires from the same facts — we will not invent certifications.",
+    body: "Forward this site to IT, security, and legal. The security page, privacy policy, and source-visible client are the packet. We answer questionnaires from the same facts — we will not invent certifications.",
   },
   {
     title: "Scoped pilot",

--- a/apps/web/src/lib/trust-center.ts
+++ b/apps/web/src/lib/trust-center.ts
@@ -1,0 +1,209 @@
+export const TRUST_CENTER_UPDATED_ON = "2026-08-29";
+
+export const securityReviewAnswers = [
+  {
+    question: "How is meeting content encrypted?",
+    summary:
+      "Notes live in local SQLite on the device. Cloud Sync encrypts content on the device before upload; Fastrepl only stores ciphertext plus operational metadata.",
+    detail:
+      "The desktop app stores notes, transcripts, and meeting metadata in a local SQLite database. Optional Cloud Sync encrypts that content on the device with keys derived from a recovery key that stays in the operating-system keychain and never reaches Fastrepl. Sync servers see encrypted records plus account and workspace identifiers, timestamps, sizes, and device names — not titles or note content. Data in transit uses HTTPS/TLS. Shared notes and Cloud API & Connectors are separate, opt-in paths that store a server-readable copy so a recipient or agent can open the note.",
+  },
+  {
+    question: "Where does data live, and which jurisdiction applies?",
+    summary:
+      "Canonical meeting data stays on employee devices. Fastrepl-operated cloud services run in the United States. A customer-hosted data plane is the path for a different region.",
+    detail:
+      "Local notes never leave the device unless a user enables a cloud feature. Fastrepl-operated cloud — accounts, optional Cloud Sync ciphertext, shared notes, and hosted AI/transcription gateways — currently runs in the United States. Customer-hosted capture and a customer-controlled data plane are the way to keep meeting infrastructure in a region you choose. We do not offer a certified-cloud EU SKU today.",
+  },
+  {
+    question: "How long do you keep data?",
+    summary:
+      "Local data stays until the user deletes it. Cloud data we control is deleted within 30 days of account deletion. Audio uploaded for cloud transcription is deleted when the job finishes.",
+    detail:
+      "Local notes, transcripts, and recordings stay on the device until the user removes them. Audio retention on the desktop is a user setting (don't save, 1 day, 3 days, 1 week, 1 month, or forever). Cloud Sync records, transcription results, shared notes, and Cloud API copies are deleted within 30 days of account deletion unless the law requires a longer hold. Audio uploaded for cloud transcription is deleted from our storage once the job completes. Cloud API copies are deleted when the feature is turned off. Shared notes remain available until sharing stops or the account is deleted.",
+  },
+  {
+    question: "Do you train models on our meetings?",
+    summary:
+      "Fastrepl does not train models on notes, transcripts, audio, or connected calendar data. Review the selected AI provider if you use hosted or bring-your-own-key models.",
+    detail:
+      "Fastrepl does not use notes, transcripts, audio, or connected calendar data to train AI models, and we do not sell that data. If a team uses on-device transcription and a local language model, meeting content never leaves the device for AI. If they use Anarlog Cloud or a bring-your-own-key provider, the audio or text needed for that request goes to the selected provider under that provider's terms — review that provider's retention and training policy before sending sensitive meetings.",
+  },
+  {
+    question: "Who are your subprocessors?",
+    summary:
+      "Hosting, encrypted sync storage, payments, analytics, and optional speech-to-text or AI providers. None of them join the meeting.",
+    detail:
+      "The current processor list lives in the table below and in the privacy policy. Providers receive only what the enabled feature needs. Cloud Sync storage holds ciphertext. Speech-to-text and model providers receive content only when a user selects a hosted or bring-your-own-key route. Analytics and error tools are designed not to include meeting audio, transcripts, notes, or summaries.",
+  },
+  {
+    question: "Does a bot join our calls?",
+    summary:
+      "No. The desktop app captures microphone and system audio locally. Nothing is added to the participant list.",
+    detail:
+      "Anarlog does not send a meeting bot into Zoom, Google Meet, Microsoft Teams, or other calls. Capture happens on the desktop from microphone and system audio. That is the product, not a setting. Customer-hosted Meet or Zoom workers, when used by an enterprise pilot, are a separate capture path and are disclosed as such — they are not the default desktop product.",
+  },
+];
+
+export const architectureLayers = [
+  {
+    title: "Employee devices",
+    body: "Canonical notes, transcripts, recordings, and most settings live in local SQLite. The MIT-licensed desktop client is auditable.",
+  },
+  {
+    title: "Optional Cloud Sync",
+    body: "End-to-end encrypted replicas so other signed-in devices stay current. Fastrepl cannot read the recovery key or the note content.",
+  },
+  {
+    title: "Optional AI and transcription",
+    body: "On-device models, bring-your-own keys, or Anarlog Cloud. Content goes only to the provider the user selected for that request.",
+  },
+  {
+    title: "Optional sharing and Cloud API",
+    body: "A server-readable copy exists only when someone shares a note or turns on Cloud API & Connectors. Turning the API off deletes those copies.",
+  },
+];
+
+export const subprocessors = [
+  {
+    name: "Fly.io, Netlify, Supabase, Render, Amazon Web Services, Cloudflare",
+    purpose: "Hosting, authentication, storage, and downloads",
+    receives:
+      "Account data, operational metadata, and any server-side records created by an enabled cloud feature",
+  },
+  {
+    name: "SQLite Cloud",
+    purpose: "Cloud Sync storage",
+    receives: "End-to-end encrypted sync records plus operational metadata",
+  },
+  {
+    name: "Nango",
+    purpose: "Calendar and connected-account integrations",
+    receives:
+      "Encrypted OAuth tokens and the calendar or issue-tracker data needed for a connected feature",
+  },
+  {
+    name: "Stripe",
+    purpose: "Payments",
+    receives: "Billing details; Fastrepl never stores card numbers",
+  },
+  {
+    name: "PostHog, Google Analytics, Microsoft Clarity",
+    purpose: "Product and website analytics",
+    receives:
+      "Pseudonymous usage events, page views, and optional website session replay — not meeting audio, transcripts, notes, or summaries",
+  },
+  {
+    name: "Sentry, Honeycomb",
+    purpose: "Error monitoring and observability",
+    receives:
+      "Sanitized diagnostics and crash reports with meeting content stripped",
+  },
+  {
+    name: "Deepgram, Soniox, AssemblyAI, Gladia, ElevenLabs, Fireworks AI, OpenAI, Mistral, Alibaba Cloud",
+    purpose: "Optional cloud transcription",
+    receives:
+      "Audio for a transcription job when a user selects a hosted speech-to-text route",
+  },
+  {
+    name: "OpenRouter, routing to providers such as Anthropic, Google, and Mistral",
+    purpose: "Optional cloud AI",
+    receives:
+      "The text and instructions needed for a summary or chat request the user starts",
+  },
+  {
+    name: "Exa, Jina",
+    purpose: "Optional web search from AI chat",
+    receives: "Search queries when a user enables web search in chat",
+  },
+  {
+    name: "Loops",
+    purpose: "Email",
+    receives:
+      "Email address and the content of transactional or marketing messages",
+  },
+];
+
+export const retentionRows = [
+  {
+    item: "Local notes, transcripts, and recordings",
+    retention: "On the device until the user deletes them",
+  },
+  {
+    item: "Desktop audio files",
+    retention:
+      "User-selected: don't save, 1 day, 3 days, 1 week, 1 month, or forever",
+  },
+  {
+    item: "Cloud Sync, transcription results, shared notes, Cloud API copies",
+    retention:
+      "Deleted within 30 days of account deletion, unless the law requires a hold",
+  },
+  {
+    item: "Audio uploaded for cloud transcription",
+    retention: "Deleted from Fastrepl storage when the job completes",
+  },
+  {
+    item: "Cloud API & Connectors copies",
+    retention: "Deleted when the feature is turned off",
+  },
+];
+
+export const certificationStatus = {
+  claimed: [] as string[],
+  planned:
+    "SOC 2, ISO 27001, AIUC-1, and HIPAA/BAA programs are planned after we have operational evidence. This page does not claim any of them.",
+};
+
+export const contractualDocs = [
+  {
+    label: "Privacy Policy",
+    href: "/privacy/",
+    note: "What we collect, local-first defaults, and processor list",
+  },
+  {
+    label: "Terms of Service",
+    href: "/terms/",
+    note: "Contract for using Anarlog",
+  },
+  {
+    label: "Data Processing Addendum",
+    href: "mailto:founders@anarlog.so?subject=Anarlog%20DPA",
+    note: "Available on request for enterprise evaluations",
+  },
+];
+
+export const shipsToday = [
+  "Desktop app on macOS, with Windows and Linux in beta",
+  "Bot-free local capture from microphone and system audio",
+  "Local SQLite as the source of truth, plus Markdown and other exports",
+  "On-device transcription and local models, or bring-your-own API keys",
+  "Optional end-to-end encrypted Cloud Sync",
+  "Optional sharing and Cloud API & Connectors, each with a distinct data path",
+];
+
+export const shipsWithPartners = [
+  "Team workspaces, domain SSO, and SCIM provisioning",
+  "Org-wide sharing, retention, and consent policies",
+  "Customer-hosted capture and a customer-controlled data plane",
+];
+
+export const pilotSteps = [
+  {
+    title: "Security review",
+    body: "Forward this site to IT, security, and legal. The trust center, privacy policy, and source-visible client are the packet. We answer questionnaires from the same facts — we will not invent certifications.",
+  },
+  {
+    title: "Scoped pilot",
+    body: "A founder-led trial with a named team, a defined data boundary (local-only, encrypted sync, or customer-hosted capture), and a success check you choose. No SDR queue.",
+  },
+  {
+    title: "Rollout",
+    body: "Expand seats and policies after the pilot. Workspace admin, SSO/SCIM, or a customer-hosted data plane land with the teams that need them — not as a surprise bot in every meeting.",
+  },
+];
+
+export const proofStatus = {
+  headline: "Named customer proof is not published yet",
+  body: "We work directly with early enterprise partners. We will only publish a named or properly anonymized outcome after that partner approves the company context, constraint, deployment mode, and result. This page does not invent metrics or logos.",
+};

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UpdatePasswordRouteImport } from './routes/update-password'
 import { Route as TermsRouteImport } from './routes/terms'
+import { Route as SecurityRouteImport } from './routes/security'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as DiscordRouteImport } from './routes/discord'
@@ -83,6 +84,11 @@ const UpdatePasswordRoute = UpdatePasswordRouteImport.update({
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
   path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SecurityRoute = SecurityRouteImport.update({
+  id: '/security',
+  path: '/security',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
@@ -414,6 +420,7 @@ export interface FileRoutesByFullPath {
   '/discord': typeof DiscordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/security': typeof SecurityRoute
   '/terms': typeof TermsRoute
   '/update-password': typeof UpdatePasswordRoute
   '/app': typeof ViewAppRouteRouteWithChildren
@@ -480,6 +487,7 @@ export interface FileRoutesByTo {
   '/discord': typeof DiscordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/security': typeof SecurityRoute
   '/terms': typeof TermsRoute
   '/update-password': typeof UpdatePasswordRoute
   '/api/shortcuts': typeof ApiShortcutsRoute
@@ -547,6 +555,7 @@ export interface FileRoutesById {
   '/discord': typeof DiscordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/security': typeof SecurityRoute
   '/terms': typeof TermsRoute
   '/update-password': typeof UpdatePasswordRoute
   '/_view/app': typeof ViewAppRouteRouteWithChildren
@@ -615,6 +624,7 @@ export interface FileRouteTypes {
     | '/discord'
     | '/privacy'
     | '/reset-password'
+    | '/security'
     | '/terms'
     | '/update-password'
     | '/app'
@@ -681,6 +691,7 @@ export interface FileRouteTypes {
     | '/discord'
     | '/privacy'
     | '/reset-password'
+    | '/security'
     | '/terms'
     | '/update-password'
     | '/api/shortcuts'
@@ -747,6 +758,7 @@ export interface FileRouteTypes {
     | '/discord'
     | '/privacy'
     | '/reset-password'
+    | '/security'
     | '/terms'
     | '/update-password'
     | '/_view/app'
@@ -815,6 +827,7 @@ export interface RootRouteChildren {
   DiscordRoute: typeof DiscordRoute
   PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  SecurityRoute: typeof SecurityRoute
   TermsRoute: typeof TermsRoute
   UpdatePasswordRoute: typeof UpdatePasswordRoute
   ApiShortcutsRoute: typeof ApiShortcutsRoute
@@ -874,6 +887,13 @@ declare module '@tanstack/react-router' {
       path: '/terms'
       fullPath: '/terms'
       preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/security': {
+      id: '/security'
+      path: '/security'
+      fullPath: '/security'
+      preLoaderRoute: typeof SecurityRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reset-password': {
@@ -1378,6 +1398,7 @@ const rootRouteChildren: RootRouteChildren = {
   DiscordRoute: DiscordRoute,
   PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  SecurityRoute: SecurityRoute,
   TermsRoute: TermsRoute,
   UpdatePasswordRoute: UpdatePasswordRoute,
   ApiShortcutsRoute: ApiShortcutsRoute,

--- a/apps/web/src/routes/enterprise/index.tsx
+++ b/apps/web/src/routes/enterprise/index.tsx
@@ -100,11 +100,11 @@ function EnterprisePage() {
               <BookFounderCall location="hero" page="enterprise" />
               <EnterpriseCtaLink
                 to="/security/"
-                cta="trust_center"
+                cta="security"
                 location="hero"
                 page="enterprise"
               >
-                Open the trust center
+                Read the security page
               </EnterpriseCtaLink>
             </div>
             <p className="mt-3 text-xs text-[#756b5d]">
@@ -156,12 +156,12 @@ function EnterprisePage() {
               The answers below are the same facts we use on questionnaires. The{" "}
               <EnterpriseCtaLink
                 to="/security/"
-                cta="trust_center"
+                cta="security"
                 location="security_review"
                 page="enterprise"
                 className="text-base text-[#4f4940]"
               >
-                trust center
+                security page
               </EnterpriseCtaLink>{" "}
               has architecture, processors, retention, and the procurement
               packet.

--- a/apps/web/src/routes/enterprise/index.tsx
+++ b/apps/web/src/routes/enterprise/index.tsx
@@ -4,17 +4,24 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { cn } from "@anlg/utils";
 
 import { AnarlogLogo } from "@/components/anarlog-logo";
+import { BookFounderCall } from "@/components/book-founder-call";
+import { EnterpriseCtaLink } from "@/components/enterprise-cta-link";
 import {
   LocalFilesVisual,
   MeetingCaptureVisual,
 } from "@/components/home-page/privacy-section";
+import { PilotPath } from "@/components/pilot-path";
+import { SecurityReviewList } from "@/components/security-review-list";
 import { SiteFooter } from "@/components/site-footer";
-import { BOOK_CALL_URL } from "@/lib/enterprise";
+import { useAnalytics } from "@/hooks/use-posthog";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { ENTERPRISE_EVENTS } from "@/lib/enterprise";
 import { getCanonicalUrl } from "@/lib/seo";
+import { proofStatus, shipsToday, shipsWithPartners } from "@/lib/trust-center";
 
 const title = "Enterprise · Anarlog";
 const description =
-  "Anarlog for teams and enterprises: end-to-end encrypted meeting notes with no meeting bots, workspace admin controls, and a self-hostable server. Book a call with the founder.";
+  "Anarlog for teams: local-first, bot-free meeting notes with end-to-end encrypted sync. Encryption, retention, training, and subprocessors — written so IT, security, and legal can review without a founder call.";
 
 export const Route = createFileRoute("/enterprise/")({
   component: EnterprisePage,
@@ -66,6 +73,12 @@ const pillarRows = [
 ];
 
 function EnterprisePage() {
+  const { track } = useAnalytics();
+
+  useMountEffect(() => {
+    track(ENTERPRISE_EVENTS.pageViewed, { page: "enterprise" });
+  });
+
   return (
     <main className="min-h-screen bg-white text-[#181613]">
       <div className="mx-auto w-full max-w-[700px] px-5 pt-4 pb-8 md:px-8 md:pt-4 md:pb-12">
@@ -78,12 +91,21 @@ function EnterprisePage() {
               Meeting memory your company owns
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
-              Bring Anarlog to your whole team without handing your
-              conversations to another cloud. Notes stay on your machines, sync
-              is end-to-end encrypted, and no bot ever joins a call.
+              Bring Anarlog to your team without handing conversations to
+              another cloud. Notes stay on employee machines, Cloud Sync is
+              end-to-end encrypted, and no bot joins the call. This page is
+              written so you can forward it to IT, security, and legal.
             </p>
-            <div className="mt-8">
-              <BookCallButton />
+            <div className="mt-8 flex flex-col items-center gap-3">
+              <BookFounderCall location="hero" page="enterprise" />
+              <EnterpriseCtaLink
+                to="/security/"
+                cta="trust_center"
+                location="hero"
+                page="enterprise"
+              >
+                Open the trust center
+              </EnterpriseCtaLink>
             </div>
             <p className="mt-3 text-xs text-[#756b5d]">
               30 minutes, directly with the founder. No SDR queue.
@@ -126,6 +148,47 @@ function EnterprisePage() {
             </div>
           </section>
 
+          <section className="pt-12 pb-4 md:pt-16 md:pb-6">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              For IT, security, and legal
+            </h2>
+            <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-[#4f4940]">
+              The answers below are the same facts we use on questionnaires. The{" "}
+              <EnterpriseCtaLink
+                to="/security/"
+                cta="trust_center"
+                location="security_review"
+                page="enterprise"
+                className="text-base text-[#4f4940]"
+              >
+                trust center
+              </EnterpriseCtaLink>{" "}
+              has architecture, processors, retention, and the procurement
+              packet.
+            </p>
+            <SecurityReviewList />
+            <div className="mt-8 flex flex-col gap-3 text-left text-sm leading-6 text-[#4f4940] md:flex-row md:gap-8">
+              <div className="flex-1">
+                <h3 className="font-medium text-[#181613]">Ships today</h3>
+                <ul className="mt-2 list-disc space-y-1.5 pl-5">
+                  {shipsToday.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="flex-1">
+                <h3 className="font-medium text-[#181613]">
+                  With early partners
+                </h3>
+                <ul className="mt-2 list-disc space-y-1.5 pl-5">
+                  {shipsWithPartners.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </section>
+
           <section className="pt-12 pb-4 md:pt-14 md:pb-6">
             <div
               className="flex items-center justify-center pb-4 select-none"
@@ -145,14 +208,12 @@ function EnterprisePage() {
               </span>
             </div>
             <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
-              Built with early partners
+              How an evaluation works
             </h2>
             <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-[#4f4940]">
-              Team workspaces with admin controls, SSO and SCIM, and the
-              self-hosted server are in active development. Early enterprise
-              partners work directly with the founding team and shape what ships
-              first.
+              {proofStatus.body}
             </p>
+            <PilotPath />
           </section>
 
           <section className="pt-8 pb-20 md:pt-10 md:pb-24">
@@ -160,17 +221,20 @@ function EnterprisePage() {
               Talk to us
             </h2>
             <p className="mx-auto mt-5 max-w-lg text-base leading-7 text-[#4f4940]">
-              Tell us about your team and your compliance needs — we'll show you
-              what works today and what lands next.
+              Tell us about the team, the data boundary you need, and who on
+              security has to sign off. We'll show what works today and what
+              lands next.
             </p>
             <div className="mt-8 flex flex-col items-center gap-4">
-              <BookCallButton />
-              <Link
+              <BookFounderCall location="talk" page="enterprise" />
+              <EnterpriseCtaLink
                 to="/pricing/"
-                className="text-sm text-[#756b5d] underline decoration-[#d9cdb8] underline-offset-4 transition-colors hover:text-[#181613]"
+                cta="pricing"
+                location="talk"
+                page="enterprise"
               >
                 Compare plans and pricing
-              </Link>
+              </EnterpriseCtaLink>
             </div>
           </section>
         </div>
@@ -294,18 +358,5 @@ function SelfHostVisual() {
         />
       </div>
     </div>
-  );
-}
-
-function BookCallButton() {
-  return (
-    <a
-      href={BOOK_CALL_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex h-11 items-center justify-center rounded-full bg-[#181613] px-6 text-sm font-medium text-white transition-all hover:scale-[102%] hover:bg-[#4f4940] active:scale-[98%]"
-    >
-      Book a call with the founder
-    </a>
   );
 }

--- a/apps/web/src/routes/security.tsx
+++ b/apps/web/src/routes/security.tsx
@@ -1,0 +1,322 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { AnarlogLogo } from "@/components/anarlog-logo";
+import { BookFounderCall } from "@/components/book-founder-call";
+import { EnterpriseCtaLink } from "@/components/enterprise-cta-link";
+import { PilotPath } from "@/components/pilot-path";
+import { SecurityReviewList } from "@/components/security-review-list";
+import { SiteFooter } from "@/components/site-footer";
+import { useAnalytics } from "@/hooks/use-posthog";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import {
+  ENTERPRISE_EVENTS,
+  PROCUREMENT_EMAIL,
+  SECURITY_ADVISORY_URL,
+  SECURITY_REPORT_EMAIL,
+} from "@/lib/enterprise";
+import { getCanonicalUrl } from "@/lib/seo";
+import {
+  architectureLayers,
+  certificationStatus,
+  contractualDocs,
+  proofStatus,
+  retentionRows,
+  shipsToday,
+  shipsWithPartners,
+  subprocessors,
+  TRUST_CENTER_UPDATED_ON,
+} from "@/lib/trust-center";
+
+const title = "Security and trust · Anarlog";
+const description =
+  "Anarlog trust center: encryption, data location, retention, training policy, subprocessors, incident reporting, and the documents an enterprise security review needs.";
+
+export const Route = createFileRoute("/security")({
+  component: SecurityPage,
+  head: () => ({
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:url", content: getCanonicalUrl("/security") },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { name: "twitter:url", content: getCanonicalUrl("/security") },
+    ],
+    links: [{ rel: "canonical", href: getCanonicalUrl("/security") }],
+  }),
+});
+
+function SecurityPage() {
+  const { track } = useAnalytics();
+
+  useMountEffect(() => {
+    track(ENTERPRISE_EVENTS.securityPageViewed, { page: "security" });
+  });
+
+  const updatedOn = new Date(
+    `${TRUST_CENTER_UPDATED_ON}T00:00:00Z`,
+  ).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 pt-4 pb-8 md:px-8 md:pt-4 md:pb-12">
+        <div className="min-w-0">
+          <section className="pt-10 pb-4 text-center md:pt-12 md:pb-6">
+            <Link to="/" aria-label="Anarlog home" className="inline-flex">
+              <AnarlogLogo className="h-8 w-auto md:h-9" />
+            </Link>
+            <h1 className="font-hand mt-12 text-4xl leading-none font-semibold text-[#181613] md:mt-16 md:text-5xl">
+              Trust center
+            </h1>
+            <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
+              What a first security review needs: how Anarlog stores meeting
+              data, who can see it, how long it is kept, and which documents we
+              can send today. Fastrepl does not claim SOC 2, ISO 27001, or HIPAA
+              here.
+            </p>
+            <p className="mt-3 text-xs text-[#756b5d]">
+              Last updated {updatedOn}
+            </p>
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Architecture
+            </h2>
+            <p className="mt-5 text-base leading-7 text-[#4f4940]">
+              Local-first by default. Cloud features are optional and named.
+              Nothing in the default product joins a meeting as a participant.
+            </p>
+            <ol className="mt-8 flex flex-col gap-4">
+              {architectureLayers.map((layer, index) => (
+                <li
+                  key={layer.title}
+                  className="rounded-2xl border border-[#eadfce] bg-[#fffaf0] px-5 py-4"
+                >
+                  <p className="text-xs tracking-[0.04em] text-[#756b5d]">
+                    {String(index + 1).padStart(2, "0")}
+                  </p>
+                  <h3 className="mt-1 text-base font-medium text-[#181613]">
+                    {layer.title}
+                  </h3>
+                  <p className="mt-1 text-sm leading-6 text-[#4f4940]">
+                    {layer.body}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Security review answers
+            </h2>
+            <SecurityReviewList detail />
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Subprocessors
+            </h2>
+            <p className="mt-5 text-base leading-7 text-[#4f4940]">
+              Grounded in the{" "}
+              <EnterpriseCtaLink
+                to="/privacy/"
+                cta="privacy"
+                location="packet"
+                page="security"
+                className="text-base text-[#4f4940]"
+              >
+                privacy policy
+              </EnterpriseCtaLink>
+              . A processor receives data only when the matching feature is
+              enabled.
+            </p>
+            <div className="mt-6 overflow-x-auto">
+              <table className="w-full min-w-[36rem] border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-[#eadfce] text-[#756b5d]">
+                    <th className="py-2 pr-4 font-medium">Processor</th>
+                    <th className="py-2 pr-4 font-medium">Purpose</th>
+                    <th className="py-2 font-medium">What they can receive</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subprocessors.map((row) => (
+                    <tr key={row.name} className="border-b border-[#eadfce]">
+                      <td className="py-3 pr-4 align-top font-medium text-[#181613]">
+                        {row.name}
+                      </td>
+                      <td className="py-3 pr-4 align-top text-[#4f4940]">
+                        {row.purpose}
+                      </td>
+                      <td className="py-3 align-top text-[#4f4940]">
+                        {row.receives}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Retention
+            </h2>
+            <div className="mt-6 overflow-x-auto">
+              <table className="w-full min-w-[28rem] border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-[#eadfce] text-[#756b5d]">
+                    <th className="py-2 pr-4 font-medium">Data</th>
+                    <th className="py-2 font-medium">Kept until</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {retentionRows.map((row) => (
+                    <tr key={row.item} className="border-b border-[#eadfce]">
+                      <td className="py-3 pr-4 align-top font-medium text-[#181613]">
+                        {row.item}
+                      </td>
+                      <td className="py-3 align-top text-[#4f4940]">
+                        {row.retention}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Certifications and contracts
+            </h2>
+            <p className="mt-5 text-base leading-7 text-[#4f4940]">
+              {certificationStatus.planned}
+            </p>
+            <ul className="mt-6 divide-y divide-[#eadfce] text-sm">
+              {contractualDocs.map((doc) => (
+                <li
+                  key={doc.label}
+                  className="flex flex-col gap-1 py-3 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6"
+                >
+                  {doc.href.startsWith("/") ? (
+                    <EnterpriseCtaLink
+                      to={doc.href as "/privacy/" | "/terms/"}
+                      cta={doc.href.includes("privacy") ? "privacy" : "terms"}
+                      location="packet"
+                      page="security"
+                      className="text-base font-medium text-[#181613]"
+                    >
+                      {doc.label}
+                    </EnterpriseCtaLink>
+                  ) : (
+                    <EnterpriseCtaLink
+                      href={doc.href}
+                      cta="dpa"
+                      location="packet"
+                      page="security"
+                      className="text-base font-medium text-[#181613]"
+                    >
+                      {doc.label}
+                    </EnterpriseCtaLink>
+                  )}
+                  <span className="text-[#4f4940]">{doc.note}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Incident response
+            </h2>
+            <p className="mt-5 text-base leading-7 text-[#4f4940]">
+              Report a vulnerability privately — do not open a public GitHub
+              issue. We acknowledge reports within 3 business days, keep you
+              updated while we investigate, and credit you in the release notes
+              if the report is accepted unless you prefer to stay anonymous.
+            </p>
+            <div className="mt-4 flex flex-col gap-2 text-sm">
+              <EnterpriseCtaLink
+                href={SECURITY_ADVISORY_URL}
+                cta="security_report"
+                location="packet"
+                page="security"
+              >
+                Report a vulnerability on GitHub
+              </EnterpriseCtaLink>
+              <a
+                href={`mailto:${SECURITY_REPORT_EMAIL}`}
+                className="text-[#756b5d] underline decoration-[#d9cdb8] underline-offset-4 hover:text-[#181613]"
+              >
+                {SECURITY_REPORT_EMAIL}
+              </a>
+            </div>
+          </section>
+
+          <section className="pt-10 pb-4 md:pt-12">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              What ships, and how a pilot works
+            </h2>
+            <div className="mt-6 flex flex-col gap-6 text-sm leading-6 text-[#4f4940] md:flex-row">
+              <div className="flex-1">
+                <h3 className="font-medium text-[#181613]">Ships today</h3>
+                <ul className="mt-2 list-disc space-y-1.5 pl-5">
+                  {shipsToday.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="flex-1">
+                <h3 className="font-medium text-[#181613]">
+                  With early partners
+                </h3>
+                <ul className="mt-2 list-disc space-y-1.5 pl-5">
+                  {shipsWithPartners.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            <p className="mt-8 text-base leading-7 text-[#4f4940]">
+              {proofStatus.body}
+            </p>
+            <PilotPath />
+          </section>
+
+          <section className="pt-10 pb-20 text-center md:pt-12 md:pb-24">
+            <h2 className="font-hand text-3xl leading-none font-semibold text-[#181613]">
+              Request the packet
+            </h2>
+            <p className="mx-auto mt-5 max-w-lg text-base leading-7 text-[#4f4940]">
+              Book a founder call, or email {PROCUREMENT_EMAIL} for a DPA and
+              questionnaire responses grounded in this page.
+            </p>
+            <div className="mt-8 flex flex-col items-center gap-4">
+              <BookFounderCall location="packet" page="security" />
+              <EnterpriseCtaLink
+                to="/enterprise/"
+                cta="enterprise"
+                location="packet"
+                page="security"
+              >
+                Back to enterprise
+              </EnterpriseCtaLink>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </main>
+  );
+}

--- a/apps/web/src/routes/security.tsx
+++ b/apps/web/src/routes/security.tsx
@@ -27,9 +27,9 @@ import {
   TRUST_CENTER_UPDATED_ON,
 } from "@/lib/trust-center";
 
-const title = "Security and trust · Anarlog";
+const title = "Security · Anarlog";
 const description =
-  "Anarlog trust center: encryption, data location, retention, training policy, subprocessors, incident reporting, and the documents an enterprise security review needs.";
+  "How Anarlog handles encryption, data location, retention, training, subprocessors, and incident reporting — the packet for a first enterprise security review.";
 
 export const Route = createFileRoute("/security")({
   component: SecurityPage,
@@ -73,7 +73,7 @@ function SecurityPage() {
               <AnarlogLogo className="h-8 w-auto md:h-9" />
             </Link>
             <h1 className="font-hand mt-12 text-4xl leading-none font-semibold text-[#181613] md:mt-16 md:text-5xl">
-              Trust center
+              Security
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
               What a first security review needs: how Anarlog stores meeting
@@ -200,7 +200,8 @@ function SecurityPage() {
               Certifications and contracts
             </h2>
             <p className="mt-5 text-base leading-7 text-[#4f4940]">
-              {certificationStatus.planned}
+              {certificationStatus.planned}{" "}
+              {certificationStatus.hostedTrustCenter}
             </p>
             <ul className="mt-6 divide-y divide-[#eadfce] text-sm">
               {contractualDocs.map((doc) => (

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -46,6 +46,10 @@ export function getSitemap(): Sitemap<TRoutes> {
         priority: 0.8,
         changeFrequency: "monthly",
       },
+      "/security": {
+        priority: 0.8,
+        changeFrequency: "monthly",
+      },
       "/pricing/": {
         priority: 0.9,
         changeFrequency: "monthly",

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -18,7 +18,7 @@ function getArticleSlugs(): string[] {
   }
 }
 
-export function getSitemap(): Sitemap<TRoutes> {
+export function getSitemap(): Sitemap<TRoutes | "/security/"> {
   const slugs = getArticleSlugs();
 
   return {
@@ -46,7 +46,7 @@ export function getSitemap(): Sitemap<TRoutes> {
         priority: 0.8,
         changeFrequency: "monthly",
       },
-      "/security": {
+      "/security/": {
         priority: 0.8,
         changeFrequency: "monthly",
       },

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -5,7 +5,7 @@ description: "Understand what stays on your computer, what can leave it, and how
 
 Anarlog stores its app data on your computer and captures meetings without adding a bot to the call. Data leaves your computer only when you use a connected or hosted feature that needs it.
 
-Security, legal, and procurement teams should use the [trust center](https://anarlog.so/security) for encryption, processors, retention, and the evaluation packet.
+Security, legal, and procurement teams should use the [security page](https://anarlog.so/security) for encryption, processors, retention, and the evaluation packet. A hosted trust center comes later, when certification programs start.
 
 ## What stays on your computer
 

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -5,6 +5,8 @@ description: "Understand what stays on your computer, what can leave it, and how
 
 Anarlog stores its app data on your computer and captures meetings without adding a bot to the call. Data leaves your computer only when you use a connected or hosted feature that needs it.
 
+Security, legal, and procurement teams should use the [trust center](https://anarlog.so/security) for encryption, processors, retention, and the evaluation packet.
+
 ## What stays on your computer
 
 Your notes, local transcripts, settings, recordings you choose to keep, and downloaded local models are stored locally. You can write notes, record audio, and use configured local models without sending meeting content to Anarlog Cloud.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,7 +42,8 @@
           "models-and-providers",
           "ai-setup",
           "offline",
-          "data-and-privacy"
+          "data-and-privacy",
+          "security"
         ]
       },
       {

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -37,7 +37,7 @@ There is no single hidden model. Your Transcription selection handles audio, and
 
 ### Where is my data stored?
 
-Anarlog stores app data locally by default. Hosted AI, calendars, sync, sharing, and the optional Cloud API receive the content needed for the feature you enable. See [Data, privacy, and retention](/data-and-privacy).
+Anarlog stores app data locally by default. Hosted AI, calendars, sync, sharing, and the optional Cloud API receive the content needed for the feature you enable. See [Data, privacy, and retention](/data-and-privacy). Enterprise security reviews should start at the [trust center](https://anarlog.so/security).
 
 ### Does Anarlog train on my meetings?
 

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -37,7 +37,7 @@ There is no single hidden model. Your Transcription selection handles audio, and
 
 ### Where is my data stored?
 
-Anarlog stores app data locally by default. Hosted AI, calendars, sync, sharing, and the optional Cloud API receive the content needed for the feature you enable. See [Data, privacy, and retention](/data-and-privacy). Enterprise security reviews should start at the [trust center](https://anarlog.so/security).
+Anarlog stores app data locally by default. Hosted AI, calendars, sync, sharing, and the optional Cloud API receive the content needed for the feature you enable. See [Data, privacy, and retention](/data-and-privacy). Enterprise security reviews should start at the [security page](https://anarlog.so/security).
 
 ### Does Anarlog train on my meetings?
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,0 +1,28 @@
+---
+title: "Security and procurement"
+description: "Where security, legal, and IT teams can review Anarlog's data handling, processors, and evaluation path."
+---
+
+Enterprise buyers should start at the [Anarlog trust center](https://anarlog.so/security). It is the public security-review packet: architecture, encryption, data location, retention, training policy, subprocessors, incident reporting, and the contracts we can send today.
+
+## What stays true in the product
+
+- Meeting notes live on the desktop in local SQLite unless someone enables a named cloud feature.
+- Cloud Sync is end-to-end encrypted. Fastrepl cannot read the recovery key.
+- Anarlog does not add a bot to Zoom, Google Meet, or Microsoft Teams.
+- Fastrepl does not train models on notes, transcripts, or audio. Hosted or bring-your-own-key providers have their own terms.
+
+See [Data, privacy, and retention](/data-and-privacy) for the in-app settings that control audio retention, analytics, and a fully local meeting.
+
+## Documents
+
+- [Trust center](https://anarlog.so/security)
+- [Privacy Policy](https://anarlog.so/privacy)
+- [Terms of Service](https://anarlog.so/terms)
+- Data Processing Addendum: email [founders@anarlog.so](mailto:founders@anarlog.so?subject=Anarlog%20DPA)
+
+We do not claim SOC 2, ISO 27001, or HIPAA on these pages.
+
+## Report a vulnerability
+
+Use [private GitHub reporting](https://github.com/fastrepl/anarlog/security/advisories/new) or email founders@fastrepl.com. Do not open a public issue. See the repository [security policy](https://github.com/fastrepl/anarlog/blob/main/SECURITY.md).

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -3,7 +3,9 @@ title: "Security and procurement"
 description: "Where security, legal, and IT teams can review Anarlog's data handling, processors, and evaluation path."
 ---
 
-Enterprise buyers should start at the [Anarlog trust center](https://anarlog.so/security). It is the public security-review packet: architecture, encryption, data location, retention, training policy, subprocessors, incident reporting, and the contracts we can send today.
+Enterprise buyers should start at the [Anarlog security page](https://anarlog.so/security). It is the public security-review packet: architecture, encryption, data location, retention, training policy, subprocessors, incident reporting, and the contracts we can send today.
+
+A hosted trust center (Vanta, Oneleet, or similar) is a separate surface. We will publish one after SOC 2 and ISO programs start — not as a substitute for this page.
 
 ## What stays true in the product
 
@@ -16,7 +18,7 @@ See [Data, privacy, and retention](/data-and-privacy) for the in-app settings th
 
 ## Documents
 
-- [Trust center](https://anarlog.so/security)
+- [Security](https://anarlog.so/security)
 - [Privacy Policy](https://anarlog.so/privacy)
 - [Terms of Service](https://anarlog.so/terms)
 - Data Processing Addendum: email [founders@anarlog.so](mailto:founders@anarlog.so?subject=Anarlog%20DPA)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** `/enterprise` was a positioning page an internal champion could not forward to IT. It did not answer encryption, jurisdiction, retention, training, or subprocessors; there was no security-review packet; and “built with early partners” had no evaluation path or measurement.

**Fix:** Turn `/enterprise` into a decision-ready security-review page, publish `/security` as the first-party procurement packet (architecture, processors, retention, incident reporting, contracts), and add a founder-led security-review → scoped-pilot → rollout path with PostHog funnel events. Named customer proof and certifications are explicitly not invented.

`/security` is the review packet, not a hosted trust center. A Vanta/Oneleet-style trust center stays a later, separate surface after SOC 2 and ISO start.

Closes ANLG-304, ANLG-305. Partial ANLG-306 (pilot path + funnel; partner case study still needs an approved interview).

## Verification

- `pnpm exec dprint fmt` / `dprint check` on changed non-Swift files
- `pnpm -F ui build && pnpm -F web typecheck`
- `node --experimental-strip-types --test` in `apps/web` (300 tests)
- `npx mint@4.2.687 validate` in `docs/`
- Sitemap loc is `/security/` so it matches the trailing-slash canonical (Bugbot)
- SSR check: `/enterprise/`, `/security/`, and `/pricing/` return 200 with the new copy
- Browser: enterprise → security → footer Security → pricing callout, plus a 390px viewport; no layout issues
- CI: `web_ci`, `fmt`, `lint`, `cli-ci` green on the PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c56d99a-1ce6-47de-b22b-808cfaf9fb8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c56d99a-1ce6-47de-b22b-808cfaf9fb8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

