### PR TITLE
Write an Otter complaints post from search and Reddit research

### DIFF
--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -267,6 +267,7 @@
     }
   ],
   "otter-ai-alternatives": [],
+  "otter-ai-complaints": [],
   "otter-ai-review": [],
   "plaud-ai-alternatives": [],
   "read-ai-alternatives": [],

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -8,6 +8,8 @@ date: "2026-07-19"
 
 Most Otter.ai alternative lists start with an outdated assumption: Otter always sends a bot into your meeting.
 
+The recurring complaints behind those switches are collected in [what people get frustrated about with Otter](/blog/otter-ai-complaints/).
+
 That is no longer accurate. Otter still offers its visible Notetaker, but it also has Mac and Windows desktop apps that record device audio without a bot. Its Chrome extension provides another bot-free path for browser meetings.
 
 The useful question is no longer simply, “Which app avoids a bot?”

--- a/apps/web/content/articles/otter-ai-complaints.mdx
+++ b/apps/web/content/articles/otter-ai-complaints.mdx
@@ -11,13 +11,15 @@ Otter is the brand people search when they want a meeting transcript that shows 
 
 It is also why the complaints are old and specific. People who leave Otter usually got the transcript. They ran into a language list that is still short, a bot that joins more meetings than they meant, a minute cap that turns a busy week into an upgrade prompt, or a consent story that is now in court.
 
