### PR TITLE
Use provider profile pictures

### DIFF
--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { commands as miscCommands } from "@anlg/plugin-misc";
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { openUrlWithInstruction } from "@anlg/plugin-windows";
+import { getProviderProfileImageUrl } from "@anlg/supabase/profile";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
 import {
@@ -732,6 +733,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [session, fingerprint]);
 
   const getAvatarUrl = useCallback(async () => {
+    const providerImageUrl = getProviderProfileImageUrl(session?.user);
+    if (providerImageUrl) {
+      return providerImageUrl;
+    }
+
     const email = session?.user.email;
 
     if (!email) {

--- a/apps/desktop/src/session-sharing/comments.test.tsx
+++ b/apps/desktop/src/session-sharing/comments.test.tsx
@@ -31,7 +31,15 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("~/auth", () => ({
   useAuth: () => ({
-    session: { user: { id: "viewer-1", is_anonymous: false } },
+    session: {
+      user: {
+        id: "viewer-1",
+        is_anonymous: false,
+        user_metadata: {
+          avatar_url: "https://google.example/viewer.png",
+        },
+      },
+    },
     supabase: {},
   }),
 }));
@@ -233,6 +241,9 @@ describe("desktop shared-note comments", () => {
     fireEvent.click(screen.getByRole("button", { name: "Mount editor" }));
     fireEvent.click(screen.getByRole("button", { name: "Select text" }));
     fireEvent.click(screen.getByRole("button", { name: "Comment" }));
+    expect(
+      document.querySelector('img[src="https://google.example/viewer.png"]'),
+    ).toBeTruthy();
     fireEvent.change(
       await screen.findByRole("textbox", { name: "Comment on selected text" }),
       { target: { value: "  Follow up  " } },

--- a/apps/desktop/src/session-sharing/comments.tsx
+++ b/apps/desktop/src/session-sharing/comments.tsx
@@ -14,6 +14,7 @@ import {
   getCommentAnchorRanges,
   setActiveCommentAnchor,
 } from "@anlg/editor/note";
+import { getProviderProfileImageUrl } from "@anlg/supabase/profile";
 import { Avatar } from "@anlg/ui/components/avatar";
 import { Button } from "@anlg/ui/components/ui/button";
 import {
@@ -394,6 +395,8 @@ export function SessionCommentsLayer({
 }: {
   controller: SessionCommentsController;
 }) {
+  const auth = useAuth();
+  const authorImageUrl = getProviderProfileImageUrl(auth.session?.user);
   const openComments = controller.openAnchor
     ? controller.comments.filter((comment) =>
         controller.openAnchor?.commentIds.includes(comment.commentId),
@@ -413,6 +416,7 @@ export function SessionCommentsLayer({
           <CommentPopoverAnchor position={controller.draft} />
           <PopoverContent align="start" side="bottom" className="w-80 p-3">
             <CommentComposer
+              authorImageUrl={authorImageUrl}
               error={controller.createError}
               pending={controller.createPending}
               onCancel={controller.cancelDraft}
@@ -437,6 +441,7 @@ export function SessionCommentsLayer({
             {openComments.map((comment) => (
               <SessionCommentItem
                 key={comment.commentId}
+                authorImageUrl={authorImageUrl}
                 comment={comment}
                 deleting={
                   controller.deletePending &&
@@ -467,11 +472,13 @@ function CommentPopoverAnchor({ position }: { position: CommentPosition }) {
 }
 
 function CommentComposer({
+  authorImageUrl,
   error,
   onCancel,
   onSubmit,
   pending,
 }: {
+  authorImageUrl: string | null;
   error: boolean;
   onCancel: () => void;
   onSubmit: (body: string) => void;
@@ -504,6 +511,7 @@ function CommentComposer({
                 <Avatar
                   seed="shared-note:you"
                   label={t`You`}
+                  imageUrl={authorImageUrl}
                   size={28}
                   className="mt-1"
                 />
@@ -574,12 +582,14 @@ function CommentComposer({
 }
 
 function SessionCommentItem({
+  authorImageUrl,
   comment,
   deleteDisabled,
   deleting,
   onDelete,
   showDelete,
 }: {
+  authorImageUrl: string | null;
   comment: SessionShareComment;
   deleteDisabled: boolean;
   deleting: boolean;
@@ -597,6 +607,7 @@ function SessionCommentItem({
               comment.isAuthor ? "shared-note:you" : "shared-note:collaborator"
             }
             label={comment.isAuthor ? t`You` : t`Collaborator`}
+            imageUrl={comment.isAuthor ? authorImageUrl : null}
             size={24}
           />
           <span className="truncate text-sm font-medium">

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -9,6 +9,7 @@ import { SessionCard } from "@/components/session-card";
 import { StartListeningButton } from "@/components/start-listening-button";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
+import { UserAvatarButton } from "@/components/user-avatar";
 import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
 import { importVoiceMemos } from "@/data/import-voice-memo";
 import { useSessionSearch } from "@/data/search";
@@ -156,11 +157,10 @@ export default function HomeScreen() {
           </>
         ) : (
           <>
-            <IconButton
+            <UserAvatarButton
               accessibilityLabel="Open settings"
-              icon="person-outline"
               onPress={() => router.push("/settings")}
-              variant="surface"
+              user={auth.session?.user ?? null}
             />
             <IconButton
               accessibilityLabel="Search meetings"

--- a/apps/mobile/src/components/profile-sheet.tsx
+++ b/apps/mobile/src/components/profile-sheet.tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from "@expo/vector-icons";
 import { useSyncExternalStore } from "react";
 import {
   KeyboardAvoidingView,
@@ -11,6 +10,7 @@ import {
 
 import { useAuth } from "@/auth/context";
 import { Button } from "@/components/ui/button";
+import { UserAvatar } from "@/components/user-avatar";
 import {
   Colors,
   CornerCurve,
@@ -108,9 +108,7 @@ export function SettingsContent() {
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.accountCard}>
-          <View style={styles.accountIcon}>
-            <Ionicons name="person-outline" size={22} color={Colors.ink} />
-          </View>
+          <UserAvatar user={auth.session?.user ?? null} />
           <View style={styles.accountIdentity}>
             <Text style={styles.accountLabel}>Account</Text>
             <Text style={styles.email} numberOfLines={1}>
@@ -177,15 +175,6 @@ const styles = StyleSheet.create({
     borderCurve: CornerCurve.squircle,
     backgroundColor: Colors.surface,
     padding: Spacing.md,
-  },
-  accountIcon: {
-    width: 40,
-    height: 40,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: Radius.pill,
-    borderCurve: CornerCurve.squircle,
-    backgroundColor: Colors.accentSurface,
   },
   accountIdentity: {
     flex: 1,

--- a/apps/mobile/src/components/user-avatar.tsx
+++ b/apps/mobile/src/components/user-avatar.tsx
@@ -1,0 +1,115 @@
+import { Ionicons } from "@expo/vector-icons";
+import type { User } from "@supabase/supabase-js";
+import { Image } from "expo-image";
+import { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  getProviderProfileImageUrl,
+  getProviderProfileName,
+} from "@anlg/supabase/profile";
+
+import { Colors, CornerCurve, Radius, Typography } from "@/constants/theme";
+
+function profileInitials(name: string | null): string {
+  if (!name) return "";
+
+  const value = name.includes("@") ? (name.split("@")[0] ?? name) : name;
+  return value
+    .trim()
+    .split(/[\s._-]+/)
+    .map((part) => Array.from(part)[0] ?? "")
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+export function UserAvatar({
+  size = 40,
+  user,
+}: {
+  size?: number;
+  user: User | null;
+}) {
+  const imageUrl = getProviderProfileImageUrl(user);
+  const initials = profileInitials(getProviderProfileName(user));
+
+  return (
+    <View
+      style={[
+        styles.avatar,
+        { borderRadius: size / 2, height: size, width: size },
+      ]}
+    >
+      {initials ? (
+        <Text style={[styles.initials, { fontSize: size * 0.36 }]}>
+          {initials}
+        </Text>
+      ) : (
+        <Ionicons name="person-outline" size={size * 0.55} color={Colors.ink} />
+      )}
+      {imageUrl ? <ProviderImage key={imageUrl} imageUrl={imageUrl} /> : null}
+    </View>
+  );
+}
+
+function ProviderImage({ imageUrl }: { imageUrl: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return null;
+
+  return (
+    <Image
+      cachePolicy="memory-disk"
+      contentFit="cover"
+      onError={() => setFailed(true)}
+      source={{ uri: imageUrl }}
+      style={StyleSheet.absoluteFill}
+    />
+  );
+}
+
+export function UserAvatarButton({
+  accessibilityLabel,
+  onPress,
+  user,
+}: {
+  accessibilityLabel: string;
+  onPress: () => void;
+  user: User | null;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      hitSlop={4}
+      onPress={onPress}
+      style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+    >
+      <UserAvatar user={user} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.accentSurface,
+  },
+  initials: {
+    ...Typography.captionStrong,
+    color: Colors.ink,
+  },
+  button: {
+    borderRadius: Radius.pill,
+    borderCurve: CornerCurve.squircle,
+  },
+  pressed: {
+    opacity: 0.72,
+  },
+});

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -6,6 +6,7 @@
     "./attachment-backups": "./src/attachment-backups.ts",
     "./billing": "./src/billing.ts",
     "./middleware": "./src/middleware.ts",
+    "./profile": "./src/profile.ts",
     "./storage": "./src/storage.ts"
   },
   "dependencies": {

--- a/packages/supabase/src/profile.test.ts
+++ b/packages/supabase/src/profile.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { getProviderProfileImageUrl, getProviderProfileName } from "./profile";
+
+describe("provider profile", () => {
+  it("prefers the provider avatar URL from user metadata", () => {
+    expect(
+      getProviderProfileImageUrl({
+        email: "ada@example.com",
+        identities: [
+          {
+            created_at: "2026-01-01T00:00:00.000Z",
+            id: "google-id",
+            identity_data: { picture: "https://google.example/identity.png" },
+            identity_id: "identity-id",
+            provider: "google",
+            user_id: "user-id",
+          },
+        ],
+        user_metadata: {
+          avatar_url: "https://google.example/user.png",
+          picture: "https://google.example/picture.png",
+        },
+      }),
+    ).toBe("https://google.example/user.png");
+  });
+
+  it("falls back to linked identity metadata", () => {
+    expect(
+      getProviderProfileImageUrl({
+        email: "ada@example.com",
+        identities: [
+          {
+            created_at: "2026-01-01T00:00:00.000Z",
+            id: "github-id",
+            identity_data: { avatar_url: "https://github.example/ada.png" },
+            identity_id: "identity-id",
+            provider: "github",
+            user_id: "user-id",
+          },
+        ],
+        user_metadata: {},
+      }),
+    ).toBe("https://github.example/ada.png");
+  });
+
+  it("reads Google's picture metadata", () => {
+    expect(
+      getProviderProfileImageUrl({
+        email: "ada@example.com",
+        identities: [],
+        user_metadata: { picture: "https://google.example/ada.png" },
+      }),
+    ).toBe("https://google.example/ada.png");
+  });
+
+  it("rejects unsafe and malformed image URLs", () => {
+    expect(
+      getProviderProfileImageUrl({
+        email: "ada@example.com",
+        identities: [],
+        user_metadata: { avatar_url: "javascript:alert(1)" },
+      }),
+    ).toBeNull();
+    expect(
+      getProviderProfileImageUrl({
+        email: "ada@example.com",
+        identities: [],
+        user_metadata: { picture: "not a URL" },
+      }),
+    ).toBeNull();
+  });
+
+  it("uses provider names before the account email", () => {
+    expect(
+      getProviderProfileName({
+        email: "ada@example.com",
+        identities: [],
+        user_metadata: { full_name: "Ada Lovelace", name: "Ada" },
+      }),
+    ).toBe("Ada Lovelace");
+    expect(
+      getProviderProfileName({
+        email: "ada@example.com",
+        identities: [],
+        user_metadata: {},
+      }),
+    ).toBe("ada@example.com");
+  });
+});

--- a/packages/supabase/src/profile.ts
+++ b/packages/supabase/src/profile.ts
@@ -1,0 +1,58 @@
+import type { User } from "@supabase/supabase-js";
+
+type ProviderProfile = Pick<User, "email" | "identities" | "user_metadata">;
+
+const metadataValue = (
+  metadata: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | null => {
+  for (const key of keys) {
+    const value = metadata?.[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+};
+
+const profileMetadata = (
+  user: ProviderProfile,
+): Array<Record<string, unknown> | undefined> => [
+  user.user_metadata,
+  ...(user.identities?.map((identity) => identity.identity_data) ?? []),
+];
+
+export function getProviderProfileImageUrl(
+  user: ProviderProfile | null | undefined,
+): string | null {
+  if (!user) return null;
+
+  for (const metadata of profileMetadata(user)) {
+    const value = metadataValue(metadata, ["avatar_url", "picture"]);
+    if (!value) continue;
+
+    try {
+      const url = new URL(value);
+      if (url.protocol === "https:" && !url.username && !url.password) {
+        return value;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export function getProviderProfileName(
+  user: ProviderProfile | null | undefined,
+): string | null {
+  if (!user) return null;
+
+  for (const metadata of profileMetadata(user)) {
+    const value = metadataValue(metadata, ["full_name", "name"]);
+    if (value) return value;
+  }
+
+  return user.email?.trim() || null;
+}

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -22,6 +22,7 @@ export type AvatarProps = Readonly<{
   sphereCount?: number;
   dither?: number;
   renderStyle?: AvatarRenderStyle;
+  imageUrl?: string | null;
   className?: string;
 }>;
 
@@ -36,6 +37,7 @@ export function Avatar({
   sphereCount = 4,
   dither = 0.3,
   renderStyle = "dithered",
+  imageUrl,
   className,
 }: AvatarProps) {
   const recipe = { seed, colorCount, sphereCount, dither, renderStyle };
@@ -43,9 +45,10 @@ export function Avatar({
 
   return (
     <AvatarImage
-      key={cacheKey}
+      key={`${cacheKey}|${imageUrl ?? ""}`}
       cacheKey={cacheKey}
       className={className}
+      imageUrl={imageUrl}
       label={label}
       recipe={recipe}
       size={size}
@@ -56,12 +59,14 @@ export function Avatar({
 function AvatarImage({
   cacheKey,
   className,
+  imageUrl,
   label,
   recipe,
   size,
 }: {
   cacheKey: string;
   className?: string;
+  imageUrl?: string | null;
   label: string;
   recipe: AvatarRecipe;
   size: number;
@@ -69,6 +74,7 @@ function AvatarImage({
   const [src, setSrc] = useState<string | undefined>(() =>
     imageCache.get(cacheKey),
   );
+  const [imageFailed, setImageFailed] = useState(false);
   const squircleRef = useSquircleRef<HTMLSpanElement>();
   const dimension = Math.max(1, size);
   const containerStyle = {
@@ -96,6 +102,8 @@ function AvatarImage({
     letterSpacing: "-0.04em",
     mixBlendMode: "overlay",
   } satisfies CSSProperties;
+  const providerImageUrl = imageFailed ? null : imageUrl;
+  const displayedImageUrl = providerImageUrl ?? src;
 
   useMountEffect(() => {
     const cached = imageCache.get(cacheKey);
@@ -120,11 +128,12 @@ function AvatarImage({
       className={className}
       style={containerStyle}
     >
-      {src ? (
+      {displayedImageUrl ? (
         <img
           alt=""
           draggable={false}
-          src={src}
+          src={displayedImageUrl}
+          onError={providerImageUrl ? () => setImageFailed(true) : undefined}
           style={{
             position: "absolute",
             inset: 0,
@@ -134,9 +143,11 @@ function AvatarImage({
           }}
         />
       ) : null}
-      <span aria-hidden="true" style={initialsStyle}>
-        {avatarInitials(label)}
-      </span>
+      {!providerImageUrl && (
+        <span aria-hidden="true" style={initialsStyle}>
+          {avatarInitials(label)}
+        </span>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only avatar sourcing with HTTPS URL validation; no auth or data-model changes beyond reading existing Supabase user metadata.
> 
> **Overview**
> Signed-in users now see **OAuth provider profile photos** (Google/GitHub, etc.) instead of only generated avatars or Gravatar, with shared parsing and safety checks in `@anlg/supabase/profile`.
> 
> The new helpers read `avatar_url` / `picture` (and names) from Supabase `user_metadata` and linked identities, **allow only plain `https:` URLs**, and reject unsafe values. Desktop **`getAvatarUrl`** returns a provider URL when present, otherwise keeps the existing Gravatar fallback. The shared **`Avatar`** component accepts an optional **`imageUrl`**, overlays it on the dithered fallback, and falls back if the image fails to load.
> 
> **Desktop** session-share comment composer and “You” rows pass the current user’s provider image into **`Avatar`**. **Mobile** adds **`UserAvatar`** / **`UserAvatarButton`** (initials or icon under a cached provider image) on the home settings entry and in the profile sheet, replacing generic person icons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae722d0a3efaf2689416289e991dc0d070c688ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->