### PR TITLE
Let folders group and inherit notes in the sidebar

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr "No emoji found"
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr "No folder"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -2904,6 +2904,7 @@ msgid "No emoji found"
 msgstr ""
 
 #: src/session/components/folder-picker.tsx
+#: src/sidebar/note-filter-menu.tsx
 msgid "No folder"
 msgstr ""
 

--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -9,6 +9,8 @@ import {
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { resetSidebarNotes } from "~/sidebar/note-filter";
+
 const mocks = vi.hoisted(() => ({
   runtimePlatform: null as "windows" | "linux" | null,
   currentTab: {
@@ -241,6 +243,7 @@ function rectWithWidth(width: number) {
 describe("ClassicMainBody", () => {
   beforeEach(() => {
     cleanup();
+    resetSidebarNotes();
     mocks.runtimePlatform = null;
     Object.defineProperty(window, "innerWidth", {
       configurable: true,

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -43,7 +43,7 @@ import {
 import { getMainContentMinWidth } from "~/shared/main/layout-widths";
 import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
-import type { SidebarNoteFilter } from "~/sidebar/note-filter";
+import { useSidebarNotes } from "~/sidebar/note-filter";
 import {
   hasCustomSidebarTab,
   hasLeftSurfaceCustomSidebarTab,
@@ -80,7 +80,9 @@ export function ClassicMainBody({
   const syncDefaultLeftSidebarPanelSizeRef = useRef<() => void>(() => {});
   const [showIgnoredTimelineEvents, setShowIgnoredTimelineEvents] =
     useState(false);
-  const [noteFilter, setNoteFilter] = useState<SidebarNoteFilter>("mine");
+  const noteFilter = useSidebarNotes((state) => state.noteFilter);
+  const folderFilter = useSidebarNotes((state) => state.folderFilter);
+  const setNotesView = useSidebarNotes((state) => state.setView);
   const showWindowControlsGutter = useWindowControlsGutter();
   const showSidebarToggleInBody = !usesWindowsStyleTitleBar();
   leftSidebarPanelConstraintsRef.current = leftSidebarPanelConstraints;
@@ -408,12 +410,13 @@ export function ClassicMainBody({
       {showSidebarTimeline ? (
         <SidebarTimelineChromeWithUpcomingMeeting
           currentSessionId={currentSessionId}
+          folderFilter={folderFilter}
           noteFilter={noteFilter}
           sidebarExpanded
           showSidebarToggle={showSidebarToggleInBody}
           showIgnoredTimelineEvents={showIgnoredTimelineEvents}
           onNewNote={createNewNote}
-          onNoteFilterChange={setNoteFilter}
+          onNoteFilterChange={setNotesView}
           onSearch={handleOpenNoteDialog}
           onToggleSidebar={handleToggleLeftSidebar}
         />
@@ -447,12 +450,13 @@ export function ClassicMainBody({
           >
             <SidebarTimelineChromeWithUpcomingMeeting
               currentSessionId={currentSessionId}
+              folderFilter={folderFilter}
               noteFilter={noteFilter}
               sidebarExpanded={false}
               showSidebarToggle={showSidebarToggleInBody}
               showIgnoredTimelineEvents={showIgnoredTimelineEvents}
               onNewNote={createNewNote}
-              onNoteFilterChange={setNoteFilter}
+              onNoteFilterChange={setNotesView}
               onSearch={handleOpenNoteDialog}
               onToggleSidebar={handleToggleLeftSidebar}
             />
@@ -520,6 +524,7 @@ export function ClassicMainBody({
                 ])}
               >
                 <ClassicMainSidebar
+                  folderFilter={folderFilter}
                   noteFilter={noteFilter}
                   timelineHeader={timelineHeader}
                   showIgnoredTimelineEvents={showIgnoredTimelineEvents}

--- a/apps/desktop/src/main/shell-sidebar.tsx
+++ b/apps/desktop/src/main/shell-sidebar.tsx
@@ -10,11 +10,13 @@ import {
 import { useTabs } from "~/store/zustand/tabs";
 
 export function ClassicMainSidebar({
+  folderFilter = null,
   noteFilter = "mine",
   timelineHeader,
   showIgnoredTimelineEvents,
   onShowIgnoredTimelineEventsChange,
 }: {
+  folderFilter?: string | null;
   noteFilter?: SidebarNoteFilter;
   timelineHeader?: ReactNode;
   showIgnoredTimelineEvents?: boolean;
@@ -34,6 +36,7 @@ export function ClassicMainSidebar({
 
   return (
     <LeftSidebar
+      folderFilter={folderFilter}
       noteFilter={noteFilter}
       timelineHeader={timelineHeader}
       showIgnoredTimelineEvents={showIgnoredTimelineEvents}

--- a/apps/desktop/src/main/sidebar-timeline-chrome.tsx
+++ b/apps/desktop/src/main/sidebar-timeline-chrome.tsx
@@ -15,6 +15,7 @@ import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-mee
 export const SidebarTimelineChromeWithUpcomingMeeting = memo(
   function SidebarTimelineChromeWithUpcomingMeeting({
     currentSessionId,
+    folderFilter = null,
     noteFilter,
     onNewNote,
     onNoteFilterChange,
@@ -25,9 +26,13 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
     showIgnoredTimelineEvents,
   }: {
     currentSessionId?: string;
+    folderFilter?: string | null;
     noteFilter: SidebarNoteFilter;
     onNewNote: () => void;
-    onNoteFilterChange: (filter: SidebarNoteFilter) => void;
+    onNoteFilterChange: (
+      filter: SidebarNoteFilter,
+      folderFilter?: string | null,
+    ) => void;
     onSearch: () => void;
     onToggleSidebar: () => void;
     sidebarExpanded: boolean;
@@ -44,6 +49,7 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
 
     return (
       <SidebarTimelineChrome
+        folderFilter={folderFilter}
         hasUpcomingMeeting={hasUpcomingMeeting}
         noteFilter={noteFilter}
         onNewNote={onNewNote}
@@ -58,6 +64,7 @@ export const SidebarTimelineChromeWithUpcomingMeeting = memo(
 );
 
 function SidebarTimelineChrome({
+  folderFilter,
   hasUpcomingMeeting,
   noteFilter,
   onNewNote,
@@ -67,10 +74,14 @@ function SidebarTimelineChrome({
   sidebarExpanded,
   showSidebarToggle,
 }: {
+  folderFilter: string | null;
   hasUpcomingMeeting: boolean;
   noteFilter: SidebarNoteFilter;
   onNewNote: () => void;
-  onNoteFilterChange: (filter: SidebarNoteFilter) => void;
+  onNoteFilterChange: (
+    filter: SidebarNoteFilter,
+    folderFilter?: string | null,
+  ) => void;
   onSearch: () => void;
   onToggleSidebar: () => void;
   sidebarExpanded: boolean;
@@ -113,6 +124,7 @@ function SidebarTimelineChrome({
               <NotePencil size={15} />
             </LeftSurfaceChromeButton>
             <SidebarNoteFilterMenu
+              folderFilter={folderFilter}
               value={noteFilter}
               onValueChange={onNoteFilterChange}
             />

--- a/apps/desktop/src/session/queries.test.ts
+++ b/apps/desktop/src/session/queries.test.ts
@@ -153,6 +153,7 @@ describe("session SQLite operations", () => {
   it("creates a session with its initial event and note content atomically", async () => {
     await createSession("Welcome", "user-1", {
       event_json: '{"tracking_id":"welcome"}',
+      folder_id: "CS 101",
       raw_md: '{"type":"doc"}',
     });
 
@@ -161,10 +162,12 @@ describe("session SQLite operations", () => {
       params: unknown[];
     }>;
     expect(statements[0].sql).toContain("event_json");
+    expect(statements[0].sql).toContain("folder_path");
     expect(statements[0].sql).toContain("cloudsync_workspace_binding");
     expect(statements[0].sql).toContain("NULLIF((");
     expect(statements[0].sql).not.toContain("COALESCE((");
     expect(statements[0].params).toContain('{"tracking_id":"welcome"}');
+    expect(statements[0].params).toContain("CS 101");
     expect(statements[1].sql).toContain("session_documents");
     expect(statements[1].sql).toContain("workspace_id");
     expect(statements[1].sql).toContain("FROM sessions");

--- a/apps/desktop/src/session/queries/creation.ts
+++ b/apps/desktop/src/session/queries/creation.ts
@@ -8,6 +8,7 @@ import {
 import type { SessionChanges } from "./types";
 
 import { executeTransaction, liveQueryClient } from "~/db";
+import { normalizeFolderPath } from "~/session/folders";
 import { DEFAULT_USER_ID, id } from "~/shared/utils";
 
 type EventSqlRow = {
@@ -33,18 +34,19 @@ type SessionIdentitySqlRow = { id: string };
 export async function createSession(
   title = "",
   userId = DEFAULT_USER_ID,
-  initial?: Pick<SessionChanges, "event_json" | "raw_md">,
+  initial?: Pick<SessionChanges, "event_json" | "folder_id" | "raw_md">,
 ): Promise<string> {
   const sessionId = id();
   const participantId = id();
   const now = new Date().toISOString();
+  const folderPath = normalizeFolderPath(initial?.folder_id ?? "") ?? "";
 
   await executeTransaction([
     {
       sql: `
         INSERT INTO sessions (
-          id, workspace_id, owner_user_id, title, event_json, created_at,
-          updated_at, deleted_at
+          id, workspace_id, owner_user_id, title, event_json, folder_path,
+          created_at, updated_at, deleted_at
         ) VALUES (
           ?, NULLIF((
             SELECT json_extract(value_json, '$.workspace_id')
@@ -57,10 +59,18 @@ export async function createSession(
               FROM app_settings
               WHERE id = 'cloudsync_workspace_binding'
             ), '')
-          ), ?, ?, ?, ?, NULL
+          ), ?, ?, ?, ?, ?, NULL
         )
       `,
-      params: [sessionId, userId, title, initial?.event_json ?? "", now, now],
+      params: [
+        sessionId,
+        userId,
+        title,
+        initial?.event_json ?? "",
+        folderPath,
+        now,
+        now,
+      ],
     },
     createEmptyNoteStatement(sessionId, now, initial?.raw_md ?? ""),
     {

--- a/apps/desktop/src/shared/useNewNote.test.tsx
+++ b/apps/desktop/src/shared/useNewNote.test.tsx
@@ -31,10 +31,12 @@ vi.mock("~/stt/pending-upload", () => ({
 
 import {
   openSessionAndListen,
+  useNewNote,
   useNewNoteAndListen,
   useNewNoteAndUpload,
 } from "./useNewNote";
 
+import { resetSidebarNotes, useSidebarNotes } from "~/sidebar/note-filter";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 import { resetTabsStore } from "~/store/zustand/tabs/test-utils";
@@ -42,7 +44,22 @@ import { resetTabsStore } from "~/store/zustand/tabs/test-utils";
 beforeEach(() => {
   vi.clearAllMocks();
   resetTabsStore();
+  resetSidebarNotes();
   listenerStore.setState(listenerStore.getInitialState(), true);
+});
+
+it("creates a note in the active sidebar folder", async () => {
+  mocks.createSession.mockResolvedValueOnce("folder-session");
+  useSidebarNotes.getState().setView("mine", "CS 101");
+  const { result } = renderHook(() => useNewNote());
+
+  act(() => result.current());
+
+  await vi.waitFor(() => {
+    expect(mocks.createSession).toHaveBeenCalledWith("", undefined, {
+      folder_id: "CS 101",
+    });
+  });
 });
 
 it("can open a listening note without a listener provider", async () => {

--- a/apps/desktop/src/shared/useNewNote.ts
+++ b/apps/desktop/src/shared/useNewNote.ts
@@ -7,9 +7,18 @@ import { useShallow } from "zustand/shallow";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
 import { createSession } from "~/session/queries";
+import { folderIdForNewNote, useSidebarNotes } from "~/sidebar/note-filter";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 import { reservePendingUpload } from "~/stt/pending-upload";
+
+function createNoteSession() {
+  const { noteFilter, folderFilter } = useSidebarNotes.getState();
+  const folderId = folderIdForNewNote(noteFilter, folderFilter);
+  return folderId === undefined
+    ? createSession()
+    : createSession("", undefined, { folder_id: folderId });
+}
 
 export function useNewNote({
   behavior = "new",
@@ -25,7 +34,7 @@ export function useNewNote({
 
   const handler = useCallback(() => {
     const ff = behavior === "new" ? openNew : openCurrent;
-    void createSession()
+    void createNoteSession()
       .then((sessionId) => {
         ff({ type: "sessions", id: sessionId });
       })
@@ -64,7 +73,7 @@ export function openNewNoteAndListen({
     return;
   }
 
-  void createSession()
+  void createNoteSession()
     .then((sessionId) => {
       openSessionAndListen(sessionId, { behavior });
     })
@@ -130,7 +139,7 @@ export function useNewNoteAndUpload() {
       }
 
       try {
-        const sessionId = await createSession();
+        const sessionId = await createNoteSession();
         if (!reservation.commit(sessionId)) {
           sonnerToast.error(
             t`Could not prepare this upload. Please try again.`,

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -13,16 +13,19 @@ vi.mock("~/store/zustand/tabs", () => ({
 
 vi.mock("~/sidebar/timeline", () => ({
   TimelineView: ({
+    folderFilter = null,
     showOpenCalendarButton = true,
     topChipsOverlapHeader = false,
     topChromeInset = false,
   }: {
+    folderFilter?: string | null;
     showOpenCalendarButton?: boolean;
     topChipsOverlapHeader?: boolean;
     topChromeInset?: boolean;
   }) => (
     <div
       data-testid="timeline-view"
+      data-folder-filter={folderFilter ?? ""}
       data-show-open-calendar-button={String(showOpenCalendarButton)}
       data-top-chips-overlap-header={String(topChipsOverlapHeader)}
       data-top-chrome-inset={String(topChromeInset)}
@@ -111,6 +114,16 @@ describe("LeftSidebar", () => {
 
     expect(screen.queryByTestId("timeline-view")).toBeNull();
     expect(screen.getByTestId("shared-notes-nav")).toBeTruthy();
+  });
+
+  it("keeps the personal timeline when filtering to a folder", () => {
+    render(<LeftSidebar folderFilter="CS 101" />);
+
+    expect(screen.getByTestId("timeline-view")).toBeTruthy();
+    expect(
+      screen.getByTestId("timeline-view").getAttribute("data-folder-filter"),
+    ).toBe("CS 101");
+    expect(screen.queryByTestId("shared-notes-nav")).toBeNull();
   });
 
   it.each([

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -15,11 +15,13 @@ import { hasOwnSidebarHeaderTab } from "./use-custom-sidebar";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function LeftSidebar({
+  folderFilter = null,
   noteFilter = "mine",
   timelineHeader,
   showIgnoredTimelineEvents,
   onShowIgnoredTimelineEventsChange,
 }: {
+  folderFilter?: string | null;
   noteFilter?: SidebarNoteFilter;
   timelineHeader?: ReactNode;
   showIgnoredTimelineEvents?: boolean;
@@ -70,6 +72,7 @@ export function LeftSidebar({
               {noteFilter === "mine" ? (
                 <div className="relative min-h-0 flex-1">
                   <TimelineView
+                    folderFilter={folderFilter}
                     showIgnoredEvents={showIgnoredTimelineEvents}
                     onShowIgnoredEventsChange={
                       onShowIgnoredTimelineEventsChange

--- a/apps/desktop/src/sidebar/note-filter-menu.test.tsx
+++ b/apps/desktop/src/sidebar/note-filter-menu.test.tsx
@@ -3,7 +3,12 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  folderPaths: [] as string[],
   onValueChange: vi.fn(),
+}));
+
+vi.mock("~/session/queries", () => ({
+  useFolderPaths: () => mocks.folderPaths,
 }));
 
 vi.mock("@lingui/react/macro", () => ({
@@ -23,6 +28,7 @@ import { SidebarNoteFilterMenu } from "./note-filter-menu";
 describe("SidebarNoteFilterMenu", () => {
   afterEach(() => {
     cleanup();
+    mocks.folderPaths = [];
     vi.clearAllMocks();
   });
 
@@ -44,6 +50,48 @@ describe("SidebarNoteFilterMenu", () => {
     expect(screen.getByRole("menuitemradio", { name: "Shared" })).toBeTruthy();
 
     fireEvent.click(screen.getByRole("menuitemradio", { name: "Shared" }));
-    expect(mocks.onValueChange).toHaveBeenCalledWith("shared");
+    expect(mocks.onValueChange).toHaveBeenCalledWith("shared", null);
+  });
+
+  it("lists folders and keeps the timeline on a selected folder", () => {
+    mocks.folderPaths = ["CS 101", "work"];
+
+    render(
+      <SidebarNoteFilterMenu
+        folderFilter="CS 101"
+        value="mine"
+        onValueChange={mocks.onValueChange}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Filter notes" });
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+
+    expect(
+      screen.getByRole("menuitemradio", { name: "No folder" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("menuitemradio", { name: "CS 101" })).toBeTruthy();
+    expect(screen.getByRole("menuitemradio", { name: "work" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "work" }));
+    expect(mocks.onValueChange).toHaveBeenCalledWith("mine", "work");
+  });
+
+  it("hides folder options until a folder exists", () => {
+    render(
+      <SidebarNoteFilterMenu
+        value="mine"
+        onValueChange={mocks.onValueChange}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Filter notes" });
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+
+    expect(
+      screen.queryByRole("menuitemradio", { name: "No folder" }),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/sidebar/note-filter-menu.tsx
+++ b/apps/desktop/src/sidebar/note-filter-menu.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { FunnelSimple } from "@phosphor-icons/react";
+import { FolderSimple, FunnelSimple } from "@phosphor-icons/react";
 
 import {
   AppFloatingPanel,
@@ -7,20 +7,35 @@ import {
   DropdownMenuContent,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@anlg/ui/components/ui/dropdown-menu";
 import { cn } from "@anlg/utils";
 
-import type { SidebarNoteFilter } from "./note-filter";
+import {
+  decodeNotesView,
+  encodeNotesView,
+  type SidebarNoteFilter,
+} from "./note-filter";
+
+import { useFolderPaths } from "~/session/queries";
 
 export function SidebarNoteFilterMenu({
+  folderFilter = null,
   value,
   onValueChange,
 }: {
+  folderFilter?: string | null;
   value: SidebarNoteFilter;
-  onValueChange: (value: SidebarNoteFilter) => void;
+  onValueChange: (
+    filter: SidebarNoteFilter,
+    folderFilter?: string | null,
+  ) => void;
 }) {
   const { t } = useLingui();
+  const folders = useFolderPaths();
+  const encodedValue = encodeNotesView(value, folderFilter);
+  const showFolderSection = folders.length > 0;
 
   return (
     <DropdownMenu>
@@ -34,22 +49,23 @@ export function SidebarNoteFilterMenu({
             "pointer-events-auto relative flex size-7 items-center justify-center rounded-full",
             "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
             "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
-            value !== "mine" && "bg-accent text-foreground",
+            encodedValue !== "mine" && "bg-accent text-foreground",
           ])}
         >
           <FunnelSimple
             size={15}
-            weight={value === "mine" ? "regular" : "fill"}
+            weight={encodedValue === "mine" ? "regular" : "fill"}
           />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="start" className="w-52">
         <AppFloatingPanel className="overflow-hidden p-1">
           <DropdownMenuRadioGroup
-            value={value}
-            onValueChange={(nextValue) =>
-              onValueChange(nextValue as SidebarNoteFilter)
-            }
+            value={encodedValue}
+            onValueChange={(nextValue) => {
+              const next = decodeNotesView(nextValue);
+              onValueChange(next.noteFilter, next.folderFilter);
+            }}
           >
             <DropdownMenuRadioItem value="mine">
               <Trans>My notes</Trans>
@@ -57,6 +73,23 @@ export function SidebarNoteFilterMenu({
             <DropdownMenuRadioItem value="shared">
               <Trans>Shared</Trans>
             </DropdownMenuRadioItem>
+            {showFolderSection ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuRadioItem value="folder:">
+                  <Trans>No folder</Trans>
+                </DropdownMenuRadioItem>
+                {folders.map((path) => (
+                  <DropdownMenuRadioItem key={path} value={`folder:${path}`}>
+                    <FolderSimple
+                      className="size-4 shrink-0 opacity-70"
+                      aria-hidden="true"
+                    />
+                    <span className="min-w-0 flex-1 truncate">{path}</span>
+                  </DropdownMenuRadioItem>
+                ))}
+              </>
+            ) : null}
           </DropdownMenuRadioGroup>
         </AppFloatingPanel>
       </DropdownMenuContent>

--- a/apps/desktop/src/sidebar/note-filter.test.ts
+++ b/apps/desktop/src/sidebar/note-filter.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  decodeNotesView,
+  encodeNotesView,
+  folderIdForNewNote,
+  resetSidebarNotes,
+  useSidebarNotes,
+} from "./note-filter";
+
+describe("sidebar note filter", () => {
+  afterEach(() => {
+    resetSidebarNotes();
+  });
+
+  it("encodes and decodes mine, shared, unfiled, and named folders", () => {
+    expect(encodeNotesView("mine", null)).toBe("mine");
+    expect(encodeNotesView("shared", null)).toBe("shared");
+    expect(encodeNotesView("mine", "")).toBe("folder:");
+    expect(encodeNotesView("mine", "CS 101")).toBe("folder:CS 101");
+
+    expect(decodeNotesView("mine")).toEqual({
+      noteFilter: "mine",
+      folderFilter: null,
+    });
+    expect(decodeNotesView("shared")).toEqual({
+      noteFilter: "shared",
+      folderFilter: null,
+    });
+    expect(decodeNotesView("folder:")).toEqual({
+      noteFilter: "mine",
+      folderFilter: "",
+    });
+    expect(decodeNotesView("folder:CS 101")).toEqual({
+      noteFilter: "mine",
+      folderFilter: "CS 101",
+    });
+  });
+
+  it("inherits a folder only while that folder is the active mine view", () => {
+    expect(folderIdForNewNote("mine", null)).toBeUndefined();
+    expect(folderIdForNewNote("shared", "CS 101")).toBeUndefined();
+    expect(folderIdForNewNote("mine", "")).toBe("");
+    expect(folderIdForNewNote("mine", "CS 101")).toBe("CS 101");
+  });
+
+  it("clears the folder filter when switching to shared notes", () => {
+    useSidebarNotes.getState().setView("mine", "CS 101");
+    useSidebarNotes.getState().setView("shared");
+
+    expect(useSidebarNotes.getState()).toMatchObject({
+      noteFilter: "shared",
+      folderFilter: null,
+    });
+  });
+});

--- a/apps/desktop/src/sidebar/note-filter.ts
+++ b/apps/desktop/src/sidebar/note-filter.ts
@@ -1,1 +1,70 @@
+import { create } from "zustand";
+
 export type SidebarNoteFilter = "mine" | "shared";
+
+type SidebarNotesState = {
+  noteFilter: SidebarNoteFilter;
+  folderFilter: string | null;
+  setView: (
+    noteFilter: SidebarNoteFilter,
+    folderFilter?: string | null,
+  ) => void;
+};
+
+export const useSidebarNotes = create<SidebarNotesState>((set) => ({
+  noteFilter: "mine",
+  folderFilter: null,
+  setView: (noteFilter, folderFilter) =>
+    set({
+      noteFilter,
+      folderFilter: noteFilter === "shared" ? null : (folderFilter ?? null),
+    }),
+}));
+
+export function resetSidebarNotes() {
+  useSidebarNotes.setState({
+    noteFilter: "mine",
+    folderFilter: null,
+  });
+}
+
+export function folderIdForNewNote(
+  noteFilter: SidebarNoteFilter,
+  folderFilter: string | null,
+): string | undefined {
+  if (noteFilter !== "mine" || folderFilter === null) {
+    return undefined;
+  }
+
+  return folderFilter;
+}
+
+export function encodeNotesView(
+  noteFilter: SidebarNoteFilter,
+  folderFilter: string | null,
+): string {
+  if (noteFilter === "shared") {
+    return "shared";
+  }
+
+  if (folderFilter !== null) {
+    return `folder:${folderFilter}`;
+  }
+
+  return "mine";
+}
+
+export function decodeNotesView(value: string): {
+  noteFilter: SidebarNoteFilter;
+  folderFilter: string | null;
+} {
+  if (value === "shared") {
+    return { noteFilter: "shared", folderFilter: null };
+  }
+
+  if (value.startsWith("folder:")) {
+    return { noteFilter: "mine", folderFilter: value.slice("folder:".length) };
+  }
+
+  return { noteFilter: "mine", folderFilter: null };
+}

--- a/apps/desktop/src/sidebar/timeline/data.ts
+++ b/apps/desktop/src/sidebar/timeline/data.ts
@@ -4,6 +4,7 @@ import { useSmartCurrentTime } from "./realtime";
 import {
   buildTimelineBuckets,
   deriveTimelineWindowData,
+  filterTimelineTablesByFolder,
   getItemTimestamp,
   type TimelineBucket,
   type TimelineEventsTable,
@@ -49,12 +50,14 @@ function isFutureBucketLabel(label: string) {
 }
 
 export function useTimelineData({
+  folderFilter = null,
   isEventIgnored,
   showIgnored,
   timelineEventsTable,
   timelineSessionsTable,
   timezone,
 }: {
+  folderFilter?: string | null;
   isEventIgnored: (
     trackingId: string | null | undefined,
     recurrenceSeriesId: string | null | undefined,
@@ -67,22 +70,25 @@ export function useTimelineData({
   buckets: TimelineBucket[];
   hasMoreFutureItems: boolean;
 } {
+  const folderScopedTables = useMemo(
+    () =>
+      filterTimelineTablesByFolder({
+        folderFilter,
+        timelineEventsTable,
+        timelineSessionsTable,
+      }),
+    [folderFilter, timelineEventsTable, timelineSessionsTable],
+  );
   const windowData = useMemo(
     () =>
       deriveTimelineWindowData({
         isEventIgnored,
         showIgnored,
-        timelineEventsTable,
-        timelineSessionsTable,
+        timelineEventsTable: folderScopedTables.timelineEventsTable,
+        timelineSessionsTable: folderScopedTables.timelineSessionsTable,
         timezone,
       }),
-    [
-      isEventIgnored,
-      showIgnored,
-      timelineEventsTable,
-      timelineSessionsTable,
-      timezone,
-    ],
+    [folderScopedTables, isEventIgnored, showIgnored, timezone],
   );
   const currentTimeMs = useSmartCurrentTime(
     windowData.timelineEventsTable,

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -49,12 +49,14 @@ import { useTimelineSelection } from "~/store/zustand/timeline-selection";
 import { useListener } from "~/stt/contexts";
 
 export const TimelineView = memo(function TimelineView({
+  folderFilter = null,
   showOpenCalendarButton = true,
   showIgnoredEvents,
   onShowIgnoredEventsChange,
   topChipsOverlapHeader = false,
   topChromeInset = false,
 }: {
+  folderFilter?: string | null;
   showOpenCalendarButton?: boolean;
   showIgnoredEvents?: boolean;
   onShowIgnoredEventsChange?: (showIgnored: boolean) => void;
@@ -73,6 +75,7 @@ export const TimelineView = memo(function TimelineView({
 
   const { isIgnored } = useIgnoredEvents();
   const { buckets, hasMoreFutureItems } = useTimelineData({
+    folderFilter,
     isEventIgnored: isIgnored,
     showIgnored,
     timelineEventsTable,

--- a/apps/desktop/src/sidebar/timeline/utils/index.test.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.test.ts
@@ -4,6 +4,7 @@ import {
   buildTimelineBuckets,
   calculateTodayIndicatorPlacement,
   deriveTimelineWindowData,
+  filterTimelineTablesByFolder,
   filterTimelineTablesUpToTomorrow,
   getBucketInfo,
   hasTimelineItemsAfterTomorrow,
@@ -635,6 +636,70 @@ describe("timeline utils", () => {
       "next month",
       "in 4 weeks",
       "in 2 weeks",
+    ]);
+  });
+
+  test("filterTimelineTablesByFolder keeps matching sessions and hides calendar events", () => {
+    const filtered = filterTimelineTablesByFolder({
+      folderFilter: "CS 101",
+      timelineEventsTable: {
+        "event-1": {
+          title: "Office hours",
+          started_at: "2024-01-16T09:00:00.000Z",
+          has_recurrence_rules: false,
+        },
+      },
+      timelineSessionsTable: {
+        "session-class": {
+          title: "Lecture 3",
+          created_at: "2024-01-15T11:00:00.000Z",
+          folder_id: "CS 101",
+        },
+        "session-nested": {
+          title: "Lab",
+          created_at: "2024-01-15T12:00:00.000Z",
+          folder_id: "CS 101/week-3",
+        },
+        "session-other": {
+          title: "Standup",
+          created_at: "2024-01-15T13:00:00.000Z",
+          folder_id: "work",
+        },
+        "session-unfiled": {
+          title: "Scratch",
+          created_at: "2024-01-15T14:00:00.000Z",
+          folder_id: "",
+        },
+      },
+    });
+
+    expect(Object.keys(filtered.timelineSessionsTable ?? {})).toEqual([
+      "session-class",
+      "session-nested",
+    ]);
+    expect(filtered.timelineEventsTable).toEqual({});
+  });
+
+  test("filterTimelineTablesByFolder can isolate unfiled notes", () => {
+    const filtered = filterTimelineTablesByFolder({
+      folderFilter: "",
+      timelineEventsTable: {},
+      timelineSessionsTable: {
+        "session-class": {
+          title: "Lecture 3",
+          created_at: "2024-01-15T11:00:00.000Z",
+          folder_id: "CS 101",
+        },
+        "session-unfiled": {
+          title: "Scratch",
+          created_at: "2024-01-15T14:00:00.000Z",
+          folder_id: "",
+        },
+      },
+    });
+
+    expect(Object.keys(filtered.timelineSessionsTable ?? {})).toEqual([
+      "session-unfiled",
     ]);
   });
 });

--- a/apps/desktop/src/sidebar/timeline/utils/index.ts
+++ b/apps/desktop/src/sidebar/timeline/utils/index.ts
@@ -10,6 +10,7 @@ import {
   TZDate,
 } from "@anlg/utils";
 
+import { folderDisplayName } from "~/session/folders";
 import { getSessionEvent } from "~/session/utils";
 
 function toTZ(date: Date, timezone?: string): Date {
@@ -291,6 +292,47 @@ function isAfterTomorrow(date: Date | null, timezone?: string): boolean {
   }
 
   return date.getTime() >= getTomorrowUpperBound(timezone);
+}
+
+export function sessionMatchesFolderFilter(
+  folderId: string | null | undefined,
+  folderFilter: string | null,
+): boolean {
+  if (folderFilter === null) {
+    return true;
+  }
+
+  return folderDisplayName(folderId) === folderFilter;
+}
+
+export function filterTimelineTablesByFolder({
+  timelineEventsTable,
+  timelineSessionsTable,
+  folderFilter,
+}: {
+  timelineEventsTable: TimelineEventsTable;
+  timelineSessionsTable: TimelineSessionsTable;
+  folderFilter: string | null;
+}): {
+  timelineEventsTable: TimelineEventsTable;
+  timelineSessionsTable: TimelineSessionsTable;
+} {
+  if (folderFilter === null) {
+    return { timelineEventsTable, timelineSessionsTable };
+  }
+
+  const filteredSessions = timelineSessionsTable
+    ? Object.fromEntries(
+        Object.entries(timelineSessionsTable).filter(([, row]) =>
+          sessionMatchesFolderFilter(row.folder_id, folderFilter),
+        ),
+      )
+    : timelineSessionsTable;
+
+  return {
+    timelineEventsTable: {},
+    timelineSessionsTable: filteredSessions,
+  };
 }
 
 export function filterTimelineTablesUpToTomorrow({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Folders already exist as a `folder_path` on sessions, but you cannot browse by folder or land new notes in the folder you are looking at. Class/project grouping still requires naming notes `Class - Number`.

**Fix:** Treat folders as the grouping surface. The sidebar filter keeps Mine / Shared and, once folders exist, adds No folder plus each folder. The timeline stays time-ordered and shows only matching notes. New notes, recordings, and uploads inherit the active folder.

## Verification

- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop exec vitest run` for the changed filter, timeline, session, new-note, and body tests
- Full desktop suite previously: 3517 passed; the two filter-menu failures were fixed and re-run
- `pnpm exec dprint fmt` / `dprint check` on changed files
- `pnpm -F desktop exec lingui extract --clean --workers 1` and compile (no catalog diff; reused existing "No folder")

Not verified in the desktop UI on this Linux environment (no interactive app session for this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0508a6b-24bb-488b-8604-13e4cc265da3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0508a6b-24bb-488b-8604-13e4cc265da3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

