### PR TITLE
Turn circle and pill controls into squircles

### DIFF
--- a/apps/desktop/src/session/components/note-input/header-shared.tsx
+++ b/apps/desktop/src/session/components/note-input/header-shared.tsx
@@ -90,7 +90,7 @@ export function iconHeaderViewClassName(
   const heightClassName = size === "tray" ? "h-[26px]" : "h-7";
 
   return cn([
-    "group/header-view flex shrink-0 items-center justify-center rounded-full transition-colors select-none [corner-shape:round] [&>svg]:shrink-0",
+    "group/header-view rounded-pill flex shrink-0 items-center justify-center transition-colors select-none [corner-shape:round] [&>svg]:shrink-0",
     isActive
       ? [
           "text-foreground bg-white shadow-xs",

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -381,6 +381,10 @@ describe("Header", () => {
     expect(viewSwitcher.className).toContain("h-[30px]");
     expect(viewSwitcher.className).toContain("p-[2px]");
     expect(viewSwitcher.className).toContain("gap-[2px]");
+    expect(viewSwitcher.className).toContain("rounded-pill");
+    expect(viewSwitcher.className).toContain("[corner-shape:round]");
+    expect(memoTab.className).toContain("rounded-pill");
+    expect(memoTab.className).toContain("[corner-shape:round]");
     expect(viewSwitcher.className).toContain("bg-foreground/10");
     expect(viewSwitcher.className).toContain("dark:bg-accent/55");
     expect(summaryTab.getAttribute("aria-current")).toBeNull();

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -47,7 +47,7 @@ export function SessionViewSwitcher({
       data-tauri-drag-region="false"
       className={cn([
         "pointer-events-auto relative z-10 w-fit max-w-full shrink-0 overflow-visible",
-        "bg-foreground/10 dark:bg-accent/55 flex h-[30px] items-center gap-[2px] rounded-full p-[2px] [corner-shape:round]",
+        "bg-foreground/10 dark:bg-accent/55 rounded-pill flex h-[30px] items-center gap-[2px] p-[2px] [corner-shape:round]",
       ])}
     >
       {editorTabs.map((view, index) => {

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -3,6 +3,7 @@
 
 @import "tailwindcss";
 @import "./dark-theme.css";
+@import "../../../../packages/ui/src/styles/corners.css";
 @import "../../../../packages/ui/src/styles/scroll-fade.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
@@ -38,6 +39,10 @@ html[data-live-caption] #root {
   --font-sans:
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-hand: "Bradley Hand", "Segoe Print", "Comic Sans MS", cursive;
+
+  /* Capsule radii still read as pills/circles; remap to a control squircle. */
+  --radius-full: 0.5rem;
+  --radius-pill: calc(infinity * 1px);
 
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
@@ -307,4 +312,18 @@ html[data-live-caption] #root {
     right: auto;
     width: var(--width);
   }
+}
+
+/*
+ * Capsule radii still read as pills/circles even with corner-shape: squircle.
+ * Keep this unlayered so it outranks Tailwind utilities from @anlg/ui.
+ * Session view tabs opt out with .rounded-pill.
+ */
+.rounded-full {
+  border-radius: 0.5rem;
+}
+
+.rounded-pill {
+  border-radius: calc(infinity * 1px);
+  corner-shape: round;
 }

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -78,7 +78,7 @@ function AvatarImage({
     overflow: "hidden",
     boxSizing: "border-box",
     border: "1px solid rgb(0 0 0 / 0.1)",
-    borderRadius: "9999px",
+    borderRadius: "0.5rem",
     background: avatarFallbackGradient(recipe.seed),
     boxShadow: "0 1px 2px rgb(0 0 0 / 0.08)",
   } satisfies CSSProperties;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Desktop chrome still used capsule radii (`rounded-full`), so icon buttons and pills rendered as circles even with global squircle corners. That includes the session header folder/calendar/share/menu controls.

**Fix:** Remap `rounded-full` to a control-sized radius (`0.5rem`) so those surfaces become squircles, and keep the summary / memos / transcript tabs as true capsules via `rounded-pill` and `corner-shape: round`.

## Verification

- `pnpm exec dprint fmt` and `dprint check` on changed non-Swift files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop typecheck`
- `pnpm -F ui typecheck`
- `pnpm -F desktop test` (417 files, 3574 tests)
- `pnpm -F desktop i18n:check` skipped (no copy or catalog changes)
- Rendered a session-header preview with the new radii: tabs stay capsules, the folder hover/active background is an 8px squircle

[Session header squircle preview](https://cursor.com/agents/bc-4b2ef1e7-8a8d-4968-88d6-07230c0f5798/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsession-header-squircles.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b2ef1e7-8a8d-4968-88d6-07230c0f5798?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b2ef1e7-8a8d-4968-88d6-07230c0f5798&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

