### PR TITLE
Fix mobile release bundle dependencies

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -41,6 +41,8 @@ export default defineConfig(() => ({
       "@codemirror/lang-jinja",
       "codemirror-readonly-ranges",
       "@uiw/react-codemirror",
+      "react",
+      "react-dom",
     ],
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   seroval: 1.5.3
   '@xhmikosr/decompress': 10.2.1
 
-packageExtensionsChecksum: sha256-uvwHnRWU8xoBnLvfCsBs2JcrYoc5w4Gh9jVhvh1h708=
+packageExtensionsChecksum: sha256-oiDI3QlSZCcWj8/SC36JZqshvUsALZQJ46ilxkTLKHc=
 
 importers:
 
@@ -35454,6 +35454,7 @@ snapshots:
   react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.86.3(@babel/core@7.29.0))(react-native@0.86.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/generator': 7.29.8
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.0)
@@ -35463,6 +35464,7 @@ snapshots:
       '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@react-native/metro-config': 0.86.3(@babel/core@7.29.0)
       convert-source-map: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,10 @@ packageExtensions:
   "@sentry/react-native@8.20.0":
     dependencies:
       "@expo/config-plugins": "~57.0.9"
+  "react-native-worklets@0.10.1":
+    dependencies:
+      "@babel/generator": "^7.29.0"
+      "@babel/traverse": "^7.29.0"
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
Declare Babel dependencies used by the worklets plugin so clean iOS release bundles resolve under pnpm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and install-metadata changes plus a Vite dedupe tweak; no runtime auth, data, or payment logic.
> 
> **Overview**
> **pnpm** now extends `react-native-worklets@0.10.1` with explicit `@babel/generator` and `@babel/traverse` dependencies so Metro/iOS release installs under pnpm can resolve the Babel packages the worklets plugin expects on a clean install.
> 
> The **desktop** Vite config adds `react` and `react-dom` to `resolve.dedupe` alongside the existing CodeMirror entries, so the Tauri app bundles a single React instance in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 568d81505c0156ef94b2db0f74703825a710c18b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->