### PR TITLE
Fix live transcription provider payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22472,6 +22472,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/owhisper-client/src/adapter/google_generative_ai/batch.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/batch.rs
@@ -97,14 +97,12 @@ fn transcription_config(params: &ListenParams) -> serde_json::Value {
     });
     let language_codes = GoogleGenerativeAiAdapter::language_codes(params);
     if !language_codes.is_empty() {
-        let codes = serde_json::Value::Array(
+        config["language_codes"] = serde_json::Value::Array(
             language_codes
                 .into_iter()
                 .map(serde_json::Value::String)
                 .collect(),
         );
-        config["language_hints"] = codes.clone();
-        config["language_codes"] = codes;
     }
     config
 }
@@ -264,12 +262,12 @@ mod tests {
     }
 
     #[test]
-    fn includes_language_hints_when_selected() {
+    fn includes_supported_language_codes_when_selected() {
         let config = transcription_config(&ListenParams {
             languages: vec!["en-US".parse().unwrap()],
             ..Default::default()
         });
-        assert_eq!(config["language_hints"][0], "en-US");
+        assert!(config.get("language_hints").is_none());
         assert_eq!(config["language_codes"][0], "en-US");
     }
 

--- a/crates/owhisper-client/src/adapter/google_generative_ai/live.rs
+++ b/crates/owhisper-client/src/adapter/google_generative_ai/live.rs
@@ -96,11 +96,12 @@ impl RealtimeSttAdapter for GoogleGenerativeAiAdapter {
             );
         }
 
-        // Omitting generationConfig.responseModalities: on the current Live
-        // endpoint that field suppresses final inputTranscription segments.
         let setup = serde_json::json!({
             "setup": {
                 "model": model,
+                "generationConfig": {
+                    "responseModalities": ["TEXT"],
+                },
                 "inputAudioTranscription": input_audio_transcription,
             }
         });
@@ -341,7 +342,10 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&payload).unwrap();
 
         assert_eq!(json["setup"]["model"], "models/gemini-3.5-transcribe-live");
-        assert!(json["setup"].get("generationConfig").is_none());
+        assert_eq!(
+            json["setup"]["generationConfig"]["responseModalities"],
+            serde_json::json!(["TEXT"])
+        );
         assert_eq!(
             json["setup"]["inputAudioTranscription"]["languageCodes"][0],
             "en-US"

--- a/crates/owhisper-client/src/adapter/openai/live.rs
+++ b/crates/owhisper-client/src/adapter/openai/live.rs
@@ -137,16 +137,18 @@ impl RealtimeSttAdapter for OpenAIAdapter {
                                 .then(|| params.keywords.clone()),
                             prompt: None,
                         }),
-                        turn_detection: Some(TurnDetectionConfig {
-                            detection_type: TurnDetectionType::ServerVad,
-                            create_response: None,
-                            interrupt_response: None,
-                            idle_timeout_ms: None,
-                            eagerness: None,
-                            threshold: Some(VAD_THRESHOLD),
-                            prefix_padding_ms: Some(VAD_PREFIX_PADDING_MS),
-                            silence_duration_ms: Some(VAD_SILENCE_DURATION_MS),
-                        }),
+                        turn_detection: (model != "gpt-live-transcribe").then_some(
+                            TurnDetectionConfig {
+                                detection_type: TurnDetectionType::ServerVad,
+                                create_response: None,
+                                interrupt_response: None,
+                                idle_timeout_ms: None,
+                                eagerness: None,
+                                threshold: Some(VAD_THRESHOLD),
+                                prefix_padding_ms: Some(VAD_PREFIX_PADDING_MS),
+                                silence_duration_ms: Some(VAD_SILENCE_DURATION_MS),
+                            },
+                        ),
                         noise_reduction: None,
                     }),
                 }),
@@ -760,6 +762,11 @@ mod tests {
         );
         assert!(transcription.get("language").is_none());
         assert!(json["session"].get("include").is_none());
+        assert!(
+            json["session"]["audio"]["input"]
+                .get("turn_detection")
+                .is_none()
+        );
     }
 
     #[test]
