### PR TITLE
Stop requiring identity scopes for cloud MCP

### DIFF
--- a/crates/api-cloud/src/mcp.rs
+++ b/crates/api-cloud/src/mcp.rs
@@ -238,7 +238,7 @@ mod tests {
                 tool.meta.unwrap().get("securitySchemes"),
                 Some(&serde_json::json!([{
                     "type": "oauth2",
-                    "scopes": ["openid", "email"],
+                    "scopes": [],
                 }]))
             );
             assert_eq!(tool.output_schema.unwrap().get("type").unwrap(), "object");

--- a/crates/api-cloud/src/oauth.rs
+++ b/crates/api-cloud/src/oauth.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use crate::state::AppState;
 
-pub(crate) const OAUTH_SCOPES: &[&str] = &["openid", "email"];
+pub(crate) const OAUTH_SCOPES: &[&str] = &[];
 pub(crate) const MCP_RESOURCE: &str = "https://api.anarlog.so/mcp";
 const OPENAI_APPS_CHALLENGE: &str = "Rueo1ui7LUWfrc8duM53jXRiYcaxExDbCNrsLp2VdvU";
 
@@ -18,7 +18,8 @@ pub(crate) struct OAuthResourceConfig {
 struct ProtectedResourceMetadata {
     resource: String,
     authorization_servers: [String; 1],
-    scopes_supported: &'static [&'static str],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scopes_supported: Option<&'static [&'static str]>,
     bearer_methods_supported: [&'static str; 1],
     resource_documentation: &'static str,
 }
@@ -59,11 +60,10 @@ impl OAuthResourceConfig {
     }
 
     pub(crate) fn challenge(&self, error: Option<(&str, &str)>) -> String {
-        let mut challenge = format!(
-            "Bearer resource_metadata=\"{}\", scope=\"{}\"",
-            self.resource_metadata,
-            OAUTH_SCOPES.join(" ")
-        );
+        let mut challenge = format!("Bearer resource_metadata=\"{}\"", self.resource_metadata);
+        if !OAUTH_SCOPES.is_empty() {
+            challenge.push_str(&format!(", scope=\"{}\"", OAUTH_SCOPES.join(" ")));
+        }
         if let Some((error, description)) = error {
             challenge.push_str(&format!(
                 ", error=\"{error}\", error_description=\"{description}\""
@@ -97,7 +97,7 @@ async fn protected_resource_metadata(
     Json(ProtectedResourceMetadata {
         resource: oauth.resource().to_string(),
         authorization_servers: [oauth.authorization_server().to_string()],
-        scopes_supported: OAUTH_SCOPES,
+        scopes_supported: (!OAUTH_SCOPES.is_empty()).then_some(OAUTH_SCOPES),
         bearer_methods_supported: ["header"],
         resource_documentation: "https://docs.anarlog.so/reference/api-cloud#remote-mcp",
     })
@@ -138,10 +138,7 @@ mod tests {
                 metadata["authorization_servers"][0],
                 "https://auth.example.com/auth/v1"
             );
-            assert_eq!(
-                metadata["scopes_supported"],
-                serde_json::json!(["openid", "email"])
-            );
+            assert!(metadata.get("scopes_supported").is_none());
         }
     }
 
@@ -174,7 +171,7 @@ mod tests {
 
         assert_eq!(
             oauth.challenge(Some(("invalid_token", "Access token is invalid"))),
-            "Bearer resource_metadata=\"https://api.anarlog.so/.well-known/oauth-protected-resource/mcp\", scope=\"openid email\", error=\"invalid_token\", error_description=\"Access token is invalid\""
+            "Bearer resource_metadata=\"https://api.anarlog.so/.well-known/oauth-protected-resource/mcp\", error=\"invalid_token\", error_description=\"Access token is invalid\""
         );
     }
 }

--- a/crates/api-cloud/src/routes.rs
+++ b/crates/api-cloud/src/routes.rs
@@ -766,7 +766,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "Bearer resource_metadata=\"https://api.anarlog.so/.well-known/oauth-protected-resource/mcp\", scope=\"openid email\""
+            "Bearer resource_metadata=\"https://api.anarlog.so/.well-known/oauth-protected-resource/mcp\""
         );
         let body = to_bytes(unauthorized.into_body(), usize::MAX)
             .await
@@ -931,36 +931,12 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                 .contains("error=\"invalid_token\"")
         );
 
-        let insufficient = app
-            .clone()
-            .oneshot(
-                Request::get("/v1/meetings")
-                    .header(
-                        "authorization",
-                        format!("Bearer {}", oauth_token(&issuer, "openid")),
-                    )
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(insufficient.status(), StatusCode::FORBIDDEN);
-        assert!(
-            insufficient
-                .headers()
-                .get("www-authenticate")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .contains("error=\"insufficient_scope\"")
-        );
-
         let response = app
             .oneshot(
                 Request::get("/v1/meetings")
                     .header(
                         "authorization",
-                        format!("Bearer {}", oauth_token(&issuer, "openid email")),
+                        format!("Bearer {}", oauth_token(&issuer, "email")),
                     )
                     .body(Body::empty())
                     .unwrap(),

--- a/docs/reference/api-cloud.mdx
+++ b/docs/reference/api-cloud.mdx
@@ -78,7 +78,7 @@ It exposes the same four read-only tools as the local MCP server:
 
 Hosts that support MCP OAuth 2.1 connect your Anarlog account without a cloud API key. The host discovers Anarlog's authorization server from the MCP endpoint, opens the Anarlog sign-in and consent flow, and stores the resulting connection.
 
-The connection requests the `openid` and `email` scopes. Meeting access remains limited to the server-readable snapshots you explicitly opted in to upload. Every MCP tool is read-only, and every access token is checked for its signature, issuer, expiry, MCP resource audience, OAuth client identifier, and required scopes.
+Anarlog does not use identity scopes as meeting permissions. Meeting access remains limited to the server-readable snapshots you explicitly opted in to upload. Every MCP tool is read-only, and every access token is checked for its signature, issuer, expiry, MCP resource audience, and OAuth client identifier.
 
 Anarlog publishes OAuth protected-resource metadata at:
 


### PR DESCRIPTION
Summary:
- omit identity scopes from protected-resource and tool metadata
- accept resource-bound OAuth tokens without treating identity claims as meeting permissions
- update API tests and public docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth discovery metadata and scope enforcement for cloud connector/MCP auth; misconfiguration could affect MCP host compatibility, though meeting access still depends on resource binding and account status checks.
> 
> **Overview**
> **Cloud MCP OAuth no longer advertises or enforces `openid` / `email` as required scopes.** `OAUTH_SCOPES` is empty, so hosted tool `securitySchemes`, protected-resource metadata, and `WWW-Authenticate` challenges omit scope hints when none are configured (`scopes_supported` is dropped from metadata JSON).
> 
> Connector auth still validates resource-bound tokens (signature, issuer, expiry, MCP audience, client id) via `verify_oauth_token` with an empty required-scope list, so tokens are not rejected for missing identity scopes. Integration tests drop the `insufficient_scope` case and expect unauthorized challenges without a `scope=` parameter; the happy-path OAuth test uses a token scoped only to `email`.
> 
> Public **api-cloud** docs now state that identity scopes are not used as meeting permissions and that scope checks are no longer part of the described token validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685656dd120af53c130374e01d08468af8467d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->