### PR TITLE
Remember the last mobile sign-in method

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -138,6 +138,7 @@ function Gate() {
     return (
       <SignInScreen
         busy={signingIn}
+        lastSignInMethod={auth.lastSignInMethod}
         onSignIn={(method) => void handleSignIn(method)}
       />
     );

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -109,6 +109,7 @@ function parseAuthCallbackUrl(
 // Deep links can be delivered twice (auth-session result + Linking event);
 // mirror desktop's 5s dedupe window (apps/desktop/src/auth/deeplink.ts).
 const RECENT_CALLBACK_WINDOW_MS = 5_000;
+const pendingSignInMethodStorageKey = "anarlog:auth:pending-sign-in-method";
 const inFlightTokens = new Map<string, Promise<boolean>>();
 const recentTokens = new Map<string, number>();
 
@@ -225,6 +226,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const identifiedUserIdRef = useRef<string | null>(null);
   const reportedUndecodableUserIdRef = useRef<string | null>(null);
   const billingRefreshRef = useRef<Promise<boolean> | null>(null);
+  const pendingSignInMethodRef = useRef<SignInMethod | null>(null);
   // Prevents double init in React StrictMode (refresh token races)
   const initStartedRef = useRef(false);
 
@@ -281,6 +283,39 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       active = false;
     };
   });