@@ -808,6 +815,11 @@ mod tests {
         assert_eq!(
             json["session"]["include"],
             serde_json::json!(["item.input_audio_transcription.logprobs"])
+        );
+        assert!(
+            json["session"]["audio"]["input"]
+                .get("turn_detection")
+                .is_some()
         );
     }
 

--- a/crates/ws-client/Cargo.toml
+++ b/crates/ws-client/Cargo.toml
@@ -14,6 +14,7 @@ futures-util = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time", "sync", "macros"] }
 tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/ws-client/src/retry.rs
+++ b/crates/ws-client/src/retry.rs
@@ -162,10 +162,35 @@ struct RedactedRequest<'a>(&'a tokio_tungstenite::tungstenite::handshake::client
 impl fmt::Debug for RedactedRequest<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RedactedRequest")
-            .field("uri", &self.0.uri())
+            .field("uri", &redact_uri(self.0.uri()))
             .field("headers", &RedactedHeaders(self.0.headers()))
             .finish()
     }
+}
+
+fn redact_uri(uri: &tokio_tungstenite::tungstenite::http::Uri) -> String {
+    let raw = uri.to_string();
+    let Ok(mut url) = url::Url::parse(&raw) else {
+        return "<redacted-uri>".to_string();
+    };
+    let has_userinfo = !url.username().is_empty() || url.password().is_some();
+    if has_userinfo {
+        let _ = url.set_username("<redacted>");
+        let _ = url.set_password(Some("<redacted>"));
+    }
+    let has_query = url.query().is_some();
+    let pairs = url
+        .query_pairs()
+        .map(|(key, _)| (key.into_owned(), "<redacted>"))
+        .collect::<Vec<_>>();
+
+    if !has_userinfo && !has_query {
+        return raw;
+    }
+    if has_query {
+        url.query_pairs_mut().clear().extend_pairs(&pairs);
+    }
+    url.to_string()
 }
 
 struct RedactedHeaders<'a>(&'a HeaderMap<HeaderValue>);
@@ -177,10 +202,10 @@ impl fmt::Debug for RedactedHeaders<'_> {
             .iter()
             .map(|(name, value)| {
                 let key = name.as_str().to_ascii_lowercase();
-                let value = if is_sensitive_header(&key) {
-                    redact_header_value(&key, value)
-                } else {
+                let value = if is_safe_header(&key) {
                     value.to_str().unwrap_or("<non-utf8>").to_string()
+                } else {
+                    redact_header_value(&key, value)
                 };
                 (key, value)
             })
@@ -197,10 +222,19 @@ impl fmt::Debug for RedactedHeaders<'_> {
     }
 }
 
