### PR TITLE
Stream chat replies as they generate

### DIFF
--- a/apps/desktop/src/chat/transport/index.test.ts
+++ b/apps/desktop/src/chat/transport/index.test.ts
@@ -32,7 +32,7 @@ describe("CustomChatTransport", () => {
     });
   });
 
-  it("paces streamed chat responses line by line like summary generation", async () => {
+  it("streams chat responses word by word instead of waiting for newlines", async () => {
     const transport = new CustomChatTransport({} as never, {});
 
     await transport.sendMessages({
@@ -50,8 +50,7 @@ describe("CustomChatTransport", () => {
     });
 
     expect(mocks.smoothStream).toHaveBeenCalledWith({
-      chunking: "line",
-      delayInMs: 250,
+      chunking: "word",
     });
     expect(mocks.agentStream).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/desktop/src/chat/transport/index.ts
+++ b/apps/desktop/src/chat/transport/index.ts
@@ -251,9 +251,10 @@ export class CustomChatTransport implements ChatTransport<AnlgUIMessage> {
     const result = await agent.stream({
       messages: await convertToModelMessages(messagesWithContext),
       abortSignal: options.abortSignal,
+      // Word chunking emits tokens as they arrive. Line chunking holds the
+      // whole reply until a newline, so short chat answers only appear at the end.
       experimental_transform: smoothStream({
-        chunking: "line",
-        delayInMs: 250,
+        chunking: "word",
       }),
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Chat answers showed up only after the model finished. The transport paced output line by line (`smoothStream` with `chunking: "line"` and a 250ms delay), so replies without newlines stayed buffered until generation ended.

**Fix:** Stream assistant text word by word so tokens appear as they arrive, matching typical chat UX. Summary generation still uses line pacing, which fits markdown bullets.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed transport files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` (0 errors)
- `pnpm -F desktop typecheck`
- `pnpm -F desktop test` (3606 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba7c367d-1df7-46a8-8e1e-7b7f8d339481?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba7c367d-1df7-46a8-8e1e-7b7f8d339481&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

