### PR TITLE
Prevent Apple Calendar listing from crashing on null EventKit titles

### DIFF
--- a/crates/apple-calendar/Cargo.toml
+++ b/crates/apple-calendar/Cargo.toml
@@ -35,7 +35,7 @@ objc2 = { workspace = true, features = ["exception"] }
 objc2-contacts = { workspace = true, features = ["CNContactStore", "CNContact", "CNLabeledValue", "CNPhoneNumber"] }
 objc2-core-graphics = { workspace = true }
 objc2-event-kit = { workspace = true, features = ["EKEventStore", "EKCalendarItem", "EKCalendar", "EKParticipant", "EKObject", "EKEvent", "EKSource", "EKTypes", "EKRecurrenceRule", "EKRecurrenceEnd", "EKAlarm", "EKStructuredLocation", "EKRecurrenceDayOfWeek", "objc2-core-graphics"] }
-objc2-foundation = { workspace = true, features = ["NSDate", "NSEnumerator", "NSPredicate", "NSError", "NSNotification"] }
+objc2-foundation = { workspace = true, features = ["NSDate", "NSEnumerator", "NSPredicate", "NSError", "NSNotification", "NSString"] }
 
 [[example]]
 name = "repro_empty_calendars"

--- a/crates/apple-calendar/src/apple/transforms/calendar.rs
+++ b/crates/apple-calendar/src/apple/transforms/calendar.rs
@@ -5,11 +5,12 @@ use crate::types::{AppleCalendar, CalendarSource, CalendarType};
 use super::enums::{transform_calendar_type, transform_source_type};
 use super::utils::{
     extract_allowed_entity_types, extract_color_components, extract_supported_availabilities,
+    objc_source_identifier, objc_title,
 };
 
 pub fn transform_calendar(calendar: &EKCalendar) -> AppleCalendar {
     let id = unsafe { calendar.calendarIdentifier() }.to_string();
-    let title = unsafe { calendar.title() }.to_string();
+    let title = objc_title(calendar);
     let calendar_type = transform_calendar_type(unsafe { calendar.r#type() });
     let color = unsafe { calendar.CGColor() }.map(|cg_color| extract_color_components(&cg_color));
 
@@ -48,8 +49,8 @@ pub fn extract_calendar_properties(calendar: &EKCalendar) -> AppleCalendar {
 
 pub fn extract_calendar_source(calendar: &EKCalendar) -> CalendarSource {
     if let Some(src) = unsafe { calendar.source() } {
-        let source_identifier = unsafe { src.sourceIdentifier() }.to_string();
-        let source_title = unsafe { src.title() }.to_string();
+        let source_identifier = objc_source_identifier(&*src);
+        let source_title = objc_title(&*src);
         let source_type = transform_source_type(unsafe { src.sourceType() });
         CalendarSource {
             identifier: source_identifier,

--- a/crates/apple-calendar/src/apple/transforms/event.rs
+++ b/crates/apple-calendar/src/apple/transforms/event.rs
@@ -11,7 +11,7 @@ use super::alarm::transform_alarm;
 use super::enums::{transform_event_availability, transform_event_status};
 use super::location::transform_structured_location;
 use super::participant::transform_participant;
-use super::utils::get_url_string;
+use super::utils::{get_url_string, objc_title};
 
 pub fn transform_event(
     event: &EKEvent,
@@ -84,7 +84,7 @@ fn extract_event_calendar_ref(event: &EKEvent) -> CalendarRef {
     let calendar = unsafe { event.calendar() }.unwrap();
     CalendarRef {
         id: unsafe { calendar.calendarIdentifier() }.to_string(),
-        title: unsafe { calendar.title() }.to_string(),
+        title: objc_title(&*calendar),
     }
 }
 
@@ -100,7 +100,7 @@ struct EventBasicInfo {
 
 fn extract_event_basic_info(event: &EKEvent) -> EventBasicInfo {
     EventBasicInfo {
-        title: unsafe { event.title() }.to_string(),
+        title: objc_title(event),
         location: unsafe { event.location() }.map(|s| s.to_string()),
         url: get_url_string(event, "URL"),
         notes: unsafe { event.notes() }.map(|s| s.to_string()),

--- a/crates/apple-calendar/src/apple/transforms/utils.rs
+++ b/crates/apple-calendar/src/apple/transforms/utils.rs
@@ -1,7 +1,7 @@
 use objc2::{msg_send, rc::Retained};
 use objc2_core_graphics::CGColor;
 use objc2_event_kit::EKCalendar;
-use objc2_foundation::{NSInteger, NSURL};
+use objc2_foundation::{NSInteger, NSString, NSURL};
 
 use crate::types::{CalendarColor, CalendarEntityType, EventAvailability};
 
@@ -91,5 +91,25 @@ where
     unsafe {
         let url_obj: Option<Retained<NSURL>> = msg_send![obj, URL];
         url_obj.and_then(|u| u.absoluteString().map(|s| s.to_string()))
+    }
+}
+
+pub fn objc_title<T>(obj: &T) -> String
+where
+    T: objc2::Message + ?Sized,
+{
+    unsafe {
+        let title: Option<Retained<NSString>> = msg_send![obj, title];
+        title.map(|s| s.to_string()).unwrap_or_default()
+    }
+}
+
+pub fn objc_source_identifier<T>(obj: &T) -> String
+where
+    T: objc2::Message + ?Sized,
+{
+    unsafe {
+        let identifier: Option<Retained<NSString>> = msg_send![obj, sourceIdentifier];
+        identifier.map(|s| s.to_string()).unwrap_or_default()
     }
 }

--- a/crates/apple-todo/Cargo.toml
+++ b/crates/apple-todo/Cargo.toml
@@ -25,4 +25,4 @@ objc2 = { workspace = true, features = ["exception"] }
 objc2-core-location = { workspace = true }
 objc2-core-graphics = { workspace = true }
 objc2-event-kit = { workspace = true, features = ["EKEventStore", "EKCalendarItem", "EKCalendar", "EKObject", "EKReminder", "EKSource", "EKTypes", "EKRecurrenceRule", "EKRecurrenceEnd", "EKAlarm", "EKStructuredLocation", "EKRecurrenceDayOfWeek", "objc2-core-graphics", "objc2-core-location"] }
-objc2-foundation = { workspace = true, features = ["NSDate", "NSEnumerator", "NSPredicate", "NSError", "NSNotification", "NSCalendar", "NSTimeZone"] }
+objc2-foundation = { workspace = true, features = ["NSDate", "NSEnumerator", "NSPredicate", "NSError", "NSNotification", "NSCalendar", "NSTimeZone", "NSString"] }

--- a/crates/apple-todo/src/apple/transforms/reminder.rs
+++ b/crates/apple-todo/src/apple/transforms/reminder.rs
@@ -7,6 +7,7 @@ use crate::types::{DateComponents, Reminder, ReminderListRef, ReminderPriority};
 
 use super::super::recurrence::{offset_date_time_from, parse_recurrence_rules};
 use super::alarm::transform_alarm;
+use super::utils::objc_title;
 
 pub fn transform_reminder(reminder: &EKReminder) -> Result<Reminder> {
     let calendar_item_identifier = unsafe { reminder.calendarItemIdentifier() }.to_string();
@@ -18,14 +19,11 @@ pub fn transform_reminder(reminder: &EKReminder) -> Result<Reminder> {
     let list = unsafe { reminder.calendar() }
         .map(|cal| ReminderListRef {
             id: unsafe { cal.calendarIdentifier() }.to_string(),
-            title: unsafe { cal.title() }.to_string(),
+            title: objc_title(&*cal),
         })
         .ok_or_else(|| Error::TransformError("reminder has no calendar".into()))?;
 
-    let title = unsafe {
-        let t: Option<Retained<objc2_foundation::NSString>> = msg_send![reminder, title];
-        t.map(|s| s.to_string()).unwrap_or_default()
-    };
+    let title = objc_title(reminder);
 
     let notes = unsafe { reminder.notes() }.map(|s| s.to_string());
 

--- a/crates/apple-todo/src/apple/transforms/reminder_list.rs
+++ b/crates/apple-todo/src/apple/transforms/reminder_list.rs
@@ -3,11 +3,11 @@ use objc2_event_kit::EKCalendar;
 use crate::types::{CalendarSource, ReminderList};
 
 use super::enums::{transform_calendar_type, transform_source_type};
-use super::utils::extract_color_components;
+use super::utils::{extract_color_components, objc_source_identifier, objc_title};
 
 pub fn transform_reminder_list(calendar: &EKCalendar, is_default: bool) -> ReminderList {
     let id = unsafe { calendar.calendarIdentifier() }.to_string();
-    let title = unsafe { calendar.title() }.to_string();
+    let title = objc_title(calendar);
     let calendar_type = transform_calendar_type(unsafe { calendar.r#type() });
     let color = unsafe { calendar.CGColor() }.map(|cg_color| extract_color_components(&cg_color));
     let allows_content_modifications = unsafe { calendar.allowsContentModifications() };
@@ -26,8 +26,8 @@ pub fn transform_reminder_list(calendar: &EKCalendar, is_default: bool) -> Remin
 
 fn extract_source(calendar: &EKCalendar) -> CalendarSource {
     if let Some(src) = unsafe { calendar.source() } {
-        let source_identifier = unsafe { src.sourceIdentifier() }.to_string();
-        let source_title = unsafe { src.title() }.to_string();
+        let source_identifier = objc_source_identifier(&*src);
+        let source_title = objc_title(&*src);
         let source_type = transform_source_type(unsafe { src.sourceType() });
         CalendarSource {
             identifier: source_identifier,

--- a/crates/apple-todo/src/apple/transforms/utils.rs
+++ b/crates/apple-todo/src/apple/transforms/utils.rs
@@ -1,6 +1,28 @@
+use objc2::{msg_send, rc::Retained};
 use objc2_core_graphics::CGColor;
+use objc2_foundation::NSString;
 
 use crate::types::CalendarColor;
+
+pub fn objc_title<T>(obj: &T) -> String
+where
+    T: objc2::Message + ?Sized,
+{
+    unsafe {
+        let title: Option<Retained<NSString>> = msg_send![obj, title];
+        title.map(|s| s.to_string()).unwrap_or_default()
+    }
+}
+
+pub fn objc_source_identifier<T>(obj: &T) -> String
+where
+    T: objc2::Message + ?Sized,
+{
+    unsafe {
+        let identifier: Option<Retained<NSString>> = msg_send![obj, sourceIdentifier];
+        identifier.map(|s| s.to_string()).unwrap_or_default()
+    }
+}
 
 pub fn extract_color_components(cg_color: &CGColor) -> CalendarColor {
     let num_components = CGColor::number_of_components(Some(cg_color));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Listing Apple calendars panics when EventKit returns a nil `EKSource` title. Sentry [ANARLOG-1T52](https://fastrepl.sentry.io/issues/ANARLOG-1T52) is `unexpected NULL returned from -[EKSource title]` in `transform_calendar` — 90 events for one user on macOS 26. The same non-null objc2 binding is used for calendar/event titles and reminder list sources.

**Fix:** Read EventKit `title` and `sourceIdentifier` as optional NSStrings and fall back to empty strings, matching the existing reminder-title pattern. Apply the same handling in `apple-calendar` and `apple-todo` so listing calendars or reminders no longer crashes on a null title.

Fixes ANARLOG-1T52

## Verification

- `cargo check -p apple-calendar -p apple-todo` on Linux (macOS EventKit modules are cfg-gated and do not compile here)
- `rustfmt` on the touched transform files
- Could not run EventKit against a nil-title calendar source in this environment (macOS-only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0515c-d7df-7924-883a-bca496f26073?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0515c-d7df-7924-883a-bca496f26073&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

