### PR TITLE
Add prefix icons to the agent skill menu

### DIFF
--- a/apps/desktop/src/settings/developers/index.test.tsx
+++ b/apps/desktop/src/settings/developers/index.test.tsx
@@ -511,6 +511,16 @@ describe("SettingsDevelopers", () => {
 
     const cursorItem = await screen.findByRole("button", { name: "Cursor" });
     expect(cursorItem.hasAttribute("disabled")).toBe(true);
+    expect(
+      screen.getByRole("button", { name: /Claude Code/ }).querySelector("svg"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Codex" }).querySelector("svg"),
+    ).toBeTruthy();
+    expect(cursorItem.querySelector("svg")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "OpenCode" }).querySelector("svg"),
+    ).toBeTruthy();
     const installedIcon = screen.getByLabelText("Skill installed");
     expect(installedIcon.closest("button")?.textContent).toContain(
       "Claude Code",

--- a/apps/desktop/src/settings/developers/skills.tsx
+++ b/apps/desktop/src/settings/developers/skills.tsx
@@ -1,5 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
+import { Claude, Cursor, OpenAI } from "@lobehub/icons";
 import { CaretDown, Check, CircleNotch } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -18,6 +19,51 @@ import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { commands, type SkillAgent } from "~/types/tauri.gen";
 
 const SKILL_AGENTS_QUERY_KEY = ["skill-agents"] as const;
+
+function OpenCodeIcon() {
+  return (
+    <svg viewBox="0 0 300 300" fill="none">
+      <g transform="translate(30 0)">
+        <path
+          className="fill-[#CFCECD] dark:fill-[#4B4646]"
+          d="M180 240H60V120h120z"
+        />
+        <path
+          className="fill-[#211E1E] dark:fill-[#F1ECEC]"
+          fillRule="evenodd"
+          d="M180 60H60v180h120V60ZM240 300H0V0h240v300Z"
+        />
+      </g>
+    </svg>
+  );
+}
+
+function SkillAgentIcon({ agent }: { agent: SkillAgent }) {
+  let icon;
+  switch (agent) {
+    case "claude_code":
+      icon = <Claude.Color size={16} />;
+      break;
+    case "codex":
+      icon = <OpenAI size={16} />;
+      break;
+    case "cursor":
+      icon = <Cursor size={16} />;
+      break;
+    case "opencode":
+      icon = <OpenCodeIcon />;
+      break;
+  }
+
+  return (
+    <span
+      aria-hidden
+      className="flex size-4 shrink-0 items-center justify-center [&>svg]:size-4"
+    >
+      {icon}
+    </span>
+  );
+}
 
 async function loadSkillAgents() {
   const result = await commands.listSkillAgents();
@@ -114,6 +160,7 @@ export function SkillsRow() {
                   disabled={!agent.detected}
                   onClick={() => installMutation.mutate([agent.agent])}
                 >
+                  <SkillAgentIcon agent={agent.agent} />
                   {agent.displayName}
                   {agent.installed && (
                     <Check


### PR DESCRIPTION
## Summary

**Problem:** The Developers “Add skill to…” menu listed Claude Code, Codex, Cursor, and OpenCode as plain text, so the agents were harder to scan.

**Fix:** Add each agent’s brand mark as a prefix icon, using OpenCode’s official pixel “O” (light and dark).

## Verification

- `pnpm -F desktop exec vitest run src/settings/developers/index.test.tsx`
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/settings/developers/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in Developers settings with no auth, API, or install logic changes.
> 
> **Overview**
> The Developers **“Add skill to…”** dropdown now shows a **prefix icon** beside each agent name (Claude Code, Codex, Cursor, OpenCode) so the list is easier to scan.
> 
> Icons come from `@lobehub/icons` for Claude, Codex (OpenAI), and Cursor; OpenCode uses a new inline **pixel “O”** SVG with light/dark fills. A `SkillAgentIcon` helper maps `SkillAgent` values to the right mark and is rendered on each per-agent menu row (including disabled entries).
> 
> Tests assert that each agent menu button contains an `svg` for the four agents in the multi-install scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476bb5c12b72792f076991410ec6b344ac8bf3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->