### PR TITLE
Restrict admin access and rename repository token

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -329,7 +329,7 @@ jobs:
           FILENAME="hyprnote-staging-${TIMESTAMP}-${COMMIT_HASH}-macos-${{ matrix.arch }}.dmg"
           cp "$DMG_FILE" "$FILENAME"
           aws s3 cp "$FILENAME" \
-            "s3://hyprnote-build/desktop/staging/$FILENAME" \
+            "s3://anarlog-build/desktop/staging/$FILENAME" \
             --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
             --region auto
         env:
@@ -561,7 +561,7 @@ jobs:
             done
           done
           aws s3 cp "$upload_dir/" \
-            s3://hyprnote-build/desktop/staging/ \
+            s3://anarlog-build/desktop/staging/ \
             --recursive \
             --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
             --region auto

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -655,7 +655,7 @@ jobs:
           gpg --batch --verify "$release_dir/Release.gpg" "$release_dir/Release"
       - name: Open the Linux package bump pull request
         env:
-          GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+          GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
           VERSION: ${{ needs.parse.outputs.version }}
         run: |
           if git diff --quiet -- packaging/aur/anarlog-bin apps/web/public/apt; then

--- a/.github/workflows/download_staging.yaml
+++ b/.github/workflows/download_staging.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           PLATFORM="${{ inputs.platform }}"
 
-          LATEST_FILE=$(aws s3 ls "s3://hyprnote-build/desktop/staging/" \
+          LATEST_FILE=$(aws s3 ls "s3://anarlog-build/desktop/staging/" \
             --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
             --region auto | grep "hyprnote-staging-.*-${PLATFORM}" | sort -r | head -1 | awk '{print $4}')
 
@@ -27,7 +27,7 @@ jobs:
 
           echo "Latest staging build: $LATEST_FILE"
 
-          aws s3 cp "s3://hyprnote-build/desktop/staging/$LATEST_FILE" \
+          aws s3 cp "s3://anarlog-build/desktop/staging/$LATEST_FILE" \
             "./$LATEST_FILE" \
             --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
             --region auto

--- a/.github/workflows/handle_release.yaml
+++ b/.github/workflows/handle_release.yaml
@@ -56,7 +56,7 @@ jobs:
           MERGE_SHA=$(echo "$PR_DATA" | jq -r '.merge_commit_sha')
           TEMP_BRANCH="release-temp-${MERGE_SHA:0:8}"
 
-          GH_TOKEN=${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }} gh api repos/$REPO/git/refs -f ref="refs/heads/$TEMP_BRANCH" -f sha="$MERGE_SHA"
+          GH_TOKEN=${{ secrets.REPO_GITHUB_TOKEN }} gh api repos/$REPO/git/refs -f ref="refs/heads/$TEMP_BRANCH" -f sha="$MERGE_SHA"
 
           echo "resolved=true" >> $GITHUB_OUTPUT
           echo "target_sha=$MERGE_SHA" >> $GITHUB_OUTPUT
