### PR TITLE
Add iPhone Action Button capture

### DIFF
--- a/apps/mobile/modules/quick-actions/expo-module.config.json
+++ b/apps/mobile/modules/quick-actions/expo-module.config.json
@@ -1,0 +1,7 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["AnarlogQuickActionsModule"],
+    "appDelegateSubscribers": ["AnarlogQuickActionsAppDelegateSubscriber"]
+  }
+}

--- a/apps/mobile/modules/quick-actions/index.ts
+++ b/apps/mobile/modules/quick-actions/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./src/AnarlogQuickActionsModule";
+export * from "./src/AnarlogQuickActions.types";

--- a/apps/mobile/modules/quick-actions/ios/AnarlogQuickActions.podspec
+++ b/apps/mobile/modules/quick-actions/ios/AnarlogQuickActions.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name           = 'AnarlogQuickActions'
+  s.version        = '1.0.0'
+  s.summary        = 'Exposes Anarlog actions to iOS Shortcuts.'
+  s.description    = 'Adds the Start or Stop Listening App Shortcut for the iPhone Action Button.'
+  s.author         = 'Anarlog'
+  s.homepage       = 'https://anarlog.so'
+  s.platform       = :ios, '16.4'
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+  s.frameworks = 'AppIntents'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/apps/mobile/modules/quick-actions/ios/AnarlogQuickActionsModule.swift
+++ b/apps/mobile/modules/quick-actions/ios/AnarlogQuickActionsModule.swift
@@ -1,0 +1,115 @@
+import AppIntents
+import ExpoModulesCore
+import Foundation
+import UIKit
+
+private let pendingActionKey = "quick-actions-pending-action"
+
+@available(iOS 16.0, *)
+struct ToggleListeningIntent: AppIntent {
+  static var title: LocalizedStringResource = "Start or Stop Listening"
+  static var description = IntentDescription(
+    "Start a new meeting recording, or stop the recording already in progress."
+  )
+  static var openAppWhenRun: Bool = true
+
+  func perform() async throws -> some IntentResult {
+    QuickActionsService.shared.enqueue(action: "toggle_listening")
+    return .result()
+  }
+}
+
+@available(iOS 16.0, *)
+struct AnarlogAppShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: ToggleListeningIntent(),
+      phrases: [
+        "Start listening with \(.applicationName)",
+        "Stop listening with \(.applicationName)",
+        "Quick capture with \(.applicationName)",
+      ],
+      shortTitle: "Start Listening",
+      systemImageName: "waveform"
+    )
+  }
+
+  static var shortcutTileColor: ShortcutTileColor = .yellow
+}
+
+public class AnarlogQuickActionsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("AnarlogQuickActions")
+
+    Events("onAction")
+
+    OnCreate {
+      QuickActionsService.shared.attach(module: self)
+    }
+
+    OnDestroy {
+      QuickActionsService.shared.detach(module: self)
+    }
+
+    Function("consumePendingAction") {
+      QuickActionsService.shared.consumePendingAction()
+    }
+  }
+
+  fileprivate func emit(action: String) {
+    sendEvent("onAction", ["action": action])
+  }
+}
+
+public class AnarlogQuickActionsAppDelegateSubscriber:
+  ExpoAppDelegateSubscriber
+{
+  public func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    if #available(iOS 16.0, *) {
+      AnarlogAppShortcuts.updateAppShortcutParameters()
+    }
+    return true
+  }
+}
+
+private final class QuickActionsService {
+  static let shared = QuickActionsService()
+
+  private let defaults = UserDefaults.standard
+  private let queue = DispatchQueue(label: "so.anarlog.quick-actions")
+  private weak var module: AnarlogQuickActionsModule?
+
+  private init() {}
+
+  func attach(module: AnarlogQuickActionsModule) {
+    self.module = module
+  }
+
+  func detach(module: AnarlogQuickActionsModule) {
+    if self.module === module {
+      self.module = nil
+    }
+  }
+
+  func enqueue(action: String) {
+    queue.sync {
+      defaults.set(action, forKey: pendingActionKey)
+    }
+    DispatchQueue.main.async { [weak self] in
+      self?.module?.emit(action: action)
+    }
+  }
+
+  func consumePendingAction() -> String? {
+    queue.sync {
+      guard let action = defaults.string(forKey: pendingActionKey) else {
+        return nil
+      }
+      defaults.removeObject(forKey: pendingActionKey)
+      return action
+    }
+  }
+}

