### PR TITLE
Overlay model download actions on hover

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -825,7 +825,17 @@ function ModelSelectItem({
   const showLocalActions = model.isDownloaded && isLocalModelId(model.id);
   const isDeprecated = model.isDeprecated === true;
   const content = (
-    <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
+    <div
+      className={cn([
+        "flex min-w-0 flex-1 items-center justify-between gap-3",
+        !model.isDownloaded &&
+          !isDownloading &&
+          (isCloud
+            ? "group-focus-within:pr-24 group-hover:pr-24"
+            : "group-focus-within:pr-16 group-hover:pr-16"),
+        "transition-[padding] duration-150",
+      ])}
+    >
       <LocalModelLabel
         model={model.id}
         label={label}
@@ -907,10 +917,13 @@ function ModelSelectItem({
         </span>
       ) : (
         <button
+          type="button"
           className={cn([
             "rounded-full px-2 text-[11px] font-medium",
-            "opacity-0 group-hover:opacity-100",
-            "transition-all duration-150",
+            "pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 opacity-0",
+            "group-hover:pointer-events-auto group-hover:opacity-100",
+            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+            "transition-opacity duration-150",
             isCloud
               ? "bg-primary text-primary-foreground hover:bg-primary/90 py-1 shadow-xs hover:shadow-md dark:!bg-white dark:!text-black dark:hover:!bg-white/90"
               : "from-muted to-accent text-foreground bg-linear-to-t py-0.5 shadow-xs hover:shadow-md",


### PR DESCRIPTION
Remove idle-row action spacing and reveal the download control over the hovered or focused model row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> STT settings UI-only styling and interaction changes with no auth, data, or transcription logic impact.
> 
> **Overview**
> Undownloaded STT model rows in the settings dropdown no longer reserve space for **Download** / **Upgrade to use** when idle. Those controls are **absolutely positioned** on the right and fade in on **hover** or **keyboard focus** (`group-focus-within`), matching the overlay pattern used for downloaded-model actions.
> 
> The label/metadata row adds **transient right padding** on hover/focus (wider for cloud upgrade) so text doesn’t sit under the button, with a short padding transition. The action button gets `type="button"` and uses opacity/pointer-events toggling instead of living in the flex layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b209703233c9fce0f2a930564dbba143a02471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->