### PR TITLE
Skip net-zero CloudSync alters that stall large-db startup

### DIFF
--- a/apps/desktop/src-tauri/src/search_index.rs
+++ b/apps/desktop/src-tauri/src/search_index.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use chrono::DateTime;
 use serde_json::{Map, Value};
 use sqlx::{Connection, Row, SqlitePool};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_tantivy::{
     SearchDocument, SearchFilters, SearchOptions, SearchRequest, TantivyPluginExt,
 };
@@ -47,6 +47,9 @@ async fn run(app: AppHandle, db: Arc<anlg_db_core::Db>) {
     let mut changes = db.change_notifier().subscribe();
 
     wait_for_tantivy(&app).await;
+    if !wait_for_database_ready(&app).await {
+        return;
+    }
 
     loop {
         match initialize(&app, db.pool()).await {
@@ -89,6 +92,21 @@ async fn run(app: AppHandle, db: Arc<anlg_db_core::Db>) {
             }
             _ = tokio::time::sleep(RETRY_INTERVAL) => {}
         }
+    }
+}
+
+async fn wait_for_database_ready(app: &AppHandle) -> bool {
+    loop {
+        if let Some(runtime) = app.try_state::<tauri_plugin_db::ManagedState>() {
+            return match runtime.wait_until_ready().await {
+                Ok(()) => true,
+                Err(error) => {
+                    tracing::error!(%error, "search index waiting for database startup failed");
+                    false
+                }
+            };
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }
 

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -442,7 +442,6 @@ const E2EE_REPLICA_PAYLOAD_HASHES_MIGRATION_VERSION: i64 = 20260816100000;
 const CURRENT_E2EE_PAYLOAD_HASH_LOCAL_STATE_CHECKSUM: &str = "1e0da0d8b5a524adf12cf1bb5a9c3910f922c9c2e7feb9c1f2704c4b093af41b50519083546409fe55a0d9d9f6f12f5a";
 const E2EE_PAYLOAD_HASH_LOCAL_STATE_ALTER: &str =
     "ALTER TABLE e2ee_records DROP COLUMN payload_hash;";
-const E2EE_PAYLOAD_HASH_LOCAL_STATE_STEP_ID: &str = "20260816100100_e2ee_payload_hash_local_state";
 
 #[derive(Debug)]
 pub enum AppSchemaError {
@@ -509,23 +508,8 @@ pub async fn prepare_schema_with_progress(
     adopt_legacy_mobile_schema_migration(db.pool()).await?;
     repair_legacy_shared_session_cache_migration(db.pool()).await?;
     repair_legacy_attachment_transfer_jobs_migration(db.pool()).await?;
-    // 1.4.15 added payload_hash to e2ee_records and 1.4.x dropped it again. Each
-    // CloudSync alter rewrites change-tracking on the whole replica; on large
-    // databases that stalls startup for many minutes even though the net schema
-    // is unchanged. Skip both alters when the add has not already been applied.
-    let e2ee_payload_hash_alter_already_applied =
-        successful_migration_exists(db.pool(), E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION).await?;
-    adopt_e2ee_record_payload_hash_alter(db.pool()).await?;
     repair_torn_e2ee_payload_hash_local_state_migration(db).await?;
-    anlg_db_migrate::migrate_with_progress(
-        db,
-        schema_before(E2EE_PAYLOAD_HASH_LOCAL_STATE_STEP_ID),
-        &mut on_migration_progress,
-    )
-    .await?;
-    if !e2ee_payload_hash_alter_already_applied {
-        apply_e2ee_payload_hash_local_state_without_drop_column(db, false).await?;
-    }
+    apply_net_zero_e2ee_payload_hash_alters(db, &mut on_migration_progress).await?;
     anlg_db_migrate::migrate_with_progress(db, schema(), on_migration_progress).await?;
     repair_missing_core_tables(db.pool(), templates_missing_before_migration).await?;
     backfill_session_share_activation(db.pool()).await?;
@@ -1013,17 +997,6 @@ async fn repair_legacy_shared_session_cache_migration(
     Ok(())
 }
 
-fn schema_before(id: &str) -> anlg_db_migrate::DbSchema {
-    let index = APP_MIGRATION_STEPS
-        .iter()
-        .position(|step| step.id == id)
-        .expect("migration step id must exist");
-    anlg_db_migrate::DbSchema {
-        steps: &APP_MIGRATION_STEPS[..index],
-        validate_cloudsync_table: cloudsync_alter_guard_required,
-    }
-}
-
 async fn successful_migration_exists(
     pool: &sqlx::SqlitePool,
     version: i64,
@@ -1049,34 +1022,137 @@ async fn successful_migration_exists(
     .await
 }
 
-async fn adopt_e2ee_record_payload_hash_alter(
-    pool: &sqlx::SqlitePool,
+async fn apply_net_zero_e2ee_payload_hash_alters(
+    db: &anlg_db_core::Db,
+    on_migration_progress: &mut (impl FnMut(anlg_db_migrate::MigrationProgress) + Send),
 ) -> Result<(), AppSchemaError> {
-    if successful_migration_exists(pool, E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION).await? {
+    if successful_migration_exists(db.pool(), E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION).await? {
+        return Ok(());
+    }
+    let e2ee_records_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'e2ee_records'
+        )",
+    )
+    .fetch_one(db.pool())
+    .await?;
+    if !e2ee_records_exists {
         return Ok(());
     }
 
-    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
-    sqlx::raw_sql(
-        "CREATE TABLE IF NOT EXISTS _sqlx_migrations (
-            version BIGINT PRIMARY KEY,
-            description TEXT NOT NULL,
-            installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            success BOOLEAN NOT NULL,
-            checksum BLOB NOT NULL,
-            execution_time BIGINT NOT NULL
-        );",
-    )
-    .execute(&mut *transaction)
-    .await?;
-    adopt_legacy_mobile_migration(
-        &mut transaction,
+    const PAIR: &[(i64, &str, &str)] = &[
+        (
+            E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION,
+            "e2ee_record_payload_hash",
+            include_str!("../migrations/20260815100300_e2ee_record_payload_hash.sql"),
+        ),
+        (
+            20260815100400,
+            "e2ee_ciphertext_ownership",
+            include_str!("../migrations/20260815100400_e2ee_ciphertext_ownership.sql"),
+        ),
+        (
+            E2EE_REPLICA_PAYLOAD_HASHES_MIGRATION_VERSION,
+            "e2ee_replica_payload_hashes",
+            include_str!("../migrations/20260816100000_e2ee_replica_payload_hashes.sql"),
+        ),
+        (
+            E2EE_PAYLOAD_HASH_LOCAL_STATE_MIGRATION_VERSION,
+            "e2ee_payload_hash_local_state",
+            include_str!("../migrations/20260816100100_e2ee_payload_hash_local_state.sql"),
+        ),
+    ];
+    let drop_checksum = migration_checksum(PAIR[3].2);
+    if checksum_hex(&drop_checksum) != CURRENT_E2EE_PAYLOAD_HASH_LOCAL_STATE_CHECKSUM {
+        return Err(AppSchemaError::E2eePayloadHashLocalStateRepair(
+            "compiled e2ee payload-hash migration has an unexpected checksum",
+        ));
+    }
+
+    let mut transaction = db.pool().begin_with("BEGIN IMMEDIATE").await?;
+    if successful_migration_exists_on(
+        &mut *transaction,
         E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION,
-        "e2ee_record_payload_hash",
-        include_str!("../migrations/20260815100300_e2ee_record_payload_hash.sql"),
     )
-    .await?;
+    .await?
+    {
+        transaction.commit().await?;
+        return Ok(());
+    }
+
+    // One alter window around the temporary payload_hash column so CloudSync
+    // never records a schema change. The final table matches the snapshot
+    // taken at begin_alter, so commit_alter only restores tracking.
+    let cloudsync_alter = db.cloudsync_enabled()
+        && anlg_db_core::cloudsync_is_enabled_on(&mut *transaction, "e2ee_records").await?;
+    if cloudsync_alter {
+        anlg_db_core::cloudsync_begin_alter_on(&mut *transaction, "e2ee_records").await?;
+    }
+
+    for (index, (version, description, sql)) in PAIR.iter().enumerate() {
+        on_migration_progress(anlg_db_migrate::MigrationProgress {
+            completed: index,
+            total: PAIR.len(),
+        });
+        if successful_migration_exists_on(&mut *transaction, *version).await? {
+            continue;
+        }
+        sqlx::raw_sql(sqlx::AssertSqlSafe(*sql))
+            .execute(&mut *transaction)
+            .await?;
+        insert_successful_migration(
+            &mut transaction,
+            *version,
+            description,
+            &migration_checksum(sql),
+        )
+        .await?;
+    }
+    on_migration_progress(anlg_db_migrate::MigrationProgress {
+        completed: PAIR.len(),
+        total: PAIR.len(),
+    });
+
+    if cloudsync_alter {
+        anlg_db_core::cloudsync_commit_alter_on(&mut *transaction, "e2ee_records").await?;
+    }
     transaction.commit().await?;
+    Ok(())
+}
+
+async fn successful_migration_exists_on<'e, E>(
+    executor: E,
+    version: i64,
+) -> Result<bool, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = ? AND success = 1
+        )",
+    )
+    .bind(version)
+    .fetch_one(executor)
+    .await
+}
+
+async fn insert_successful_migration(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    version: i64,
+    description: &'static str,
+    checksum: &[u8],
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO _sqlx_migrations (
+            version, description, success, checksum, execution_time
+         ) VALUES (?, ?, 1, ?, 0)",
+    )
+    .bind(version)
+    .bind(description)
+    .bind(checksum)
+    .execute(&mut **transaction)
+    .await?;
     Ok(())
 }
 

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -436,11 +436,13 @@ const LEGACY_ATTACHMENT_TRANSFER_JOBS_CHECKSUM: &str = "fd846a54c653d8e737371a95
 const CURRENT_ATTACHMENT_TRANSFER_JOBS_CHECKSUM: &str = "9250233e7b51b83bb74ef4e4af159a9c2bbc753ee64751cac8316968b66bb1b2e0e224770d8b63a631350183dc81c2e0";
 const LEGACY_ATTACHMENT_TRANSFER_JOBS_SCHEMA_CHECKSUM: &str = "5702d2831ccfe75bfca957aa6d37cacc54347090c0d106aaaa9c3af124fcf7e57e49b0432ad5191ff3075f2d9d489916";
 const CURRENT_ATTACHMENT_TRANSFER_JOBS_SCHEMA_CHECKSUM: &str = "3beb182b60f84e0f53ae6069fc7a6e4ba28e51e87d37e4fda7e5ab9b8e8ca713bd43bb8bd79100c6116a4d23dfff55ef";