--- a/apps/mobile/modules/quick-actions/src/AnarlogQuickActions.types.ts
+++ b/apps/mobile/modules/quick-actions/src/AnarlogQuickActions.types.ts
@@ -1,0 +1,5 @@
+export type QuickAction = "toggle_listening";
+
+export type AnarlogQuickActionsModuleEvents = {
+  onAction: (event: { action: QuickAction }) => void;
+};

--- a/apps/mobile/modules/quick-actions/src/AnarlogQuickActionsModule.ts
+++ b/apps/mobile/modules/quick-actions/src/AnarlogQuickActionsModule.ts
@@ -1,0 +1,14 @@
+import { NativeModule, requireOptionalNativeModule } from "expo";
+
+import type {
+  AnarlogQuickActionsModuleEvents,
+  QuickAction,
+} from "./AnarlogQuickActions.types";
+
+declare class AnarlogQuickActionsModule extends NativeModule<AnarlogQuickActionsModuleEvents> {
+  consumePendingAction(): QuickAction | null;
+}
+
+export default requireOptionalNativeModule<AnarlogQuickActionsModule>(
+  "AnarlogQuickActions",
+);

--- a/apps/mobile/modules/quick-actions/src/AnarlogQuickActionsModule.web.ts
+++ b/apps/mobile/modules/quick-actions/src/AnarlogQuickActionsModule.web.ts
@@ -1,0 +1,17 @@
+import { NativeModule, registerWebModule } from "expo";
+
+import type {
+  AnarlogQuickActionsModuleEvents,
+  QuickAction,
+} from "./AnarlogQuickActions.types";
+
+class AnarlogQuickActionsModule extends NativeModule<AnarlogQuickActionsModuleEvents> {
+  consumePendingAction(): QuickAction | null {
+    return null;
+  }
+}
+
+export default registerWebModule(
+  AnarlogQuickActionsModule,
+  "AnarlogQuickActions",
+);

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -4,6 +4,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { StyleSheet, Text, View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 import {
   getMobileCaptureActive,
@@ -23,6 +24,7 @@ import {
   initializeErrorReporting,
 } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
+import { QuickActionLifecycle } from "@/quick-actions/quick-action-lifecycle";
 import { MobileSyncLifecycle } from "@/sync/mobile-sync-lifecycle";
 import { initializeWatchConnectivity } from "@/watch-connectivity";
 
@@ -74,12 +76,15 @@ function Screens({ accountUserId }: { accountUserId: string | null }) {
   });
 
   return (
-    <Stack
-      screenOptions={{
-        headerShown: false,
-        contentStyle: { backgroundColor: Colors.paper },
-      }}
-    />
+    <>
+      <QuickActionLifecycle accountUserId={accountUserId} />
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: Colors.paper },
+        }}
+      />
+    </>
   );
 }
 
