### PR TITLE
Simplify mobile home actions

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useRouter } from "expo-router";
 import { useRef, useState } from "react";
@@ -16,11 +15,9 @@ import { useAuth } from "@/auth/context";
 import { ActionButtonCard } from "@/components/action-button-card";
 import { SessionCard } from "@/components/session-card";
 import { StartListeningButton } from "@/components/start-listening-button";
-import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
 import { UserAvatarButton } from "@/components/user-avatar";
 import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
-import { importVoiceMemos } from "@/data/import-voice-memo";
 import { useSessionSearch } from "@/data/search";
 import { createSession, deleteSession } from "@/data/session";
 import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
@@ -46,7 +43,6 @@ export default function HomeScreen() {
   const router = useRouter();
   const auth = useAuth();
   const { items, isLoading } = useTimelineSessions();
-  const [importing, setImporting] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const [settledSearchQuery, setSettledSearchQuery] = useState("");
   const [showActionButtonCard, setShowActionButtonCard] = useState(false);
@@ -149,25 +145,6 @@ export default function HomeScreen() {
     }
   };
 
-  const handleImport = async () => {
-    if (busyRef.current) return;
-    busyRef.current = true;
-    setImporting(true);
-    try {
-      const sessionIds = await importVoiceMemos(auth.session?.user.id);
-      if (sessionIds.length === 1) {
-        router.push(`/note/${sessionIds[0]}`);
-      }
-    } catch (error) {
-      captureOperationalError(error, {
-        operation: "voice_memo_picker",
-      });
-    } finally {
-      busyRef.current = false;
-      setImporting(false);
-    }
-  };
-
   const dismissActionButtonCard = () => {
     setShowActionButtonCard(false);
     void AsyncStorage.setItem(ACTION_BUTTON_CARD_DISMISSED_KEY, "1").catch(
@@ -206,11 +183,18 @@ export default function HomeScreen() {
               onPress={() => router.push("/settings")}
               user={auth.session?.user ?? null}
             />
-            <IconButton
-              accessibilityLabel="Search meetings"
-              icon="search"
-              onPress={() => setQuery("")}
-            />
+            <View style={styles.headerActions}>
+              <IconButton
+                accessibilityLabel="Create new note"
+                icon="create-outline"
+                onPress={() => void createAndOpen()}
+              />
+              <IconButton
+                accessibilityLabel="Search meetings"
+                icon="search"
+                onPress={() => setQuery("")}
+              />
+            </View>
           </>
         )}
       </View>
@@ -264,7 +248,7 @@ export default function HomeScreen() {
               <View style={styles.empty}>
                 <Text style={styles.emptyTitle}>No meetings yet</Text>
                 <Text style={styles.emptyBody}>
-                  Start listening, create a meeting, or import a recording.
+                  Start listening or create a new note.
                 </Text>
               </View>
             )}
@@ -297,39 +281,10 @@ export default function HomeScreen() {
       </ScrollView>
 
       {!searching && (
-        <>
-          <View style={styles.actions}>
-            <Button
-              label="New meeting"
-              onPress={() => void createAndOpen()}
-              leading={
-                <Ionicons name="create-outline" size={17} color={Colors.ink} />
-              }
-              style={styles.secondaryButton}
-              variant="outline"
-            />
-            <Button
-              label={importing ? "Importing…" : "Import recording"}
-              onPress={handleImport}
-              disabled={importing}
-              leading={
-                <Ionicons
-                  name="cloud-upload-outline"
-                  size={17}
-                  color={Colors.ink}
-                />
-              }
-              loading={importing}
-              style={styles.secondaryButton}
-              variant="outline"
-            />
-          </View>
-
-          <StartListeningButton
-            bottomSpacing={Spacing.xs}
-            onPress={() => void createAndOpen("?listen=1")}
-          />
-        </>
+        <StartListeningButton
+          bottomSpacing={Spacing.xs}
+          onPress={() => void createAndOpen("?listen=1")}
+        />
       )}
     </SafeAreaView>
   );
@@ -348,6 +303,10 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.sm,
     paddingBottom: Spacing.md,
   },
