### PR TITLE
Restore pill-shaped toggle switches.

### DIFF
--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@anlg/utils";
 
 const switchVariants = cva(
-  "peer border-border focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+  "peer border-border focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted rounded-pill inline-flex shrink-0 cursor-pointer items-center border-2 transition-colors [corner-shape:round] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {
@@ -21,7 +21,7 @@ const switchVariants = cva(
 );
 
 const thumbVariants = cva(
-  "bg-background data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full shadow-lg ring-0 transition-transform",
+  "bg-background data-[state=checked]:bg-primary-foreground rounded-pill pointer-events-none block shadow-lg ring-0 transition-transform [corner-shape:round]",
   {
     variants: {
       size: {

--- a/packages/ui/src/styles/corners.css
+++ b/packages/ui/src/styles/corners.css
@@ -9,3 +9,8 @@
     corner-shape: squircle;
   }
 }
+
+.rounded-pill {
+  border-radius: calc(infinity * 1px);
+  corner-shape: round;
+}


### PR DESCRIPTION
Desktop remaps rounded-full to a squircle radius, so switches now opt out with rounded-pill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling for the Switch component; no behavior or data-path changes.
> 
> **Overview**
> **Switch** track and thumb no longer use `rounded-full`; they use a new **`rounded-pill`** utility so toggles stay true capsules instead of squircles.
> 
> Global **`corners.css`** now defines **`.rounded-pill`** with `border-radius: calc(infinity * 1px)` and `corner-shape: round`, matching the existing base rule that applies **`corner-shape: squircle`** everywhere. Switch variants also add **`[corner-shape:round]`** on the CVA classes for explicit round corners on the control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b16b3848e0f71a32b49975483d8689ae7f0d905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->