### PR TITLE
fix(desktop): keep sidebar resize cursor visible on Windows

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -289,6 +289,9 @@ describe("ClassicMainBody", () => {
       "after:w-2",
     );
     expect(screen.getByTestId("resize-handle").dataset.className).toContain(
+      "cursor-ew-resize",
+    );
+    expect(screen.getByTestId("resize-handle").dataset.className).toContain(
       "w-1",
     );
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -529,7 +529,7 @@ export function ClassicMainBody({
             </ResizablePanel>
             <ResizableHandle
               className={cn([
-                "z-10 !bg-transparent after:w-2",
+                "z-10 cursor-ew-resize !bg-transparent after:w-2",
                 showLeftSidebarPanel && canResizeLeftSidebarPanel
                   ? "w-1"
                   : "pointer-events-none w-0 after:w-0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small styling change on the sidebar resize handle with a test update; no auth, data, or layout logic changes.
> 
> **Overview**
> The classic main left sidebar **resize handle** now includes the `cursor-ew-resize` Tailwind class so the horizontal resize cursor shows when hovering the divider.
> 
> On desktop, global cursor styles force `default` on most elements; explicit `cursor-ew-resize` (and matching rules in `cursor.css`) restores the expected east–west resize affordance on Windows. A **body test** asserts the handle’s class list includes `cursor-ew-resize` when the sidebar is resizable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ca902b6e991faeeb82d448f24048b46d2dc094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->