### PR TITLE
Round settings dropdowns more.

### DIFF
--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -89,7 +89,7 @@ export function SearchableSelect({
           aria-describedby={ariaDescribedBy}
           className={cn([
             "bg-card justify-between font-normal shadow-none focus-visible:ring-0",
-            "rounded-full px-3",
+            "rounded-pill px-3 [corner-shape:round]",
             className,
           ])}
         >

--- a/apps/desktop/src/settings/setting-row.tsx
+++ b/apps/desktop/src/settings/setting-row.tsx
@@ -4,7 +4,7 @@ import { Switch } from "@anlg/ui/components/ui/switch";
 import { cn } from "@anlg/utils";
 
 export const SETTING_CONTROL_CLASS =
-  "bg-card h-9 w-full shadow-none focus:ring-0";
+  "bg-card h-9 w-full rounded-pill shadow-none [corner-shape:round] focus:ring-0";
 
 export function SettingRow({
   title,

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn([
-      "border-input ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring flex h-9 w-full items-center justify-between rounded-full border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs focus:ring-1 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "border-input ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring rounded-pill flex h-9 w-full items-center justify-between border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs [corner-shape:round] focus:ring-1 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     ])}
     {...props}


### PR DESCRIPTION
Desktop remaps rounded-full to 8px, so select triggers now use rounded-pill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only class changes on settings and shared select UI with no logic or data-handling impact.
> 
> **Overview**
> Settings dropdown triggers were using **`rounded-full`**, which on desktop is remapped to an **8px** radius, so they looked less pill-like than intended.
> 
> This PR switches those controls to **`rounded-pill`** and adds **`[corner-shape:round]`** on the shared **`SelectTrigger`**, desktop **`SearchableSelect`** combobox button, and **`SETTING_CONTROL_CLASS`** so settings selects and other row controls share the same corner treatment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7843a6f83314d38c42a1f912b678450b029665bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->