### PR TITLE
Light the selected app icon from below.

### DIFF
--- a/apps/desktop/src/settings/appearance/app-icon.test.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.test.tsx
@@ -74,6 +74,10 @@ describe("AppIconSelector", () => {
 
     const defaultOption = screen.getByRole("radio", { name: "Default" });
     expect(defaultOption.getAttribute("aria-checked")).toBe("true");
+    expect(defaultOption.className).not.toMatch(/\bborder(?:-|\s|$)/);
+    expect(
+      defaultOption.querySelector("[data-app-icon-stage]")?.className,
+    ).toContain("opacity-100");
     expect(
       defaultOption
         .querySelector('source[media="(prefers-color-scheme: dark)"]')

--- a/apps/desktop/src/settings/appearance/app-icon.tsx
+++ b/apps/desktop/src/settings/appearance/app-icon.tsx
@@ -102,10 +102,7 @@ export function AppIconSelector() {
               title={labels[option]}
               disabled={locked && billing.isUpgradingToPro}
               className={cn([
-                "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative flex cursor-pointer items-center justify-center rounded-[22px] border bg-transparent p-0.5 transition-[border-color,scale] duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98] disabled:cursor-wait",
-                selected
-                  ? "border-transparent"
-                  : "border-border hover:border-foreground/30",
+                "group text-foreground focus-visible:ring-ring focus-visible:ring-offset-background relative flex cursor-pointer items-center justify-center rounded-[22px] bg-transparent p-0.5 pb-2.5 transition-transform duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98] disabled:cursor-wait",
               ])}
               onClick={() => {
                 if (locked) {
@@ -119,18 +116,28 @@ export function AppIconSelector() {
             >
               <span
                 aria-hidden
+                data-app-icon-stage=""
                 className={cn([
-                  "pointer-events-none absolute inset-x-2.5 bottom-0 h-2 rounded-full",
-                  "bg-black/35 blur-[6px] dark:bg-white/25",
+                  "rounded-pill pointer-events-none absolute bottom-0.5 left-1/2 h-4 w-14 -translate-x-1/2",
+                  "bg-sky-400/60 blur-md dark:bg-sky-300/55",
+                  "transition-opacity duration-150",
+                  selected ? "opacity-100" : "opacity-0",
+                ])}
+              />
+              <span
+                aria-hidden
+                className={cn([
+                  "rounded-pill pointer-events-none absolute bottom-1.5 left-1/2 h-1.5 w-8 -translate-x-1/2",
+                  "bg-sky-300/90 blur-[3px] dark:bg-sky-200/80",
                   "transition-opacity duration-150",
                   selected ? "opacity-100" : "opacity-0",
                 ])}
               />
               <span
                 className={cn([
-                  "flex size-16 overflow-hidden rounded-[18px]",
+                  "relative flex size-16 overflow-hidden rounded-[18px]",
                   "transition-transform duration-150",
-                  selected && "-translate-y-1",
+                  selected && "-translate-y-1.5",
                 ])}
               >
                 {theme === "system" && hasDarkVariant ? (
@@ -158,7 +165,7 @@ export function AppIconSelector() {
                 )}
               </span>
               {locked ? (
-                <span className="bg-background border-border text-muted-foreground pointer-events-none absolute right-0.5 bottom-0.5 flex size-5 items-center justify-center rounded-full border shadow-sm">
+                <span className="bg-background border-border text-muted-foreground pointer-events-none absolute right-1 bottom-3 flex size-5 items-center justify-center rounded-full border shadow-sm">
                   {billing.isUpgradingToPro ? (
                     <CircleNotch className="size-3 animate-spin" aria-hidden />
                   ) : (


### PR DESCRIPTION
Replace the selected border with a blue stage glow so the icon sits in front of the highlight.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only visual polish with no behavior, auth, or data changes beyond existing selection tests.
> 
> **Overview**
> Updates **Appearance → App icon** so the active choice is shown with a **blue under-glow** instead of a border ring.
> 
> Selected radios drop border/hover border classes and gain two blurred sky layers (`data-app-icon-stage` plus a tighter highlight) that fade in only when selected, with a bit more vertical lift (`-translate-y-1.5`) and extra bottom padding so the glow fits. The Pro lock badge moves up slightly to sit above the glow.
> 
> Tests now assert the default selection has **no border** styling and that the stage element is **fully opaque** when selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d5d4b596347b50c09f70f4d043e44b4ba295d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->