### PR TITLE
Make the folder picker as tight as the template picker

### DIFF
--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -78,10 +78,11 @@ describe("FolderPicker", () => {
     const content = input.closest("[data-radix-popper-content-wrapper] > *");
     const classes = content?.className.split(/\s+/) ?? [];
 
-    expect(classes).toContain("w-85");
+    expect(classes).toContain("w-80");
     expect(classes).toContain("p-0.5");
     expect(classes).not.toContain("p-0");
-    expect(input.closest(".p-4")).not.toBeNull();
+    expect(input.closest(".p-4")).toBeNull();
+    expect(input.className).toContain("h-8");
   });
 
   it("lets the user select an existing folder for the current note", async () => {

--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -78,7 +78,7 @@ describe("FolderPicker", () => {
     const content = input.closest("[data-radix-popper-content-wrapper] > *");
     const classes = content?.className.split(/\s+/) ?? [];
 
-    expect(classes).toContain("w-80");
+    expect(classes).toContain("w-56");
     expect(classes).toContain("p-0.5");
     expect(classes).not.toContain("p-0");
     expect(input.closest(".p-4")).toBeNull();

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -126,7 +126,7 @@ export function FolderPicker({
       <PopoverContent
         variant="app"
         align={align}
-        className="w-80 overflow-hidden"
+        className="w-56 overflow-hidden"
       >
         <AppFloatingPanel className="overflow-hidden">
           <Command

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -126,77 +126,74 @@ export function FolderPicker({
       <PopoverContent
         variant="app"
         align={align}
-        className="w-85 overflow-hidden"
+        className="w-80 overflow-hidden"
       >
         <AppFloatingPanel className="overflow-hidden">
           <Command
             filter={filterFolders}
-            className="rounded-[inherit] border-0 bg-transparent **:[[cmdk-input-wrapper]]:h-7 **:[[cmdk-input-wrapper]]:border-0 **:[[cmdk-input-wrapper]]:px-0"
+            className="rounded-[inherit] border-0 bg-transparent **:[[cmdk-input-wrapper]]:h-8 **:[[cmdk-input-wrapper]]:px-2.5"
           >
-            <div className="flex flex-col gap-4 p-4">
-              <CommandInput
-                placeholder={t`Search or create folder`}
-                value={query}
-                onValueChange={setQuery}
-                className="h-7 py-0"
-              />
-              <div className="bg-accent h-px" />
-              <CommandList>
-                <CommandEmpty className="text-muted-foreground py-0 text-left text-sm">
-                  {trimmedQuery
-                    ? normalizedQuery === null
-                      ? t`Enter a valid folder name.`
-                      : t`No folders found.`
-                    : t`No folders yet.`}
-                </CommandEmpty>
-                {currentPath ? (
-                  <CommandGroup>
+            <CommandInput
+              placeholder={t`Search or create folder`}
+              value={query}
+              onValueChange={setQuery}
+              className="h-8 py-0"
+            />
+            <CommandList className="p-1">
+              <CommandEmpty className="text-muted-foreground px-2.5 py-2 text-left text-sm">
+                {trimmedQuery
+                  ? normalizedQuery === null
+                    ? t`Enter a valid folder name.`
+                    : t`No folders found.`
+                  : t`No folders yet.`}
+              </CommandEmpty>
+              {currentPath ? (
+                <CommandGroup>
+                  <CommandItem
+                    value={`no-folder ${t`No folder`}`}
+                    onSelect={() => handleSelect("")}
+                    className="cursor-pointer"
+                  >
+                    <span className="flex-1 truncate">{t`No folder`}</span>
+                  </CommandItem>
+                </CommandGroup>
+              ) : null}
+              {currentPath && (folders.length > 0 || canCreateFolder) ? (
+                <CommandSeparator />
+              ) : null}
+              {folders.length > 0 ? (
+                <CommandGroup>
+                  {folders.map((path) => (
                     <CommandItem
-                      value={`no-folder ${t`No folder`}`}
-                      onSelect={() => handleSelect("")}
+                      key={path}
+                      value={path}
+                      onSelect={() => handleSelect(path)}
                       className="cursor-pointer"
                     >
-                      <span className="flex-1 truncate">{t`No folder`}</span>
+                      <FolderSimple className="size-4 shrink-0 opacity-70" />
+                      <span className="min-w-0 flex-1 truncate">{path}</span>
+                      {path === currentPath ? (
+                        <Check className="size-4 shrink-0" />
+                      ) : null}
                     </CommandItem>
-                  </CommandGroup>
-                ) : null}
-                {currentPath && (folders.length > 0 || canCreateFolder) ? (
-                  <CommandSeparator />
-                ) : null}
-                {folders.length > 0 ? (
-                  <CommandGroup>
-                    {folders.map((path) => (
-                      <CommandItem
-                        key={path}
-                        value={path}
-                        onSelect={() => handleSelect(path)}
-                        className="cursor-pointer"
-                      >
-                        <FolderSimple className="size-4 shrink-0 opacity-70" />
-                        <span className="min-w-0 flex-1 truncate">{path}</span>
-                        {path === currentPath ? (
-                          <Check className="size-4 shrink-0" />
-                        ) : null}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                ) : null}
-                {canCreateFolder && normalizedQuery ? (
-                  <CommandGroup>
-                    <CommandItem
-                      value={`create-folder ${normalizedQuery}`}
-                      onSelect={() => handleSelect(normalizedQuery)}
-                      className="cursor-pointer"
-                    >
-                      <Plus className="size-4 shrink-0" />
-                      <span className="min-w-0 flex-1 truncate">
-                        {t`Create "${folderName}"`}
-                      </span>
-                    </CommandItem>
-                  </CommandGroup>
-                ) : null}
-              </CommandList>
-            </div>
+                  ))}
+                </CommandGroup>
+              ) : null}
+              {canCreateFolder && normalizedQuery ? (
+                <CommandGroup>
+                  <CommandItem
+                    value={`create-folder ${normalizedQuery}`}
+                    onSelect={() => handleSelect(normalizedQuery)}
+                    className="cursor-pointer"
+                  >
+                    <Plus className="size-4 shrink-0" />
+                    <span className="min-w-0 flex-1 truncate">
+                      {t`Create "${folderName}"`}
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              ) : null}
+            </CommandList>
           </Command>
         </AppFloatingPanel>
       </PopoverContent>

--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -124,11 +124,11 @@ function EditableDateForm({
     <div className="flex flex-col gap-2">
       <form.Field name="createdAt">
         {(field) => (
-          <div className="flex min-w-0 flex-wrap items-center gap-1">
+          <div className="flex min-w-0 flex-col gap-1">
             <Input
               autoFocus
               type="datetime-local"
-              className="h-7 min-w-0 flex-1 basis-32 border-0 px-0 py-0 shadow-none focus-visible:ring-0"
+              className="h-7 w-full min-w-0 border-0 px-0 py-0 shadow-none focus-visible:ring-0"
               value={field.state.value}
               onChange={(e) => field.handleChange(e.target.value)}
               onKeyDown={(e) => {
@@ -144,7 +144,7 @@ function EditableDateForm({
               }}
             />
 
-            <div className="ml-auto flex shrink-0 items-center">
+            <div className="flex shrink-0 items-center justify-end">
               {onCancel && (
                 <Button
                   type="button"

--- a/apps/desktop/src/session/components/outer-header/metadata/date.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/date.tsx
@@ -124,11 +124,11 @@ function EditableDateForm({
     <div className="flex flex-col gap-2">
       <form.Field name="createdAt">
         {(field) => (
-          <div className="flex h-7 items-center gap-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-1">
             <Input
               autoFocus
               type="datetime-local"
-              className="h-7 flex-1 border-0 px-0 py-0 shadow-none focus-visible:ring-0"
+              className="h-7 min-w-0 flex-1 basis-32 border-0 px-0 py-0 shadow-none focus-visible:ring-0"
               value={field.state.value}
               onChange={(e) => field.handleChange(e.target.value)}
               onKeyDown={(e) => {
@@ -144,34 +144,36 @@ function EditableDateForm({
               }}
             />
 
-            {onCancel && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="text-muted-foreground size-7 shrink-0 rounded-full hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/50 dark:hover:text-red-300"
-                onClick={onCancel}
-                aria-label={t`Cancel date edit`}
-              >
-                <X size={16} />
-              </Button>
-            )}
-
-            <form.Subscribe selector={(state) => [state.canSubmit]}>
-              {([canSubmit]) => (
+            <div className="ml-auto flex shrink-0 items-center">
+              {onCancel && (
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="text-muted-foreground size-7 shrink-0 rounded-full hover:bg-green-50 hover:text-green-600 dark:hover:bg-green-950/50 dark:hover:text-green-300"
-                  onClick={() => void form.handleSubmit()}
-                  disabled={!canSubmit}
-                  aria-label={t`Save date`}
+                  className="text-muted-foreground size-7 shrink-0 rounded-full hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/50 dark:hover:text-red-300"
+                  onClick={onCancel}
+                  aria-label={t`Cancel date edit`}
                 >
-                  <Check size={16} />
+                  <X size={16} />
                 </Button>
               )}
-            </form.Subscribe>
+
+              <form.Subscribe selector={(state) => [state.canSubmit]}>
+                {([canSubmit]) => (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground size-7 shrink-0 rounded-full hover:bg-green-50 hover:text-green-600 dark:hover:bg-green-950/50 dark:hover:text-green-300"
+                    onClick={() => void form.handleSubmit()}
+                    disabled={!canSubmit}
+                    aria-label={t`Save date`}
+                  >
+                    <Check size={16} />
+                  </Button>
+                )}
+              </form.Subscribe>
+            </div>
           </div>
         )}
       </form.Field>

--- a/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
@@ -74,7 +74,7 @@ describe("Metadata controls", () => {
       .getByRole("button", { name: "Edit date" })
       .closest("[data-radix-popper-content-wrapper] > *");
 
-    expect(content?.className.split(/\s+/) ?? []).toContain("w-56");
+    expect(content?.className.split(/\s+/) ?? []).toContain("w-72");
   });
 
   it("renders the metadata calendar trigger as a circle", () => {
@@ -117,9 +117,11 @@ describe("Metadata controls", () => {
     }).parentElement;
 
     expect(input).not.toBeNull();
+    expect(input?.className).toContain("w-full");
     expect(input?.className).toContain("min-w-0");
-    expect(input?.className).toContain("basis-32");
     expect(actions?.className).toContain("shrink-0");
+    expect(actions?.className).toContain("justify-end");
+    expect(actions?.parentElement?.className).toContain("flex-col");
     expect(
       screen.getByRole("button", { name: "Cancel date edit" }),
     ).not.toBeNull();

--- a/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
@@ -65,6 +65,18 @@ describe("Metadata controls", () => {
     cleanup();
   });
 
+  it("uses a narrow floating panel", () => {
+    render(<MetadataButton sessionId="session-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open note metadata" }));
+
+    const content = screen
+      .getByRole("button", { name: "Edit date" })
+      .closest("[data-radix-popper-content-wrapper] > *");
+
+    expect(content?.className.split(/\s+/) ?? []).toContain("w-56");
+  });
+
   it("renders the metadata calendar trigger as a circle", () => {
     render(<MetadataButton sessionId="session-1" />);
 

--- a/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.test.tsx
@@ -104,4 +104,24 @@ describe("Metadata controls", () => {
       screen.getByRole("button", { name: "Save date" }).className,
     ).toContain("rounded-full");
   });
+
+  it("keeps date edit actions available in the narrow panel", () => {
+    render(<MetadataButton sessionId="session-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open note metadata" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit date" }));
+
+    const input = document.querySelector('input[type="datetime-local"]');
+    const actions = screen.getByRole("button", {
+      name: "Save date",
+    }).parentElement;
+
+    expect(input).not.toBeNull();
+    expect(input?.className).toContain("min-w-0");
+    expect(input?.className).toContain("basis-32");
+    expect(actions?.className).toContain("shrink-0");
+    expect(
+      screen.getByRole("button", { name: "Cancel date edit" }),
+    ).not.toBeNull();
+  });
 });

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -30,7 +30,7 @@ export function MetadataButton({ sessionId }: { sessionId: string }) {
       <PopoverContent
         variant="app"
         align="end"
-        className="w-85 overflow-hidden"
+        className="w-56 overflow-hidden"
       >
         <AppFloatingPanel className="scrollbar-soft max-h-[80vh] min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain">
           <ContentInner sessionId={sessionId} />

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -81,7 +81,7 @@ function ContentInner({ sessionId }: { sessionId: string }) {
     : null;
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex min-w-0 flex-col gap-4 p-4">
       {!eventDisplayData && <DateEditor sessionId={sessionId} />}
       {eventDisplayData && (
         <EventDisplay event={eventDisplayData}>

--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -30,7 +30,7 @@ export function MetadataButton({ sessionId }: { sessionId: string }) {
       <PopoverContent
         variant="app"
         align="end"
-        className="w-56 overflow-hidden"
+        className="w-72 overflow-hidden"
       >
         <AppFloatingPanel className="scrollbar-soft max-h-[80vh] min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain">
           <ContentInner sessionId={sessionId} />


### PR DESCRIPTION
## Summary

**Problem:** The folder picker popover was wider and had extra search padding, so it sat farther from the trigger than the template picker.

**Fix:** Drop the padded search block and match the template picker width so the popover sits closer to the trigger.

## Verification

- `pnpm -F desktop test -- src/session/components/folder-picker.test.tsx`
- Visual check against the template picker popover density

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and Tailwind class changes in session header popovers; session update behavior is unchanged.
> 
> **Overview**
> Narrows the **folder picker** popover from `w-85` to **`w-56`** and drops the extra `p-4` wrapper, divider, and loose padding so the command search and list match the denser floating-panel pattern (taller search input, list padding on `CommandList`).
> 
> The **note metadata** popover is narrowed from `w-85` to **`w-72`**, with `min-w-0` on the inner content so it can shrink cleanly.
> 
> **Date editing** inside metadata is reflowed for the smaller width: the datetime input is full-width on its own row, with cancel/save icon buttons on a second row aligned to the end instead of sharing one horizontal row with the input.
> 
> Tests assert the new widths, folder chrome, and that date-edit controls remain usable in the narrow metadata panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2148ba3a4a0726a563aa9dfbbb7be47ff89351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->