### PR TITLE
Add legal notice to mobile login sheet

### DIFF
--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -9,10 +9,7 @@ import {
   useWindowDimensions,
   View,
 } from "react-native";
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from "react-native-safe-area-context";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import type { BillingInfo } from "@/auth/billing";
 import {
@@ -45,7 +42,6 @@ export function SignInScreen({
 }) {
   const [showSignInMethods, setShowSignInMethods] = useState(false);
   const { width } = useWindowDimensions();
-  const insets = useSafeAreaInsets();
 
   return (
     <SafeAreaView style={[styles.safeArea, styles.brandBackground]}>
@@ -75,12 +71,7 @@ export function SignInScreen({
         testID="sign-in-methods"
       >
         <RNHostView matchContents>
-          <View
-            style={[
-              styles.signInMethodList,
-              { width, paddingBottom: Math.max(insets.bottom, Spacing.md) },
-            ]}
-          >
+          <View style={[styles.signInMethodList, { width }]}>
             <SignInMethodButton
               method="apple"
               label="Sign in with Apple"
@@ -129,6 +120,29 @@ export function SignInScreen({
               iconSource={require("../../assets/images/auth/sso.svg")}
               lastSignInMethod={lastSignInMethod}
             />
+            <Text style={styles.legalNotice}>
+              By signing up, you agree to our{" "}
+              <Text
+                accessibilityRole="link"
+                onPress={() =>
+                  void WebBrowser.openBrowserAsync("https://anarlog.so/terms")
+                }
+                style={styles.legalLink}
+              >
+                Terms of Service
+              </Text>{" "}
+              and{" "}
+              <Text
+                accessibilityRole="link"
+                onPress={() =>
+                  void WebBrowser.openBrowserAsync("https://anarlog.so/privacy")
+                }
+                style={styles.legalLink}
+              >
+                Privacy Policy
+              </Text>
+              .
+            </Text>
           </View>
         </RNHostView>
       </BottomSheet>
@@ -351,6 +365,7 @@ const styles = StyleSheet.create({
   signInMethodList: {
     gap: Spacing.sm,
     paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.md,
   },
   signInMethodContainer: {
     position: "relative",
@@ -381,6 +396,18 @@ const styles = StyleSheet.create({
   providerIcon: {
     width: 18,
     height: 18,
+  },
+  legalNotice: {
+    alignSelf: "center",
+    maxWidth: 320,
+    marginTop: Spacing.sm,
+    ...Typography.caption,
+    color: Colors.muted,
+    textAlign: "center",
+  },
+  legalLink: {
+    color: Colors.muted,
+    textDecorationLine: "underline",
   },
   titleRow: {
     flexDirection: "row",


### PR DESCRIPTION
Reuse web login copy and links, with sheet-only bottom inset handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only copy and link handling on the sign-in sheet with no auth, billing, or data-path changes.
> 
> **Overview**
> Adds a **Terms of Service** and **Privacy Policy** disclaimer below the sign-in provider buttons in the mobile sign-in bottom sheet, matching the web auth copy and `anarlog.so` URLs. Taps open each page in the in-app browser via `WebBrowser.openBrowserAsync`.
> 
> Sheet layout no longer uses `useSafeAreaInsets` for the method list; bottom spacing is a fixed `Spacing.md` on `signInMethodList` instead of `max(insets.bottom, Spacing.md)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48a6b2f2d699d107dfabff339267b3cb335f095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->