### PR TITLE
Fix template picker footer spacing and inner radius

### DIFF
--- a/apps/desktop/src/session/components/note-input/template-picker.tsx
+++ b/apps/desktop/src/session/components/note-input/template-picker.tsx
@@ -390,9 +390,9 @@ export function TemplatePickerPopover({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent variant="app" className="w-80" align="start">
-        <div className="flex flex-col gap-1">
-          <AppFloatingPanel className="flex flex-col overflow-hidden">
+      <PopoverContent variant="app" className="w-80 pb-0" align="start">
+        <div className="flex flex-col">
+          <AppFloatingPanel className="flex flex-col overflow-hidden rounded-[20px]">
             <div className="border-border border-b py-1">
               <div
                 className={cn([
@@ -421,9 +421,9 @@ export function TemplatePickerPopover({
               </div>
             </div>
 
-            <div className="relative">
+            <div className="relative overflow-hidden rounded-b-[20px]">
               <div
-                className={cn(["scroll-fade-y max-h-80 overflow-y-auto p-1.5"])}
+                className={cn(["scroll-fade-y max-h-80 overflow-y-auto p-1"])}
               >
                 <div className="flex flex-col gap-0">
                   {resultSections.map((section) => (
@@ -485,7 +485,7 @@ export function TemplatePickerPopover({
           <button
             onClick={handleSeeAllTemplates}
             className={cn([
-              "flex h-7 w-full items-center justify-center gap-1 rounded-lg px-3 text-xs font-medium",
+              "flex w-full items-center justify-center gap-1 px-3 py-1.5 text-xs font-medium",
               "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
             ])}
           >

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -12,7 +12,7 @@ export function AppFloatingPanel({
   return (
     <div
       className={cn([
-        "bg-app-floating-panel text-popover-foreground border-app-floating-border rounded-[18px] border",
+        "bg-app-floating-panel text-popover-foreground border-app-floating-border rounded-[20px] border",
         className,
       ])}
       {...props}


### PR DESCRIPTION
## Summary

**Problem:** "See all templates" padding and list clipping made the footer look uneven, and the inner corners were not concentric with the chrome.

**Fix:** Give the footer its own even padding and clip the list so the 20px inner corners stay concentric with the popover chrome.

## Verification

- Inspected `template-picker.tsx` and `floating-content.tsx` spacing/clip changes
- Visual check of the template picker footer against the popover radius

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only spacing and border-radius tweaks; `AppFloatingPanel` radius also updates calendar popovers that use the shared component.
> 
> **Overview**
> Polishes the session **template picker** popover layout so the **See all templates** footer has even vertical padding and the scrollable list no longer clips awkwardly against the chrome.
> 
> The popover drops extra outer gap/padding (`pb-0`, tighter list `p-1`), clips the list with **`rounded-b-[20px]`** and **`overflow-hidden`**, and restyles the footer button (no fixed height/`rounded-lg`, uses **`py-1.5`**). **`AppFloatingPanel`** default corner radius moves from **18px to 20px** in shared UI, with an explicit **`rounded-[20px]`** on the picker panel so inner corners stay concentric with the popover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abd1099e7ad6073721dd8c5b59d59cb3e14e685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->