### PR TITLE
Document supported languages in the FAQ

### DIFF
--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Frequently asked questions"
-description: "Answers about recording, transcription cost, local models, privacy, sharing, sync, and developer tools."
+description: "Answers about recording, transcription cost, languages, local models, privacy, sharing, sync, and developer tools."
 ---
 
 Browse a topic, then expand the question. If something is not working, go to [Troubleshooting](/troubleshooting). For a question not covered here, email [founders@anarlog.so](mailto:founders@anarlog.so) or [join Discord](https://anarlog.so/discord).
@@ -87,6 +87,23 @@ Browse a topic, then expand the question. If something is not working, go to [Tr
 <AccordionGroup>
   <Accordion title="Can I use Anarlog offline?" id="can-i-use-anarlog-offline">
     Yes, if you prepare local models before disconnecting. Soniqo, Apple Speech, and Local file transcription require a supported Apple Silicon Mac; Apple Speech also needs macOS 26 to report compatible system assets. LM Studio, Ollama, Unsloth, and eligible Apple Intelligence can provide local Intelligence models. See [Use Anarlog offline](/offline).
+  </Accordion>
+
+  <Accordion title="What languages does Anarlog support?" id="supported-languages">
+    **Settings → General → Language & Region** lets you choose a main language and additional spoken languages from this list:
+
+    Arabic, Belarusian, Bulgarian, Bangla, Bosnian, Catalan, Czech, Danish, German, Greek, English, Spanish, Estonian, Persian, Finnish, French, Hebrew, Hindi, Croatian, Hungarian, Indonesian, Italian, Japanese, Kannada, Korean, Lithuanian, Latvian, Macedonian, Marathi, Malay, Dutch, Norwegian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Serbian, Swedish, Tamil, Telugu, Thai, Filipino, Turkish, Ukrainian, Urdu, Vietnamese, and Chinese.
+
+    The selected Transcription model must support those languages. Coverage today:
+
+    | Selection | Languages |
+    | --- | --- |
+    | Anarlog Cloud | Routes to a provider that supports the languages you selected. The Settings list is the Cloud picker. |
+    | Soniqo | Bulgarian, Czech, Danish, German, Greek, English, Spanish, Estonian, Finnish, French, Croatian, Hungarian, Italian, Lithuanian, Latvian, Maltese, Dutch, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Swedish, and Ukrainian |
+    | Apple Speech | German, English, Spanish, French, Italian, Japanese, Korean, Portuguese, Cantonese, or Chinese — one language at a time |
+    | Your API key | The provider and model you configure. Check that model's language list before a multilingual meeting. |
+
+    Summaries and chat use the main language. See [Use multiple languages](/languages).
   </Accordion>
 
   <Accordion title="Which AI models does Anarlog use?" id="which-ai-models-does-anarlog-use">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,6 +26,9 @@ Anarlog records your microphone and computer audio without joining the call as a
 ## Popular questions
 
 <CardGroup cols={2}>
+  <Card title="What languages does Anarlog support?" icon="language" href="/help#supported-languages">
+    See the Settings language list and which models cover it.
+  </Card>
   <Card title="How do I compare transcription costs?" icon="coins" href="/help#compare-transcription-costs">
     See on-device, Anarlog Cloud, and bring-your-own-key pricing.
   </Card>

--- a/docs/languages.mdx
+++ b/docs/languages.mdx
@@ -19,7 +19,17 @@ Under **Additional spoken languages**, add other languages people may use in the
 
 The selected Transcription provider and model must support those languages. If a language is missing or performs poorly, try another model under **Settings → Transcription**.
 
-Apple Speech live transcription uses one supported language at a time: German, English, Spanish, French, Italian, Japanese, Korean, Portuguese, Cantonese, or Chinese. Add that language in macOS System Settings before selecting Apple Speech.
+## Languages you can choose
+
+Settings offers these languages for the main language and additional spoken languages:
+
+Arabic, Belarusian, Bulgarian, Bangla, Bosnian, Catalan, Czech, Danish, German, Greek, English, Spanish, Estonian, Persian, Finnish, French, Hebrew, Hindi, Croatian, Hungarian, Indonesian, Italian, Japanese, Kannada, Korean, Lithuanian, Latvian, Macedonian, Marathi, Malay, Dutch, Norwegian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Serbian, Swedish, Tamil, Telugu, Thai, Filipino, Turkish, Ukrainian, Urdu, Vietnamese, and Chinese.
+
+That list is the Anarlog Cloud picker. On-device and bring-your-own-key models can support a subset or a different set:
+
+- **Soniqo** transcribes Bulgarian, Czech, Danish, German, Greek, English, Spanish, Estonian, Finnish, French, Croatian, Hungarian, Italian, Lithuanian, Latvian, Maltese, Dutch, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Swedish, and Ukrainian.
+- **Apple Speech** live transcription uses one supported language at a time: German, English, Spanish, French, Italian, Japanese, Korean, Portuguese, Cantonese, or Chinese. Add that language in macOS System Settings before selecting Apple Speech.
+- A bring-your-own-key provider uses that provider's language list.
 
 ## Improve names and jargon
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** The FAQ said multilingual meetings were possible, but it never listed the languages Anarlog supports or which models cover them.

**Fix:** Add a "What languages does Anarlog support?" FAQ that lists the Settings picker languages and Cloud / Soniqo / Apple Speech / BYOK coverage. The same list is now on the languages page.

## Verification

- `pnpm exec dprint fmt` and `pnpm exec dprint check` on the changed docs
- `npx mint@4.2.687 validate` and `broken-links --check-anchors --check-redirects` from `docs/`
- Local Mintlify preview: homepage card, FAQ accordion, and languages page

[Homepage popular questions including supported languages](https://cursor.com/agents/bc-01a05167-bca6-794b-8d30-8c0f64ee4262/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-faq-languages-card.webp)

[FAQ accordion listing supported languages and model coverage](https://cursor.com/agents/bc-01a05167-bca6-794b-8d30-8c0f64ee4262/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-faq-supported-languages.webp)

[Languages page with the Settings language list](https://cursor.com/agents/bc-01a05167-bca6-794b-8d30-8c0f64ee4262/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs-languages-page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05167-bca6-794b-8d30-8c0f64ee4262?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05167-bca6-794b-8d30-8c0f64ee4262&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

