### PR TITLE
Make menu hover highlights concentric with their chrome.

### DIFF
--- a/apps/desktop/src/chat/components/toolbar-controls.test.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@anlg/ui/components/ui/button", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
+  appFloatingMenuPanelClassName: "overflow-hidden p-1.5",
   AppFloatingPanel: ({
     children,
     className,

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -13,10 +13,12 @@ import { useState } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@anlg/ui/components/ui/dropdown-menu";
+import { appFloatingItemClassName } from "@anlg/ui/components/ui/floating-content";
 import { cn, formatDistanceToNow } from "@anlg/utils";
 
 import {
@@ -205,7 +207,7 @@ function ChatGroups({
         collisionPadding={8}
         className="max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] w-72 max-w-[var(--radix-dropdown-menu-content-available-width)] overflow-y-auto"
       >
-        <AppFloatingPanel className="p-1.5">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <div className="px-2 py-1.5">
             <h4 className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
               Recent Chats
@@ -260,6 +262,7 @@ function ChatGroupItem({
       onClick={() => onSelect(chatGroup.id)}
       className={cn([
         "group h-auto w-full justify-start px-2.5 py-1.5",
+        appFloatingItemClassName,
         isActive
           ? "bg-muted hover:bg-accent shadow-xs"
           : "hover:bg-accent active:bg-muted",

--- a/apps/desktop/src/contacts/contact-page-header.tsx
+++ b/apps/desktop/src/contacts/contact-page-header.tsx
@@ -5,6 +5,7 @@ import { type ReactNode } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -58,7 +59,7 @@ export function ContactPageHeader({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent variant="app" align="end" className="w-48">
-            <AppFloatingPanel className="overflow-hidden p-1">
+            <AppFloatingPanel className={appFloatingMenuPanelClassName}>
               <DropdownMenuItem
                 onClick={onTogglePin}
                 className="cursor-pointer"

--- a/apps/desktop/src/contacts/related-notes.tsx
+++ b/apps/desktop/src/contacts/related-notes.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuRadioGroup,
@@ -49,7 +50,7 @@ export function RelatedNotesSection({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent variant="app" align="start">
-              <AppFloatingPanel className="overflow-hidden p-1">
+              <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                 <DropdownMenuRadioGroup
                   value={sortOrder}
                   onValueChange={(value) =>

--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -6,6 +6,7 @@ import { Avatar } from "@anlg/ui/components/avatar";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuRadioGroup,
@@ -54,7 +55,7 @@ function SortDropdown({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="end">
-        <AppFloatingPanel className="overflow-hidden p-1">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <DropdownMenuRadioGroup
             value={sortOption}
             onValueChange={(value) => setSortOption(value as SortOption)}

--- a/apps/desktop/src/imports/screen.tsx
+++ b/apps/desktop/src/imports/screen.tsx
@@ -20,6 +20,7 @@ import { Button } from "@anlg/ui/components/ui/button";
 import { ButtonGroup } from "@anlg/ui/components/ui/button-group";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -606,7 +607,9 @@ export function MeetingImportScreen({
                                 align="end"
                                 className="w-40"
                               >
-                                <AppFloatingPanel className="p-1">
+                                <AppFloatingPanel
+                                  className={appFloatingMenuPanelClassName}
+                                >
                                   <DropdownMenuItem
                                     onClick={() =>
                                       fileImportMutation.mutate(provider)

--- a/apps/desktop/src/session-sharing/delivery-panel.test.tsx
+++ b/apps/desktop/src/session-sharing/delivery-panel.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@iconify-icon/react", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
+  appFloatingMenuPanelClassName: "overflow-hidden p-1.5",
   AppFloatingPanel: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),

--- a/apps/desktop/src/session-sharing/delivery-panel.tsx
+++ b/apps/desktop/src/session-sharing/delivery-panel.tsx
@@ -13,6 +13,7 @@ import { useState, type ReactNode } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -72,7 +73,7 @@ export function ShareRecapOverflowMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="end" className="w-44">
-        <AppFloatingPanel className="overflow-hidden p-1">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <DropdownMenuItem
             onSelect={() => onValueChange("email")}
             className="cursor-pointer"

--- a/apps/desktop/src/session/components/floating/options-menu.tsx
+++ b/apps/desktop/src/session/components/floating/options-menu.tsx
@@ -3,8 +3,10 @@ import { DotsThreeVertical } from "@phosphor-icons/react";
 import { useCallback, useState } from "react";
 
 import { Button } from "@anlg/ui/components/ui/button";
+import { appFloatingItemClassName } from "@anlg/ui/components/ui/floating-content";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -14,6 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@anlg/ui/components/ui/tooltip";
+import { cn } from "@anlg/utils";
 
 import { ActionableTooltipContent } from "./shared";
 
@@ -124,10 +127,15 @@ export function OptionsMenu({
         sideOffset={8}
         className="w-43"
       >
-        <AppFloatingPanel className="flex flex-col gap-1 p-1">
+        <AppFloatingPanel
+          className={cn([appFloatingMenuPanelClassName, "flex flex-col gap-1"])}
+        >
           <Button
             variant="ghost"
-            className="h-9 justify-center px-3 whitespace-nowrap"
+            className={cn([
+              "h-9 justify-center px-3 whitespace-nowrap",
+              appFloatingItemClassName,
+            ])}
             onClick={handleUploadAudio}
           >
             <span className="text-sm">
@@ -136,7 +144,10 @@ export function OptionsMenu({
           </Button>
           <Button
             variant="ghost"
-            className="h-9 justify-center px-3 whitespace-nowrap"
+            className={cn([
+              "h-9 justify-center px-3 whitespace-nowrap",
+              appFloatingItemClassName,
+            ])}
             onClick={handleUploadTranscript}
           >
             <span className="text-sm">

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -56,6 +56,7 @@ vi.mock("@anlg/ui/components/ui/button", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
+  appFloatingMenuPanelClassName: "overflow-hidden p-1.5",
   AppFloatingPanel: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -129,7 +130,7 @@ export function OverflowButton({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent variant="app" align="end" className="w-56">
-          <AppFloatingPanel className="overflow-hidden p-1">
+          <AppFloatingPanel className={appFloatingMenuPanelClassName}>
             <DropdownMenuItem
               onClick={openExportModal}
               className="cursor-pointer"

--- a/apps/desktop/src/settings/automations/index.tsx
+++ b/apps/desktop/src/settings/automations/index.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@anlg/ui/components/ui/badge";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -234,7 +235,7 @@ function AutomationActionsMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="end">
-        <AppFloatingPanel className="overflow-hidden p-1">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <DropdownMenuItem onClick={onAction} className="cursor-pointer">
             {actionLabel}
           </DropdownMenuItem>

--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -46,6 +46,7 @@ vi.mock("~/types/tauri.gen", () => ({
 }));
 
 vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
+  appFloatingMenuPanelClassName: "overflow-hidden p-1.5",
   AppFloatingPanel: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/apps/desktop/src/settings/developers/skills.tsx
+++ b/apps/desktop/src/settings/developers/skills.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -97,7 +98,7 @@ export function SkillsRow() {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent variant="app" align="end" className="w-52">
-            <AppFloatingPanel className="p-1">
+            <AppFloatingPanel className={appFloatingMenuPanelClassName}>
               <DropdownMenuItem
                 disabled={detected.length === 0}
                 onClick={() =>

--- a/apps/desktop/src/shared/ui/floating-content.test.ts
+++ b/apps/desktop/src/shared/ui/floating-content.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  APP_FLOATING_CHROME_PADDING_PX,
+  APP_FLOATING_CHROME_RADIUS_PX,
+  APP_FLOATING_ITEM_RADIUS_PX,
+  APP_FLOATING_PANEL_PADDING_PX,
+  APP_FLOATING_PANEL_RADIUS_PX,
+  FLOATING_MENU_ITEM_RADIUS_PX,
+  FLOATING_MENU_PADDING_PX,
+  FLOATING_MENU_RADIUS_PX,
+  appFloatingContentClassName,
+  appFloatingItemClassName,
+  appFloatingMenuPanelClassName,
+} from "@anlg/ui/components/ui/floating-content";
+
+describe("floating content radii", () => {
+  it("keeps app chrome, panel, and item corners concentric", () => {
+    expect(APP_FLOATING_PANEL_RADIUS_PX).toBe(
+      APP_FLOATING_CHROME_RADIUS_PX - APP_FLOATING_CHROME_PADDING_PX,
+    );
+    expect(APP_FLOATING_ITEM_RADIUS_PX).toBe(
+      APP_FLOATING_PANEL_RADIUS_PX - APP_FLOATING_PANEL_PADDING_PX,
+    );
+    expect(appFloatingContentClassName).toContain(
+      `rounded-[${APP_FLOATING_CHROME_RADIUS_PX}px]`,
+    );
+    expect(appFloatingContentClassName).toContain("p-0.5");
+    expect(appFloatingMenuPanelClassName).toContain("p-1.5");
+    expect(appFloatingItemClassName).toContain(
+      `rounded-[${APP_FLOATING_ITEM_RADIUS_PX}px]`,
+    );
+  });
+
+  it("keeps default menu and item corners concentric", () => {
+    expect(FLOATING_MENU_ITEM_RADIUS_PX).toBe(
+      FLOATING_MENU_RADIUS_PX - FLOATING_MENU_PADDING_PX,
+    );
+    expect(FLOATING_MENU_ITEM_RADIUS_PX).toBe(APP_FLOATING_ITEM_RADIUS_PX);
+  });
+});

--- a/apps/desktop/src/sidebar/note-filter-menu.tsx
+++ b/apps/desktop/src/sidebar/note-filter-menu.tsx
@@ -10,6 +10,7 @@ import {
 
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -52,7 +53,7 @@ export function SidebarNoteFilterMenu() {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="start" className="w-56">
-        <AppFloatingPanel className="overflow-hidden p-1">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger
               aria-label={t`Grouping, ${groupingLabel}`}
@@ -65,7 +66,7 @@ export function SidebarNoteFilterMenu() {
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent variant="app" className="w-44">
-                <AppFloatingPanel className="overflow-hidden p-1">
+                <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                   <DropdownMenuItem
                     onSelect={() => setGroupBy("date")}
                     className="cursor-pointer"
@@ -112,7 +113,7 @@ export function SidebarNoteFilterMenu() {
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent variant="app" className="w-44">
-                <AppFloatingPanel className="overflow-hidden p-1">
+                <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                   <DropdownMenuItem
                     onSelect={() => setSortOrder("newest")}
                     className="cursor-pointer"

--- a/apps/desktop/src/templates/auto-form.tsx
+++ b/apps/desktop/src/templates/auto-form.tsx
@@ -16,6 +16,7 @@ import { commands as templateCommands } from "@anlg/plugin-template";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -196,7 +197,7 @@ export function AutoFormatForm({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent variant="app" align="end" className="w-56">
-                  <AppFloatingPanel className="overflow-hidden p-1">
+                  <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                     <DropdownMenuItem
                       className="cursor-pointer"
                       disabled={

--- a/apps/desktop/src/templates/details.tsx
+++ b/apps/desktop/src/templates/details.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -181,7 +182,7 @@ function WebTemplatePreview({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent variant="app" align="end">
-                <AppFloatingPanel className="overflow-hidden p-1">
+                <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                   <DropdownMenuItem
                     onClick={() => onClone(nextTemplate)}
                     className="cursor-pointer"

--- a/apps/desktop/src/templates/sections-editor.tsx
+++ b/apps/desktop/src/templates/sections-editor.tsx
@@ -7,6 +7,7 @@ import type { TemplateSection } from "@anlg/store";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -242,7 +243,7 @@ function SectionItem({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent variant="app" align="end">
-              <AppFloatingPanel className="overflow-hidden p-1">
+              <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                 <DropdownMenuItem
                   onClick={() => onInsertAbove(index)}
                   className="cursor-pointer"

--- a/apps/desktop/src/templates/template-form.tsx
+++ b/apps/desktop/src/templates/template-form.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@anlg/ui/components/ui/badge";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -285,7 +286,7 @@ export function TemplateForm({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent variant="app" align="end">
-              <AppFloatingPanel className="overflow-hidden p-1">
+              <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                 <DropdownMenuItem
                   onClick={() => handleDuplicateTemplate(id)}
                   className="cursor-pointer"

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -350,7 +351,7 @@ export function TemplatesSidebarContent({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent variant="app" align="end">
-                <AppFloatingPanel className="overflow-hidden p-1">
+                <AppFloatingPanel className={appFloatingMenuPanelClassName}>
                   <DropdownMenuItem
                     onClick={() => setSortOption("alphabetical")}
                   >

--- a/apps/web/src/routes/_view/app/-account-integrations.tsx
+++ b/apps/web/src/routes/_view/app/-account-integrations.tsx
@@ -8,6 +8,7 @@ import { listConnections } from "@anlg/api-client";
 import { OutlookIcon } from "@anlg/ui/components/icons/outlook";
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -173,7 +174,7 @@ function IntegrationRowMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="end" className="w-44">
-        <AppFloatingPanel className="overflow-hidden p-1">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           {needsReconnect && (
             <>
               <DropdownMenuItem asChild className="cursor-pointer">

--- a/apps/web/src/routes/_view/app/-account-shares.tsx
+++ b/apps/web/src/routes/_view/app/-account-shares.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -239,7 +240,7 @@ function ShareRowMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="end" className="w-44">
-        <AppFloatingPanel className="overflow-hidden p-1">
+        <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <DropdownMenuItem asChild className="cursor-pointer">
             <Link
               to="/share/$shareId/"

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -6,6 +6,8 @@ import * as React from "react";
 import { Dialog, DialogContent } from "@anlg/ui/components/ui/dialog";
 import { cn } from "@anlg/utils";
 
+import { appFloatingItemClassName } from "./floating-content";
+
 const Command = React.forwardRef<
   React.ComponentRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
@@ -116,7 +118,8 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn([
-      "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-full px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      appFloatingItemClassName,
       className,
     ])}
     {...props}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -7,6 +7,8 @@ import { cn } from "@anlg/utils";
 import {
   AppFloatingPanel,
   appFloatingContentClassName,
+  appFloatingItemClassName,
+  appFloatingMenuPanelClassName,
   type FloatingContentVariant,
 } from "./floating-content";
 
@@ -26,7 +28,8 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn([
-      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-2 rounded-full px-2 py-1.5 text-sm outline-hidden [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      appFloatingItemClassName,
       inset && "pl-8",
       className,
     ])}
@@ -92,7 +95,8 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-full px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      appFloatingItemClassName,
       inset && "pl-8",
       className,
     ])}
@@ -108,7 +112,8 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-full py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
+      appFloatingItemClassName,
       className,
     ])}
     checked={checked}
@@ -132,7 +137,8 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn([
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-full py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50",
+      appFloatingItemClassName,
       className,
     ])}
     {...props}
@@ -192,6 +198,7 @@ DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -4,8 +4,25 @@ import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { panelSquircle } from "@anlg/ui/lib/squircle";
 import { cn } from "@anlg/utils";
 
+// Nested radii stay concentric: outer = inner + padding.
+export const APP_FLOATING_CHROME_RADIUS_PX = 22;
+export const APP_FLOATING_CHROME_PADDING_PX = 2;
+export const APP_FLOATING_PANEL_RADIUS_PX =
+  APP_FLOATING_CHROME_RADIUS_PX - APP_FLOATING_CHROME_PADDING_PX;
+export const APP_FLOATING_PANEL_PADDING_PX = 6;
+export const APP_FLOATING_ITEM_RADIUS_PX =
+  APP_FLOATING_PANEL_RADIUS_PX - APP_FLOATING_PANEL_PADDING_PX;
+export const FLOATING_MENU_RADIUS_PX = 18;
+export const FLOATING_MENU_PADDING_PX = 4;
+export const FLOATING_MENU_ITEM_RADIUS_PX =
+  FLOATING_MENU_RADIUS_PX - FLOATING_MENU_PADDING_PX;
+
 export const appFloatingContentClassName =
   "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-[22px] border p-0.5 shadow-lg";
+
+export const appFloatingMenuPanelClassName = "overflow-hidden p-1.5";
+export const appFloatingItemClassName = "rounded-[14px]";
+export const floatingMenuItemClassName = "rounded-[14px]";
 
 export type FloatingContentVariant = "default" | "app";
 

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -6,6 +6,7 @@ import { cn } from "@anlg/utils";
 import {
   AppFloatingPanel,
   appFloatingContentClassName,
+  appFloatingMenuPanelClassName,
   type FloatingContentVariant,
 } from "./floating-content";
 
@@ -52,6 +53,7 @@ PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export {
   AppFloatingPanel,
+  appFloatingMenuPanelClassName,
   Popover,
   PopoverAnchor,
   PopoverContent,

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 
 import { cn } from "@anlg/utils";
 
+import { appFloatingItemClassName } from "./floating-content";
+
 const Select = SelectPrimitive.Root;
 const SelectGroup = SelectPrimitive.Group;
 const SelectValue = SelectPrimitive.Value;
@@ -114,7 +116,8 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn([
-      "data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-full py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      appFloatingItemClassName,
       className,
     ])}
     {...props}


### PR DESCRIPTION
## Summary

**Problem:** Nested floating menu item pills used radii that did not account for panel padding, so hover highlights clashed with the panel corners.

**Fix:** Nested floating radii now follow outer = inner + padding, and shared menu panel padding keeps chrome concentric across desktop and web menus.

## Verification

- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop exec vitest run src/shared/ui/floating-content.test.ts src/chat/components/toolbar-controls.test.tsx src/session/components/outer-header/overflow/index.test.tsx src/settings/developers/index.test.tsx src/session-sharing/delivery-panel.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling and shared class tokens across UI primitives; no auth, data, or business logic changes.
> 
> **Overview**
> Aligns **app floating menus** so outer chrome, inner panel padding, and item hover shapes share one radius system instead of mixing `rounded-full` pills with panel corners that did not account for padding.
> 
> **`floating-content`** now exports pixel constants (`outer = inner + padding`), `appFloatingMenuPanelClassName` (`overflow-hidden p-1.5`), and `appFloatingItemClassName` (`rounded-[14px]`). **Dropdown, command, and select** primitives apply the shared item class and drop per-item `rounded-full`. Desktop, web, and a few custom menus (chat history rows, session options popover) swap ad hoc `AppFloatingPanel` padding for the shared panel class.
> 
> Adds **`floating-content.test.ts`** to lock the concentric radius relationships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99ff725ee2336933c1c7039844820598d1817ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->