-fn is_sensitive_header(name: &str) -> bool {
+fn is_safe_header(name: &str) -> bool {
     matches!(
         name,
-        "authorization" | "proxy-authorization" | "x-api-key" | "xi-api-key" | "x-gladia-key"
+        "accept"
+            | "accept-encoding"
+            | "cache-control"
+            | "connection"
+            | "host"
+            | "pragma"
+            | "sec-websocket-key"
+            | "sec-websocket-version"
+            | "upgrade"
+            | "user-agent"
     )
 }
 
@@ -218,9 +252,12 @@ fn redact_header_value(name: &str, value: &HeaderValue) -> String {
 
 #[cfg(test)]
 mod tests {
-    use tokio_tungstenite::tungstenite::http::{HeaderMap, HeaderValue};
+    use tokio_tungstenite::tungstenite::{
+        client::IntoClientRequest,
+        http::{HeaderMap, HeaderValue},
+    };
 
-    use super::{RedactedHeaders, redact_header_value};
+    use super::{RedactedHeaders, RedactedRequest, redact_header_value};
 
     #[test]
     fn redacted_headers_redacts_sensitive_values() {
@@ -230,13 +267,63 @@ mod tests {
             HeaderValue::from_static("Token secret-key"),
         );
         headers.insert("x-api-key", HeaderValue::from_static("secret-api-key"));
+        headers.insert(
+            "x-goog-api-key",
+            HeaderValue::from_static("secret-google-key"),
+        );
+        headers.insert(
+            "ocp-apim-subscription-key",
+            HeaderValue::from_static("secret-azure-key"),
+        );
+        headers.insert("api-key", HeaderValue::from_static("secret-generic-key"));
+        headers.insert("cookie", HeaderValue::from_static("session=secret-cookie"));
+        headers.insert(
+            "x-custom-token",
+            HeaderValue::from_static("secret-custom-token"),
+        );
         headers.insert("user-agent", HeaderValue::from_static("ws-client/0.1.0"));
 
         let redacted = format!("{:?}", RedactedHeaders(&headers));
 
         assert!(redacted.contains("(\"authorization\", \"Token <redacted>\")"));
         assert!(redacted.contains("(\"x-api-key\", \"<redacted>\")"));
+        assert!(redacted.contains("(\"x-goog-api-key\", \"<redacted>\")"));
+        assert!(redacted.contains("(\"ocp-apim-subscription-key\", \"<redacted>\")"));
+        assert!(redacted.contains("(\"api-key\", \"<redacted>\")"));
+        assert!(redacted.contains("(\"cookie\", \"<redacted>\")"));
+        assert!(redacted.contains("(\"x-custom-token\", \"<redacted>\")"));
         assert!(redacted.contains("(\"user-agent\", \"ws-client/0.1.0\")"));
+        assert!(!redacted.contains("secret-google-key"));
+        assert!(!redacted.contains("secret-azure-key"));
+        assert!(!redacted.contains("secret-generic-key"));
+        assert!(!redacted.contains("secret-cookie"));
+        assert!(!redacted.contains("secret-custom-token"));
+    }
+
+    #[test]
+    fn redacted_request_hides_query_and_header_credentials() {
+        let mut request = "wss://username-secret:secret-password@example.com/live?key=secret-query-key&provider=google_generative_ai&access_token=secret-access-token&apikey=secret-alias-key"
+            .into_client_request()
+            .unwrap();
+        request.headers_mut().insert(
+            "x-goog-api-key",
+            HeaderValue::from_static("secret-header-key"),
+        );
+
+        let redacted = format!("{:?}", RedactedRequest(&request));
+
+        assert!(redacted.contains("example.com/live?"));
+        assert!(redacted.contains("key=%3Credacted%3E"));
+        assert!(redacted.contains("provider=%3Credacted%3E"));
+        assert!(redacted.contains("access_token=%3Credacted%3E"));
+        assert!(redacted.contains("apikey=%3Credacted%3E"));
+        assert!(redacted.contains("(\"x-goog-api-key\", \"<redacted>\")"));
+        assert!(!redacted.contains("username-secret"));
+        assert!(!redacted.contains("secret-password"));
+        assert!(!redacted.contains("secret-query-key"));
+        assert!(!redacted.contains("secret-access-token"));
+        assert!(!redacted.contains("secret-alias-key"));
+        assert!(!redacted.contains("secret-header-key"));
     }
 
     #[test]


### PR DESCRIPTION
Align OpenAI and Gemini requests with provider contracts and redact WebSocket credentials from diagnostic logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live STT session payloads for OpenAI and Gemini, which can affect transcription behavior; logging changes reduce credential exposure with low runtime risk.
> 
> **Overview**
> Aligns **Google** and **OpenAI** live/batch request shapes with current provider contracts, and tightens **WebSocket connect** logging so credentials do not leak.
> 
> **Google Generative AI:** Batch transcription now sends only `language_codes` (drops duplicate `language_hints`). Live setup again includes `generationConfig.responseModalities: ["TEXT"]`.
> 
> **OpenAI:** For `gpt-live-transcribe`, server VAD `turn_detection` is omitted from the session update; other live models still send it.
> 
> **ws-client:** Connect retry logs redact URI userinfo and all query values, and use an allowlist of safe headers so API keys, cookies, and other auth headers are redacted by default. Adds `url` for URI parsing and expands redaction tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df6a91b1531cf6edac5e577b9ef10a260c0021b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->