-This is not another alternatives list. We already have an [Otter.ai alternatives guide](/blog/otter-ai-alternatives/) and a longer [Otter review](/blog/otter-ai-review/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and public traffic data. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+We already have an [Otter.ai alternatives guide](/blog/otter-ai-alternatives/) and a longer [Otter review](/blog/otter-ai-review/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and public traffic data. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+
+**Disclosure:** I co-founded Anarlog, an open-source Otter alternative. Our bias is toward bot-free capture, local ownership, and a choice of AI providers. Product limits below link to Otter's own documentation where possible.
 
 ## What the search data actually shows
 
-Otter's own site is a destination, not a research paper. [Hypestat's Semrush-attributed snapshot](https://hypestat.com/info/otter.ai) puts otter.ai around 2.2 million monthly visits. [Inpages' keyword breakdown](https://inpages.ai/insight/marketing-strategy/otter.ai) says most of the organic value is still navigational: `otter ai`, login queries, and "AI note taker" variants. Commercial queries sit next to that: OtterPilot, transcription, and Pro.
+Otter's own site is a destination, not a research paper. [Hypestat's Semrush-attributed snapshot](https://hypestat.com/info/otter.ai) estimates about 2.2 million monthly visits for otter.ai. [Inpages' keyword breakdown](https://inpages.ai/insight/marketing-strategy/otter.ai) says most of the organic value is still navigational: `otter ai`, login queries, and "AI note taker" variants. Commercial queries sit next to that: OtterPilot, transcription, and Pro.
 
-That mix matches the Google landscape. Brand searches go to Otter. The surrounding SERP is packed with reviews, pricing explainers, and alternatives pages, because that is where intent sits once someone already knows the product. Reddit is harsher than G2. Threads titled "is Otter worth it" lean no. The reasons repeat: the bot, the minutes, the notes, the invites.
+That mix matches the Google landscape. Brand searches go to Otter. The surrounding SERP is packed with reviews, pricing explainers, and alternatives pages, because that is where intent sits once someone already knows the product. Across Reddit threads and review pages, the reasons repeat: the bot, the minutes, the notes, and the invites.
 
 <Image src="/images/blog/library/products/otter/notetaker/2026-07-17-notetaker-overview.png" alt="Otter Notetaker joining a calendar meeting as a visible guest and producing a transcript" />
 
@@ -43,9 +45,9 @@ Older reviews still say "three languages." That was true. It is six now. The com
 
 ## The bot joins more meetings than people meant
 
-OtterPilot auto-joins calendar meetings after setup. That is the feature buyers wanted when they needed notes for a call they might miss. It is also the complaint that shows up in Reddit, BBB-style write-ups, and court filings.
+OtterPilot auto-joins calendar meetings after setup. That is the feature buyers wanted when they needed notes for a call they might miss. It is also the complaint that shows up in Reddit, review sites, and court filings.
 
-Users describe the Notetaker arriving on a client board call they forgot was on the calendar. Hosts kick it. Other participants get an invite to sign up. One Reddit cluster calls the invite-the-room behavior malware-adjacent. That is overstated. The social effect is not: a visible bot changes how people talk, and an unexpected join is a relationship problem before it is a product bug.
+Users describe the Notetaker arriving on a client or board call they forgot was on the calendar. Hosts kick it. Other participants can get an invite to sign up. The social effect is the part that matters: a visible bot changes how people talk, and an unexpected join is a relationship problem before it is a product bug.
 
 Otter now has bot-free desktop and Chrome capture. That matters. It does not retire the auto-join path. If calendar sync is on and Notetaker is the default, the bot still goes to the meeting you did not intend to record.
 
@@ -53,9 +55,9 @@ The legal version of this complaint is [In re Otter.AI Privacy Litigation](https
 
 ## Minutes, billing, and a free plan that is a preview
 
-Otter's free plan is 300 minutes a month, with a per-conversation cap around 30 minutes. Pro is $16.99 a month for 1,200 minutes. Business is $30 a month, often with a seat minimum. Imports and chat questions have their own ceilings.
+[Otter's current pricing table](https://otter.ai/pricing) gives Free 300 minutes a month with a 30-minute conversation cap. Pro is $16.99 a month for 1,200 minutes. Business is $30 a month with unlimited meeting transcription. Imports and chat questions have their own ceilings.
 
-The recurring frustration is not the list price. It is hitting the wall mid-week and discovering that summaries, imports, and longer calls were the product you thought you already had. SaaS Flags and BBB-style complaints add a second layer: annual renewals that feel sudden, and cancellation that is not a single toggle.
+The recurring frustration is not the list price. It is hitting the wall mid-week and discovering that imports, longer calls, and more chat queries were the product you thought you already had. Annual billing and cancellation are a separate buying decision; check the renewal terms before the trial becomes the archive.
 
 If you live in meetings, 300 minutes is a trial. If you need unattended attendance, you will pay. If you wanted a local archive you can keep using after the subscription ends, Otter is the wrong shape of tool.
 
@@ -79,6 +81,10 @@ Look elsewhere when the recurring complaints match your week:
 
 If the issue is the visible Notetaker, read the [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/). If the issue is consent and training, start with [Is Otter AI safe?](/blog/is-otter-ai-safe/). If you already want a different product, the [Otter alternatives](/blog/otter-ai-alternatives/) piece is the workflow map.
 
-Anarlog is the option we built for the last group: bot-free capture, local SQLite, and a language stack you can point at a local model or your own keys. It will not sit in a meeting when your computer is closed. That is the trade.
+Anarlog is the open-source option we built for the last group: bot-free capture, local SQLite, and a language stack you can point at a local model or your own keys. It will not sit in a meeting when your computer is closed. That is the trade.
+
+![Anarlog desktop app with a local meeting note and recording controls](/images/blog/library/products/anarlog/desktop/2026-08-27-new-note.png)
+
+*Anarlog keeps the canonical meeting record in local SQLite and lets you choose the speech and AI providers.*
 
 If the frustration is language, auto-join, or a minute cap, [try Anarlog](/).

--- a/apps/web/content/articles/otter-ai-complaints.mdx
+++ b/apps/web/content/articles/otter-ai-complaints.mdx
@@ -1,0 +1,84 @@
+---
+meta_title: "Otter AI Complaints in 2026: Language Limits, Auto-Join, and Minute Caps"
+display_title: "What People Get Frustrated About With Otter"
+meta_description: "What Google, Reddit, and public search data show about Otter: six-language transcription, auto-join bots, minute caps, billing friction, and consent lawsuits."
+author: "John Jeong"
+category: "Comparisons"
+date: "2026-08-30"
+---
+
+Otter is the brand people search when they want a meeting transcript that shows up without them. It can still send a Notetaker into Zoom, Meet, or Teams. It can also capture from a desktop app or Chrome extension. The archive is searchable. The summaries arrive. That is why the brand stays huge.
+
+It is also why the complaints are old and specific. People who leave Otter usually got the transcript. They ran into a language list that is still short, a bot that joins more meetings than they meant, a minute cap that turns a busy week into an upgrade prompt, or a consent story that is now in court.
+
+This is not another alternatives list. We already have an [Otter.ai alternatives guide](/blog/otter-ai-alternatives/) and a longer [Otter review](/blog/otter-ai-review/). This post maps the frustrations that keep showing up in Google results, Reddit threads, and public traffic data. It is part of the same series as [what people get frustrated about with Granola](/blog/granola-ai-complaints/).
+
+## What the search data actually shows
+
+Otter's own site is a destination, not a research paper. [Hypestat's Semrush-attributed snapshot](https://hypestat.com/info/otter.ai) puts otter.ai around 2.2 million monthly visits. [Inpages' keyword breakdown](https://inpages.ai/insight/marketing-strategy/otter.ai) says most of the organic value is still navigational: `otter ai`, login queries, and "AI note taker" variants. Commercial queries sit next to that: OtterPilot, transcription, and Pro.
+
+That mix matches the Google landscape. Brand searches go to Otter. The surrounding SERP is packed with reviews, pricing explainers, and alternatives pages, because that is where intent sits once someone already knows the product. Reddit is harsher than G2. Threads titled "is Otter worth it" lean no. The reasons repeat: the bot, the minutes, the notes, the invites.
+
+<Image src="/images/blog/library/products/otter/notetaker/2026-07-17-notetaker-overview.png" alt="Otter Notetaker joining a calendar meeting as a visible guest and producing a transcript" />
+
+*Otter's official Notetaker overview. The visible guest is still the product people argue about. Source: [Otter](https://help.otter.ai/hc/en-us/articles/4425393298327-Otter-Notetaker-Overview).*
+
+## Language support is still a short list
+
+Otter expanded past English. The remaining limit is still the one international teams hit first.
+
+Otter's [help center](https://help.otter.ai/hc/en-us/articles/26660468516631-Transcribe-a-conversation-in-Spanish-French-or-English-US-or-UK) currently lists six transcription languages: English, Spanish, French, German, Japanese, and Simplified Chinese. You pick one language in settings before the meeting. Otter transcribes that language. It does not auto-detect a switch mid-call, except for a French-plus-English path if the default is French. Cantonese and other Chinese dialects are not supported. The UI stays English.
+
+| Constraint | What Otter does today |
+| --- | --- |
+| Transcription languages | English, Spanish, French, German, Japanese, Simplified Chinese |
+| Mixed-language calls | One language at a time, plus French+English when French is the default |
+| Language changes | Set before the meeting. Mid-call switches are not the product |
+| App interface | English |
+| Offline | No. Spotty WiFi means a partial transcript |
+
+A German weekly, a Korean customer call, or a Hindi standup is outside that list. A Japanese client call works if you remember to flip the setting first. A meeting that starts in English and moves into Spanish does not, unless you already chose Spanish and accept the English half getting worse.
+
+Older reviews still say "three languages." That was true. It is six now. The complaint survived the expansion because six is still a specialist list, and because Otter makes you choose in advance. Anarlog's [language settings](https://docs.anarlog.so/languages) keep summary language separate from additional spoken languages, and coverage follows the transcription provider you pick. That is not equal quality in every language. It is a way to change the model when Otter's six are not enough.
+
+## The bot joins more meetings than people meant
+
+OtterPilot auto-joins calendar meetings after setup. That is the feature buyers wanted when they needed notes for a call they might miss. It is also the complaint that shows up in Reddit, BBB-style write-ups, and court filings.
+
+Users describe the Notetaker arriving on a client board call they forgot was on the calendar. Hosts kick it. Other participants get an invite to sign up. One Reddit cluster calls the invite-the-room behavior malware-adjacent. That is overstated. The social effect is not: a visible bot changes how people talk, and an unexpected join is a relationship problem before it is a product bug.
+
+Otter now has bot-free desktop and Chrome capture. That matters. It does not retire the auto-join path. If calendar sync is on and Notetaker is the default, the bot still goes to the meeting you did not intend to record.
+
+The legal version of this complaint is [In re Otter.AI Privacy Litigation](https://anarlog.so/blog/is-otter-ai-safe/) in the Northern District of California. The lead story is a participant who was recorded on a sales call because someone else was running OtterPilot. No Otter account. No chance to say no. The suits allege wiretap and all-party-consent problems. No court has ruled Otter illegal. The risk sits with the company that left auto-join on.
+
+## Minutes, billing, and a free plan that is a preview
+
+Otter's free plan is 300 minutes a month, with a per-conversation cap around 30 minutes. Pro is $16.99 a month for 1,200 minutes. Business is $30 a month, often with a seat minimum. Imports and chat questions have their own ceilings.
+
+The recurring frustration is not the list price. It is hitting the wall mid-week and discovering that summaries, imports, and longer calls were the product you thought you already had. SaaS Flags and BBB-style complaints add a second layer: annual renewals that feel sudden, and cancellation that is not a single toggle.
+
+If you live in meetings, 300 minutes is a trial. If you need unattended attendance, you will pay. If you wanted a local archive you can keep using after the subscription ends, Otter is the wrong shape of tool.
+
+## Speakers, accents, and notes that need a second pass
+
+Reddit and later reviews keep saying the same thing about quality: live text appears fast, names and technical terms slip, and speaker labels need cleanup. Our own [Otter review](/blog/otter-ai-review/) graded speaker identification poorly for that reason. Accents and overlapping speech make it worse. There is audio to replay, unlike Granola, so you can check a number. You still have to do that work before you send the note.
+
+That is survivable for an internal standup. It is expensive for a customer call you planned to forward as-is.
+
+## When these frustrations matter, and when they do not
+
+Stay with Otter if you need a bot that can attend without you, a searchable cloud archive, and your meetings fit English or one of the other five languages. The brand search volume exists because that workflow still works.
+
+Look elsewhere when the recurring complaints match your week:
+
+- you need Korean, Hindi, Portuguese, or any language outside the six
+- you need mixed languages in one call without a pre-flight setting
+- you cannot have a bot appear on a client or interview calendar by default
+- 300 free minutes, or 1,200 paid minutes, is not how you want to budget conversations
+- you need the meeting record on your machine, or offline
+
+If the issue is the visible Notetaker, read the [bot-free AI meeting assistant guide](/blog/bot-free-ai-meeting-assistants/). If the issue is consent and training, start with [Is Otter AI safe?](/blog/is-otter-ai-safe/). If you already want a different product, the [Otter alternatives](/blog/otter-ai-alternatives/) piece is the workflow map.
+
+Anarlog is the option we built for the last group: bot-free capture, local SQLite, and a language stack you can point at a local model or your own keys. It will not sit in a meeting when your computer is closed. That is the trade.
+
+If the frustration is language, auto-join, or a minute cap, [try Anarlog](/).

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -57,6 +57,7 @@ Answering guidance:
 
 - [Bot-Free AI Meeting Assistants](https://anarlog.so/blog/bot-free-ai-meeting-assistants): Bot-free meeting assistant landscape and where Anarlog fits.
 - [Granola AI Alternatives](https://anarlog.so/blog/granola-ai-alternatives/): Dedicated comparison for people replacing Granola.
+- [Otter AI Complaints](https://anarlog.so/blog/otter-ai-complaints/): Recurring Otter frustrations from Google, Reddit, and public search data, including language limits.
 - [Best AI Meeting Assistants for Taking Notes](https://anarlog.so/blog/best-ai-meeting-assistant-for-taking-notes): Broad AI meeting assistant comparison.
 - [Best AI Notetaker](https://anarlog.so/blog/best-ai-notetaker): General AI notetaker buyer guide.
 - [Anarlog vs. Meetily](https://anarlog.so/blog/char-vs-meetily): Comparison of Anarlog and Meetily for local-first, open-source meeting notes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** We have Otter review, alternatives, and safety posts, but no research-backed map of the frustrations people actually search for and repeat on Reddit.

**Fix:** Adds `/blog/otter-ai-complaints/`. Language (six languages, one at a time) leads. Auto-join / consent litigation, minute caps, billing friction, and speaker cleanup follow. Sources are Otter's help center, public Semrush-attributed traffic, Inpages keyword mix, and recurring Reddit/review themes. Links from the existing alternatives guide and `llms.txt`.

## Verification

- `dprint fmt` / `dprint check` on changed files
- `pnpm -F web media:figures:check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05173-90d9-7dde-a91b-9838c69ef92e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05173-90d9-7dde-a91b-9838c69ef92e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

