### PR TITLE
Stop reporting closed OAuth windows as Sentry errors

### DIFF
--- a/apps/web/src/lib/integration-connection-error.test.ts
+++ b/apps/web/src/lib/integration-connection-error.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getConnectionErrorMessage,
   getNangoAuthErrorType,
+  shouldReportConnectionAuthError,
 } from "./integration-connection-error.ts";
 
 test("reads Nango AuthError types and falls back for unknown values", () => {
@@ -31,6 +32,12 @@ test("keeps Outlook window-closed copy generic", () => {
     getConnectionErrorMessage("window_closed", "Outlook Calendar", "outlook"),
     "The Outlook Calendar sign-in window closed before the connection finished. Please try again.",
   );
+});
+
+test("does not report a closed sign-in window as an operational error", () => {
+  assert.equal(shouldReportConnectionAuthError("window_closed"), false);
+  assert.equal(shouldReportConnectionAuthError("blocked_by_browser"), true);
+  assert.equal(shouldReportConnectionAuthError("unknown_error"), true);
 });
 
 test("asks users to allow pop-ups when the browser blocks the window", () => {

--- a/apps/web/src/lib/integration-connection-error.ts
+++ b/apps/web/src/lib/integration-connection-error.ts
@@ -10,6 +10,10 @@ export function getNangoAuthErrorType(error: unknown) {
   return "unknown_error";
 }
 
+export function shouldReportConnectionAuthError(errorType: string) {
+  return errorType !== "window_closed";
+}
+
 export function getConnectionErrorMessage(
   errorType: string,
   providerName: string,

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -14,6 +14,7 @@ import { captureOperationalError } from "@/lib/error-reporting";
 import {
   getConnectionErrorMessage,
   getNangoAuthErrorType,
+  shouldReportConnectionAuthError,
 } from "@/lib/integration-connection-error";
 import {
   isConnectSessionFailed,
@@ -120,19 +121,21 @@ export function ConnectFlow({ sessionToken }: { sessionToken?: string } = {}) {
   const finishWithAuthError = (error: unknown) => {
     if (disposedRef.current) return;
     const errorType = getNangoAuthErrorType(error);
-    captureOperationalError(
-      error instanceof Error
-        ? error
-        : new Error("Integration authorization failed"),
-      {
-        operation: "integration_connection_authorization",
-        tags: {
-          integration: search.integration_id,
-          mode: search.action,
-          error_type: errorType,
+    if (shouldReportConnectionAuthError(errorType)) {
+      captureOperationalError(
+        error instanceof Error
+          ? error
+          : new Error("Integration authorization failed"),
+        {
+          operation: "integration_connection_authorization",
+          tags: {
+            integration: search.integration_id,
+            mode: search.action,
+            error_type: errorType,
+          },
         },
-      },
-    );
+      );
+    }
     inFlightRef.current = false;
     setConnectionError(
       getConnectionErrorMessage(errorType, display.name, search.integration_id),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Closing the Google Calendar (or other) sign-in popup is expected. The web connect flow still called `captureOperationalError`, so Sentry [ANARLOG-2N5B](https://fastrepl.sentry.io/issues/ANARLOG-2N5B) collected 100+ `window_closed` events from `/app/integration/`.

**Fix:** Keep the existing in-app message and `integration_connection_failed` analytics. Skip Sentry only for `window_closed`. Browser-blocked pop-ups and unknown auth failures still report.

Fixes ANARLOG-2N5B

## Verification

- `pnpm -F web typecheck`
- `node --test --experimental-strip-types apps/web/src/lib/integration-connection-error.test.ts`
- `pnpm exec dprint check` on the changed files
- Could not exercise live Nango OAuth in this environment (needs a real provider popup)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0515c-d7df-7924-883a-bca496f26073?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0515c-d7df-7924-883a-bca496f26073&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