@@ -209,17 +214,22 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
 
 function RootLayout() {
   return (
-    <AuthProvider>
-      <AnalyticsLifecycle />
-      <Gate />
-      <StatusBar style="dark" />
-    </AuthProvider>
+    <GestureHandlerRootView style={styles.root}>
+      <AuthProvider>
+        <AnalyticsLifecycle />
+        <Gate />
+        <StatusBar style="dark" />
+      </AuthProvider>
+    </GestureHandlerRootView>
   );
 }
 
 export default Sentry.wrap(RootLayout);
 
 const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
   routeError: {
     flex: 1,
     alignItems: "center",

--- a/apps/mobile/src/app/action-button.tsx
+++ b/apps/mobile/src/app/action-button.tsx
@@ -1,0 +1,220 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+
+import { DancingSticks } from "@/components/dancing-sticks";
+import { IPhoneDeviceFrame } from "@/components/iphone-device-frame";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { IconButton } from "@/components/ui/icon-button";
+import {
+  Colors,
+  ControlSize,
+  Radius,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
+
+const steps = [
+  {
+    title: "Open Action Button settings",
+    description: "In iPhone Settings, tap Action Button.",
+  },
+  {
+    title: "Choose Shortcut",
+    description: "Swipe to Shortcut, then tap Choose a Shortcut.",
+  },
+  {
+    title: "Pick Anarlog",
+    description: "Choose Anarlog, then Start Listening.",
+  },
+];
+
+export default function ActionButtonScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const handleBack = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace("/");
+  };
+
+  return (
+    <SafeAreaView edges={["top", "left", "right"]} style={styles.safeArea}>
+      <View style={styles.header}>
+        <IconButton
+          accessibilityLabel="Back"
+          icon="arrow-back"
+          iconSize={22}
+          onPress={handleBack}
+        />
+        <Text style={styles.headerTitle}>Action Button</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[
+          styles.content,
+          {
+            paddingBottom:
+              ControlSize.default + Spacing.lg + insets.bottom + Spacing.xs,
+          },
+        ]}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View style={styles.hero}>
+          <IPhoneDeviceFrame
+            width={104}
+            liveActivity={
+              <DancingSticks
+                amplitude={1}
+                color={Colors.inkInverse}
+                gap={2}
+                height={18}
+                stickWidth={2}
+                width={52}
+              />
+            }
+          />
+          <Text style={styles.title}>Start listening in one press</Text>
+          <Text style={styles.description}>
+            Your iPhone Action Button can start a new Anarlog recording or stop
+            the one already in progress.
+          </Text>
+        </View>
+
+        <Card style={styles.stepsCard}>
+          {steps.map((step, index) => (
+            <View key={step.title} style={styles.step}>
+              <View style={styles.stepNumber}>
+                <Text style={styles.stepNumberLabel}>{index + 1}</Text>
+              </View>
+              <View style={styles.stepCopy}>
+                <Text style={styles.stepTitle}>{step.title}</Text>
+                <Text style={styles.stepDescription}>{step.description}</Text>
+              </View>
+            </View>
+          ))}
+        </Card>
+
+        <View style={styles.usage}>
+          <Ionicons name="radio-button-on" size={18} color={Colors.primary} />
+          <Text style={styles.usageLabel}>Long press</Text>
+          <Ionicons name="arrow-forward" size={16} color={Colors.muted} />
+          <Ionicons name="mic" size={18} color={Colors.primary} />
+          <Text style={styles.usageLabel}>Listen</Text>
+          <Ionicons name="arrow-forward" size={16} color={Colors.muted} />
+          <Ionicons name="radio-button-on" size={18} color={Colors.primary} />
+          <Text style={styles.usageLabel}>Long press</Text>
+        </View>
+      </ScrollView>
+      <View
+        style={[styles.footer, { paddingBottom: insets.bottom + Spacing.xs }]}
+      >
+        <Button label="Done" onPress={handleBack} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+  },
+  headerTitle: {
+    ...Typography.section,
+    color: Colors.ink,
+  },
+  headerSpacer: {
+    width: ControlSize.compact,
+    height: ControlSize.compact,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: Spacing.lg,
+  },
+  hero: {
+    alignItems: "center",
+    paddingTop: Spacing.lg,
+  },
+  title: {
+    marginTop: Spacing.lg,
+    ...Typography.title,
+    color: Colors.ink,
+    textAlign: "center",
+  },
+  description: {
+    marginTop: Spacing.sm,
+    ...Typography.body,
+    color: Colors.muted,
+    textAlign: "center",
+  },
+  stepsCard: {
+    marginTop: Spacing.xl,
+    padding: Spacing.md,
+    gap: Spacing.md,
+  },
+  step: {
+    flexDirection: "row",
+    gap: Spacing.sm,
+  },
+  stepNumber: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    backgroundColor: Colors.accentSurface,
+  },
+  stepNumberLabel: {
+    ...Typography.captionStrong,
+    color: Colors.ink,
+  },
+  stepCopy: {
+    flex: 1,
+  },
+  stepTitle: {
+    ...Typography.bodyStrong,
+    color: Colors.ink,
+  },
+  stepDescription: {
+    marginTop: Spacing.xs,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  usage: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    flexWrap: "wrap",
+    gap: Spacing.xs,
+    marginVertical: Spacing.xl,
+  },
+  usageLabel: {
+    ...Typography.captionStrong,
+    color: Colors.ink,
+  },
+  footer: {
+    position: "absolute",
+    right: 0,
+    bottom: 0,
+    left: 0,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.sm,
+    backgroundColor: Colors.background,
+  },
+});

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,10 +1,19 @@
 import { Ionicons } from "@expo/vector-icons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useRouter } from "expo-router";
 import { useRef, useState } from "react";
-import { ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useAuth } from "@/auth/context";
+import { ActionButtonCard } from "@/components/action-button-card";
 import { SessionCard } from "@/components/session-card";
 import { StartListeningButton } from "@/components/start-listening-button";
 import { Button } from "@/components/ui/button";
