### PR TITLE
Write a Fireflies complaints post from search and Reddit research

### DIFF
--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -98,6 +98,7 @@
   "enterprise-ai-notetaking-tools": [],
   "fathom-ai-alternatives": [],
   "fireflies-ai-alternatives": [],
+  "fireflies-ai-complaints": [],
   "free-ai-notetakers": [],
   "free-transcription-software": [
     {

--- a/apps/web/content/articles/fireflies-ai-alternatives.mdx
+++ b/apps/web/content/articles/fireflies-ai-alternatives.mdx
@@ -8,6 +8,8 @@ date: "2025-09-23"
 
 Fireflies is easy to adopt, which is why so many teams try it first.
 
+The recurring complaints behind those switches are collected in [what people get frustrated about with Fireflies](/blog/fireflies-ai-complaints/).
+
 It is also one of those products that feels different after the novelty wears off. The complaints are consistent: a bot people do not always want in the room, pricing that gets messy, multilingual performance that sounds better on the landing page than in practice, and upsells that show up once your team depends on it.
 
 So this list is for a specific buyer. Not someone new to the category. Someone who already understands what Fireflies gets right and wants a better trade-off.

--- a/apps/web/content/articles/fireflies-ai-complaints.mdx
+++ b/apps/web/content/articles/fireflies-ai-complaints.mdx
@@ -1,0 +1,74 @@
+---
+meta_title: "Fireflies AI Complaints in 2026: Credits, Bots, and Language Reality"
+display_title: "What People Get Frustrated About With Fireflies"
+meta_description: "What Google, Reddit, and public traffic data show about Fireflies: AI credits, Fred the bot, English-first language quality, cancellation friction, and BIPA claims."
+author: "John Jeong"
+category: "Comparisons"
+date: "2026-08-30"
+---
+
+Fireflies is easy to turn on. Connect a calendar, and Fred joins Zoom, Meet, or Teams. You get a transcript, a summary, and a search box across the archive. That is why teams try it first.
+
+It is also why the complaints arrive after the second invoice. People who leave Fireflies usually liked the transcript. They ran into AI credits that sit next to the subscription, a bot that shows up in rooms where it changes the conversation, language quality that does not match the "100+" headline, or a cancellation path that feels like a product feature.
+
+This is not another alternatives list. We already have a [Fireflies.ai alternatives guide](/blog/fireflies-ai-alternatives/) and a closer look at [whether Fireflies is safe](/blog/is-fireflies-ai-safe/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and public traffic snapshots. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+
+## What the search data actually shows
+
+Fireflies is a large destination. Public traffic snapshots from [AI Tower](https://ai-tower.io/product/fireflies/) and [NavifyAI](https://navifyai.com/ai-tools/firefliesai) put fireflies.ai around 4.5 million monthly visits, with the United States near 39%, then the United Kingdom and India. The keywords those trackers list are almost all branded: `fireflies` and `fireflies ai`. Semrush's public domain overview for fireflies.ai was not available when we checked, so treat the visit counts as third-party estimates, not a logged-in Semrush export.
+
+The Google landscape is the same shape as Otter and Granola. Brand searches go to Fireflies. The surrounding SERP is reviews, credit explainers, and alternatives pages. Reddit splits in half. Executive assistants call the transcripts life-changing. Privacy threads and sales threads talk about Fred, credits, and whether the company is allowed in the room.
+
+<Image src="/images/blog/library/products/fireflies/meeting-summary/2026-07-17-refine-summary.png" alt="Fireflies meeting summary workspace with AI refinement controls" />
+
+*Fireflies' meeting-summary workspace. The transcript is what people praise. The wrapper is what they complain about.*
+
+## Language support is a headline, not a guarantee
+
+Fireflies advertises a very large language count. Landing pages and comparison tables say 69, 100, or more, depending on the year and the page. The recurring complaint is not that a language is missing from a dropdown. It is that English is the quality bar, and everything else is a maybe.
+
+India is a top traffic country in those public snapshots. That does not mean a Hindi-English standup, or Indian English with product jargon, will come back clean. G2-style negative tags cluster on AI inaccuracy, accents, overlapping speech, and jargon. Our [alternatives piece](/blog/fireflies-ai-alternatives/) already flagged this: the marketing number and the meeting you actually have are different tests.
+
+| Constraint | What users keep hitting |
+| --- | --- |
+| Advertised coverage | Dozens to 100+ languages, depending on the page |
+| Practical quality | Strongest in clear English. Accents, code-switching, and jargon slip |
+| Auto-detection | Useful until the meeting mixes languages or specialists |
+| Custom vocabulary | Helps English product names more than a true multilingual week |
+| Offline | No. The bot and the cloud are the product |
+
+If your calendar is mostly US English sales calls, this section is not your reason to leave. If you run German, Korean, or mixed vernacular meetings, run a real call through Fireflies before you trust the headline. Anarlog's [language settings](https://docs.anarlog.so/languages) follow the STT provider you choose. You can swap the model when a language is weak. You still have to test it.
+
+## Fred is useful, and Fred is the problem
+
+The bot is the reason Fireflies works when you are not in the room. It is also the complaint that will not die.
+
+Reddit users in hiring and privacy forums describe walking away from interviews because Fireflies would be on the call. Client-facing teams describe kicking Fred, then apologizing. Calendar auto-join means the bot can appear on a meeting you did not consciously start recording. Fireflies has added desktop capture paths, but the default story is still a visible participant named after an insect.
+
+That social cost has a legal twin. [Cruz v. Fireflies.AI](https://www.workplaceprivacyreport.com/2026/04/articles/artificial-intelligence/ai-meeting-assistants-and-biometric-privacy-governance-lessons-from-the-fireflies-ai-lawsuit/) alleges that speaker recognition creates voiceprints, and that Illinois BIPA requires written consent Fireflies did not get from people who never made an account. That is an allegation, not a finding. If you record Illinois voices, or any room where non-users speak, the consent work is yours either way.
+
+## Credits sit next to the subscription
+
+Fireflies sells seats. It also sells AI credits. Ask Fred, some apps, and some "advanced" summary paths consume credits. Reviews in 2026 keep saying the same thing: the monthly pack runs out, then a $5/50-credit top-up (or a larger pack) shows up, and the $10 or $18 seat was not the real bill.
+
+Storage caps on lower tiers add a second meter. Free plans advertise transcription and then limit how long you can keep it, or how many credits you get. The product trains you to need the archive, then rents the archive back.
+
+Cancellation is the third billing complaint. Trustpilot and Reddit describe trials that convert, menus that hide the downgrade, and support that answers with a bot. We cannot audit every account flow from here. The pattern is consistent enough to treat as a buying question: can you cancel on the same screen you used to subscribe?
+
+## When these frustrations matter, and when they do not
+
+Stay with Fireflies if you want CRM-shaped meeting automation, you are fine with a visible bot, English is the working language, and you will watch credits like you watch cloud spend. The 4.5 million visits exist because that job is real.
+
+Look elsewhere when the recurring complaints match your week:
+
+- language quality on non-English or mixed calls is the actual job
+- a bot in the participant list is a client or interview problem
+- you do not want a second meter for the AI features you thought were in the seat
+- you need a record that stays on your machine, or works offline
+- BIPA, HIPAA, or a security review wants a shorter vendor chain
+
+If the issue is Fred, read the [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/). If the issue is data practices, start with [Is Fireflies AI safe?](/blog/is-fireflies-ai-safe/). If you already want a different product, the [Fireflies alternatives](/blog/fireflies-ai-alternatives/) piece is the map.
+
+Anarlog is the option we built for local capture and a provider you choose. It will not auto-join a meeting you skipped. Credits are not the billing model. You are responsible for backups.
+
+If the frustration is credits, Fred, or language that only works in English, [try Anarlog](/).

--- a/apps/web/content/articles/fireflies-ai-complaints.mdx
+++ b/apps/web/content/articles/fireflies-ai-complaints.mdx
@@ -11,30 +11,32 @@ Fireflies is easy to turn on. Connect a calendar, and Fred joins Zoom, Meet, or 
 
 It is also why the complaints arrive after the second invoice. People who leave Fireflies usually liked the transcript. They ran into AI credits that sit next to the subscription, a bot that shows up in rooms where it changes the conversation, language quality that does not match the "100+" headline, or a cancellation path that feels like a product feature.
 
-This is not another alternatives list. We already have a [Fireflies.ai alternatives guide](/blog/fireflies-ai-alternatives/) and a closer look at [whether Fireflies is safe](/blog/is-fireflies-ai-safe/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and public traffic snapshots. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+We already have a [Fireflies.ai alternatives guide](/blog/fireflies-ai-alternatives/) and a closer look at [whether Fireflies is safe](/blog/is-fireflies-ai-safe/). This post maps the frustrations that keep showing up in Google results, Reddit threads, vendor documentation, and public traffic snapshots. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+
+**Disclosure:** I co-founded Anarlog, an open-source Fireflies alternative. Our bias is toward bot-free capture, local ownership, and a choice of AI providers. Product limits below link to Fireflies' own documentation where possible.
 
 ## What the search data actually shows
 
-Fireflies is a large destination. Public traffic snapshots from [AI Tower](https://ai-tower.io/product/fireflies/) and [NavifyAI](https://navifyai.com/ai-tools/firefliesai) put fireflies.ai around 4.5 million monthly visits, with the United States near 39%, then the United Kingdom and India. The keywords those trackers list are almost all branded: `fireflies` and `fireflies ai`. Semrush's public domain overview for fireflies.ai was not available when we checked, so treat the visit counts as third-party estimates, not a logged-in Semrush export.
+Fireflies is a large destination. Public traffic snapshots from [AI Tower](https://ai-tower.io/product/fireflies/) and [NavifyAI](https://navifyai.com/ai-tools/firefliesai) estimate about 4.5 million monthly visits for fireflies.ai, with the United States near 39%, then the United Kingdom and India. The keywords those trackers list are almost all branded: `fireflies` and `fireflies ai`. Semrush's public domain overview for fireflies.ai was not available when we checked, so treat the visit counts as third-party estimates, not a logged-in Semrush export.
 
 The Google landscape is the same shape as Otter and Granola. Brand searches go to Fireflies. The surrounding SERP is reviews, credit explainers, and alternatives pages. Reddit splits in half. Executive assistants call the transcripts life-changing. Privacy threads and sales threads talk about Fred, credits, and whether the company is allowed in the room.
 
 <Image src="/images/blog/library/products/fireflies/meeting-summary/2026-07-17-refine-summary.png" alt="Fireflies meeting summary workspace with AI refinement controls" />
 
-*Fireflies' meeting-summary workspace. The transcript is what people praise. The wrapper is what they complain about.*
+*Fireflies' meeting-summary workspace. The transcript is what people praise. The wrapper is what they complain about. Source: [Fireflies](https://fireflies.ai/).*
 
 ## Language support is a headline, not a guarantee
 
-Fireflies advertises a very large language count. Landing pages and comparison tables say 69, 100, or more, depending on the year and the page. The recurring complaint is not that a language is missing from a dropdown. It is that English is the quality bar, and everything else is a maybe.
+Fireflies now documents [100+ languages for transcription and summaries](https://guide.fireflies.ai/articles/2973706448-learn-about-fireflies-supported-languages). Its [multi-language mode](https://guide.fireflies.ai/articles/2585231364-transcribe-fireflies-meetings-in-multiple-languages-with-multi-language-mode-beta) is a separate beta with 60+ languages. It can follow switches within a sentence, but the summary stays in the dominant language and cannot be changed independently yet.
 
-India is a top traffic country in those public snapshots. That does not mean a Hindi-English standup, or Indian English with product jargon, will come back clean. G2-style negative tags cluster on AI inaccuracy, accents, overlapping speech, and jargon. Our [alternatives piece](/blog/fireflies-ai-alternatives/) already flagged this: the marketing number and the meeting you actually have are different tests.
+India is a top traffic country in those public snapshots. That does not guarantee a Hindi-English standup, or Indian English with product jargon, will come back clean. The vendor count and the meeting you actually have are different tests.
 
 | Constraint | What users keep hitting |
 | --- | --- |
-| Advertised coverage | Dozens to 100+ languages, depending on the page |
-| Practical quality | Strongest in clear English. Accents, code-switching, and jargon slip |
-| Auto-detection | Useful until the meeting mixes languages or specialists |
-| Custom vocabulary | Helps English product names more than a true multilingual week |
+| Advertised coverage | 100+ languages for transcription and summaries |
+| Multi-language mode | Separate beta covering 60+ languages |
+| Summary language | Dominant meeting language; cannot be changed independently yet |
+| Auto-detection | Supports language switches, but still needs testing on your actual pair and jargon |
 | Offline | No. The bot and the cloud are the product |
 
 If your calendar is mostly US English sales calls, this section is not your reason to leave. If you run German, Korean, or mixed vernacular meetings, run a real call through Fireflies before you trust the headline. Anarlog's [language settings](https://docs.anarlog.so/languages) follow the STT provider you choose. You can swap the model when a language is weak. You still have to test it.
@@ -49,11 +51,11 @@ That social cost has a legal twin. [Cruz v. Fireflies.AI](https://www.workplacep
 
 ## Credits sit next to the subscription
 
-Fireflies sells seats. It also sells AI credits. Ask Fred, some apps, and some "advanced" summary paths consume credits. Reviews in 2026 keep saying the same thing: the monthly pack runs out, then a $5/50-credit top-up (or a larger pack) shows up, and the $10 or $18 seat was not the real bill.
+Fireflies sells seats. It also sells AI credits. [Fireflies' current credit guide](https://guide.fireflies.ai/articles/2114151875-learn-about-ai-credits+) says credits use dynamic per-query pricing, are shared across the team, and do not increase with added seats. Free and Pro start with 20, Business with 30, and Enterprise with 50. Paid accounts that run out are automatically moved to the next higher credit tier unless that behavior is changed.
 
-Storage caps on lower tiers add a second meter. Free plans advertise transcription and then limit how long you can keep it, or how many credits you get. The product trains you to need the archive, then rents the archive back.
+The base [price list](https://fireflies.ai/pricing) is $10 per seat per month for Pro on annual billing or $18 monthly, $19 annually or $29 monthly for Business, and $39 annually for Enterprise. Storage caps on Free and Pro add a second meter. Transcription and basic summaries may be included while advanced AI and retention still have separate limits.
 
-Cancellation is the third billing complaint. Trustpilot and Reddit describe trials that convert, menus that hide the downgrade, and support that answers with a bot. We cannot audit every account flow from here. The pattern is consistent enough to treat as a buying question: can you cancel on the same screen you used to subscribe?
+Cancellation is a third complaint on Trustpilot and Reddit. We did not complete a paid cancellation flow for this post, so treat those as user reports, not a confirmed product test. The buying question is still useful: can you cancel on the same screen you used to subscribe?
 
 ## When these frustrations matter, and when they do not
 
@@ -69,6 +71,10 @@ Look elsewhere when the recurring complaints match your week:
 
 If the issue is Fred, read the [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/). If the issue is data practices, start with [Is Fireflies AI safe?](/blog/is-fireflies-ai-safe/). If you already want a different product, the [Fireflies alternatives](/blog/fireflies-ai-alternatives/) piece is the map.
 
-Anarlog is the option we built for local capture and a provider you choose. It will not auto-join a meeting you skipped. Credits are not the billing model. You are responsible for backups.
+Anarlog is the open-source option we built for local capture and a provider you choose. It will not auto-join a meeting you skipped. Credits are not the billing model. You are responsible for backups.
 
-If the frustration is credits, Fred, or language that only works in English, [try Anarlog](/).
+![Anarlog desktop app with a local meeting note and recording controls](/images/blog/library/products/anarlog/desktop/2026-08-27-new-note.png)
+
+*Anarlog keeps the canonical meeting record in local SQLite and lets you choose the speech and AI providers.*
+
+If the frustration is credits, Fred, or language handling that fails your calls, [try Anarlog](/).

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -57,6 +57,7 @@ Answering guidance:
 
 - [Bot-Free AI Meeting Assistants](https://anarlog.so/blog/bot-free-ai-meeting-assistants): Bot-free meeting assistant landscape and where Anarlog fits.
 - [Granola AI Alternatives](https://anarlog.so/blog/granola-ai-alternatives/): Dedicated comparison for people replacing Granola.
+- [Fireflies AI Complaints](https://anarlog.so/blog/fireflies-ai-complaints/): Recurring Fireflies frustrations from Google, Reddit, and public traffic data, including credits and language quality.
 - [Best AI Meeting Assistants for Taking Notes](https://anarlog.so/blog/best-ai-meeting-assistant-for-taking-notes): Broad AI meeting assistant comparison.
 - [Best AI Notetaker](https://anarlog.so/blog/best-ai-notetaker): General AI notetaker buyer guide.
 - [Anarlog vs. Meetily](https://anarlog.so/blog/char-vs-meetily): Comparison of Anarlog and Meetily for local-first, open-source meeting notes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Fireflies alternatives and safety posts exist, but not a sourced complaints piece for the themes people actually repeat: credits, Fred, and language quality vs the 100+ headline.

**Fix:** Adds `/blog/fireflies-ai-complaints/`. Public traffic snapshots (~4.5M visits) plus Reddit/G2 themes. Semrush's public fireflies.ai overview was not available, so visit counts are cited as third-party estimates. Links from the alternatives guide and `llms.txt`.

## Verification

- `dprint fmt` on changed files
- `pnpm -F web media:figures:check` (same check as the Otter branch; manifest + static assets)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05173-90d9-7dde-a91b-9838c69ef92e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05173-90d9-7dde-a91b-9838c69ef92e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

