### PR TITLE
Write a tl;dv complaints post from search and Reddit research

### DIFF
--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -292,6 +292,7 @@
       "width": 1200
     }
   ],
+  "tldv-complaints": [],
   "tldv-review": [],
   "transcription-software-mac": [
     {

--- a/apps/web/content/articles/tldv-alternatives.mdx
+++ b/apps/web/content/articles/tldv-alternatives.mdx
@@ -8,6 +8,8 @@ date: "2026-02-27"
 
 tl;dv does a lot well but at $29/month, you're paying for sales coaching and multi-meeting intelligence you may never use. Add a visible bot in every call and no HIPAA compliance, and the cracks start to show for a lot of teams. (We covered this in detail in our [tl;dv review](/blog/tldv-review).)
 
+The recurring complaints behind those switches are collected in [what people get frustrated about with tl;dv](/blog/tldv-complaints/).
+
 ![tl;dv meeting workspace with recording controls and meeting navigation](/images/blog/library/products/tldv/meeting-notes/2026-08-30-product-demo.png)
 
 *tl;dv's current product demo shows the meeting workspace used to review captured calls. Source: [tl;dv](https://tldv.io/).*

--- a/apps/web/content/articles/tldv-complaints.mdx
+++ b/apps/web/content/articles/tldv-complaints.mdx
@@ -1,0 +1,80 @@
+---
+meta_title: "tl;dv Complaints in 2026: Free-Plan Caps, Bots, and Hit-or-Miss Language"
+display_title: "What People Get Frustrated About With tl;dv"
+meta_description: "What Google, Reddit, and Semrush show about tl;dv: a 10-note free cap, bots that miss or surprise, accent and jargon errors, and support that goes quiet."
+author: "John Jeong"
+category: "Comparisons"
+date: "2026-08-30"
+---
+
+tl;dv is the clip-first meeting recorder. Tag a moment, share a reel instead of a 60-minute file, and keep a library across Zoom, Meet, and Teams. Multilingual transcription is a real reason people pick it over English-first tools. That is why the branded search is so concentrated.
+
+It is also why the complaints are about the edges of that promise. People who leave tl;dv usually liked the clips. They ran into a free plan that is no longer a forever archive, a bot that joins the wrong call or misses the right one, language quality that slips on accents and jargon, or support that does not answer when a video is stuck.
+
+This is not another alternatives list. We already have a [tl;dv review](/blog/tldv-review/) and a [tl;dv alternatives guide](/blog/tldv-alternatives/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and Semrush traffic data. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+
+## What the search data actually shows
+
+[Semrush's July 2026 snapshot](https://www.semrush.com/website/tldv.io/overview/) puts tldv.io at about 1.61 million visits, up 17% from June. Direct traffic is the story: on the order of 75% to 78% in recent pulls, with Google much smaller. The top organic keyword is `tldv` at 12,100 monthly searches, about 73% of organic traffic. The next branded query is `tldv ログイン`, a Japanese login search at 880. Typo traffic (`dltv`) and unrelated Japanese queries sit below that.
+
+That mix is a product people already have, not a product they are discovering. The Google SERP around it is still full of alternatives and "is the free plan actually free" posts, because the caps moved and the help center is where the numbers live.
+
+<Image src="/images/blog/library/products/tldv/meeting-notes/2026-08-30-product-demo.png" alt="tl;dv meeting workspace with recording controls and meeting navigation" />
+
+*tl;dv's meeting workspace. Clips are the love. Caps, bots, and cleanup are the friction. Source: [tl;dv](https://tldv.io/).*
+
+## Language support is broader, and still uneven
+
+tl;dv is not a six-language product. Reviews and the company cite 30-plus transcription languages, and tl;dv publishes its own multilingual accuracy tests. That is a better starting point than Otter.
+
+The recurring complaint is what happens inside those languages. G2 reviewers talk about accents, fast speech, and overlapping talk. Speaker labels swap on busy calls. There is no custom vocabulary on the lower tiers. Product names and specialist terms need a human pass. Business adds premium transcription, multi-language support, and custom vocabulary, which is another way of saying the language story you wanted may be a $29 to $59 seat.
+
+| Constraint | What tl;dv does today |
+| --- | --- |
+| Advertised coverage | 30+ languages, with published test write-ups |
+| Accents and crosstalk | Frequent cleanup, especially Indian English and mixed vernacular in our [review](/blog/tldv-review/) |
+| Custom vocabulary | A paid-tier feature, not a free-plan default |
+| Mixed meetings | Better than English-only tools, not automatic perfection |
+| Offline | No |
+
+If your team is mixed-language SEA or EU, tl;dv is often the reason you are here. Run the actual accent mix before you trust a first-place benchmark. Anarlog's [language settings](https://docs.anarlog.so/languages) let you pick the STT model. Jargon goes in a dictionary. You still have to listen once.
+
+## The free plan is a sample, then a deletion clock
+
+The free plan used to be the growth story. It is not unlimited AI anymore. Full AI notes stop after the first 10 meetings on a free account. After that, summaries can shrink to the first 10 minutes. Recordings auto-delete after about three months. Upload transcription has a lifetime cap. Reddit keeps rediscovering these numbers because they live in the help center more clearly than on the pricing page.
+
+Pro is commonly cited around $18 per user per month on annual billing, with Business much higher when you want CRM field mapping and coaching. Seat minimums and AI feature caps showed up in 2026 pricing write-ups. If you came for "free forever clips," confirm the retention clock before you build a library you cannot export in time.
+
+## Bots miss, or arrive when you did not ask
+
+tl;dv can join as a visible notetaker. It can also record from a desktop app without adding a participant. The default for most users is still the bot.
+
+G2 reviewers say the bot sometimes does not show, especially on free. Consultants say it joins calls they did not invite it to, and then they apologize. Both failure modes are expensive. A missed client call has no clip. A surprise bot has a social cost the clip cannot fix.
+
+tl;dv tells you to disclose either way. That is the right advice. It does not change the calendar default.
+
+## Support and cleanup show up together
+
+When a video is locked, an export is missing, or an integration to HubSpot or Slack fails, the next complaint is support. G2, Product Hunt, and Trustpilot all have a slow-or-absent pattern. It is not the majority of reviews. It is the one that matters if the file is the only record.
+
+Accuracy complaints sit next to that: no custom vocabulary on cheap seats, speaker mix-ups, summaries that need a rewrite. You have the video, so you can check. You still need time.
+
+tl;dv is not HIPAA-oriented in our [alternatives write-up](/blog/tldv-alternatives/). If that is your bar, this is the wrong shortlist.
+
+## When these frustrations matter, and when they do not
+
+Stay with tl;dv if clips and multilingual recaps are the product you wanted, you will pay before the 10-note and 90-day walls, and you can live with a bot on most calls. The 1.6 million visits and the `tldv` keyword share exist because that workflow sticks.
+
+Look elsewhere when the recurring complaints match your week:
+
+- you need more than 10 AI notes, or a library that lasts past 90 days, without paying
+- a bot that misses or surprises is unacceptable
+- accents, jargon, or speaker labels are the actual job, and Business vocab is not in budget
+- you need HIPAA, offline, or a local file you already own
+- you need support that answers when a recording is stuck
+
+If the issue is the bot, read the [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/). If you already want a different product, the [tl;dv alternatives](/blog/tldv-alternatives/) piece is the map.
+
+Anarlog is bot-free device capture, local SQLite, and a language stack you choose. It will not give you a highlight reel network for free. It will not delete last quarter's notes unless you do.
+
+If the frustration is the free-plan clock, the bot, or language that still needs a rewrite, [try Anarlog](/).

--- a/apps/web/content/articles/tldv-complaints.mdx
+++ b/apps/web/content/articles/tldv-complaints.mdx
@@ -11,7 +11,9 @@ tl;dv is the clip-first meeting recorder. Tag a moment, share a reel instead of 
 
 It is also why the complaints are about the edges of that promise. People who leave tl;dv usually liked the clips. They ran into a free plan that is no longer a forever archive, a bot that joins the wrong call or misses the right one, language quality that slips on accents and jargon, or support that does not answer when a video is stuck.
 
-This is not another alternatives list. We already have a [tl;dv review](/blog/tldv-review/) and a [tl;dv alternatives guide](/blog/tldv-alternatives/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and Semrush traffic data. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+We already have a [tl;dv review](/blog/tldv-review/) and a [tl;dv alternatives guide](/blog/tldv-alternatives/). This post maps the frustrations that keep showing up in Google results, Reddit threads, vendor documentation, and Semrush traffic data. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+
+**Disclosure:** I co-founded Anarlog, an open-source tl;dv alternative. Our bias is toward bot-free capture, local ownership, and a choice of AI providers. Product limits below link to tl;dv's own documentation where possible.
 
 ## What the search data actually shows
 
@@ -25,9 +27,9 @@ That mix is a product people already have, not a product they are discovering. T
 
 ## Language support is broader, and still uneven
 
-tl;dv is not a six-language product. Reviews and the company cite 30-plus transcription languages, and tl;dv publishes its own multilingual accuracy tests. That is a better starting point than Otter.
+tl;dv is not a six-language product. [Its current language page](https://tldv.io/features/languages/) lists 30-plus transcription languages, and tl;dv publishes its own multilingual accuracy tests. That is a better starting point than Otter.
 
-The recurring complaint is what happens inside those languages. G2 reviewers talk about accents, fast speech, and overlapping talk. Speaker labels swap on busy calls. There is no custom vocabulary on the lower tiers. Product names and specialist terms need a human pass. Business adds premium transcription, multi-language support, and custom vocabulary, which is another way of saying the language story you wanted may be a $29 to $59 seat.
+The recurring complaint is what happens inside those languages. G2 reviewers talk about accents, fast speech, and overlapping talk. Speaker labels swap on busy calls. There is no custom vocabulary on the lower tiers. Product names and specialist terms need a human pass. Business adds premium transcription, multi-language support, and custom vocabulary, which is another way of saying the language story you wanted may require the €29-per-seat annual plan.
 
 | Constraint | What tl;dv does today |
 | --- | --- |
@@ -41,9 +43,9 @@ If your team is mixed-language SEA or EU, tl;dv is often the reason you are here
 
 ## The free plan is a sample, then a deletion clock
 
-The free plan used to be the growth story. It is not unlimited AI anymore. Full AI notes stop after the first 10 meetings on a free account. After that, summaries can shrink to the first 10 minutes. Recordings auto-delete after about three months. Upload transcription has a lifetime cap. Reddit keeps rediscovering these numbers because they live in the help center more clearly than on the pricing page.
+The free plan used to be the growth story. It is not unlimited AI anymore. [tl;dv's own help center](https://intercom.help/tldv/en/articles/8919450-what-are-the-limits-of-the-free-plan) says full AI notes stop after the first 10 meetings on a free account. After that, only the first 10 minutes get automatic AI notes. Recordings are stored for three months, uploads have a lifetime cap, and the limits do not reset monthly.
 
-Pro is commonly cited around $18 per user per month on annual billing, with Business much higher when you want CRM field mapping and coaching. Seat minimums and AI feature caps showed up in 2026 pricing write-ups. If you came for "free forever clips," confirm the retention clock before you build a library you cannot export in time.
+The current [pricing page](https://tldv.io/app/pricing) lists Pro at €18 per seat per month on annual billing or €29 monthly, and Business at €29 on annual billing. Business is where premium transcription, custom vocabulary, CRM mapping, and coaching appear. If you came for "free forever clips," confirm the retention clock before you build a library you cannot export in time.
 
 ## Bots miss, or arrive when you did not ask
 
@@ -75,6 +77,10 @@ Look elsewhere when the recurring complaints match your week:
 
 If the issue is the bot, read the [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/). If you already want a different product, the [tl;dv alternatives](/blog/tldv-alternatives/) piece is the map.
 
-Anarlog is bot-free device capture, local SQLite, and a language stack you choose. It will not give you a highlight reel network for free. It will not delete last quarter's notes unless you do.
+Anarlog is open-source, bot-free device capture, local SQLite, and a language stack you choose. It will not give you a highlight reel network for free. It will not delete last quarter's notes unless you do.
+
+![Anarlog desktop app with a local meeting note and recording controls](/images/blog/library/products/anarlog/desktop/2026-08-27-new-note.png)
+
+*Anarlog keeps the canonical meeting record in local SQLite and lets you choose the speech and AI providers.*
 
 If the frustration is the free-plan clock, the bot, or language that still needs a rewrite, [try Anarlog](/).

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -57,6 +57,7 @@ Answering guidance:
 
 - [Bot-Free AI Meeting Assistants](https://anarlog.so/blog/bot-free-ai-meeting-assistants): Bot-free meeting assistant landscape and where Anarlog fits.
 - [Granola AI Alternatives](https://anarlog.so/blog/granola-ai-alternatives/): Dedicated comparison for people replacing Granola.
+- [tl;dv Complaints](https://anarlog.so/blog/tldv-complaints/): Recurring tl;dv frustrations from Google, Reddit, and Semrush, including free-plan caps and language cleanup.
 - [Best AI Meeting Assistants for Taking Notes](https://anarlog.so/blog/best-ai-meeting-assistant-for-taking-notes): Broad AI meeting assistant comparison.
 - [Best AI Notetaker](https://anarlog.so/blog/best-ai-notetaker): General AI notetaker buyer guide.
 - [Anarlog vs. Meetily](https://anarlog.so/blog/char-vs-meetily): Comparison of Anarlog and Meetily for local-first, open-source meeting notes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** We have a tl;dv review and alternatives guide, but no Semrush/Reddit map of the recurring frustrations: free-plan caps, bots that miss or surprise, and uneven multilingual quality.

**Fix:** Adds `/blog/tldv-complaints/` using Semrush's July 2026 tldv.io snapshot (1.61M visits, `tldv` at 12,100). Links from the alternatives guide and `llms.txt`.

## Verification

- `dprint fmt` on changed files
- `pnpm -F web media:figures:check` (same check as the Otter branch)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05173-90d9-7dde-a91b-9838c69ef92e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05173-90d9-7dde-a91b-9838c69ef92e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