+  headerActions: {
+    flexDirection: "row",
+    gap: Spacing.xs,
+  },
   searchInput: {
     flex: 1,
     height: ControlSize.compact,
@@ -361,12 +320,15 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   listContent: {
+    flexGrow: 1,
     paddingHorizontal: Spacing.lg,
     paddingBottom: Spacing.lg,
   },
   empty: {
+    flex: 1,
     alignItems: "center",
-    paddingVertical: Spacing.xl * 2,
+    justifyContent: "center",
+    paddingHorizontal: Spacing.lg,
     gap: Spacing.sm,
   },
   emptyTitle: {
@@ -389,14 +351,5 @@ const styles = StyleSheet.create({
     color: Colors.ink,
     marginTop: Spacing.lg,
     marginBottom: Spacing.sm,
-  },
-  actions: {
-    flexDirection: "row",
-    gap: Spacing.sm,
-    marginHorizontal: Spacing.lg,
-    marginBottom: Spacing.sm,
-  },
-  secondaryButton: {
-    flex: 1,
   },
 });

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -32,6 +32,7 @@ import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Colors, Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
+import { importRecordingIntoSession } from "@/data/import-voice-memo";
 import {
   type NoteAttachment,
   useNoteAttachments,
@@ -430,6 +431,27 @@ export default function NoteScreen() {
     }
   };
 
+  const handleImportRecording = async () => {
+    if (audioRestoreBusyRef.current || hasRecordingHistory) return;
+    audioRestoreBusyRef.current = true;
+    try {
+      await importRecordingIntoSession(id, auth.session?.user.id);
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "voice_memo_import",
+        tags: { entry_point: "mobile_note" },
+      });
+      Alert.alert(
+        "Couldn’t import recording",
+        error instanceof Error
+          ? error.message
+          : "The selected recording could not be imported.",
+      );
+    } finally {
+      audioRestoreBusyRef.current = false;
+    }
+  };
+
   const handleDownloadRecording = async () => {
     const accessToken = auth.session?.access_token;
     if (
@@ -815,6 +837,7 @@ export default function NoteScreen() {
         onClose={() => setActionsOpen(false)}
         onDelete={() => void handleDelete()}
         onExport={() => void handleExport()}
+        onImportRecording={() => void handleImportRecording()}
         onToggleListening={handleListeningAction}
         visible={actionsOpen}
       />

--- a/apps/mobile/src/components/note-actions-sheet.tsx
+++ b/apps/mobile/src/components/note-actions-sheet.tsx
@@ -16,6 +16,7 @@ export function NoteActionsSheet({
   onClose,
   onDelete,
   onExport,
+  onImportRecording,
   onToggleListening,
   visible,
 }: {
@@ -24,6 +25,7 @@ export function NoteActionsSheet({
   onClose: () => void;
   onDelete: () => void;
   onExport: () => void;
+  onImportRecording: () => void;
   onToggleListening: () => void;
   visible: boolean;
 }) {
@@ -77,6 +79,23 @@ export function NoteActionsSheet({
             <Ionicons name="download-outline" size={20} color={Colors.ink} />
             <Text style={styles.actionLabel}>Export</Text>
           </Pressable>
+          {!listening && !hasRecordingHistory && (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => select(onImportRecording)}
+              style={({ pressed }) => [
+                styles.action,
+                pressed && styles.actionPressed,
+              ]}
+            >
+              <Ionicons
+                name="cloud-upload-outline"
+                size={20}
+                color={Colors.ink}
+              />
+              <Text style={styles.actionLabel}>Import recording</Text>
+            </Pressable>
+          )}
           {(listening || !hasRecordingHistory) && (
             <Pressable
               accessibilityRole="button"

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -29,6 +29,7 @@ type AudioImportOptions = {
   sessionId?: string;
   ownerUserId?: string;
   signal?: AbortSignal;
+  trackCreated?: boolean;
 };
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
@@ -117,7 +118,7 @@ async function importAsset(
           "application/octet-stream",
         size_bytes: asset.size ?? destination.size ?? 0,
       });
-      if (!options?.sessionId) {
+      if (options?.trackCreated ?? !options?.sessionId) {
         captureAnalytics("note_created", {
           entry_point: entryPoint,
           has_initial_title: Boolean(title),
@@ -238,6 +239,7 @@ export async function importWatchRecording(
       sessionId: recording.id,
       ownerUserId: recording.accountUserId,
       signal,
+      trackCreated: !existing,
     },
   );
 }

--- a/apps/mobile/src/data/import-voice-memo.ts
+++ b/apps/mobile/src/data/import-voice-memo.ts
@@ -117,10 +117,12 @@ async function importAsset(
           "application/octet-stream",
         size_bytes: asset.size ?? destination.size ?? 0,
       });
-      captureAnalytics("note_created", {
-        entry_point: entryPoint,
-        has_initial_title: Boolean(title),
-      });
+      if (!options?.sessionId) {
+        captureAnalytics("note_created", {
+          entry_point: entryPoint,
+          has_initial_title: Boolean(title),
+        });
+      }
     }
   } catch (error) {
     if (!cataloged) {
@@ -152,32 +154,23 @@ async function importAsset(
   return sessionId;
 }
 
-export async function importVoiceMemos(
+export async function importRecordingIntoSession(
+  sessionId: string,
   ownerUserId?: string,
-): Promise<string[]> {
+): Promise<boolean> {
   const result = await getDocumentAsync({
     type: ["audio/*"],
-    multiple: true,
+    multiple: false,
     copyToCacheDirectory: true,
   });
-  if (result.canceled) return [];
+  if (result.canceled) return false;
 
-  const created: string[] = [];
-  for (const asset of result.assets) {
-    try {
-      created.push(
-        await importAsset(asset, "voice_memo_import", { ownerUserId }),
-      );
-    } catch (error) {
-      captureOperationalError(error, {
-        operation: "voice_memo_import",
-        context: {
-          content_type: asset.mimeType ?? "unknown",
-        },
-      });
-    }
-  }
-  return created;
+  await importAsset(result.assets[0], "voice_memo_import", {
+    preserveSessionOnFailure: true,
+    sessionId,
+    ownerUserId,
+  });
+  return true;
 }
 
 export async function importWatchRecording(


### PR DESCRIPTION
Replace the secondary home buttons with a create-note icon, center the empty state, and move recording import into note actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where and how recordings enter the app (no home bulk import; session-scoped import with preserve-on-failure), which affects user workflows and local session/audio state.
> 
> **Overview**
> **Simplifies the mobile home screen** by dropping the bottom **New meeting** and **Import recording** buttons and keeping only **Start listening**. **Create note** moves to a header icon beside search, and the empty-state copy/layout is updated so the message is centered and no longer mentions import.
> 
> **Recording import** is relocated to the open note’s **More actions** sheet as **Import recording**, shown only when the note isn’t listening and has no recording history. The note screen wires this to new `importRecordingIntoSession`, which picks a single audio file and attaches it to the current session (with errors surfaced via alert).
> 
> **Import module changes:** `importVoiceMemos` (multi-select, create new sessions from home) is replaced by `importRecordingIntoSession`. Analytics adds a `trackCreated` guard so `note_created` isn’t emitted when audio is added to an existing session (watch import uses the same pattern).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6af5a9938be0ae9b3d17fd5c55709a9a6a234c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->