### PR TITLE
Give chat the active folder as default context

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.test.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
     startNewChat: vi.fn(),
     selectChat: vi.fn(),
   },
+  noteFilter: "mine",
+  folderFilter: null as string | null,
 }));
 
 vi.mock("./toolbar-controls", () => ({
@@ -67,6 +69,21 @@ vi.mock("./use-session-tab", () => ({
   useSessionTab: () => ({ currentSessionId: "session-1" }),
 }));
 
+vi.mock("~/sidebar/note-filter", () => ({
+  folderIdForNewNote: (noteFilter: string, folderFilter: string | null) =>
+    noteFilter === "mine" && folderFilter !== null ? folderFilter : undefined,
+  useSidebarNotes: (
+    selector: (state: {
+      noteFilter: string;
+      folderFilter: string | null;
+    }) => unknown,
+  ) =>
+    selector({
+      noteFilter: mocks.noteFilter,
+      folderFilter: mocks.folderFilter,
+    }),
+}));
+
 vi.mock("~/contexts/shell", () => ({
   useShell: () => ({ chat: mocks.chat }),
 }));
@@ -99,6 +116,8 @@ describe("ChatView", () => {
     cleanup();
     mocks.chatSession.mockClear();
     mocks.chat.scope = "general";
+    mocks.noteFilter = "mine";
+    mocks.folderFilter = null;
     mocks.hasAvailableTranscript = false;
     mocks.sessionMode = "inactive";
     mocks.requestedLiveTranscription = null;
@@ -137,8 +156,21 @@ describe("ChatView", () => {
     );
   });
 
+  it("passes the active folder into the chat session", () => {
+    mocks.folderFilter = "CS 101";
+
+    render(<ChatView />);
+
+    expect(mocks.chatSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folderId: "CS 101",
+      }),
+    );
+  });
+
   it("does not inherit note context in the automations scope", () => {
     mocks.chat.scope = "automations";
+    mocks.folderFilter = "CS 101";
     mocks.hasAvailableTranscript = true;
     mocks.sessionMode = "active";
 
@@ -147,6 +179,7 @@ describe("ChatView", () => {
     expect(mocks.chatSession).toHaveBeenCalledWith(
       expect.objectContaining({
         currentSessionId: undefined,
+        folderId: undefined,
         hasAvailableTranscript: false,
         isBatchTranscriptionPending: false,
       }),

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -15,6 +15,7 @@ import { chatFloatingPanelClassNames } from "~/chat/surface";
 import { useShell } from "~/contexts/shell";
 import { useSessionHasTranscript } from "~/session/queries";
 import { useOwnerUserId } from "~/shared/owner-user";
+import { folderIdForNewNote, useSidebarNotes } from "~/sidebar/note-filter";
 import { isBatchTranscriptionPending } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 
@@ -49,8 +50,14 @@ export function ChatSessionHost({
   const { chat } = useShell();
   const { groupId, sessionId } = chat;
   const { currentSessionId } = useSessionTab();
+  const noteFilter = useSidebarNotes((state) => state.noteFilter);
+  const folderFilter = useSidebarNotes((state) => state.folderFilter);
   const contextSessionId =
     chat.scope === "automations" ? undefined : currentSessionId;
+  const folderId =
+    chat.scope === "automations"
+      ? undefined
+      : folderIdForNewNote(noteFilter, folderFilter);
   const ownerUserId = useOwnerUserId();
   const hasAvailableTranscript = useSessionHasTranscript(
     contextSessionId ?? "",
@@ -75,6 +82,7 @@ export function ChatSessionHost({
       sessionId={sessionId}
       chatGroupId={groupId}
       currentSessionId={contextSessionId}
+      folderId={folderId}
       hasAvailableTranscript={hasAvailableTranscript}
       isBatchTranscriptionPending={batchTranscriptionPending}
       unstyled

--- a/apps/desktop/src/chat/components/context-bar.test.tsx
+++ b/apps/desktop/src/chat/components/context-bar.test.tsx
@@ -45,6 +45,26 @@ describe("ContextBar", () => {
     expect(screen.queryByText("Search sessions...")).toBeNull();
   });
 
+  it("renders a folder chip from the active folder filter", () => {
+    render(
+      <ContextBar
+        entities={[
+          {
+            kind: "folder",
+            key: "folder:auto:CS 101",
+            source: "auto-current",
+            folderId: "CS 101",
+            title: "CS 101",
+            pending: true,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("CS 101")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
   it("does not render chip tooltips", () => {
     render(
       <ContextBar

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -75,6 +75,7 @@ interface ChatSessionProps {
   sessionId: string;
   chatGroupId?: string;
   currentSessionId?: string;
+  folderId?: string;
   hasAvailableTranscript?: boolean;
   isBatchTranscriptionPending?: boolean;
   modelOverride?: LanguageModel;
@@ -109,6 +110,7 @@ function ChatSessionLifecycle({
   sessionId,
   chatGroupId,
   currentSessionId,
+  folderId,
   hasAvailableTranscript = false,
   isBatchTranscriptionPending = false,
   modelOverride,
@@ -733,6 +735,7 @@ function ChatSessionLifecycle({
   const { contextEntities, pendingRefs } = useChatContextPipeline({
     messages,
     currentSessionId,
+    folderId,
     pendingManualRefs: pendingMessageRefs,
   });
 

--- a/apps/desktop/src/chat/context/entities.ts
+++ b/apps/desktop/src/chat/context/entities.ts
@@ -34,10 +34,16 @@ export type OrganizationContextRef = BaseContextRef & {
   organizationId: string;
 };
 
+export type FolderContextRef = BaseContextRef & {
+  kind: "folder";
+  folderId: string;
+};
+
 export type ContextRef =
   | SessionContextRef
   | HumanContextRef
-  | OrganizationContextRef;
+  | OrganizationContextRef
+  | FolderContextRef;
 
 export type CalendarEventContextRef = BaseContextRef & {
   kind: "calendar_event";
@@ -59,6 +65,10 @@ export type ContextEntity =
     })
   | (OrganizationContextRef & {
       name?: string | null;
+      removable?: boolean;
+    })
+  | (FolderContextRef & {
+      title?: string | null;
       removable?: boolean;
     })
   | (CalendarEventContextRef & {

--- a/apps/desktop/src/chat/context/folder-context.test.ts
+++ b/apps/desktop/src/chat/context/folder-context.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadSessionSummariesByFolder: vi.fn(),
+}));
+
+vi.mock("~/session/queries", () => ({
+  loadSessionSummariesByFolder: mocks.loadSessionSummariesByFolder,
+}));
+
+import { renderFolderContext } from "./folder-context";
+
+describe("folder chat context", () => {
+  beforeEach(() => {
+    mocks.loadSessionSummariesByFolder.mockReset();
+  });
+
+  it("renders a folder index with session ids", async () => {
+    mocks.loadSessionSummariesByFolder.mockResolvedValue([
+      {
+        id: "session-1",
+        title: "Lecture 1",
+        created_at: "2026-08-01T09:00:00.000Z",
+      },
+      {
+        id: "session-2",
+        title: "",
+        created_at: "2026-08-08T09:00:00.000Z",
+      },
+    ]);
+
+    await expect(renderFolderContext("CS 101")).resolves.toEqual(
+      [
+        "Folder context: CS 101",
+        "Answer from notes in this folder. Use get_meeting or search_meetings with the listed IDs when you need full notes or transcripts.",
+        "",
+        "- Lecture 1 (2026-08-01T09:00:00.000Z) [session-1]",
+        "- Untitled (2026-08-08T09:00:00.000Z) [session-2]",
+      ].join("\n"),
+    );
+  });
+
+  it("labels the unfiled view and empty folders", async () => {
+    mocks.loadSessionSummariesByFolder.mockResolvedValue([]);
+
+    await expect(renderFolderContext("")).resolves.toContain(
+      "Folder context: No folder",
+    );
+    await expect(renderFolderContext("")).resolves.toContain(
+      "This folder has no notes yet.",
+    );
+  });
+});

--- a/apps/desktop/src/chat/context/folder-context.ts
+++ b/apps/desktop/src/chat/context/folder-context.ts
@@ -1,0 +1,34 @@
+import { loadSessionSummariesByFolder } from "~/session/queries";
+
+const FOLDER_CONTEXT_SESSION_LIMIT = 50;
+
+export async function renderFolderContext(
+  folderId: string,
+): Promise<string | null> {
+  const sessions = await loadSessionSummariesByFolder(folderId);
+  const label = folderId || "No folder";
+  const lines = [
+    `Folder context: ${label}`,
+    "Answer from notes in this folder. Use get_meeting or search_meetings with the listed IDs when you need full notes or transcripts.",
+  ];
+
+  if (sessions.length === 0) {
+    lines.push("This folder has no notes yet.");
+    return lines.join("\n");
+  }
+
+  const visible = sessions.slice(0, FOLDER_CONTEXT_SESSION_LIMIT);
+  lines.push("");
+  for (const session of visible) {
+    const title = session.title.trim() || "Untitled";
+    const date = session.created_at.trim();
+    lines.push(`- ${title}${date ? ` (${date})` : ""} [${session.id}]`);
+  }
+
+  const hiddenCount = sessions.length - visible.length;
+  if (hiddenCount > 0) {
+    lines.push(`- and ${hiddenCount} more`);
+  }
+
+  return lines.join("\n");
+}

--- a/apps/desktop/src/chat/context/refs.ts
+++ b/apps/desktop/src/chat/context/refs.ts
@@ -32,6 +32,10 @@ function isContextRef(value: unknown): value is ContextRef {
     return typeof value.organizationId === "string";
   }
 
+  if (value.kind === "folder") {
+    return typeof value.folderId === "string";
+  }
+
   return false;
 }
 

--- a/apps/desktop/src/chat/context/registry.ts
+++ b/apps/desktop/src/chat/context/registry.ts
@@ -1,6 +1,7 @@
 import {
   Buildings,
   CalendarBlank,
+  FolderSimple,
   MagnifyingGlass,
   Monitor,
   User,
@@ -76,6 +77,17 @@ const renderers: RendererMap = {
             selected: { type: "organization", id: entity.organizationId },
           },
         },
+      };
+    },
+  },
+
+  folder: {
+    toChip: (entity) => {
+      return {
+        key: entity.key,
+        icon: FolderSimple,
+        label: entity.title || "No folder",
+        removable: entity.removable,
       };
     },
   },

--- a/apps/desktop/src/chat/context/use-chat-context-pipeline.test.tsx
+++ b/apps/desktop/src/chat/context/use-chat-context-pipeline.test.tsx
@@ -99,6 +99,34 @@ describe("chat context display pipeline", () => {
     expect(queryMocks.organizationIds).toHaveBeenCalledWith(["organization-1"]);
   });
 
+  it("attaches the active folder as pending context", () => {
+    const { result } = renderHook(() =>
+      useChatContextPipeline({
+        messages: [],
+        folderId: "CS 101",
+        pendingManualRefs: [],
+      }),
+    );
+
+    expect(result.current.pendingRefs).toEqual([
+      {
+        kind: "folder",
+        key: "folder:auto:CS 101",
+        source: "auto-current",
+        folderId: "CS 101",
+      },
+    ]);
+    expect(result.current.contextEntities).toEqual([
+      expect.objectContaining({
+        kind: "folder",
+        title: "CS 101",
+        removable: false,
+        pending: true,
+      }),
+    ]);
+    expect(queryMocks.sessionIds).toHaveBeenCalledWith([]);
+  });
+
   it("does not request unreferenced context catalogs", () => {
     const { result } = renderHook(() =>
       useChatContextPipeline({

--- a/apps/desktop/src/chat/context/use-chat-context-pipeline.ts
+++ b/apps/desktop/src/chat/context/use-chat-context-pipeline.ts
@@ -82,6 +82,14 @@ function toDisplayEntity(
     };
   }
 
+  if (ref.kind === "folder") {
+    return {
+      ...ref,
+      title: ref.folderId || null,
+      removable,
+    };
+  }
+
   return {
     ...ref,
     ...getOrganizationDisplayData(organizations, ref.organizationId),
@@ -92,6 +100,7 @@ function toDisplayEntity(
 type UseChatContextPipelineParams = {
   messages: AnlgUIMessage[];
   currentSessionId?: string;
+  folderId?: string;
   pendingManualRefs: ContextRef[];
 };
 
@@ -100,6 +109,7 @@ export type DisplayEntity = ContextEntity & { pending: boolean };
 export function useChatContextPipeline({
   messages,
   currentSessionId,
+  folderId,
   pendingManualRefs,
 }: UseChatContextPipelineParams): {
   contextEntities: DisplayEntity[];
@@ -126,9 +136,17 @@ export function useChatContextPipeline({
         sessionId: currentSessionId,
       });
     }
+    if (folderId !== undefined) {
+      refs.push({
+        kind: "folder",
+        key: `folder:auto:${folderId}`,
+        source: "auto-current",
+        folderId,
+      });
+    }
     refs.push(...pendingManualRefs);
     return refs;
-  }, [currentSessionId, pendingManualRefs]);
+  }, [currentSessionId, folderId, pendingManualRefs]);
 
   const referencedIds = useMemo(() => {
     const sessionIds = new Set<string>();
@@ -140,7 +158,7 @@ export function useChatContextPipeline({
         sessionIds.add(ref.sessionId);
       } else if (ref.kind === "human") {
         humanIds.add(ref.humanId);
-      } else {
+      } else if (ref.kind === "organization") {
         organizationIds.add(ref.organizationId);
       }
     }

--- a/apps/desktop/src/chat/tools/note-files.test.ts
+++ b/apps/desktop/src/chat/tools/note-files.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   loadActiveSessionIds: vi.fn(),
   loadMeetingChatRecords: vi.fn(),
   loadSessionContentSnapshot: vi.fn(),
+  loadSessionSummariesByFolder: vi.fn(),
 }));
 
 vi.mock("~/stt/meeting-chat-records", () => ({
@@ -15,6 +16,10 @@ vi.mock("~/stt/meeting-chat-records", () => ({
 vi.mock("~/session/content-queries", () => ({
   loadActiveSessionIds: mocks.loadActiveSessionIds,
   loadSessionContentSnapshot: mocks.loadSessionContentSnapshot,
+}));
+
+vi.mock("~/session/queries", () => ({
+  loadSessionSummariesByFolder: mocks.loadSessionSummariesByFolder,
 }));
 
 import {
@@ -44,6 +49,7 @@ describe("note file chat tools", () => {
     mocks.formatMeetingChatRecordsAsMarkdown.mockReturnValue("");
     mocks.loadMeetingChatRecords.mockResolvedValue([]);
     mocks.loadSessionContentSnapshot.mockResolvedValue(snapshot);
+    mocks.loadSessionSummariesByFolder.mockResolvedValue([]);
   });
 
   it("extracts raw, enhanced, and transcript sections from session files", () => {
@@ -163,6 +169,50 @@ describe("note file chat tools", () => {
     });
     expect(mocks.loadActiveSessionIds).toHaveBeenCalledOnce();
     expect(mocks.loadSessionContentSnapshot).toHaveBeenCalledWith("session-1");
+  });
+
+  it("does not scan all notes when a folder has no matching sessions", async () => {
+    mocks.loadSessionSummariesByFolder.mockResolvedValue([]);
+    mocks.loadActiveSessionIds.mockResolvedValue(["session-1"]);
+
+    const tool = buildSearchMeetingContentTool({
+      getFolderFilter: () => "CS 101",
+    } as any);
+    const result = await (tool as any).execute({ query: "midterm" });
+
+    expect(result).toMatchObject({
+      query: "midterm",
+      scanned: 0,
+      results: [],
+    });
+    expect(mocks.loadActiveSessionIds).not.toHaveBeenCalled();
+    expect(mocks.loadSessionContentSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not scan all notes when meeting ids fall outside the folder", async () => {
+    mocks.loadSessionSummariesByFolder.mockResolvedValue([
+      {
+        id: "cs-101",
+        title: "Lecture",
+        created_at: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+
+    const tool = buildSearchMeetingContentTool({
+      getFolderFilter: () => "CS 101",
+    } as any);
+    const result = await (tool as any).execute({
+      query: "midterm",
+      meeting_ids: ["other-folder"],
+    });
+
+    expect(result).toMatchObject({
+      query: "midterm",
+      scanned: 0,
+      results: [],
+    });
+    expect(mocks.loadActiveSessionIds).not.toHaveBeenCalled();
+    expect(mocks.loadSessionContentSnapshot).not.toHaveBeenCalled();
   });
 
   it("returns metadata snippets for participant matches", () => {

--- a/apps/desktop/src/chat/tools/note-files.ts
+++ b/apps/desktop/src/chat/tools/note-files.ts
@@ -357,7 +357,7 @@ function searchNote(note: LoadedNoteFile, query: string): SearchMatch | null {
   };
 }
 
-async function searchMeetingContent({
+export async function searchMeetingContent({
   query,
   sessionIds,
   limit,
@@ -375,9 +375,8 @@ async function searchMeetingContent({
     };
   }
 
-  const candidateIds = sessionIds?.length
-    ? sessionIds
-    : await loadActiveSessionIds();
+  const candidateIds =
+    sessionIds === undefined ? await loadActiveSessionIds() : sessionIds;
   const results: SearchMatch[] = [];
 
   for (const sessionId of candidateIds) {
@@ -578,11 +577,12 @@ export const buildSearchMeetingContentTool = (deps: ToolDependencies) =>
           : (await loadSessionSummariesByFolder(folderFilter)).map(
               (session) => session.id,
             );
-      const sessionIds = folderSessionIds
-        ? params.meeting_ids?.length
-          ? params.meeting_ids.filter((id) => folderSessionIds.includes(id))
-          : folderSessionIds
-        : params.meeting_ids;
+      const sessionIds =
+        folderSessionIds === undefined
+          ? params.meeting_ids
+          : params.meeting_ids?.length
+            ? params.meeting_ids.filter((id) => folderSessionIds.includes(id))
+            : folderSessionIds;
       const result = await searchMeetingContent({
         query: params.query,
         sessionIds,

--- a/apps/desktop/src/chat/tools/note-files.ts
+++ b/apps/desktop/src/chat/tools/note-files.ts
@@ -9,6 +9,7 @@ import {
   loadSessionContentSnapshot,
   type SessionContentSnapshot,
 } from "~/session/content-queries";
+import { loadSessionSummariesByFolder } from "~/session/queries";
 import {
   formatMeetingChatRecordsAsMarkdown,
   loadMeetingChatRecords,
@@ -547,7 +548,7 @@ export const buildReadNoteTool = (_deps: ToolDependencies) =>
       }),
   });
 
-export const buildSearchMeetingContentTool = (_deps: ToolDependencies) =>
+export const buildSearchMeetingContentTool = (deps: ToolDependencies) =>
   tool({
     description:
       "Search local meeting notes and transcripts for exact words or phrases. Use search_meetings first for open-ended questions about past meetings, people, decisions, or topics. This is lexical content search, not vector search.",
@@ -570,9 +571,21 @@ export const buildSearchMeetingContentTool = (_deps: ToolDependencies) =>
       meeting_ids?: string[];
       limit?: number;
     }) => {
+      const folderFilter = deps.getFolderFilter?.() ?? null;
+      const folderSessionIds =
+        folderFilter === null
+          ? undefined
+          : (await loadSessionSummariesByFolder(folderFilter)).map(
+              (session) => session.id,
+            );
+      const sessionIds = folderSessionIds
+        ? params.meeting_ids?.length
+          ? params.meeting_ids.filter((id) => folderSessionIds.includes(id))
+          : folderSessionIds
+        : params.meeting_ids;
       const result = await searchMeetingContent({
         query: params.query,
-        sessionIds: params.meeting_ids,
+        sessionIds,
         limit: Math.min(params.limit ?? DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT),
       });
       return {

--- a/apps/desktop/src/chat/tools/search-meetings.test.ts
+++ b/apps/desktop/src/chat/tools/search-meetings.test.ts
@@ -85,6 +85,7 @@ describe("search meetings chat tool", () => {
         id: "cs-101",
         title: "CS 101 lecture",
         created_at: "2026-08-01T00:00:00.000Z",
+        event_json: "",
       },
     ]);
     vi.mocked(searchMeetingContent).mockResolvedValue({
@@ -120,6 +121,78 @@ describe("search meetings chat tool", () => {
         created_at: Date.parse("2026-08-01T00:00:00.000Z"),
       },
     ]);
+  });
+
+  it("filters folder meetings by event started_at, not session created_at", async () => {
+    const search = vi.fn();
+    const meetingSearchTool = buildSearchMeetingsTool({
+      search,
+      getFolderFilter: () => "CS 101",
+    } as any);
+    const startedAt = "2026-08-15T10:00:00.000Z";
+    const createdAt = "2025-01-01T00:00:00.000Z";
+
+    vi.mocked(loadSessionSummariesByFolder).mockResolvedValue([
+      {
+        id: "cs-101",
+        title: "CS 101 lecture",
+        created_at: createdAt,
+        event_json: JSON.stringify({ started_at: startedAt }),
+      },
+    ]);
+
+    const result = await (meetingSearchTool as any).execute({
+      query: "",
+      filters: {
+        created_at: {
+          kind: "absolute",
+          gte: Date.parse("2026-08-14T00:00:00.000Z"),
+          lte: Date.parse("2026-08-16T00:00:00.000Z"),
+        },
+      },
+    });
+
+    expect(search).not.toHaveBeenCalled();
+    expect(result.results).toEqual([
+      {
+        id: "cs-101",
+        title: "CS 101 lecture",
+        excerpt: "",
+        score: 0,
+        created_at: Date.parse(startedAt),
+      },
+    ]);
+  });
+
+  it("drops folder meetings whose event start is outside the date filter", async () => {
+    const meetingSearchTool = buildSearchMeetingsTool({
+      search: vi.fn(),
+      getFolderFilter: () => "CS 101",
+    } as any);
+
+    vi.mocked(loadSessionSummariesByFolder).mockResolvedValue([
+      {
+        id: "cs-101",
+        title: "Old lecture",
+        created_at: "2026-08-15T10:00:00.000Z",
+        event_json: JSON.stringify({
+          started_at: "2025-01-01T00:00:00.000Z",
+        }),
+      },
+    ]);
+
+    const result = await (meetingSearchTool as any).execute({
+      query: "",
+      filters: {
+        created_at: {
+          kind: "absolute",
+          gte: Date.parse("2026-08-14T00:00:00.000Z"),
+          lte: Date.parse("2026-08-16T00:00:00.000Z"),
+        },
+      },
+    });
+
+    expect(result).toEqual({ results: [] });
   });
 
   it("returns no meetings when the active folder is empty", async () => {

--- a/apps/desktop/src/chat/tools/search-meetings.test.ts
+++ b/apps/desktop/src/chat/tools/search-meetings.test.ts
@@ -1,14 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { searchMeetingContent } from "./note-files";
 import { buildSearchMeetingsTool } from "./search-meetings";
 
 import { loadSessionSummariesByFolder } from "~/session/queries";
+
+vi.mock("./note-files", () => ({
+  searchMeetingContent: vi.fn(),
+}));
 
 vi.mock("~/session/queries", () => ({
   loadSessionSummariesByFolder: vi.fn(),
 }));
 
 describe("search meetings chat tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("keeps full-content search results behind meeting vocabulary", async () => {
     const search = vi.fn().mockResolvedValue([
       {
@@ -64,29 +73,8 @@ describe("search meetings chat tool", () => {
     });
   });
 
-  it("keeps search results inside the active folder", async () => {
-    const search = vi.fn().mockResolvedValue([
-      {
-        score: 0.9,
-        document: {
-          id: "other-folder",
-          type: "session",
-          title: "Other class",
-          content: "midterm review",
-          created_at: 100,
-        },
-      },
-      {
-        score: 0.8,
-        document: {
-          id: "cs-101",
-          type: "session",
-          title: "CS 101 lecture",
-          content: "midterm review",
-          created_at: 200,
-        },
-      },
-    ]);
+  it("searches only the active folder instead of post-filtering global hits", async () => {
+    const search = vi.fn();
     const meetingSearchTool = buildSearchMeetingsTool({
       search,
       getFolderFilter: () => "CS 101",
@@ -99,13 +87,56 @@ describe("search meetings chat tool", () => {
         created_at: "2026-08-01T00:00:00.000Z",
       },
     ]);
+    vi.mocked(searchMeetingContent).mockResolvedValue({
+      query: "midterm",
+      scanned: 1,
+      results: [
+        {
+          sessionId: "cs-101",
+          title: "CS 101 lecture",
+          date: "2026-08-01T00:00:00.000Z",
+          score: 0.8,
+          snippets: [{ section: "Raw note", text: "midterm review" }],
+        },
+      ],
+    });
 
     const result = await (meetingSearchTool as any).execute({
       query: "midterm",
     });
 
+    expect(search).not.toHaveBeenCalled();
+    expect(searchMeetingContent).toHaveBeenCalledWith({
+      query: "midterm",
+      sessionIds: ["cs-101"],
+      limit: 5,
+    });
     expect(result.results).toEqual([
-      expect.objectContaining({ id: "cs-101", title: "CS 101 lecture" }),
+      {
+        id: "cs-101",
+        title: "CS 101 lecture",
+        excerpt: "midterm review",
+        score: 0.8,
+        created_at: Date.parse("2026-08-01T00:00:00.000Z"),
+      },
     ]);
+  });
+
+  it("returns no meetings when the active folder is empty", async () => {
+    const search = vi.fn();
+    const meetingSearchTool = buildSearchMeetingsTool({
+      search,
+      getFolderFilter: () => "CS 101",
+    } as any);
+
+    vi.mocked(loadSessionSummariesByFolder).mockResolvedValue([]);
+
+    const result = await (meetingSearchTool as any).execute({
+      query: "midterm",
+    });
+
+    expect(result).toEqual({ results: [] });
+    expect(search).not.toHaveBeenCalled();
+    expect(searchMeetingContent).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/chat/tools/search-meetings.test.ts
+++ b/apps/desktop/src/chat/tools/search-meetings.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import { buildSearchMeetingsTool } from "./search-meetings";
 
+import { loadSessionSummariesByFolder } from "~/session/queries";
+
+vi.mock("~/session/queries", () => ({
+  loadSessionSummariesByFolder: vi.fn(),
+}));
+
 describe("search meetings chat tool", () => {
   it("keeps full-content search results behind meeting vocabulary", async () => {
     const search = vi.fn().mockResolvedValue([
@@ -56,5 +62,50 @@ describe("search meetings chat tool", () => {
         },
       ],
     });
+  });
+
+  it("keeps search results inside the active folder", async () => {
+    const search = vi.fn().mockResolvedValue([
+      {
+        score: 0.9,
+        document: {
+          id: "other-folder",
+          type: "session",
+          title: "Other class",
+          content: "midterm review",
+          created_at: 100,
+        },
+      },
+      {
+        score: 0.8,
+        document: {
+          id: "cs-101",
+          type: "session",
+          title: "CS 101 lecture",
+          content: "midterm review",
+          created_at: 200,
+        },
+      },
+    ]);
+    const meetingSearchTool = buildSearchMeetingsTool({
+      search,
+      getFolderFilter: () => "CS 101",
+    } as any);
+
+    vi.mocked(loadSessionSummariesByFolder).mockResolvedValue([
+      {
+        id: "cs-101",
+        title: "CS 101 lecture",
+        created_at: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+
+    const result = await (meetingSearchTool as any).execute({
+      query: "midterm",
+    });
+
+    expect(result.results).toEqual([
+      expect.objectContaining({ id: "cs-101", title: "CS 101 lecture" }),
+    ]);
   });
 });

--- a/apps/desktop/src/chat/tools/search-meetings.ts
+++ b/apps/desktop/src/chat/tools/search-meetings.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 
+import { searchMeetingContent } from "./note-files";
 import type { ToolDependencies } from "./types";
 
 import type { SearchFilters } from "~/search/contexts/engine/types";
@@ -76,6 +77,100 @@ const searchMeetingsFiltersSchema = z
 type AbsoluteCreatedAtFilter = z.infer<typeof absoluteCreatedAtFilterSchema>;
 type SearchMeetingsFiltersInput = z.infer<typeof searchMeetingsFiltersSchema>;
 
+function sessionMatchesCreatedAt(
+  createdAt: string,
+  filter: SearchFilters["created_at"],
+): boolean {
+  if (!filter) {
+    return true;
+  }
+
+  const timestamp = Date.parse(createdAt);
+  if (Number.isNaN(timestamp)) {
+    return false;
+  }
+
+  if (filter.eq !== undefined && timestamp !== filter.eq) {
+    return false;
+  }
+  if (filter.gte !== undefined && timestamp < filter.gte) {
+    return false;
+  }
+  if (filter.lte !== undefined && timestamp > filter.lte) {
+    return false;
+  }
+  if (filter.gt !== undefined && timestamp <= filter.gt) {
+    return false;
+  }
+  if (filter.lt !== undefined && timestamp >= filter.lt) {
+    return false;
+  }
+
+  return true;
+}
+
+async function searchFolderMeetings({
+  query,
+  folderFilter,
+  createdAt,
+  limit,
+}: {
+  query: string;
+  folderFilter: string;
+  createdAt: SearchFilters["created_at"];
+  limit: number;
+}): Promise<{
+  results: Array<{
+    id: string;
+    title: string;
+    excerpt: string;
+    score: number;
+    created_at: number;
+  }>;
+}> {
+  const sessions = (await loadSessionSummariesByFolder(folderFilter)).filter(
+    (session) => sessionMatchesCreatedAt(session.created_at, createdAt),
+  );
+
+  if (sessions.length === 0) {
+    return { results: [] };
+  }
+
+  if (!query.trim()) {
+    return {
+      results: sessions.slice(0, limit).map((session) => ({
+        id: session.id,
+        title: session.title,
+        excerpt: "",
+        score: 0,
+        created_at: Date.parse(session.created_at) || 0,
+      })),
+    };
+  }
+
+  const content = await searchMeetingContent({
+    query,
+    sessionIds: sessions.map((session) => session.id),
+    limit,
+  });
+  const createdAtById = new Map(
+    sessions.map((session) => [
+      session.id,
+      Date.parse(session.created_at) || 0,
+    ]),
+  );
+
+  return {
+    results: content.results.map((match) => ({
+      id: match.sessionId,
+      title: match.title,
+      excerpt: match.snippets[0]?.text ?? "",
+      score: match.score,
+      created_at: createdAtById.get(match.sessionId) ?? 0,
+    })),
+  };
+}
+
 function getRecentDaysFilter(
   days: number,
 ): NonNullable<SearchFilters["created_at"]> {
@@ -148,23 +243,20 @@ Returns relevant meetings with matching content excerpts.
           }
         : null;
 
-      const hits = await deps.search(query, effectiveFilters);
       const folderFilter = deps.getFolderFilter?.() ?? null;
-      const folderSessionIds =
-        folderFilter === null
-          ? null
-          : new Set(
-              (await loadSessionSummariesByFolder(folderFilter)).map(
-                (session) => session.id,
-              ),
-            );
-      const meetingHits = hits.filter((hit) => {
-        if (hit.document.type !== "session") {
-          return false;
-        }
-        return folderSessionIds ? folderSessionIds.has(hit.document.id) : true;
-      });
       const limit = params.limit ?? 5;
+
+      if (folderFilter !== null) {
+        return searchFolderMeetings({
+          query,
+          folderFilter,
+          createdAt: effectiveFilters?.created_at,
+          limit,
+        });
+      }
+
+      const hits = await deps.search(query, effectiveFilters);
+      const meetingHits = hits.filter((hit) => hit.document.type === "session");
       const results = meetingHits.slice(0, limit).map((hit) => ({
         id: hit.document.id,
         title: hit.document.title,

--- a/apps/desktop/src/chat/tools/search-meetings.ts
+++ b/apps/desktop/src/chat/tools/search-meetings.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { ToolDependencies } from "./types";
 
 import type { SearchFilters } from "~/search/contexts/engine/types";
+import { loadSessionSummariesByFolder } from "~/session/queries";
 
 const gteSchema = z
   .number()
@@ -148,7 +149,21 @@ Returns relevant meetings with matching content excerpts.
         : null;
 
       const hits = await deps.search(query, effectiveFilters);
-      const meetingHits = hits.filter((hit) => hit.document.type === "session");
+      const folderFilter = deps.getFolderFilter?.() ?? null;
+      const folderSessionIds =
+        folderFilter === null
+          ? null
+          : new Set(
+              (await loadSessionSummariesByFolder(folderFilter)).map(
+                (session) => session.id,
+              ),
+            );
+      const meetingHits = hits.filter((hit) => {
+        if (hit.document.type !== "session") {
+          return false;
+        }
+        return folderSessionIds ? folderSessionIds.has(hit.document.id) : true;
+      });
       const limit = params.limit ?? 5;
       const results = meetingHits.slice(0, limit).map((hit) => ({
         id: hit.document.id,

--- a/apps/desktop/src/chat/tools/search-meetings.ts
+++ b/apps/desktop/src/chat/tools/search-meetings.ts
@@ -6,6 +6,7 @@ import type { ToolDependencies } from "./types";
 
 import type { SearchFilters } from "~/search/contexts/engine/types";
 import { loadSessionSummariesByFolder } from "~/session/queries";
+import { sessionSearchTimestamp } from "~/session/utils";
 
 const gteSchema = z
   .number()
@@ -78,15 +79,14 @@ type AbsoluteCreatedAtFilter = z.infer<typeof absoluteCreatedAtFilterSchema>;
 type SearchMeetingsFiltersInput = z.infer<typeof searchMeetingsFiltersSchema>;
 
 function sessionMatchesCreatedAt(
-  createdAt: string,
+  timestamp: number,
   filter: SearchFilters["created_at"],
 ): boolean {
   if (!filter) {
     return true;
   }
 
-  const timestamp = Date.parse(createdAt);
-  if (Number.isNaN(timestamp)) {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
     return false;
   }
 
@@ -128,9 +128,12 @@ async function searchFolderMeetings({
     created_at: number;
   }>;
 }> {
-  const sessions = (await loadSessionSummariesByFolder(folderFilter)).filter(
-    (session) => sessionMatchesCreatedAt(session.created_at, createdAt),
-  );
+  const sessions = (await loadSessionSummariesByFolder(folderFilter))
+    .map((session) => ({
+      ...session,
+      searchAt: sessionSearchTimestamp(session.event_json, session.created_at),
+    }))
+    .filter((session) => sessionMatchesCreatedAt(session.searchAt, createdAt));
 
   if (sessions.length === 0) {
     return { results: [] };
@@ -143,7 +146,7 @@ async function searchFolderMeetings({
         title: session.title,
         excerpt: "",
         score: 0,
-        created_at: Date.parse(session.created_at) || 0,
+        created_at: session.searchAt,
       })),
     };
   }
@@ -154,10 +157,7 @@ async function searchFolderMeetings({
     limit,
   });
   const createdAtById = new Map(
-    sessions.map((session) => [
-      session.id,
-      Date.parse(session.created_at) || 0,
-    ]),
+    sessions.map((session) => [session.id, session.searchAt]),
   );
 
   return {

--- a/apps/desktop/src/chat/tools/types.ts
+++ b/apps/desktop/src/chat/tools/types.ts
@@ -51,6 +51,7 @@ export interface ToolDependencies {
     limit: number,
   ) => Promise<CalendarEventSearchResult[]>;
   getSessionId: () => string | undefined;
+  getFolderFilter?: () => string | null;
   getEnhancedNoteId: () => string | undefined;
   openEditTab: (requestId: string) => void;
   getAuthHeaders: () => Record<string, string> | null | undefined;

--- a/apps/desktop/src/chat/transport/use-transport.test.ts
+++ b/apps/desktop/src/chat/transport/use-transport.test.ts
@@ -13,6 +13,7 @@ describe("chat transport prompt guidance", () => {
     expect(prompt).toContain("use get_meeting");
     expect(prompt).toContain("Use get_meeting_transcript");
     expect(prompt).toContain("Use get_recurring_meeting_history");
+    expect(prompt).toContain("When folder context is attached");
     expect(prompt).toContain("Use typed meeting tools");
     expect(prompt).toContain("Do not ask the user to open or share a meeting");
     expect(prompt).toContain("call edit_memo");

--- a/apps/desktop/src/chat/transport/use-transport.ts
+++ b/apps/desktop/src/chat/transport/use-transport.ts
@@ -8,6 +8,7 @@ import type { ResolvedChatContext } from "./index";
 
 import { useLanguageModel } from "~/ai/hooks";
 import type { ContextRef } from "~/chat/context/entities";
+import { renderFolderContext } from "~/chat/context/folder-context";
 import { hydrateSessionContext } from "~/chat/context/session-context-hydrator";
 import { loadHuman, loadOrganization } from "~/contacts/queries";
 import { useToolRegistry } from "~/contexts/tool";
@@ -20,6 +21,7 @@ Context and local meeting tool guidance:
 - After resolving an ID, use get_meeting for the canonical note, summaries, participants, and action items. Use get_meeting_transcript separately for bounded transcript pages, following pagination.next_offset only when more context is needed.
 - Use get_recurring_meeting_history for meetings in the same recurring series. Use find_related_meetings only for broader relationships such as shared participants or nearby dates.
 - When the user refers to the current meeting, prefer the attached meeting context. Do not fetch it again unless the task needs newer structured data.
+- When folder context is attached, prefer the notes listed in that folder. Search and content tools stay scoped to that folder.
 - When the user asks to prepare for a meeting, create an agenda, organize talking points, or add drafted content before or during a meeting, call edit_memo with the complete replacement markdown so they can review and apply it. Preserve relevant existing memo content. Use edit_memo even when the memo is empty; do not use edit_summary for meeting preparation.
 - When the user asks to rewrite, revise, refocus, shorten, or restructure an existing summary, call edit_summary with the complete replacement markdown so they can review and apply it. Do not return the rewrite only as a fenced markdown block.
 - Use edit_summary only for existing generated post-meeting summaries. Use apply_session_correction for narrow exact old-to-new corrections and edit_summary for broader summary rewrites. Only return a draft without calling edit_memo or edit_summary when the user explicitly asks not to change the meeting content or no target session can be resolved.
@@ -176,6 +178,13 @@ export function useTransport(
 
         if (ref.kind === "human") {
           const text = await renderHumanContext(ref.humanId);
+          return text
+            ? ({ kind: "text", text } satisfies ResolvedChatContext)
+            : null;
+        }
+
+        if (ref.kind === "folder") {
+          const text = await renderFolderContext(ref.folderId);
           return text
             ? ({ kind: "text", text } satisfies ResolvedChatContext)
             : null;

--- a/apps/desktop/src/chat/types.ts
+++ b/apps/desktop/src/chat/types.ts
@@ -30,6 +30,12 @@ const messageMetadataSchema = z.object({
           source: z.enum(CONTEXT_ENTITY_SOURCES).optional(),
           organizationId: z.string(),
         }),
+        z.object({
+          kind: z.literal("folder"),
+          key: z.string(),
+          source: z.enum(CONTEXT_ENTITY_SOURCES).optional(),
+          folderId: z.string(),
+        }),
       ]),
     )
     .optional(),

--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -20,6 +20,7 @@ import { SharedNotePreviewAuthLifecycle } from "~/shared-notes/preview";
 import { DurableSharedNoteCacheSync } from "~/shared-notes/sync";
 import { useConfigValue } from "~/shared/config";
 import { useDesktopTabLifecycle } from "~/shared/desktop-tab-lifecycle";
+import { folderIdForNewNote, useSidebarNotes } from "~/sidebar/note-filter";
 import { useTabs } from "~/store/zustand/tabs";
 import { LiveCaptureRecovery } from "~/stt/live-capture-recovery";
 import { ScheduledMeetingAutoStart } from "~/stt/scheduled-auto-start";
@@ -74,6 +75,10 @@ function ToolRegistration() {
   const getCalendarEventSearchResults = searchCalendarEvents;
 
   const { getSessionId, getEnhancedNoteId } = useSessionTab();
+  const getFolderFilter = useCallback(() => {
+    const { noteFilter, folderFilter } = useSidebarNotes.getState();
+    return folderIdForNewNote(noteFilter, folderFilter) ?? null;
+  }, []);
   const getAuthHeaders = useCallback(() => auth?.getHeaders(), [auth]);
   const openEditTab = useCallback((requestId: string) => {
     useTabs.getState().openNew({ type: "edit", requestId });
@@ -87,6 +92,7 @@ function ToolRegistration() {
         getContactSearchResults,
         getCalendarEventSearchResults,
         getSessionId,
+        getFolderFilter,
         getEnhancedNoteId,
         openEditTab,
         getAuthHeaders,
@@ -96,6 +102,7 @@ function ToolRegistration() {
       getContactSearchResults,
       getCalendarEventSearchResults,
       getSessionId,
+      getFolderFilter,
       getEnhancedNoteId,
       openEditTab,
       getAuthHeaders,

--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -16,7 +16,10 @@ export {
   createSession,
   getOrCreateSessionForEventId,
 } from "./queries/creation";
-export { useFolderPaths } from "./queries/folders";
+export {
+  loadSessionSummariesByFolder,
+  useFolderPaths,
+} from "./queries/folders";
 export {
   applySessionProposal,
   declineSessionProposal,

--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -20,6 +20,7 @@ export {
   loadSessionSummariesByFolder,
   useFolderPaths,
 } from "./queries/folders";
+export type { FolderSessionSummary } from "./queries/folders";
 export {
   applySessionProposal,
   declineSessionProposal,

--- a/apps/desktop/src/session/queries/folders.test.ts
+++ b/apps/desktop/src/session/queries/folders.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+vi.mock("~/db", () => ({
+  liveQueryClient: { execute: mocks.execute },
+  useLiveQuery: () => ({ data: [] }),
+}));
+
+import { loadSessionSummariesByFolder } from "./folders";
+
+describe("folder session queries", () => {
+  beforeEach(() => {
+    mocks.execute.mockReset();
+  });
+
+  it("loads unfiled sessions", async () => {
+    mocks.execute.mockResolvedValue([
+      {
+        id: "unfiled",
+        title: "Scratch",
+        created_at: "2026-08-01T00:00:00.000Z",
+        folder_path: "",
+      },
+    ]);
+
+    await expect(loadSessionSummariesByFolder("")).resolves.toEqual([
+      {
+        id: "unfiled",
+        title: "Scratch",
+        created_at: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining("folder_path = ''"),
+      [],
+    );
+  });
+
+  it("keeps nested paths under the top-level folder name", async () => {
+    mocks.execute.mockResolvedValue([
+      {
+        id: "nested",
+        title: "Week 3",
+        created_at: "2026-08-10T00:00:00.000Z",
+        folder_path: "CS 101/week-3",
+      },
+      {
+        id: "other",
+        title: "Other class",
+        created_at: "2026-08-11T00:00:00.000Z",
+        folder_path: "CS 101 Extra",
+      },
+    ]);
+
+    await expect(loadSessionSummariesByFolder("CS 101")).resolves.toEqual([
+      {
+        id: "nested",
+        title: "Week 3",
+        created_at: "2026-08-10T00:00:00.000Z",
+      },
+    ]);
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining("folder_path = ?"),
+      ["CS 101", "CS 101/%", "CS 101\\%"],
+    );
+  });
+});

--- a/apps/desktop/src/session/queries/folders.test.ts
+++ b/apps/desktop/src/session/queries/folders.test.ts
@@ -22,6 +22,7 @@ describe("folder session queries", () => {
         id: "unfiled",
         title: "Scratch",
         created_at: "2026-08-01T00:00:00.000Z",
+        event_json: "",
         folder_path: "",
       },
     ]);
@@ -31,6 +32,7 @@ describe("folder session queries", () => {
         id: "unfiled",
         title: "Scratch",
         created_at: "2026-08-01T00:00:00.000Z",
+        event_json: "",
       },
     ]);
     expect(mocks.execute).toHaveBeenCalledWith(
@@ -45,12 +47,14 @@ describe("folder session queries", () => {
         id: "nested",
         title: "Week 3",
         created_at: "2026-08-10T00:00:00.000Z",
+        event_json: "",
         folder_path: "CS 101/week-3",
       },
       {
         id: "other",
         title: "Other class",
         created_at: "2026-08-11T00:00:00.000Z",
+        event_json: "",
         folder_path: "CS 101 Extra",
       },
     ]);
@@ -60,6 +64,7 @@ describe("folder session queries", () => {
         id: "nested",
         title: "Week 3",
         created_at: "2026-08-10T00:00:00.000Z",
+        event_json: "",
       },
     ]);
     expect(mocks.execute).toHaveBeenCalledWith(

--- a/apps/desktop/src/session/queries/folders.ts
+++ b/apps/desktop/src/session/queries/folders.ts
@@ -30,7 +30,12 @@ type FolderSessionSqlRow = {
   id: string;
   title: string;
   created_at: string;
+  event_json: string;
   folder_path: string;
+};
+
+export type FolderSessionSummary = SessionSummaryRecord & {
+  event_json: string;
 };
 
 function folderSessionFilterSql(folderFilter: string): {
@@ -49,11 +54,11 @@ function folderSessionFilterSql(folderFilter: string): {
 
 export async function loadSessionSummariesByFolder(
   folderFilter: string,
-): Promise<SessionSummaryRecord[]> {
+): Promise<FolderSessionSummary[]> {
   const { sql, params } = folderSessionFilterSql(folderFilter);
   const rows = await liveQueryClient.execute<FolderSessionSqlRow>(
     `
-      SELECT id, title, created_at, folder_path
+      SELECT id, title, created_at, event_json, folder_path
       FROM sessions
       WHERE deleted_at IS NULL
         AND ${sql}
@@ -68,5 +73,6 @@ export async function loadSessionSummariesByFolder(
       id: row.id,
       title: row.title,
       created_at: row.created_at,
+      event_json: row.event_json,
     }));
 }

--- a/apps/desktop/src/session/queries/folders.ts
+++ b/apps/desktop/src/session/queries/folders.ts
@@ -1,6 +1,7 @@
-import { collectFolderPaths } from "../folders";
+import { collectFolderPaths, folderDisplayName } from "../folders";
+import type { SessionSummaryRecord } from "./types";
 
-import { useLiveQuery } from "~/db";
+import { liveQueryClient, useLiveQuery } from "~/db";
 
 type FolderPathSqlRow = {
   folder_path: string;
@@ -23,4 +24,49 @@ export function useFolderPaths(): string[] {
     mapRows: (rows) => collectFolderPaths(rows.map((row) => row.folder_path)),
   });
   return data;
+}
+
+type FolderSessionSqlRow = {
+  id: string;
+  title: string;
+  created_at: string;
+  folder_path: string;
+};
+
+function folderSessionFilterSql(folderFilter: string): {
+  sql: string;
+  params: string[];
+} {
+  if (folderFilter === "") {
+    return { sql: "folder_path = ''", params: [] };
+  }
+
+  return {
+    sql: "(folder_path = ? OR folder_path LIKE ? OR folder_path LIKE ?)",
+    params: [folderFilter, `${folderFilter}/%`, `${folderFilter}\\%`],
+  };
+}
+
+export async function loadSessionSummariesByFolder(
+  folderFilter: string,
+): Promise<SessionSummaryRecord[]> {
+  const { sql, params } = folderSessionFilterSql(folderFilter);
+  const rows = await liveQueryClient.execute<FolderSessionSqlRow>(
+    `
+      SELECT id, title, created_at, folder_path
+      FROM sessions
+      WHERE deleted_at IS NULL
+        AND ${sql}
+      ORDER BY created_at DESC
+    `,
+    params,
+  );
+
+  return rows
+    .filter((row) => folderDisplayName(row.folder_path) === folderFilter)
+    .map((row) => ({
+      id: row.id,
+      title: row.title,
+      created_at: row.created_at,
+    }));
 }

--- a/apps/desktop/src/session/utils.test.ts
+++ b/apps/desktop/src/session/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionSearchTimestamp } from "./utils";
+
+describe("sessionSearchTimestamp", () => {
+  it("prefers event started_at over session created_at", () => {
+    expect(
+      sessionSearchTimestamp(
+        JSON.stringify({ started_at: "2026-07-14T01:02:03.000Z" }),
+        "2025-01-01T00:00:00.000Z",
+      ),
+    ).toBe(Date.parse("2026-07-14T01:02:03.000Z"));
+  });
+
+  it("falls back to created_at without a usable event start", () => {
+    expect(sessionSearchTimestamp("{}", "2025-01-01T00:00:00.000Z")).toBe(
+      Date.parse("2025-01-01T00:00:00.000Z"),
+    );
+    expect(sessionSearchTimestamp('{"started_at":1234}', "")).toBe(1234);
+  });
+});

--- a/apps/desktop/src/session/utils.ts
+++ b/apps/desktop/src/session/utils.ts
@@ -11,3 +11,34 @@ export function getSessionEvent(session: {
     return null;
   }
 }
+
+export function sessionSearchTimestamp(
+  eventJson: string | null | undefined,
+  createdAt: string,
+): number {
+  const event = getSessionEvent({ event_json: eventJson });
+  const fromEvent = toEpochMs(event?.started_at);
+  if (fromEvent > 0) {
+    return fromEvent;
+  }
+
+  return toEpochMs(createdAt);
+}
+
+function toEpochMs(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value !== "string" || !value.trim()) {
+    return 0;
+  }
+
+  const parsed = Date.parse(value);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.trunc(numeric) : 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Slice 1 lets you browse a folder and inherit it on new notes, but chat still only attached the open session. Asking “what did we cover in CS 101?” required manually pinning notes.

**Fix:** When the sidebar is on a folder (or unfiled), chat attaches that folder as default context: one chip, a title/id index for the notes in it, and meeting search scoped to those sessions. Full note/transcript content is still fetched via tools. Automations chat is unchanged.

Folder search no longer falls back to every note when the folder is empty or `meeting_ids` do not overlap it, and it no longer post-filters the global Tantivy top hits. Date filters and result timestamps use event `started_at` for calendar-backed meetings, same as the unscoped search index.

## Verification

- `pnpm exec dprint fmt` on changed files, then scoped `dprint check`
- `pnpm exec oxlint --quiet --format=github` on changed files
- `pnpm -F desktop typecheck`
- `pnpm -F desktop exec vitest run src/session/utils.test.ts src/session/queries/folders.test.ts src/chat/tools/search-meetings.test.ts src/chat/context/folder-context.test.ts`

Did not click through the desktop UI in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0508a6b-24bb-488b-8604-13e4cc265da3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0508a6b-24bb-488b-8604-13e4cc265da3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