+const E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION: i64 = 20260815100300;
 const E2EE_PAYLOAD_HASH_LOCAL_STATE_MIGRATION_VERSION: i64 = 20260816100100;
 const E2EE_REPLICA_PAYLOAD_HASHES_MIGRATION_VERSION: i64 = 20260816100000;
 const CURRENT_E2EE_PAYLOAD_HASH_LOCAL_STATE_CHECKSUM: &str = "1e0da0d8b5a524adf12cf1bb5a9c3910f922c9c2e7feb9c1f2704c4b093af41b50519083546409fe55a0d9d9f6f12f5a";
 const E2EE_PAYLOAD_HASH_LOCAL_STATE_ALTER: &str =
     "ALTER TABLE e2ee_records DROP COLUMN payload_hash;";
+const E2EE_PAYLOAD_HASH_LOCAL_STATE_STEP_ID: &str = "20260816100100_e2ee_payload_hash_local_state";
 
 #[derive(Debug)]
 pub enum AppSchemaError {
@@ -501,13 +503,29 @@ pub async fn prepare_schema(db: &anlg_db_core::Db) -> Result<(), AppSchemaError>
 
 pub async fn prepare_schema_with_progress(
     db: &anlg_db_core::Db,
-    on_migration_progress: impl FnMut(anlg_db_migrate::MigrationProgress) + Send,
+    mut on_migration_progress: impl FnMut(anlg_db_migrate::MigrationProgress) + Send,
 ) -> Result<(), AppSchemaError> {
     let templates_missing_before_migration = !templates_table_exists(db.pool()).await?;
     adopt_legacy_mobile_schema_migration(db.pool()).await?;
     repair_legacy_shared_session_cache_migration(db.pool()).await?;
     repair_legacy_attachment_transfer_jobs_migration(db.pool()).await?;
+    // 1.4.15 added payload_hash to e2ee_records and 1.4.x dropped it again. Each
+    // CloudSync alter rewrites change-tracking on the whole replica; on large
+    // databases that stalls startup for many minutes even though the net schema
+    // is unchanged. Skip both alters when the add has not already been applied.
+    let e2ee_payload_hash_alter_already_applied =
+        successful_migration_exists(db.pool(), E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION).await?;
+    adopt_e2ee_record_payload_hash_alter(db.pool()).await?;
     repair_torn_e2ee_payload_hash_local_state_migration(db).await?;
+    anlg_db_migrate::migrate_with_progress(
+        db,
+        schema_before(E2EE_PAYLOAD_HASH_LOCAL_STATE_STEP_ID),
+        &mut on_migration_progress,
+    )
+    .await?;
+    if !e2ee_payload_hash_alter_already_applied {
+        apply_e2ee_payload_hash_local_state_without_drop_column(db, false).await?;
+    }
     anlg_db_migrate::migrate_with_progress(db, schema(), on_migration_progress).await?;
     repair_missing_core_tables(db.pool(), templates_missing_before_migration).await?;
     backfill_session_share_activation(db.pool()).await?;
@@ -995,12 +1013,86 @@ async fn repair_legacy_shared_session_cache_migration(
     Ok(())
 }
 
+fn schema_before(id: &str) -> anlg_db_migrate::DbSchema {
+    let index = APP_MIGRATION_STEPS
+        .iter()
+        .position(|step| step.id == id)
+        .expect("migration step id must exist");
+    anlg_db_migrate::DbSchema {
+        steps: &APP_MIGRATION_STEPS[..index],
+        validate_cloudsync_table: cloudsync_alter_guard_required,
+    }
+}
+
+async fn successful_migration_exists(
+    pool: &sqlx::SqlitePool,
+    version: i64,
+) -> Result<bool, sqlx::Error> {
+    let migration_table_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'table' AND name = '_sqlx_migrations'
+        )",
+    )
+    .fetch_one(pool)
+    .await?;
+    if !migration_table_exists {
+        return Ok(false);
+    }
+    sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = ? AND success = 1
+        )",
+    )
+    .bind(version)
+    .fetch_one(pool)
+    .await
+}
+
+async fn adopt_e2ee_record_payload_hash_alter(
+    pool: &sqlx::SqlitePool,
+) -> Result<(), AppSchemaError> {
+    if successful_migration_exists(pool, E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION).await? {
+        return Ok(());
+    }
+
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    sqlx::raw_sql(
+        "CREATE TABLE IF NOT EXISTS _sqlx_migrations (
+            version BIGINT PRIMARY KEY,
+            description TEXT NOT NULL,
+            installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            success BOOLEAN NOT NULL,
+            checksum BLOB NOT NULL,
+            execution_time BIGINT NOT NULL
+        );",
+    )
+    .execute(&mut *transaction)
+    .await?;
+    adopt_legacy_mobile_migration(
+        &mut transaction,
+        E2EE_RECORD_PAYLOAD_HASH_MIGRATION_VERSION,
+        "e2ee_record_payload_hash",
+        include_str!("../migrations/20260815100300_e2ee_record_payload_hash.sql"),
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(())
+}
+
 // Builds of 1.4.10 without the transactional CloudsyncAlter runner executed
 // this migration statement-by-statement with autocommit, so a force-quit after
 // the ALTER left the column dropped, some views/triggers missing, and no
 // history row. The re-run then dies on the ALTER with "no such column".
 async fn repair_torn_e2ee_payload_hash_local_state_migration(
     db: &anlg_db_core::Db,
+) -> Result<(), AppSchemaError> {
+    apply_e2ee_payload_hash_local_state_without_drop_column(db, true).await
+}
+
+async fn apply_e2ee_payload_hash_local_state_without_drop_column(
+    db: &anlg_db_core::Db,
+    refresh_stale_cloudsync_schema: bool,
 ) -> Result<(), AppSchemaError> {
     let pool = db.pool();
     let migration_table_exists: bool = sqlx::query_scalar(
@@ -1048,7 +1140,10 @@ async fn repair_torn_e2ee_payload_hash_local_state_migration(
     // for e2ee_records still describes the dropped column. Redo the alter
     // window around the repair so commit_alter records the current schema;
     // otherwise sync fails with a schema-hash mismatch after the unbrick.
-    let cloudsync_alter = db.cloudsync_enabled()
+    // Net-zero upgrades never told CloudSync about payload_hash, so refreshing
+    // the hash would only rewrite change-tracking for no schema change.
+    let cloudsync_alter = refresh_stale_cloudsync_schema
+        && db.cloudsync_enabled()
         && anlg_db_core::cloudsync_is_enabled_on(&mut *transaction, "e2ee_records").await?;
     if cloudsync_alter {
         anlg_db_core::cloudsync_begin_alter_on(&mut *transaction, "e2ee_records").await?;

--- a/crates/db-app/src/schema_tests/encrypted_replica.rs
+++ b/crates/db-app/src/schema_tests/encrypted_replica.rs
@@ -1293,3 +1293,155 @@ async fn e2ee_payload_hash_repair_leaves_cleanly_migrated_databases_alone() {
     assert_eq!(checksum_before, checksum_after);
     assert_eq!(before, e2ee_schema_objects(&db).await);
 }
+
+#[tokio::test]
+async fn prepare_schema_skips_net_zero_e2ee_payload_hash_alters() {
+    let clean_db = test_db().await;
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260815100300_e2ee_record_payload_hash"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+
+    prepare_schema(&db).await.unwrap();
+
+    let add_applied: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = 20260815100300 AND success = 1
+        )",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    let drop_applied: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM _sqlx_migrations WHERE version = 20260816100100 AND success = 1
+        )",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(add_applied);
+    assert!(drop_applied);
+
+    let payload_hash_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM pragma_table_info('e2ee_records') WHERE name = 'payload_hash'
+        )",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(!payload_hash_exists);
+    assert_eq!(
+        e2ee_schema_objects(&db).await,
+        e2ee_schema_objects(&clean_db).await
+    );
+}
+
+#[tokio::test]
+async fn prepare_schema_still_drops_an_already_applied_payload_hash_column() {
+    let db = Db::connect_memory_plain().await.unwrap();
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260816100100_e2ee_payload_hash_local_state"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+
+    let payload_hash_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM pragma_table_info('e2ee_records') WHERE name = 'payload_hash'
+        )",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(payload_hash_exists);
+
+    prepare_schema(&db).await.unwrap();
+
+    let payload_hash_exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM pragma_table_info('e2ee_records') WHERE name = 'payload_hash'
+        )",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(!payload_hash_exists);
+}
+
+#[cfg(any(
+    all(test, target_os = "macos", target_arch = "aarch64"),
+    all(test, target_os = "macos", target_arch = "x86_64"),
+    all(test, target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+    all(test, target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+    all(
+        test,
+        target_os = "linux",
+        target_env = "musl",
+        target_arch = "aarch64"
+    ),
+    all(test, target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+    all(test, target_os = "windows", target_arch = "x86_64"),
+))]
+#[tokio::test]
+async fn prepare_schema_does_not_rewrite_cloudsync_for_net_zero_payload_hash_alters() {
+    async fn open_cloudsync_db(path: &std::path::Path) -> Db {
+        Db::open(anlg_db_core::DbOpenOptions {
+            storage: anlg_db_core::DbStorage::Local(path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap()
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_cloudsync_db(&dir.path().join("app.db")).await;
+    anlg_db_migrate::migrate(
+        &db,
+        anlg_db_migrate::DbSchema {
+            steps: migration_steps_before("20260815100300_e2ee_record_payload_hash"),
+            validate_cloudsync_table: cloudsync_alter_guard_required,
+        },
+    )
+    .await
+    .unwrap();
+    db.cloudsync_init("e2ee_records", None, None).await.unwrap();
+
+    let versions_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cloudsync_schema_versions")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    let hash_before: i64 =
+        sqlx::query_scalar("SELECT hash FROM cloudsync_schema_versions ORDER BY seq DESC LIMIT 1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+    prepare_schema(&db).await.unwrap();
+
+    let versions_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cloudsync_schema_versions")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    let hash_after: i64 =
+        sqlx::query_scalar("SELECT hash FROM cloudsync_schema_versions ORDER BY seq DESC LIMIT 1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(versions_before, versions_after);
+    assert_eq!(hash_before, hash_after);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Stable `desktop_v1.4.15` startup can sit on *Migrating your local database* for many minutes on large E2EE databases. The released `e2ee_records.payload_hash` add/drop pair is a net-zero CloudSync schema change, but each `cloudsync_commit_alter` rewrites change-tracking on the whole replica (observed at ~13 minutes). Search-index also starts during that window, hits `database is locked`, then queries a partial schema (`no such column: locked`).

**Fix:** When that add has not already been applied, `prepare_schema` runs the add, ciphertext-ownership, replica-hash, and drop steps in one CloudSync alter window. The final table matches the pre-add schema, so `commit_alter` restores tracking instead of rewriting the replica twice. Torn upgrades that already committed the add still refresh the CloudSync schema hash. Search-index waits for database startup before querying.

Fixes [ANLG-310](https://linear.app/fastrepl-inc/issue/ANLG-310/avoid-net-zero-cloudsync-alters-that-stall-stable-startup-on-large).

## Verification

- `cargo test --locked -p db-app --lib` — 199 passed
- `cargo clippy --locked -p db-app --all-targets --no-deps -- -D warnings` — passed
- `rustfmt --edition 2024 --check` on the changed files — passed
- `cargo test --locked -p desktop --lib search_index` — skipped locally: `gdk-3.0.pc` is not installed in this environment (runtime GTK is present, dev headers are not)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d83ee655-9a5d-44e3-a502-f0516b933017?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d83ee655-9a5d-44e3-a502-f0516b933017&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