@@ -110,5 +110,5 @@ jobs:
           data: ${{ steps.result.outputs.data }}
       - if: ${{ always() && steps.resolve.outputs.resolved == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+          GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
         run: gh api repos/${{ github.repository }}/git/refs/heads/${{ steps.resolve.outputs.branch }} -X DELETE || true

--- a/.github/workflows/handle_staging.yaml
+++ b/.github/workflows/handle_staging.yaml
@@ -56,7 +56,7 @@ jobs:
               output_ref "$EXPLICIT_REF" "$SHA" "$EXPLICIT_REF" "false"
             else
               TEMP_BRANCH="staging-temp-${SHA:0:8}"
-              GH_TOKEN=${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }} gh api repos/$REPO/git/refs -f ref="refs/heads/$TEMP_BRANCH" -f sha="$SHA"
+              GH_TOKEN=${{ secrets.REPO_GITHUB_TOKEN }} gh api repos/$REPO/git/refs -f ref="refs/heads/$TEMP_BRANCH" -f sha="$SHA"
               output_ref "$EXPLICIT_REF" "$SHA" "$TEMP_BRANCH" "true"
             fi
           fi
@@ -105,5 +105,5 @@ jobs:
           data: ${{ steps.result.outputs.data }}
       - if: ${{ always() && steps.resolve.outputs.needs_cleanup == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+          GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
         run: gh api repos/${{ github.repository }}/git/refs/heads/${{ steps.resolve.outputs.branch }} -X DELETE || true

--- a/.github/workflows/handle_update.yaml
+++ b/.github/workflows/handle_update.yaml
@@ -16,13 +16,13 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+      GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/add-reaction
         with:
-          token: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+          token: ${{ secrets.REPO_GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           comment: ${{ inputs.comment_id }}
           reaction: eyes
@@ -51,14 +51,14 @@ jobs:
       - if: steps.rebase.outputs.success == 'true'
         uses: ./.github/actions/add-reaction
         with:
-          token: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+          token: ${{ secrets.REPO_GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           comment: ${{ inputs.comment_id }}
           reaction: "+1"
       - if: steps.rebase.outputs.success != 'true'
         uses: ./.github/actions/add-reaction
         with:
-          token: ${{ secrets.YUJONGLEE_GITHUB_TOKEN_REPO }}
+          token: ${{ secrets.REPO_GITHUB_TOKEN }}
           repo: ${{ github.repository }}
           comment: ${{ inputs.comment_id }}
           reaction: confused

--- a/apps/web/src/lib/team.ts
+++ b/apps/web/src/lib/team.ts
@@ -36,13 +36,7 @@ export const AUTHORS = Object.values(EDITORS).map((m) => ({
   avatar: m.avatar,
 }));
 
-export const ADMIN_EMAILS = [
-  "john@hyprnote.com",
-  "marketing@hyprnote.com",
-  "artem@hyprnote.com",
-  "stua@fastmail.com",
-  "thestua@gmail.com",
-];
+export const ADMIN_EMAILS = ["john@fastrepl.com", "artem@fastrepl.com"];
 
 export const TEAM_PHOTOS = [
   { id: "john-1", name: "john-1.jpg", url: "/api/assets/team/john-1.jpg" },

--- a/scripts/s3/cp.sh
+++ b/scripts/s3/cp.sh
@@ -1,7 +1,7 @@
 CREDENTIALS_FILE="$HOME/hyprnote-r2.toml"
-ENDPOINT_URL="https://3db5267cdeb5f79263ede3ec58090fe0.r2.cloudflarestorage.com"
+ENDPOINT_URL="https://45207bf426d0acf3baf9f70fd2c610c8.r2.cloudflarestorage.com"
 BUCKET_FROM="hyprnote-cache"
-BUCKET_TO="hyprnote-cache2"
+BUCKET_TO="anarlog-cache"
 
 AWS_REGION=auto s5cmd \
     --log trace \

--- a/scripts/s3/delete.sh
+++ b/scripts/s3/delete.sh
@@ -1,5 +1,5 @@
 CREDENTIALS_FILE="$HOME/hyprnote-r2.toml"
-ENDPOINT_URL="https://3db5267cdeb5f79263ede3ec58090fe0.r2.cloudflarestorage.com"
+ENDPOINT_URL="https://45207bf426d0acf3baf9f70fd2c610c8.r2.cloudflarestorage.com"
 BUCKET="hyprnote-cache"
 
 TARGET="quantized-whisper-large-v3-turbo/*"

--- a/scripts/s3/download.sh
+++ b/scripts/s3/download.sh
@@ -1,6 +1,6 @@
 CREDENTIALS_FILE="$HOME/hyprnote-r2.toml"
-ENDPOINT_URL="https://3db5267cdeb5f79263ede3ec58090fe0.r2.cloudflarestorage.com"
-BUCKET="hyprnote-cache2"
+ENDPOINT_URL="https://45207bf426d0acf3baf9f70fd2c610c8.r2.cloudflarestorage.com"
+BUCKET="anarlog-cache"
 
 FROM_PATH="s3://$BUCKET/v0/*"
 TO_PATH="/Users/yujonglee/dev/anarlog/.cache/"

--- a/supabase/migrations/20260901141500_restrict_media_admins.sql
+++ b/supabase/migrations/20260901141500_restrict_media_admins.sql
@@ -1,0 +1,25 @@
+DO $$
+BEGIN
+  IF to_regclass('public.media_assets') IS NOT NULL THEN
+    DROP POLICY IF EXISTS media_assets_admin_all ON public.media_assets;
+
+    CREATE POLICY media_assets_admin_all
+      ON public.media_assets
+      AS PERMISSIVE
+      FOR ALL
+      TO authenticated
+      USING (
+        (SELECT lower(auth.jwt() ->> 'email')) = ANY (ARRAY[
+          'john@fastrepl.com',
+          'artem@fastrepl.com'
+        ])
+      )
+      WITH CHECK (
+        (SELECT lower(auth.jwt() ->> 'email')) = ANY (ARRAY[
+          'john@fastrepl.com',
+          'artem@fastrepl.com'
+        ])
+      );
+  END IF;
+END;
+$$;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removes several admin emails from app and database policies (immediate lockout for former admins), and renames GitHub/R2 targets so workflows fail if secrets or buckets are not updated.
> 
> **Overview**
> Narrows **who counts as an admin** for media and web tooling: `ADMIN_EMAILS` in `team.ts` is cut to `john@fastrepl.com` and `artem@fastrepl.com`, and a new Supabase migration replaces the `media_assets` admin RLS policy so only those emails get full access on `media_assets`.
> 
> **CI and release automation** switch from `YUJONGLEE_GITHUB_TOKEN_REPO` to `REPO_GITHUB_TOKEN` in publish, release/staging handlers, and PR rebase workflows (branch creation, cleanup, Linux package bump PRs, reactions).
> 
> **Staging artifact storage** moves from `s3://hyprnote-build/desktop/staging/` to `s3://anarlog-build/desktop/staging/` for macOS/Linux uploads and the download-staging workflow. Local `scripts/s3` helpers point at a new R2 endpoint and use `anarlog-cache` where downloads/copies target the new cache bucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd0782cf9dcb77d87f58840468ac44c203e7c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->