+
+  const handleCompletedAuthCallback = useCallback(async (url: string) => {
+    const signedIn = await handleAuthCallbackUrl(url);
+    if (!signedIn) return false;
+
+    let signInMethod = pendingSignInMethodRef.current;
+    if (!signInMethod) {
+      try {
+        signInMethod = parseLastSignInMethod(
+          await AsyncStorage.getItem(pendingSignInMethodStorageKey),
+        );
+      } catch (error) {
+        captureOperationalError(error, {
+          operation: "auth_pending_sign_in_method_read",
+          level: "warning",
+        });
+      }
+    }
+    if (!signInMethod) return true;
+
+    pendingSignInMethodRef.current = null;
+    setLastSignInMethod(signInMethod);
+    try {
+      await AsyncStorage.setItem(lastSignInMethodStorageKey, signInMethod);
+      await AsyncStorage.removeItem(pendingSignInMethodStorageKey);
+    } catch (error) {
+      captureOperationalError(error, {
+        operation: "auth_last_sign_in_method_write",
+        level: "warning",
+      });
+    }
+    return true;
+  }, []);
 
   useEffect(() => {
     const client = supabase;
@@ -345,18 +380,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [setSession]);
 
-  useEffect(() => {
+  useMountEffect(() => {
     if (!supabase) {
       return;
     }
 
     const subscription = Linking.addEventListener("url", (event) => {
-      void handleAuthCallbackUrl(event.url);
+      void handleCompletedAuthCallback(event.url);
     });
     void Linking.getInitialURL().then(
       (url) => {
         if (url) {
-          void handleAuthCallbackUrl(url);
+          void handleCompletedAuthCallback(url);
         }
       },
       (error) => {
@@ -370,57 +405,58 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       subscription.remove();
     };
-  }, []);
+  });
 
-  const signIn = useCallback(async (signInMethod: SignInMethod) => {
-    if (!supabase) {
-      return;
-    }
+  const signIn = useCallback(
+    async (signInMethod: SignInMethod) => {
+      if (!supabase) {
+        return;
+      }
 
-    captureAnalytics("auth_started", {
-      method: "browser_handoff",
-      sign_in_method: signInMethod,
-      entry_point: "mobile_sign_in",
-    });
-    try {
-      const result = await WebBrowser.openAuthSessionAsync(
-        buildSignInUrl(env.appUrl, signInMethod),
-        "anarlog://auth/callback",
-      );
-      if (result.type === "success") {
-        const signedIn = await handleAuthCallbackUrl(result.url);
-        if (signedIn) {
-          setLastSignInMethod(signInMethod);
-          await AsyncStorage.setItem(
-            lastSignInMethodStorageKey,
-            signInMethod,
-          ).catch((error) => {
-            captureOperationalError(error, {
-              operation: "auth_last_sign_in_method_write",
-              level: "warning",
-            });
+      captureAnalytics("auth_started", {
+        method: "browser_handoff",
+        sign_in_method: signInMethod,
+        entry_point: "mobile_sign_in",
+      });
+      pendingSignInMethodRef.current = signInMethod;
+      await AsyncStorage.setItem(
+        pendingSignInMethodStorageKey,
+        signInMethod,
+      ).catch((error) => {
+        captureOperationalError(error, {
+          operation: "auth_pending_sign_in_method_write",
+          level: "warning",
+        });
+      });
+      try {
+        const result = await WebBrowser.openAuthSessionAsync(
+          buildSignInUrl(env.appUrl, signInMethod),
+          "anarlog://auth/callback",
+        );
+        if (result.type === "success") {
+          await handleCompletedAuthCallback(result.url);
+        } else {
+          captureAnalytics("auth_failed", {
+            method: "browser_handoff",
+            sign_in_method: signInMethod,
+            failure_stage: "cancelled",
           });
         }
-      } else {
+      } catch (error) {
+        captureOperationalError(error, {
+          operation: "auth_browser_open",
+          tags: { method: "browser_handoff" },
+        });
         captureAnalytics("auth_failed", {
           method: "browser_handoff",
           sign_in_method: signInMethod,
-          failure_stage: "cancelled",
+          failure_stage: "open_browser",
         });
+        throw error;
       }
-    } catch (error) {
-      captureOperationalError(error, {
-        operation: "auth_browser_open",
-        tags: { method: "browser_handoff" },
-      });
-      captureAnalytics("auth_failed", {
-        method: "browser_handoff",
-        sign_in_method: signInMethod,
-        failure_stage: "open_browser",
-      });
-      throw error;
-    }
-  }, []);
+    },
+    [handleCompletedAuthCallback],
+  );
 
   const refreshBilling = useCallback((): Promise<boolean> => {
     const client = supabase;

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -28,6 +28,7 @@ import { authStorageKey, supabase } from "@/auth/client";
 import {
   buildSignInUrl,
   lastSignInMethodStorageKey,
+  parseAuthCallbackSignInMethod,
   parseLastSignInMethod,
   type SignInMethod,
 } from "@/auth/sign-in";
@@ -109,7 +110,6 @@ function parseAuthCallbackUrl(
 // Deep links can be delivered twice (auth-session result + Linking event);
 // mirror desktop's 5s dedupe window (apps/desktop/src/auth/deeplink.ts).
 const RECENT_CALLBACK_WINDOW_MS = 5_000;
-const pendingSignInMethodStorageKey = "anarlog:auth:pending-sign-in-method";
 const inFlightTokens = new Map<string, Promise<boolean>>();
 const recentTokens = new Map<string, number>();
 
@@ -226,7 +226,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const identifiedUserIdRef = useRef<string | null>(null);
   const reportedUndecodableUserIdRef = useRef<string | null>(null);
   const billingRefreshRef = useRef<Promise<boolean> | null>(null);
-  const pendingSignInMethodRef = useRef<SignInMethod | null>(null);
   // Prevents double init in React StrictMode (refresh token races)
   const initStartedRef = useRef(false);
 
@@ -284,38 +283,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   });
 
-  const handleCompletedAuthCallback = useCallback(async (url: string) => {
-    const signedIn = await handleAuthCallbackUrl(url);
-    if (!signedIn) return false;
+  const handleCompletedAuthCallback = useCallback(
+    async (url: string, expectedSignInMethod?: SignInMethod) => {
+      const signedIn = await handleAuthCallbackUrl(url);
+      if (!signedIn) return false;
 
-    let signInMethod = pendingSignInMethodRef.current;
-    if (!signInMethod) {
+      const signInMethod =
+        parseAuthCallbackSignInMethod(url) ?? expectedSignInMethod;
+      if (!signInMethod) return true;
+
+      setLastSignInMethod(signInMethod);
       try {
-        signInMethod = parseLastSignInMethod(
-          await AsyncStorage.getItem(pendingSignInMethodStorageKey),
-        );
+        await AsyncStorage.setItem(lastSignInMethodStorageKey, signInMethod);
       } catch (error) {
         captureOperationalError(error, {
-          operation: "auth_pending_sign_in_method_read",
+          operation: "auth_last_sign_in_method_write",
           level: "warning",
         });
       }
-    }
-    if (!signInMethod) return true;
-
-    pendingSignInMethodRef.current = null;
-    setLastSignInMethod(signInMethod);
-    try {
-      await AsyncStorage.setItem(lastSignInMethodStorageKey, signInMethod);
-      await AsyncStorage.removeItem(pendingSignInMethodStorageKey);
-    } catch (error) {
-      captureOperationalError(error, {
-        operation: "auth_last_sign_in_method_write",
-        level: "warning",
-      });
-    }
-    return true;
-  }, []);
+      return true;
+    },
+    [],
+  );
 
   useEffect(() => {
     const client = supabase;
@@ -418,23 +407,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         sign_in_method: signInMethod,
         entry_point: "mobile_sign_in",
       });
-      pendingSignInMethodRef.current = signInMethod;
-      await AsyncStorage.setItem(
-        pendingSignInMethodStorageKey,
-        signInMethod,
-      ).catch((error) => {
-        captureOperationalError(error, {
-          operation: "auth_pending_sign_in_method_write",
-          level: "warning",
-        });
-      });
       try {
         const result = await WebBrowser.openAuthSessionAsync(
           buildSignInUrl(env.appUrl, signInMethod),
           "anarlog://auth/callback",
         );
         if (result.type === "success") {
-          await handleCompletedAuthCallback(result.url);
+          await handleCompletedAuthCallback(result.url, signInMethod);
         } else {
           captureAnalytics("auth_failed", {
             method: "browser_handoff",

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -25,7 +25,12 @@ import {
 } from "@/auth/billing";
 import { refreshBillingEntitlement as retryBillingEntitlement } from "@/auth/billing-handoff";
 import { authStorageKey, supabase } from "@/auth/client";
-import { buildSignInUrl, type SignInMethod } from "@/auth/sign-in";
+import {
+  buildSignInUrl,
+  lastSignInMethodStorageKey,
+  parseLastSignInMethod,
+  type SignInMethod,
+} from "@/auth/sign-in";
 import {
   captureAnalytics,
   identifyAnalytics,
@@ -37,6 +42,7 @@ import {
   captureOperationalError,
   setErrorReportingUser,
 } from "@/lib/error-reporting";
+import { useMountEffect } from "@/lib/use-mount-effect";
 import { suspendMobileSync } from "@/sync/mobile-sync";
 import { updateWatchAccount } from "@/watch-connectivity";
 
@@ -46,6 +52,7 @@ export type AuthState = {
   session: Session | null;
   billing: BillingInfo;
   billingReady: boolean;
+  lastSignInMethod: SignInMethod | null;
   signIn: (method: SignInMethod) => Promise<void>;
   refreshBilling: () => Promise<boolean>;
   signOut: () => Promise<void>;
@@ -102,13 +109,16 @@ function parseAuthCallbackUrl(
 // Deep links can be delivered twice (auth-session result + Linking event);
 // mirror desktop's 5s dedupe window (apps/desktop/src/auth/deeplink.ts).
 const RECENT_CALLBACK_WINDOW_MS = 5_000;
-const inFlightTokens = new Set<string>();
+const inFlightTokens = new Map<string, Promise<boolean>>();
 const recentTokens = new Map<string, number>();
 
-function acceptAuthTokens(accessToken: string, refreshToken: string): void {
+function acceptAuthTokens(
+  accessToken: string,
+  refreshToken: string,
+): Promise<boolean> {
   const client = supabase;
   if (!client) {
-    return;
+    return Promise.resolve(false);
   }
 
   const now = Date.now();
@@ -119,16 +129,18 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
   }
 
   const key = `${accessToken}\n${refreshToken}`;
-  if (inFlightTokens.has(key) || recentTokens.has(key)) {
-    return;
+  if (recentTokens.has(key)) {
+    return Promise.resolve(true);
+  }
+  const inFlight = inFlightTokens.get(key);
+  if (inFlight) {
+    return inFlight;
   }
 
-  inFlightTokens.add(key);
-  void client.auth
+  const request = client.auth
     .setSession({ access_token: accessToken, refresh_token: refreshToken })
     .then(
       ({ error }) => {
-        inFlightTokens.delete(key);
         if (error) {
           captureOperationalError(error, {
             operation: "auth_session_set",
@@ -138,12 +150,12 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
             method: "browser_handoff",
             failure_stage: "set_session",
           });
-        } else {
-          recentTokens.set(key, Date.now());
+          return false;
         }
+        recentTokens.set(key, Date.now());
+        return true;
       },
       (error) => {
-        inFlightTokens.delete(key);
         captureOperationalError(error, {
           operation: "auth_session_set",
           tags: { method: "browser_handoff" },
@@ -152,15 +164,20 @@ function acceptAuthTokens(accessToken: string, refreshToken: string): void {
           method: "browser_handoff",
           failure_stage: "set_session",
         });
+        return false;
       },
-    );
+    )
+    .finally(() => inFlightTokens.delete(key));
+  inFlightTokens.set(key, request);
+  return request;
 }
 
-function handleAuthCallbackUrl(url: string): void {
+function handleAuthCallbackUrl(url: string): Promise<boolean> {
   const tokens = parseAuthCallbackUrl(url);
-  if (tokens) {
-    acceptAuthTokens(tokens.accessToken, tokens.refreshToken);
+  if (!tokens) {
+    return Promise.resolve(false);
   }
+  return acceptAuthTokens(tokens.accessToken, tokens.refreshToken);
 }
 
 // Offline fallback: a retryable getSession error must not lock a Pro user out
@@ -200,6 +217,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const bypass = !hasSupabaseEnv;
   const [session, setSessionState] = useState<Session | null | undefined>(
     bypass ? null : undefined,
+  );
+  const [lastSignInMethod, setLastSignInMethod] = useState<SignInMethod | null>(
+    null,
   );
   const sessionRef = useRef<Session | null | undefined>(session);
   const identifiedUserIdRef = useRef<string | null>(null);
@@ -241,6 +261,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       identifiedUserIdRef.current = null;
     }
   }, []);
+
+  useMountEffect(() => {
+    let active = true;
+    void AsyncStorage.getItem(lastSignInMethodStorageKey).then(
+      (value) => {
+        if (active) {
+          setLastSignInMethod(parseLastSignInMethod(value));
+        }
+      },
+      (error) => {
+        captureOperationalError(error, {
+          operation: "auth_last_sign_in_method_read",
+          level: "warning",
+        });
+      },
+    );
+    return () => {
+      active = false;
+    };
+  });
 
   useEffect(() => {
     const client = supabase;
@@ -311,12 +351,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     const subscription = Linking.addEventListener("url", (event) => {
-      handleAuthCallbackUrl(event.url);
+      void handleAuthCallbackUrl(event.url);
     });
     void Linking.getInitialURL().then(
       (url) => {
         if (url) {
-          handleAuthCallbackUrl(url);
+          void handleAuthCallbackUrl(url);
         }
       },
       (error) => {
@@ -348,7 +388,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         "anarlog://auth/callback",
       );
       if (result.type === "success") {
-        handleAuthCallbackUrl(result.url);
+        const signedIn = await handleAuthCallbackUrl(result.url);
+        if (signedIn) {
+          setLastSignInMethod(signInMethod);
+          await AsyncStorage.setItem(
+            lastSignInMethodStorageKey,
+            signInMethod,
+          ).catch((error) => {
+            captureOperationalError(error, {
+              operation: "auth_last_sign_in_method_write",
+              level: "warning",
+            });
+          });
+        }
       } else {
         captureAnalytics("auth_failed", {
           method: "browser_handoff",
@@ -464,6 +516,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       session: session ?? null,
       billing,
       billingReady,
+      lastSignInMethod,
       signIn,
       refreshBilling,
       signOut,
@@ -474,6 +527,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       session,
       billing,
       billingReady,
+      lastSignInMethod,
       signIn,
       refreshBilling,
       signOut,

--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -25,6 +25,7 @@ import {
   Colors,
   CornerCurve,
   Gradients,
+  Radius,
   Spacing,
   Typography,
 } from "@/constants/theme";
@@ -36,9 +37,11 @@ import { useMountEffect } from "@/lib/use-mount-effect";
 export function SignInScreen({
   onSignIn,
   busy,
+  lastSignInMethod,
 }: {
   onSignIn: (method: SignInMethod) => void;
   busy: boolean;
+  lastSignInMethod: SignInMethod | null;
 }) {
   const [showSignInMethods, setShowSignInMethods] = useState(false);
   const { width } = useWindowDimensions();
@@ -78,82 +81,103 @@ export function SignInScreen({
               { width, paddingBottom: Math.max(insets.bottom, Spacing.md) },
             ]}
           >
-            <Button
+            <SignInMethodButton
+              method="apple"
               label="Sign in with Apple"
-              onPress={() => onSignIn("apple")}
+              onSignIn={onSignIn}
               disabled={busy}
-              leading={
-                <ProviderIcon
-                  source={require("../../assets/images/auth/apple.svg")}
-                />
-              }
-              variant="outline"
-              style={styles.signInMethod}
+              iconSource={require("../../assets/images/auth/apple.svg")}
+              lastSignInMethod={lastSignInMethod}
             />
-            <Button
+            <SignInMethodButton
+              method="google"
               label="Sign in with Google"
-              onPress={() => onSignIn("google")}
+              onSignIn={onSignIn}
               disabled={busy}
-              leading={
-                <ProviderIcon
-                  source={require("../../assets/images/auth/google.svg")}
-                />
-              }
-              variant="outline"
-              style={styles.signInMethod}
+              iconSource={require("../../assets/images/auth/google.svg")}
+              lastSignInMethod={lastSignInMethod}
             />
-            <Button
+            <SignInMethodButton
+              method="azure"
               label="Sign in with Microsoft"
-              onPress={() => onSignIn("azure")}
+              onSignIn={onSignIn}
               disabled={busy}
-              leading={
-                <ProviderIcon
-                  source={require("../../assets/images/auth/microsoft.svg")}
-                />
-              }
-              variant="outline"
-              style={styles.signInMethod}
+              iconSource={require("../../assets/images/auth/microsoft.svg")}
+              lastSignInMethod={lastSignInMethod}
             />
-            <Button
+            <SignInMethodButton
+              method="github"
               label="Sign in with GitHub"
-              onPress={() => onSignIn("github")}
+              onSignIn={onSignIn}
               disabled={busy}
-              leading={
-                <ProviderIcon
-                  source={require("../../assets/images/auth/github.svg")}
-                />
-              }
-              variant="outline"
-              style={styles.signInMethod}
+              iconSource={require("../../assets/images/auth/github.svg")}
+              lastSignInMethod={lastSignInMethod}
             />
-            <Button
+            <SignInMethodButton
+              method="email"
               label="Sign in with Email"
-              onPress={() => onSignIn("email")}
+              onSignIn={onSignIn}
               disabled={busy}
-              leading={
-                <ProviderIcon
-                  source={require("../../assets/images/auth/email.svg")}
-                />
-              }
-              variant="outline"
-              style={styles.signInMethod}
+              iconSource={require("../../assets/images/auth/email.svg")}
+              lastSignInMethod={lastSignInMethod}
             />
-            <Button
+            <SignInMethodButton
+              method="sso"
               label="Sign in with SSO"
-              onPress={() => onSignIn("sso")}
+              onSignIn={onSignIn}
               disabled={busy}
-              leading={
-                <ProviderIcon
-                  source={require("../../assets/images/auth/sso.svg")}
-                />
-              }
-              variant="outline"
-              style={styles.signInMethod}
+              iconSource={require("../../assets/images/auth/sso.svg")}
+              lastSignInMethod={lastSignInMethod}
             />
           </View>
         </RNHostView>
       </BottomSheet>
     </SafeAreaView>
+  );
+}
+
+function SignInMethodButton({
+  method,
+  label,
+  iconSource,
+  onSignIn,
+  disabled,
+  lastSignInMethod,
+}: {
+  method: SignInMethod;
+  label: string;
+  iconSource: number;
+  onSignIn: (method: SignInMethod) => void;
+  disabled: boolean;
+  lastSignInMethod: SignInMethod | null;
+}) {
+  const isLastUsed = method === lastSignInMethod;
+
+  return (
+    <View
+      style={[
+        styles.signInMethodContainer,
+        isLastUsed && styles.signInMethodLastUsed,
+      ]}
+    >
+      <Button
+        label={label}
+        onPress={() => onSignIn(method)}
+        disabled={disabled}
+        leading={<ProviderIcon source={iconSource} />}
+        variant="outline"
+        style={styles.signInMethod}
+      />
+      {isLastUsed && (
+        <View
+          pointerEvents="none"
+          style={styles.lastUsedBadge}
+          testID={`last-used-${method}`}
+        >
+          <Text style={styles.lastUsedLabel}>Last used</Text>
+        </View>
+      )}
+    </View>
   );
 }
 
@@ -328,8 +352,31 @@ const styles = StyleSheet.create({
     gap: Spacing.sm,
     paddingHorizontal: Spacing.md,
   },
+  signInMethodContainer: {
+    position: "relative",
+    width: "100%",
+  },
+  signInMethodLastUsed: {
+    paddingTop: Spacing.xs,
+  },
   signInMethod: {
     width: "100%",
+  },
+  lastUsedBadge: {
+    position: "absolute",
+    top: 0,
+    right: Spacing.md,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 1,
+    borderWidth: 2,
+    borderColor: Colors.surface,
+    borderRadius: Radius.pill,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.ink,
+  },
+  lastUsedLabel: {
+    ...Typography.captionStrong,
+    color: Colors.inkInverse,
   },
   providerIcon: {
     width: 18,

--- a/apps/mobile/src/auth/sign-in.test.mjs
+++ b/apps/mobile/src/auth/sign-in.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildSignInUrl } from "./sign-in.ts";
+import { buildSignInUrl, parseLastSignInMethod } from "./sign-in.ts";
 
 for (const provider of ["apple", "google", "azure", "github"]) {
   test(`builds a direct ${provider} OAuth URL`, () => {
@@ -27,3 +27,12 @@ for (const view of ["email", "sso"]) {
     assert.equal(url.searchParams.has("provider"), false);
   });
 }
+
+test("accepts only supported last-used sign-in methods", () => {
+  for (const method of ["apple", "google", "azure", "github", "email", "sso"]) {
+    assert.equal(parseLastSignInMethod(method), method);
+  }
+
+  assert.equal(parseLastSignInMethod("password"), null);
+  assert.equal(parseLastSignInMethod(null), null);
+});

--- a/apps/mobile/src/auth/sign-in.test.mjs
+++ b/apps/mobile/src/auth/sign-in.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildSignInUrl, parseLastSignInMethod } from "./sign-in.ts";
+import {
+  buildSignInUrl,
+  parseAuthCallbackSignInMethod,
+  parseLastSignInMethod,
+} from "./sign-in.ts";
 
 for (const provider of ["apple", "google", "azure", "github"]) {
   test(`builds a direct ${provider} OAuth URL`, () => {
@@ -35,4 +39,20 @@ test("accepts only supported last-used sign-in methods", () => {
 
   assert.equal(parseLastSignInMethod("password"), null);
   assert.equal(parseLastSignInMethod(null), null);
+});
+
+test("reads the sign-in method carried by an auth callback", () => {
+  assert.equal(
+    parseAuthCallbackSignInMethod(
+      "anarlog://auth/callback?access_token=token&method=google",
+    ),
+    "google",
+  );
+  assert.equal(
+    parseAuthCallbackSignInMethod(
+      "anarlog://auth/callback?access_token=token&method=password",
+    ),
+    null,
+  );
+  assert.equal(parseAuthCallbackSignInMethod("not a url"), null);
 });

--- a/apps/mobile/src/auth/sign-in.ts
+++ b/apps/mobile/src/auth/sign-in.ts
@@ -24,6 +24,18 @@ export function parseLastSignInMethod(
   }
 }
 
+export function parseAuthCallbackSignInMethod(
+  callbackUrl: string,
+): SignInMethod | null {
+  try {
+    return parseLastSignInMethod(
+      new URL(callbackUrl).searchParams.get("method"),
+    );
+  } catch {
+    return null;
+  }
+}
+
 export function buildSignInUrl(appUrl: string, method: SignInMethod): string {
   const url = new URL(`${appUrl.replace(/\/+$/, "")}/auth`);
   url.searchParams.set("flow", "desktop");

--- a/apps/mobile/src/auth/sign-in.ts
+++ b/apps/mobile/src/auth/sign-in.ts
@@ -6,6 +6,24 @@ export type SignInMethod =
   | "email"
   | "sso";
 
+export const lastSignInMethodStorageKey = "anarlog:auth:last-sign-in-method";
+
+export function parseLastSignInMethod(
+  value: string | null,
+): SignInMethod | null {
+  switch (value) {
+    case "apple":
+    case "google":
+    case "azure":
+    case "github":
+    case "email":
+    case "sso":
+      return value;
+    default:
+      return null;
+  }
+}
+
 export function buildSignInUrl(appUrl: string, method: SignInMethod): string {
   const url = new URL(`${appUrl.replace(/\/+$/, "")}/auth`);
   url.searchParams.set("flow", "desktop");

--- a/apps/web/src/lib/desktop-auth-handoff.test.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.test.ts
@@ -9,6 +9,7 @@ import {
   buildDesktopAuthCallbackPath,
   buildDesktopAuthDeeplink,
   getDesktopAppOpenLinkProps,
+  resolveDesktopAuthCallbackMethod,
   useDesktopAppAutoOpen,
 } from "./desktop-auth-handoff.ts";
 
@@ -48,6 +49,12 @@ test("builds a web callback that preserves the sign-in method", () => {
     ),
     "/callback/auth?flow=desktop&access_token=fake+access&refresh_token=fake%26refresh&scheme=anarlog-staging&method=email",
   );
+});
+
+test("prefers the requested desktop sign-in method over a remembered method", () => {
+  assert.equal(resolveDesktopAuthCallbackMethod("github", "google"), "github");
+  assert.equal(resolveDesktopAuthCallbackMethod(undefined, "google"), "google");
+  assert.equal(resolveDesktopAuthCallbackMethod(undefined, null), undefined);
 });
 
 test("attempts the external protocol through an anchor navigation", () => {

--- a/apps/web/src/lib/desktop-auth-handoff.test.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.test.ts
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 
 import {
   attemptDesktopAppOpen,
+  buildDesktopAuthCallbackPath,
   buildDesktopAuthDeeplink,
   getDesktopAppOpenLinkProps,
   useDesktopAppAutoOpen,
@@ -34,6 +35,18 @@ test("builds an encoded desktop auth callback", () => {
   assert.equal(
     buildDesktopAuthDeeplink("anarlog-staging", undefined, "fake-refresh"),
     null,
+  );
+});
+
+test("builds a web callback that preserves the sign-in method", () => {
+  assert.equal(
+    buildDesktopAuthCallbackPath(
+      "fake access",
+      "fake&refresh",
+      "anarlog-staging",
+      "email",
+    ),
+    "/callback/auth?flow=desktop&access_token=fake+access&refresh_token=fake%26refresh&scheme=anarlog-staging&method=email",
   );
 });
 

--- a/apps/web/src/lib/desktop-auth-handoff.test.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.test.ts
@@ -23,8 +23,13 @@ const { JSDOM } = require("jsdom") as {
 
 test("builds an encoded desktop auth callback", () => {
   assert.equal(
-    buildDesktopAuthDeeplink("anarlog-staging", "fake access", "fake&refresh"),
-    "anarlog-staging://auth/callback?access_token=fake+access&refresh_token=fake%26refresh",
+    buildDesktopAuthDeeplink(
+      "anarlog-staging",
+      "fake access",
+      "fake&refresh",
+      "google",
+    ),
+    "anarlog-staging://auth/callback?access_token=fake+access&refresh_token=fake%26refresh&method=google",
   );
   assert.equal(
     buildDesktopAuthDeeplink("anarlog-staging", undefined, "fake-refresh"),

--- a/apps/web/src/lib/desktop-auth-handoff.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.ts
@@ -5,6 +5,13 @@ import { useMountEffect } from "../hooks/useMountEffect.ts";
 
 const autoOpenAttempts = new WeakMap<Document, Set<string>>();
 
+export function resolveDesktopAuthCallbackMethod(
+  requestedMethod: AuthSignInMethod | undefined,
+  rememberedMethod: AuthSignInMethod | null,
+) {
+  return requestedMethod ?? rememberedMethod ?? undefined;
+}
+
 export function buildDesktopAuthDeeplink(
   scheme: DesktopScheme,
   accessToken: string | undefined,

--- a/apps/web/src/lib/desktop-auth-handoff.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.ts
@@ -25,6 +25,26 @@ export function buildDesktopAuthDeeplink(
   return `${scheme}://auth/callback?${params.toString()}`;
 }
 
+export function buildDesktopAuthCallbackPath(
+  accessToken: string,
+  refreshToken: string,
+  scheme?: DesktopScheme,
+  method?: AuthSignInMethod,
+) {
+  const params = new URLSearchParams({
+    flow: "desktop",
+    access_token: accessToken,
+    refresh_token: refreshToken,
+  });
+  if (scheme) {
+    params.set("scheme", scheme);
+  }
+  if (method) {
+    params.set("method", method);
+  }
+  return `/callback/auth?${params.toString()}`;
+}
+
 export function attemptDesktopAppOpen(
   deeplink: string,
   documentRef: Document = document,

--- a/apps/web/src/lib/desktop-auth-handoff.ts
+++ b/apps/web/src/lib/desktop-auth-handoff.ts
@@ -1,4 +1,5 @@
 import type { DesktopScheme } from "@/functions/desktop-flow";
+import type { AuthSignInMethod } from "@/lib/auth-last-sign-in-method";
 
 import { useMountEffect } from "../hooks/useMountEffect.ts";
 
@@ -8,6 +9,7 @@ export function buildDesktopAuthDeeplink(
   scheme: DesktopScheme,
   accessToken: string | undefined,
   refreshToken: string | undefined,
+  method?: AuthSignInMethod,
 ) {
   if (!accessToken || !refreshToken) {
     return null;
@@ -17,6 +19,9 @@ export function buildDesktopAuthDeeplink(
     access_token: accessToken,
     refresh_token: refreshToken,
   });
+  if (method) {
+    params.set("method", method);
+  }
   return `${scheme}://auth/callback?${params.toString()}`;
 }
 

--- a/apps/web/src/routes/_view/callback/auth.tsx
+++ b/apps/web/src/routes/_view/callback/auth.tsx
@@ -106,6 +106,7 @@ export const Route = createFileRoute("/_view/callback/auth")({
           scheme: search.scheme,
           access_token: result.access_token,
           refresh_token: result.refresh_token,
+          method: search.method,
           auto_open: "oauth",
         },
       });
@@ -120,6 +121,7 @@ export const Route = createFileRoute("/_view/callback/auth")({
           flow: search.flow,
           scheme: search.scheme,
           redirect: search.redirect,
+          method: search.method,
         },
       });
     }
@@ -143,6 +145,7 @@ function Component() {
     search.scheme,
     accessToken,
     refreshToken,
+    search.method,
   );
 
   useMountEffect(() => {

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -35,6 +35,7 @@ import {
   buildPostAuthDestination,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
+import { buildDesktopAuthCallbackPath } from "@/lib/desktop-auth-handoff";
 import {
   capturePrivateRouteEvent,
   identifyPrivateRouteUser,
@@ -287,12 +288,12 @@ function DesktopReauthView({
     },
     onSuccess: (result) => {
       if (result) {
-        const params = new URLSearchParams();
-        params.set("flow", "desktop");
-        params.set("scheme", scheme);
-        params.set("access_token", result.access_token);
-        params.set("refresh_token", result.refresh_token);
-        window.location.href = `/callback/auth?${params.toString()}`;
+        window.location.href = buildDesktopAuthCallbackPath(
+          result.access_token,
+          result.refresh_token,
+          scheme,
+          lastSignInMethod ?? undefined,
+        );
       }
     },
     onError: () => {
@@ -804,12 +805,12 @@ function handlePasswordSuccess(
   newAccount = false,
 ) {
   if (flow === "desktop") {
-    const params = new URLSearchParams();
-    params.set("flow", "desktop");
-    if (scheme) params.set("scheme", scheme);
-    params.set("access_token", accessToken);
-    params.set("refresh_token", refreshToken);
-    window.location.href = `/callback/auth?${params.toString()}`;
+    window.location.href = buildDesktopAuthCallbackPath(
+      accessToken,
+      refreshToken,
+      scheme,
+      "email",
+    );
   } else {
     window.location.href = buildPostAuthDestination({
       newAccount,

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -35,7 +35,10 @@ import {
   buildPostAuthDestination,
   sanitizeInternalReturnPath,
 } from "@/lib/auth-redirect";
-import { buildDesktopAuthCallbackPath } from "@/lib/desktop-auth-handoff";
+import {
+  buildDesktopAuthCallbackPath,
+  resolveDesktopAuthCallbackMethod,
+} from "@/lib/desktop-auth-handoff";
 import {
   capturePrivateRouteEvent,
   identifyPrivateRouteUser,
@@ -132,6 +135,10 @@ function Component() {
         <DesktopReauthView
           email={existingUser.email}
           scheme={scheme ?? DEFAULT_DESKTOP_SCHEME}
+          callbackMethod={resolveDesktopAuthCallbackMethod(
+            provider ?? initialView,
+            lastSignInMethod,
+          )}
           lastSignInMethod={lastSignInMethod}
         />
       </AuthShell>
@@ -272,10 +279,12 @@ function Component() {
 function DesktopReauthView({
   email,
   scheme,
+  callbackMethod,
   lastSignInMethod,
 }: {
   email: string;
   scheme: DesktopScheme;
+  callbackMethod: AuthSignInMethod | undefined;
   lastSignInMethod: AuthSignInMethod | null;
 }) {
   const retryMutation = useMutation({
@@ -292,7 +301,7 @@ function DesktopReauthView({
           result.access_token,
           result.refresh_token,
           scheme,
-          lastSignInMethod ?? undefined,
+          callbackMethod,
         );
       }
     },

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -82,6 +82,7 @@ export const Route = createFileRoute("/auth")({
               scheme: search.scheme ?? DEFAULT_DESKTOP_SCHEME,
               access_token: result.access_token,
               refresh_token: result.refresh_token,
+              method: search.provider ?? search.view,
             },
           });
         }

--- a/apps/web/src/routes/confirm-auth.tsx
+++ b/apps/web/src/routes/confirm-auth.tsx
@@ -18,6 +18,7 @@ import {
   resolveAuthFlowContext,
   toAuthFlowSearch,
 } from "@/lib/auth-flow-context";
+import { authSignInMethods } from "@/lib/auth-last-sign-in-method";
 import { buildPostAuthDestination } from "@/lib/auth-redirect";
 import { identifyPrivateRouteUser } from "@/lib/private-route-analytics";
 
@@ -35,6 +36,7 @@ const validateSearch = z.object({
   scheme: desktopSchemeSchema.optional(),
   redirect: z.string().optional(),
   redirect_to: z.string().max(2048).optional(),
+  method: z.enum(authSignInMethods).optional(),
 });
 
 export const Route = createFileRoute("/confirm-auth")({
@@ -106,6 +108,9 @@ function Component() {
         access_token: result.access_token,
         refresh_token: result.refresh_token,
       });
+      if (search.method) {
+        params.set("method", search.method);
+      }
       window.location.href = `/callback/auth?${params.toString()}`;
     },
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches auth callback handling and session deduplication; incorrect method propagation or race behavior could affect sign-in UX but not broad security surface area.
> 
> **Overview**
> Adds **last-used sign-in method** on mobile: the auth provider loads and saves the method in AsyncStorage after a successful browser handoff, exposes `lastSignInMethod` on context, and the sign-in sheet highlights the matching provider with a **Last used** badge.
> 
> The web auth handoff now carries an optional **`method`** query param through desktop/mobile deeplinks and `/callback/auth` redirects (OAuth, email password desktop flow, OTP confirm, and existing-user desktop reauth), so the app can learn the method from the callback URL when present. Mobile also **awaits** session setup on duplicate deep links by sharing in-flight `setSession` promises instead of dropping repeat callbacks.
> 
> Unit tests cover method parsing on mobile and callback/deeplink builders on web.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0132bd3d5fc10a77d8b8e5739b58cda9d22d767c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->