### PR TITLE
Prevent stale subscription webhook state

### DIFF
--- a/apps/stripe/src/integration/create-stripe-sync.test.ts
+++ b/apps/stripe/src/integration/create-stripe-sync.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import type Stripe from "stripe";
+
+import { createStripeSync } from "./create-stripe-sync";
+
+describe("createStripeSync", () => {
+  it("revalidates subscription events before writing them", async () => {
+    const sync = createStripeSync({
+      databaseUrl: "postgres://localhost/stripe_sync_test",
+      stripeApiVersion: "2026-02-25.clover",
+      stripeSecretKey: "test-secret",
+      stripeWebhookSecret: "test-webhook-secret",
+    });
+    const eventCreated = 1_700_000_000;
+    const webhookSubscription = {
+      id: "sub_test",
+      object: "subscription",
+      status: "trialing",
+    } as Stripe.Subscription;
+    const currentSubscription = {
+      ...webhookSubscription,
+      status: "active",
+    } as Stripe.Subscription;
+    const retrievedIds: string[] = [];
+    const upserts: Array<{
+      subscriptions: Stripe.Subscription[];
+      syncTimestamp?: string;
+    }> = [];
+
+    sync.stripe.subscriptions.retrieve = (async (id: string) => {
+      retrievedIds.push(id);
+      return currentSubscription;
+    }) as typeof sync.stripe.subscriptions.retrieve;
+    sync.upsertSubscriptions = (async (
+      subscriptions: Stripe.Subscription[],
+      _backfillRelatedEntities?: boolean,
+      syncTimestamp?: string,
+    ) => {
+      upserts.push({ subscriptions, syncTimestamp });
+      return subscriptions;
+    }) as typeof sync.upsertSubscriptions;
+
+    try {
+      await sync.processEvent({
+        id: "evt_subscription_updated",
+        type: "customer.subscription.updated",
+        created: eventCreated,
+        data: { object: webhookSubscription },
+      } as Stripe.Event);
+    } finally {
+      await sync.postgresClient.pool.end();
+    }
+
+    expect(retrievedIds).toEqual(["sub_test"]);
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]?.subscriptions).toEqual([currentSubscription]);
+    expect(new Date(upserts[0]?.syncTimestamp ?? 0).getTime()).toBeGreaterThan(
+      eventCreated * 1_000,
+    );
+  });
+});

--- a/apps/stripe/src/integration/create-stripe-sync.ts
+++ b/apps/stripe/src/integration/create-stripe-sync.ts
@@ -1,0 +1,25 @@
+import { StripeSync } from "@supabase/stripe-sync-engine";
+
+export function createStripeSync({
+  databaseUrl,
+  stripeApiVersion,
+  stripeSecretKey,
+  stripeWebhookSecret,
+}: {
+  databaseUrl: string;
+  stripeApiVersion: string;
+  stripeSecretKey: string;
+  stripeWebhookSecret: string;
+}) {
+  return new StripeSync({
+    schema: "stripe",
+    poolConfig: { connectionString: databaseUrl },
+    stripeSecretKey,
+    stripeWebhookSecret,
+    stripeApiVersion,
+    backfillRelatedEntities: true,
+    // Stripe event timestamps have one-second precision, so same-second lifecycle
+    // events must reconcile against the current subscription instead of payload order.
+    revalidateObjectsViaStripeApi: ["subscription"],
+  });
+}

--- a/apps/stripe/src/integration/stripe-sync.ts
+++ b/apps/stripe/src/integration/stripe-sync.ts
@@ -1,13 +1,10 @@
-import { StripeSync } from "@supabase/stripe-sync-engine";
-
 import { env } from "../env";
+import { createStripeSync } from "./create-stripe-sync";
 import { STRIPE_API_VERSION } from "./stripe";
 
-export const stripeSync = new StripeSync({
-  schema: "stripe",
-  poolConfig: { connectionString: env.DATABASE_URL },
+export const stripeSync = createStripeSync({
+  databaseUrl: env.DATABASE_URL,
   stripeSecretKey: env.STRIPE_SECRET_KEY,
   stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
   stripeApiVersion: STRIPE_API_VERSION,
-  backfillRelatedEntities: true,
 });


### PR DESCRIPTION
Revalidate subscription objects against Stripe before syncing webhook state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how subscription webhook data is persisted and adds Stripe API reads on those events, which affects billing sync correctness and external call volume.
> 
> **Overview**
> **Prevents stale subscription rows when webhook payloads lag behind Stripe’s current state** (e.g. same-second lifecycle events with one-second timestamp precision).
> 
> Stripe sync setup is moved into a shared `createStripeSync` factory that turns on `revalidateObjectsViaStripeApi: ["subscription"]`, so subscription webhook handling refetches the subscription from Stripe before upserting instead of trusting the event object alone. The app’s `stripeSync` singleton now uses that factory; behavior otherwise matches the previous config (`backfillRelatedEntities`, schema, credentials).
> 
> A Bun integration test drives `customer.subscription.updated` through `processEvent` and asserts the subscription is retrieved by id and the upsert uses the API snapshot (not the webhook payload) with a sync timestamp after the event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d0aea206c8d5a4516a9b20f5a9107d30106ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->