@@ -19,6 +28,8 @@ import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
+
+const ACTION_BUTTON_CARD_DISMISSED_KEY = "action-button-card-dismissed";
 
 function SearchAnalytics({ resultCount }: { resultCount: number }) {
   useMountEffect(() => {
@@ -38,6 +49,7 @@ export default function HomeScreen() {
   const [importing, setImporting] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const [settledSearchQuery, setSettledSearchQuery] = useState("");
+  const [showActionButtonCard, setShowActionButtonCard] = useState(false);
   const searching = query !== null;
   const search = useSessionSearch(query ?? "");
   // Ref, not state: two taps in the same frame both pass a state check.
@@ -50,6 +62,26 @@ export default function HomeScreen() {
     if (searchAnalyticsTimerRef.current) {
       clearTimeout(searchAnalyticsTimerRef.current);
     }
+  });
+
+  useMountEffect(() => {
+    if (Platform.OS !== "ios") return;
+    let active = true;
+    void AsyncStorage.getItem(ACTION_BUTTON_CARD_DISMISSED_KEY).then(
+      (dismissed) => {
+        if (active && dismissed !== "1") setShowActionButtonCard(true);
+      },
+      (error) => {
+        if (active) setShowActionButtonCard(true);
+        captureOperationalError(error, {
+          operation: "action_button_card_load",
+          level: "warning",
+        });
+      },
+    );
+    return () => {
+      active = false;
+    };
   });
 
   const handleSearchChange = (value: string) => {
@@ -136,6 +168,18 @@ export default function HomeScreen() {
     }
   };
 
+  const dismissActionButtonCard = () => {
+    setShowActionButtonCard(false);
+    void AsyncStorage.setItem(ACTION_BUTTON_CARD_DISMISSED_KEY, "1").catch(
+      (error) => {
+        captureOperationalError(error, {
+          operation: "action_button_card_dismiss",
+          level: "warning",
+        });
+      },
+    );
+  };
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.header}>
@@ -210,6 +254,12 @@ export default function HomeScreen() {
           </>
         ) : (
           <>
+            {showActionButtonCard && (
+              <ActionButtonCard
+                onConfigure={() => router.push("/action-button")}
+                onDismiss={dismissActionButtonCard}
+              />
+            )}
             {!isLoading && items.length === 0 && (
               <View style={styles.empty}>
                 <Text style={styles.emptyTitle}>No meetings yet</Text>

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,10 +1,18 @@
+import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { StyleSheet, Text, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { SettingsContent } from "@/components/profile-sheet";
 import { IconButton } from "@/components/ui/icon-button";
-import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
+import {
+  Colors,
+  ControlSize,
+  CornerCurve,
+  Radius,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -26,6 +34,27 @@ export default function SettingsScreen() {
         <Text style={styles.title}>Settings</Text>
         <View style={styles.headerSpacer} />
       </View>
+      {Platform.OS === "ios" && (
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => router.push("/action-button")}
+          style={({ pressed }) => [
+            styles.actionButtonRow,
+            pressed && styles.actionButtonRowPressed,
+          ]}
+        >
+          <View style={styles.actionButtonIcon}>
+            <Ionicons name="mic-outline" size={20} color={Colors.ink} />
+          </View>
+          <View style={styles.actionButtonCopy}>
+            <Text style={styles.actionButtonTitle}>Action Button</Text>
+            <Text style={styles.actionButtonDescription}>
+              Start or stop listening in one press
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={Colors.muted} />
+        </Pressable>
+      )}
       <SettingsContent />
     </SafeAreaView>
   );
@@ -50,5 +79,42 @@ const styles = StyleSheet.create({
   headerSpacer: {
     width: ControlSize.compact,
     height: ControlSize.compact,
+  },
+  actionButtonRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.sm,
+    marginHorizontal: Spacing.lg,
+    marginBottom: Spacing.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderRadius: Radius.card,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.surface,
+    padding: Spacing.md,
+  },
+  actionButtonRowPressed: {
+    opacity: 0.78,
+  },
+  actionButtonIcon: {
+    width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.pill,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.accentSurface,
+  },
+  actionButtonCopy: {
+    flex: 1,
+  },
+  actionButtonTitle: {
+    ...Typography.bodyStrong,
+    color: Colors.ink,
+  },
+  actionButtonDescription: {
+    marginTop: Spacing.xs,
+    ...Typography.caption,
+    color: Colors.muted,
   },
 });

--- a/apps/mobile/src/audio/capture-lifecycle.test.mjs
+++ b/apps/mobile/src/audio/capture-lifecycle.test.mjs
@@ -5,6 +5,7 @@ import {
   beginMobileCapture,
   endMobileCapture,
   getMobileCaptureActive,
+  stopMobileCapture,
 } from "./capture-lifecycle.ts";
 
 test("keeps the mobile gate open until every active capture is settled", () => {
@@ -17,4 +18,17 @@ test("keeps the mobile gate open until every active capture is settled", () => {
 
   endMobileCapture("session-2");
   assert.equal(getMobileCaptureActive(), false);
+});
+
+test("stops the active capture through the registered handler", async () => {
+  const stopped = [];
+  beginMobileCapture("session-1", async () => {
+    stopped.push("session-1");
+    endMobileCapture("session-1");
+  });
+
+  assert.equal(await stopMobileCapture(), true);
+  assert.deepEqual(stopped, ["session-1"]);
+  assert.equal(getMobileCaptureActive(), false);
+  assert.equal(await stopMobileCapture(), false);
 });

--- a/apps/mobile/src/audio/capture-lifecycle.test.mjs
+++ b/apps/mobile/src/audio/capture-lifecycle.test.mjs
@@ -32,3 +32,15 @@ test("stops the active capture through the registered handler", async () => {
   assert.equal(getMobileCaptureActive(), false);
   assert.equal(await stopMobileCapture(), false);
 });
+
+test("waits for a starting capture to register its stop handler", async () => {
+  beginMobileCapture("session-1");
+  const stopRequested = stopMobileCapture();
+
+  beginMobileCapture("session-1", async () => {
+    endMobileCapture("session-1");
+  });
+
+  assert.equal(await stopRequested, true);
+  assert.equal(getMobileCaptureActive(), false);
+});

--- a/apps/mobile/src/audio/capture-lifecycle.ts
+++ b/apps/mobile/src/audio/capture-lifecycle.ts
@@ -1,19 +1,25 @@
 const activeSessions = new Set<string>();
+const stopHandlers = new Map<string, () => Promise<unknown>>();
 const listeners = new Set<() => void>();
 
 function notify() {
   for (const listener of listeners) listener();
 }
 
-export function beginMobileCapture(sessionId: string): void {
+export function beginMobileCapture(
+  sessionId: string,
+  stop?: () => Promise<unknown>,
+): void {
   const wasActive = activeSessions.size > 0;
   activeSessions.add(sessionId);
+  if (stop) stopHandlers.set(sessionId, stop);
   if (!wasActive) notify();
 }
 
 export function endMobileCapture(sessionId: string): void {
   const wasActive = activeSessions.size > 0;
   activeSessions.delete(sessionId);
+  stopHandlers.delete(sessionId);
   if (wasActive && activeSessions.size === 0) notify();
 }
 
@@ -24,4 +30,11 @@ export function subscribeMobileCapture(listener: () => void): () => void {
 
 export function getMobileCaptureActive(): boolean {
   return activeSessions.size > 0;
+}
+
+export async function stopMobileCapture(): Promise<boolean> {
+  const stop = stopHandlers.values().next().value;
+  if (!stop) return false;
+  await stop();
+  return true;
 }

--- a/apps/mobile/src/audio/capture-lifecycle.ts
+++ b/apps/mobile/src/audio/capture-lifecycle.ts
@@ -1,5 +1,9 @@
 const activeSessions = new Set<string>();
 const stopHandlers = new Map<string, () => Promise<unknown>>();
+const stopWaiters = new Map<
+  string,
+  Array<(stop: (() => Promise<unknown>) | null) => void>
+>();
 const listeners = new Set<() => void>();
 
 function notify() {
@@ -12,7 +16,11 @@ export function beginMobileCapture(
 ): void {
   const wasActive = activeSessions.size > 0;
   activeSessions.add(sessionId);
-  if (stop) stopHandlers.set(sessionId, stop);
+  if (stop) {
+    stopHandlers.set(sessionId, stop);
+    for (const resolve of stopWaiters.get(sessionId) ?? []) resolve(stop);
+    stopWaiters.delete(sessionId);
+  }
   if (!wasActive) notify();
 }
 
@@ -20,6 +28,8 @@ export function endMobileCapture(sessionId: string): void {
   const wasActive = activeSessions.size > 0;
   activeSessions.delete(sessionId);
   stopHandlers.delete(sessionId);
+  for (const resolve of stopWaiters.get(sessionId) ?? []) resolve(null);
+  stopWaiters.delete(sessionId);
   if (wasActive && activeSessions.size === 0) notify();
 }
 
@@ -33,7 +43,19 @@ export function getMobileCaptureActive(): boolean {
 }
 
 export async function stopMobileCapture(): Promise<boolean> {
-  const stop = stopHandlers.values().next().value;
+  const registeredStop = stopHandlers.values().next().value;
+  if (registeredStop) {
+    await registeredStop();
+    return true;
+  }
+
+  const sessionId = activeSessions.values().next().value;
+  if (!sessionId) return false;
+  const stop = await new Promise<(() => Promise<unknown>) | null>((resolve) => {
+    const waiters = stopWaiters.get(sessionId) ?? [];
+    waiters.push(resolve);
+    stopWaiters.set(sessionId, waiters);
+  });
   if (!stop) return false;
   await stop();
   return true;

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -72,11 +72,12 @@ export function useSessionRecorder(
   const reportedFailureRef = useRef<string | null>(null);
   const durationRef = useRef(0);
   const captureRegisteredRef = useRef(false);
+  const stopRef = useRef<() => Promise<StopResult>>(async () => "noop");
 
   const registerCapture = useCallback(() => {
     if (captureRegisteredRef.current) return;
     captureRegisteredRef.current = true;
-    beginMobileCapture(sessionId);
+    beginMobileCapture(sessionId, () => stopRef.current());
   }, [sessionId]);
 
   const unregisterCapture = useCallback(() => {
@@ -385,7 +386,6 @@ export function useSessionRecorder(
     return "noop";
   };
 
-  const stopRef = useRef(stop);
   stopRef.current = stop;
   useMountEffect(() => () => {
     activeRef.current = false;

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -180,6 +180,7 @@ export function useSessionRecorder(
     setFailure(null);
     reportedFailureRef.current = null;
     setPhase("starting");
+    registerCapture();
     try {
       let permission = await getRecordingPermissionsAsync();
       if (!permission.granted) {
@@ -205,6 +206,7 @@ export function useSessionRecorder(
         captureAnalytics("session_start_failed", {
           failure_stage: "microphone_permission",
         });
+        unregisterCapture();
         setPhase("unavailable");
         return;
       }
@@ -217,7 +219,6 @@ export function useSessionRecorder(
       });
       if (!isCurrent()) return;
       writerRef.current = new SessionWavWriter(sessionId);
-      registerCapture();
       await stream.start();
       if (!isCurrent()) {
         phaseRef.current = "recording";

--- a/apps/mobile/src/components/action-button-card.tsx
+++ b/apps/mobile/src/components/action-button-card.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+import { StyleSheet, Text, useWindowDimensions, View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  Easing,
+  Extrapolation,
+  interpolate,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+
+import { IPhoneDeviceFrame } from "@/components/iphone-device-frame";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Colors, Spacing, Typography } from "@/constants/theme";
+
+const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);
+
+function project(velocity: number, decelerationRate = 0.998) {
+  "worklet";
+  return ((velocity / 1_000) * decelerationRate) / (1 - decelerationRate);
+}
+
+export function ActionButtonCard({
+  onConfigure,
+  onDismiss,
+}: {
+  onConfigure: () => void;
+  onDismiss: () => void;
+}) {
+  const { width } = useWindowDimensions();
+  const reducedMotion = useReducedMotion();
+  const translateX = useSharedValue(0);
+  const gestureStartX = useSharedValue(0);
+  const dismissThreshold = width * 0.28;
+
+  const pan = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetX([-10, 10])
+        .failOffsetY([-10, 10])
+        .onStart(() => {
+          gestureStartX.set(translateX.get());
+        })
+        .onUpdate((event) => {
+          translateX.set(gestureStartX.get() + event.translationX);
+        })
+        .onEnd((event) => {
+          const projectedX = translateX.get() + project(event.velocityX);
+          if (Math.abs(projectedX) > dismissThreshold) {
+            const direction = projectedX < 0 ? -1 : 1;
+            translateX.set(
+              withTiming(
+                direction * width,
+                { duration: 200, easing: EASE_OUT },
+                (finished) => {
+                  if (finished) scheduleOnRN(onDismiss);
+                },
+              ),
+            );
+            return;
+          }
+          translateX.set(
+            withSpring(0, {
+              duration: 400,
+              dampingRatio: 1,
+              velocity: event.velocityX,
+            }),
+          );
+        }),
+    [dismissThreshold, gestureStartX, onDismiss, translateX, width],
+  );
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const offset = translateX.get();
+    return {
+      opacity: interpolate(
+        Math.abs(offset),
+        [0, width * 0.65],
+        [1, 0],
+        Extrapolation.CLAMP,
+      ),
+      transform: [{ translateX: reducedMotion ? 0 : offset }],
+    };
+  });
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={animatedStyle}>
+        <Card style={styles.card}>
+          <View
+            accessible
+            accessibilityActions={[{ name: "dismiss", label: "Dismiss" }]}
+            accessibilityLabel="Listen with the Action Button"
+            onAccessibilityAction={(event) => {
+              if (event.nativeEvent.actionName === "dismiss") onDismiss();
+            }}
+            style={styles.heading}
+          >
+            <IPhoneDeviceFrame width={30} />
+            <Text style={styles.title}>Listen with the Action Button</Text>
+          </View>
+          <Text style={styles.description}>
+            Long-press once to start a meeting recording and again to stop.
+          </Text>
+          <Button label="Configure Action Button" onPress={onConfigure} />
+        </Card>
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: Spacing.lg,
+    padding: Spacing.md,
+    gap: Spacing.md,
+  },
+  heading: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.md,
+  },
+  title: {
+    flex: 1,
+    ...Typography.section,
+    color: Colors.ink,
+  },
+  description: {
+    ...Typography.body,
+    color: Colors.muted,
+  },
+});

--- a/apps/mobile/src/components/iphone-device-frame.tsx
+++ b/apps/mobile/src/components/iphone-device-frame.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+import { StyleSheet, View } from "react-native";
+
+import { Colors, CornerCurve, Radius } from "@/constants/theme";
+
+const IPHONE_17_PRO_ASPECT_RATIO = 71.9 / 150;
+const IPHONE_17_PRO_DEVICE_CORNER_RADIUS_RATIO = 62 / 402;
+
+export function IPhoneDeviceFrame({
+  liveActivity,
+  width,
+}: {
+  liveActivity?: ReactNode;
+  width: number;
+}) {
+  const height = width / IPHONE_17_PRO_ASPECT_RATIO;
+  const borderWidth = Math.max(1.5, width * 0.029);
+  const actionButtonWidth = Math.max(3, width * 0.058);
+
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        styles.frame,
+        {
+          width,
+          height,
+          borderWidth,
+          borderRadius: width * IPHONE_17_PRO_DEVICE_CORNER_RADIUS_RATIO,
+        },
+      ]}
+    >
+      <View
+        style={[
+          styles.dynamicIsland,
+          {
+            top: width * 0.087,
+            width: width * 0.346,
+            height: width * 0.096,
+          },
+        ]}
+      />
+      <View
+        style={[
+          styles.actionButton,
+          {
+            left: -actionButtonWidth,
+            top: width * 0.327,
+            width: actionButtonWidth,
+            height: width * 0.269,
+          },
+        ]}
+      />
+      {liveActivity && (
+        <View
+          style={[
+            styles.liveActivity,
+            {
+              bottom: width * 0.23,
+              width: width * 0.846,
+              height: width * 0.308,
+            },
+          ]}
+        >
+          {liveActivity}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    alignItems: "center",
+    borderColor: Colors.ink,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.surface,
+  },
+  dynamicIsland: {
+    position: "absolute",
+    borderRadius: Radius.pill,
+    backgroundColor: Colors.ink,
+  },
+  actionButton: {
+    position: "absolute",
+    borderRadius: Radius.pill,
+    backgroundColor: Colors.primary,
+  },
+  liveActivity: {
+    position: "absolute",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: Radius.card,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.ink,
+  },
+});

--- a/apps/mobile/src/quick-actions/index.ts
+++ b/apps/mobile/src/quick-actions/index.ts
@@ -1,0 +1,16 @@
+import { Platform } from "react-native";
+
+import QuickActionsModule, {
+  type QuickAction,
+} from "../../modules/quick-actions";
+
+export function consumePendingQuickAction(): QuickAction | null {
+  if (Platform.OS !== "ios" || !QuickActionsModule) return null;
+  return QuickActionsModule.consumePendingAction();
+}
+
+export function subscribeQuickActions(listener: () => void): () => void {
+  if (Platform.OS !== "ios" || !QuickActionsModule) return () => {};
+  const subscription = QuickActionsModule.addListener("onAction", listener);
+  return () => subscription.remove();
+}

--- a/apps/mobile/src/quick-actions/quick-action-lifecycle.tsx
+++ b/apps/mobile/src/quick-actions/quick-action-lifecycle.tsx
@@ -22,12 +22,9 @@ export function QuickActionLifecycle({
 }) {
   const router = useRouter();
   const busyRef = useRef(false);
+  const queuedToggleRef = useRef(false);
 
-  const handleAction = async () => {
-    const action = consumePendingQuickAction();
-    if (action !== "toggle_listening") return;
-    if (busyRef.current) return;
-
+  const runToggle = async () => {
     busyRef.current = true;
     try {
       if (getMobileCaptureActive()) {
@@ -52,12 +49,26 @@ export function QuickActionLifecycle({
       });
     } finally {
       busyRef.current = false;
+      if (queuedToggleRef.current) {
+        queuedToggleRef.current = false;
+        void runToggle();
+      }
     }
   };
 
+  const handleAction = () => {
+    const action = consumePendingQuickAction();
+    if (action !== "toggle_listening") return;
+    if (busyRef.current) {
+      queuedToggleRef.current = !queuedToggleRef.current;
+      return;
+    }
+    void runToggle();
+  };
+
   useMountEffect(() => {
-    const unsubscribe = subscribeQuickActions(() => void handleAction());
-    void handleAction();
+    const unsubscribe = subscribeQuickActions(handleAction);
+    handleAction();
     return unsubscribe;
   });
 

--- a/apps/mobile/src/quick-actions/quick-action-lifecycle.tsx
+++ b/apps/mobile/src/quick-actions/quick-action-lifecycle.tsx
@@ -1,0 +1,57 @@
+import { useRouter } from "expo-router";
+import { useRef } from "react";
+
+import {
+  getMobileCaptureActive,
+  stopMobileCapture,
+} from "@/audio/capture-lifecycle";
+import { createSession } from "@/data/session";
+import { captureOperationalError } from "@/lib/error-reporting";
+import { useMountEffect } from "@/lib/use-mount-effect";
+import {
+  consumePendingQuickAction,
+  subscribeQuickActions,
+} from "@/quick-actions";
+
+export function QuickActionLifecycle({
+  accountUserId,
+}: {
+  accountUserId: string | null;
+}) {
+  const router = useRouter();
+  const busyRef = useRef(false);
+
+  const handleAction = async () => {
+    if (busyRef.current) return;
+    const action = consumePendingQuickAction();
+    if (action !== "toggle_listening") return;
+
+    busyRef.current = true;
+    try {
+      if (getMobileCaptureActive()) {
+        await stopMobileCapture();
+        return;
+      }
+
+      const sessionId = await createSession({
+        entryPoint: "start_listening",
+        ownerUserId: accountUserId ?? undefined,
+      });
+      router.push(`/note/${sessionId}?listen=1`);
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "quick_action_toggle_listening",
+      });
+    } finally {
+      busyRef.current = false;
+    }
+  };
+
+  useMountEffect(() => {
+    const unsubscribe = subscribeQuickActions(() => void handleAction());
+    void handleAction();
+    return unsubscribe;
+  });
+
+  return null;
+}

--- a/apps/mobile/src/quick-actions/quick-action-lifecycle.tsx
+++ b/apps/mobile/src/quick-actions/quick-action-lifecycle.tsx
@@ -2,6 +2,8 @@ import { useRouter } from "expo-router";
 import { useRef } from "react";
 
 import {
+  beginMobileCapture,
+  endMobileCapture,
   getMobileCaptureActive,
   stopMobileCapture,
 } from "@/audio/capture-lifecycle";
@@ -22,9 +24,9 @@ export function QuickActionLifecycle({
   const busyRef = useRef(false);
 
   const handleAction = async () => {
-    if (busyRef.current) return;
     const action = consumePendingQuickAction();
     if (action !== "toggle_listening") return;
+    if (busyRef.current) return;
 
     busyRef.current = true;
     try {
@@ -37,7 +39,13 @@ export function QuickActionLifecycle({
         entryPoint: "start_listening",
         ownerUserId: accountUserId ?? undefined,
       });
-      router.push(`/note/${sessionId}?listen=1`);
+      beginMobileCapture(sessionId);
+      try {
+        router.push(`/note/${sessionId}?listen=1`);
+      } catch (error) {
+        endMobileCapture(sessionId);
+        throw error;
+      }
     } catch (error) {
       captureOperationalError(error, {
         operation: "quick_action_toggle_listening",


### PR DESCRIPTION
Expose a Start Listening shortcut and add setup guidance in the mobile app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> External shortcuts can start/stop live recording and depend on new capture stop-handler timing; failures are reported but could leave capture state inconsistent if navigation or stop fails.
> 
> **Overview**
> Adds **iOS App Shortcuts / Action Button** support so users can **start or stop meeting capture** from outside the app via a **Start or Stop Listening** intent that opens Anarlog and enqueues a `toggle_listening` action.
> 
> A new **Expo native module** (`AnarlogQuickActions`) registers the App Intent, persists pending actions in `UserDefaults`, and bridges them to JS through **`onAction`** and **`consumePendingAction`**. **`QuickActionLifecycle`** handles toggles: stop via **`stopMobileCapture`** when capture is active, otherwise **create a session** and navigate to **`/note/:id?listen=1`**.
> 
> **Capture lifecycle** is extended so **`beginMobileCapture`** can register a stop handler and **`stopMobileCapture`** can invoke it (including while a recording is still starting). The session recorder wires its stop function into that path and registers capture earlier in the start flow.
> 
> **In-app discovery**: dismissible **Action Button** promo on the home screen (iOS, AsyncStorage dismiss), a **Settings** entry, and an **`/action-button`** setup guide. Root layout adds **`GestureHandlerRootView`** for the swipe-to-dismiss card and mounts **`QuickActionLifecycle`** for signed-in users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a904f732bc885b51fe7642a53d6652677e5e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->