### PR TITLE
Keep note header action icons on one size and stroke

### DIFF
--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -620,6 +620,10 @@ describe("SessionShareButton", () => {
     const trigger = screen.getByRole("button", { name: "Share note" });
     expect(trigger.textContent).toBe("");
     expect(trigger.querySelectorAll("svg")).toHaveLength(1);
+    expect(trigger.className).toContain("[&_svg]:size-4");
+    expect(trigger.querySelector("svg")?.getAttribute("class")).toContain(
+      "size-4",
+    );
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
     expect(trigger.className).not.toContain("mr-1");
 

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -617,7 +617,7 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
           title={t`Share note`}
           onClick={handleShare}
           className={cn([
-            "text-muted-foreground hover:text-foreground rounded-full",
+            "text-muted-foreground hover:text-foreground rounded-full [&_svg]:size-4",
             sharePopoverOpen && "bg-accent text-foreground",
           ])}
         >

--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -53,6 +53,7 @@ describe("FolderPicker", () => {
 
     expect(trigger.textContent).toBe("");
     expect(trigger.className).toContain("w-7");
+    expect(trigger.className).toContain("[&_svg]:size-4");
     expect(icons).toHaveLength(1);
     expect(icons[0]?.getAttribute("class")).toContain("size-4");
   });

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -1,5 +1,5 @@
 import { useLingui } from "@lingui/react/macro";
-import { Check, FolderSimple, Plus } from "@phosphor-icons/react";
+import { Check, Folder, FolderSimple, Plus } from "@phosphor-icons/react";
 import { useCallback, useMemo, useState } from "react";
 
 import {
@@ -106,7 +106,7 @@ export function FolderPicker({
           }
           title={currentPath ? currentPath : t`Select folder`}
           className={cn([
-            "flex h-7 items-center rounded-full",
+            "flex h-7 items-center rounded-full [&_svg]:size-4",
             currentPath
               ? "max-w-full min-w-0 gap-1 px-1.5"
               : "w-7 justify-center",
@@ -115,7 +115,7 @@ export function FolderPicker({
             open && "bg-accent text-foreground",
           ])}
         >
-          <FolderSimple className="size-4 shrink-0" aria-hidden="true" />
+          <Folder className="size-4 shrink-0" aria-hidden="true" />
           {currentPath ? (
             <span className="min-w-0 truncate text-xs text-neutral-600 dark:text-neutral-300">
               {currentPath}

--- a/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
@@ -74,6 +74,10 @@ describe("Metadata controls", () => {
 
     expect(metadataButton.className).toContain("size-7");
     expect(metadataButton.className).toContain("rounded-full");
+    expect(metadataButton.className).toContain("[&_svg]:size-4");
+    expect(
+      metadataButton.querySelector("svg")?.getAttribute("class"),
+    ).toContain("size-4");
   });
 
   it("renders date edit action buttons as circles", () => {

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -55,7 +55,7 @@ const TriggerInner = forwardRef<
       aria-label={label}
       title={label}
       className={cn([
-        "size-7 rounded-full",
+        "size-7 rounded-full [&_svg]:size-4",
         "text-muted-foreground hover:bg-accent hover:text-foreground",
         open && "bg-muted text-foreground",
       ])}

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -321,6 +321,10 @@ describe("OverflowButton", () => {
     );
 
     expect(trigger).not.toBeNull();
+    expect(trigger?.className).toContain("[&_svg]:size-4");
+    expect(trigger?.querySelector("svg")?.getAttribute("class")).toContain(
+      "size-4",
+    );
   });
 
   it("mounts the export modal only after export is selected", () => {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -123,7 +123,7 @@ export function OverflowButton({
             size="icon"
             variant="ghost"
             data-tauri-drag-region="false"
-            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full [&_svg]:size-4"
           >
             <DotsThree className="size-4" />
           </Button>


### PR DESCRIPTION
## Summary

**Problem:** Optical size tweaks made some Phosphor icons look heavier, because strokes scale with the SVG.

**Fix:** Use 16px for all four header actions, and Folder instead of FolderSimple so the folder fills the box.

## Verification

- `pnpm -F desktop test -- src/session-sharing/index.test.tsx src/session/components/folder-picker.test.tsx src/session/components/outer-header`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic desktop header styling and icon choice only; no auth, data, or sharing logic changes.
> 
> **Overview**
> Aligns the note header toolbar so **share**, **folder**, **metadata**, and **overflow** triggers all force nested SVGs to **16px** via `[&_svg]:size-4` on each control (alongside existing `size-4` on the icons themselves), addressing uneven stroke weight when Phosphor icons were sized differently.
> 
> The folder picker trigger swaps **`FolderSimple` for `Folder`** so the folder glyph fills the circle like the other actions. Dropdown list rows still use `FolderSimple`.
> 
> Unit tests for those four controls now assert the trigger carries `[&_svg]:size-4` and the SVG has `size-4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af4dcc099981cef1a87b2a668a588521a9bd4d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->