### PR TITLE
Polish the mobile onboarding and home experience

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -54,6 +54,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       ...config.ios,
       icon: variant.icon,
       bundleIdentifier: variant.bundleIdentifier,
+      infoPlist: {
+        ...config.ios?.infoPlist,
+        ITSAppUsesNonExemptEncryption: false,
+      },
     },
     android: {
       ...config.android,

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -45,6 +45,12 @@
     "experiments": {
       "typedRoutes": true,
       "reactCompiler": true
-    }
+    },
+    "extra": {
+      "eas": {
+        "projectId": "fcaa4e46-0da5-4dfc-a9e2-6447de0030d2"
+      }
+    },
+    "owner": "john_fastrepl"
   }
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -30,6 +30,11 @@
     }
   },
   "submit": {
-    "stable": {}
+    "stable": {
+      "ios": {
+        "appleId": "john@fastrepl.com",
+        "ascAppId": "6807350358"
+      }
+    }
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -23,6 +23,7 @@
     "@anlg/design-system": "workspace:^",
     "@anlg/mobile-bridge": "workspace:*",
     "@anlg/supabase": "workspace:*",
+    "@expo/material-symbols": "^0.1.1",
     "@expo/metro-runtime": "^57.0.14",
     "@expo/ui": "~57.0.14",
     "@expo/vector-icons": "^15.1.1",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -218,8 +218,17 @@ function RootLayout() {
   const [fontsLoaded, fontError] = useFonts({
     CaveatSemiBold: require("../../assets/fonts/Caveat-SemiBold.ttf"),
   });
+  const [startupAnimationComplete, setStartupAnimationComplete] =
+    useState(false);
 
-  if (!fontsLoaded && !fontError) return <BrandLoadingView />;
+  if (!startupAnimationComplete || (!fontsLoaded && !fontError)) {
+    return (
+      <BrandLoadingView
+        animated={!startupAnimationComplete}
+        onAnimationComplete={() => setStartupAnimationComplete(true)}
+      />
+    );
+  }
 
   return (
     <GestureHandlerRootView style={styles.root}>

--- a/apps/mobile/src/app/action-button.tsx
+++ b/apps/mobile/src/app/action-button.tsx
@@ -48,7 +48,7 @@ export default function ActionButtonScreen() {
       <View style={styles.header}>
         <IconButton
           accessibilityLabel="Back"
-          icon="arrow-back"
+          icon="back"
           iconSize={22}
           onPress={handleBack}
         />
@@ -138,8 +138,8 @@ const styles = StyleSheet.create({
     color: Colors.ink,
   },
   headerSpacer: {
-    width: ControlSize.compact,
-    height: ControlSize.compact,
+    width: ControlSize.default,
+    height: ControlSize.default,
   },
   scroll: {
     flex: 1,

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -20,6 +20,7 @@ import { UserAvatarButton } from "@/components/user-avatar";
 import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
 import { useSessionSearch } from "@/data/search";
 import { createSession, deleteSession } from "@/data/session";
+import { useSidebarItemPreferences } from "@/data/sidebar-preferences";
 import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
 import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
@@ -43,6 +44,7 @@ export default function HomeScreen() {
   const router = useRouter();
   const auth = useAuth();
   const { items, isLoading } = useTimelineSessions();
+  const sidebarPreferences = useSidebarItemPreferences();
   const [query, setQuery] = useState<string | null>(null);
   const [settledSearchQuery, setSettledSearchQuery] = useState("");
   const [showActionButtonCard, setShowActionButtonCard] = useState(false);
@@ -225,6 +227,8 @@ export default function HomeScreen() {
               <SessionCard
                 key={session.id}
                 session={session}
+                showFolder={sidebarPreferences.showFolder}
+                showTags={sidebarPreferences.showTags}
                 onPress={() => {
                   captureAnalytics("search_result_opened", {
                     entry_point: "mobile_home",
@@ -253,13 +257,6 @@ export default function HomeScreen() {
               </View>
             )}
             {items.map((item) => {
-              if (item.type === "group") {
-                return (
-                  <Text key={item.key} style={styles.groupLabel}>
-                    {item.label}
-                  </Text>
-                );
-              }
               if (item.type === "header") {
                 return (
                   <Text key={item.key} style={styles.sectionLabel}>
@@ -271,6 +268,8 @@ export default function HomeScreen() {
                 <SessionCard
                   key={item.key}
                   session={item.session}
+                  showFolder={sidebarPreferences.showFolder}
+                  showTags={sidebarPreferences.showTags}
                   onPress={() => router.push(`/note/${item.session.id}`)}
                   onDelete={() => void handleDelete(item.session)}
                 />
@@ -341,15 +340,9 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   sectionLabel: {
-    ...Typography.captionStrong,
+    ...Typography.section,
     color: Colors.muted,
-    marginTop: Spacing.xs,
-    marginBottom: Spacing.sm,
-  },
-  groupLabel: {
-    ...Typography.title,
-    color: Colors.ink,
-    marginTop: Spacing.lg,
+    marginTop: Spacing.md,
     marginBottom: Spacing.sm,
   },
 });

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -188,7 +188,7 @@ export default function HomeScreen() {
             <View style={styles.headerActions}>
               <IconButton
                 accessibilityLabel="Create new note"
-                icon="create-outline"
+                icon="new-note"
                 onPress={() => void createAndOpen()}
               />
               <IconButton

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -681,14 +681,14 @@ export default function NoteScreen() {
       <View style={styles.header}>
         <IconButton
           accessibilityLabel="Back"
-          icon="arrow-back"
+          icon="back"
           iconSize={22}
           onPress={() => void handleBack()}
         />
         <IconButton
           accessibilityLabel="More actions"
           disabled={!data}
-          icon="ellipsis-horizontal"
+          icon="more"
           iconSize={22}
           onPress={handleMoreActions}
           tone="muted"

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -27,7 +27,7 @@ export default function SettingsScreen() {
       <View style={styles.header}>
         <IconButton
           accessibilityLabel="Back"
-          icon="arrow-back"
+          icon="back"
           iconSize={22}
           onPress={handleBack}
         />
@@ -77,8 +77,8 @@ const styles = StyleSheet.create({
     color: Colors.ink,
   },
   headerSpacer: {
-    width: ControlSize.compact,
-    height: ControlSize.compact,
+    width: ControlSize.default,
+    height: ControlSize.default,
   },
   actionButtonRow: {
     flexDirection: "row",

--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -57,7 +57,7 @@ export function SignInScreen({
       </View>
 
       <Button
-        label="Sign in"
+        label="Get started"
         onPress={() => setShowSignInMethods(true)}
         disabled={busy}
         loading={busy}

--- a/apps/mobile/src/components/brand-loading-view.tsx
+++ b/apps/mobile/src/components/brand-loading-view.tsx
@@ -1,9 +1,118 @@
 import { Image } from "expo-image";
 import { StyleSheet, View } from "react-native";
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
 
-import { Colors, Gradients } from "@/constants/theme";
+import { Colors } from "@/constants/theme";
+import { useMountEffect } from "@/lib/use-mount-effect";
 
-export function BrandLoadingView() {
+const WORDMARK_WIDTH = 200;
+const WORDMARK_HEIGHT = 56;
+const WORDMARK_SOURCE_WIDTH = 1_205;
+const REVEAL_STEPS = [154, 357, 538, 714, 786, 1_006, 1_205].map(
+  (width) => (width / WORDMARK_SOURCE_WIDTH) * WORDMARK_WIDTH,
+);
+const FIRST_REVEAL = REVEAL_STEPS[0];
+const LOGO_SHIFT = -(WORDMARK_WIDTH - FIRST_REVEAL) / 2;
+const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);
+
+export function BrandLoadingView({
+  animated = false,
+  onAnimationComplete,
+}: {
+  animated?: boolean;
+  onAnimationComplete?: () => void;
+}) {
+  const reducedMotion = useReducedMotion();
+  const shouldAnimate = animated && !reducedMotion;
+  const logoOpacity = useSharedValue(shouldAnimate ? 1 : 0);
+  const logoScale = useSharedValue(1);
+  const logoTranslateX = useSharedValue(0);
+  const revealWidth = useSharedValue(
+    shouldAnimate ? FIRST_REVEAL : WORDMARK_WIDTH,
+  );
+  const wordmarkOpacity = useSharedValue(shouldAnimate ? 0 : 1);
+  const cursorOpacity = useSharedValue(0);
+
+  useMountEffect(() => {
+    if (!animated || reducedMotion) {
+      onAnimationComplete?.();
+      return;
+    }
+
+    logoScale.set(
+      withDelay(160, withTiming(0.6, { duration: 200, easing: EASE_OUT })),
+    );
+    logoTranslateX.set(
+      withDelay(
+        160,
+        withTiming(LOGO_SHIFT, { duration: 200, easing: EASE_OUT }),
+      ),
+    );
+    logoOpacity.set(
+      withDelay(320, withTiming(0, { duration: 100, easing: EASE_OUT })),
+    );
+    wordmarkOpacity.set(
+      withDelay(400, withTiming(1, { duration: 100, easing: EASE_OUT })),
+    );
+    revealWidth.set(
+      withSequence(
+        ...REVEAL_STEPS.slice(1).map((width, index) =>
+          withDelay(index === 0 ? 560 : 90, withTiming(width, { duration: 1 })),
+        ),
+      ),
+    );
+    cursorOpacity.set(
+      withSequence(
+        withDelay(400, withTiming(1, { duration: 100, easing: EASE_OUT })),
+        withDelay(650, withTiming(1, { duration: 1 })),
+        withTiming(0, { duration: 100 }),
+        withTiming(1, { duration: 100 }),
+        withTiming(0, { duration: 100 }, (finished) => {
+          if (finished && onAnimationComplete) {
+            scheduleOnRN(onAnimationComplete);
+          }
+        }),
+      ),
+    );
+
+    return () => {
+      cancelAnimation(cursorOpacity);
+      cancelAnimation(logoOpacity);
+      cancelAnimation(logoScale);
+      cancelAnimation(logoTranslateX);
+      cancelAnimation(revealWidth);
+      cancelAnimation(wordmarkOpacity);
+    };
+  });
+
+  const logoStyle = useAnimatedStyle(() => ({
+    opacity: logoOpacity.get(),
+    transform: [
+      { translateX: logoTranslateX.get() },
+      { scale: logoScale.get() },
+    ],
+  }));
+  const wordmarkStyle = useAnimatedStyle(() => ({
+    opacity: wordmarkOpacity.get(),
+  }));
+  const coverStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: revealWidth.get() }],
+  }));
+  const cursorStyle = useAnimatedStyle(() => ({
+    opacity: cursorOpacity.get(),
+    transform: [{ translateX: revealWidth.get() + 4 }],
+  }));
+
   return (
     <View
       accessible
@@ -11,11 +120,26 @@ export function BrandLoadingView() {
       accessibilityRole="progressbar"
       style={styles.container}
     >
-      <Image
-        contentFit="contain"
-        source={require("../../assets/images/splash-icon.png")}
-        style={styles.mark}
-      />
+      <View style={styles.animationFrame}>
+        <Animated.View style={[styles.mark, logoStyle]}>
+          <Image
+            contentFit="contain"
+            source={require("../../assets/images/splash-icon.png")}
+            style={StyleSheet.absoluteFill}
+          />
+        </Animated.View>
+        <Animated.View style={[styles.wordmark, wordmarkStyle]}>
+          <View style={styles.wordmarkClip}>
+            <Image
+              contentFit="contain"
+              source={require("../../assets/images/anarlog-wordmark.png")}
+              style={StyleSheet.absoluteFill}
+            />
+            <Animated.View style={[styles.wordmarkCover, coverStyle]} />
+          </View>
+          <Animated.View style={[styles.cursor, cursorStyle]} />
+        </Animated.View>
+      </View>
     </View>
   );
 }
@@ -26,11 +150,39 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: Colors.brandBackgroundTop,
-    experimental_backgroundImage: Gradients.brandBackground,
+  },
+  animationFrame: {
+    width: WORDMARK_WIDTH,
+    height: WORDMARK_HEIGHT,
+    alignItems: "center",
+    justifyContent: "center",
   },
   mark: {
+    position: "absolute",
     width: 76,
     height: 76,
-    opacity: 0.72,
+  },
+  wordmark: {
+    position: "absolute",
+    width: WORDMARK_WIDTH,
+    height: WORDMARK_HEIGHT,
+  },
+  wordmarkClip: {
+    width: WORDMARK_WIDTH,
+    height: WORDMARK_HEIGHT,
+    overflow: "hidden",
+  },
+  wordmarkCover: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: Colors.brandBackgroundTop,
+  },
+  cursor: {
+    position: "absolute",
+    top: 44,
+    left: 0,
+    width: 14,
+    height: 5,
+    borderRadius: 2.5,
+    backgroundColor: Colors.ink,
   },
 });

--- a/apps/mobile/src/components/profile-sheet.tsx
+++ b/apps/mobile/src/components/profile-sheet.tsx
@@ -1,3 +1,4 @@
+import { Host, Switch } from "@expo/ui";
 import { useSyncExternalStore } from "react";
 import {
   KeyboardAvoidingView,
@@ -19,6 +20,11 @@ import {
   Typography,
 } from "@/constants/theme";
 import {
+  setSidebarItemPreference,
+  useSidebarItemPreferences,
+} from "@/data/sidebar-preferences";
+import { captureOperationalError } from "@/lib/error-reporting";
+import {
   getMobileSyncSnapshot,
   retryMobileSync,
   subscribeMobileSync,
@@ -33,6 +39,7 @@ export function SettingsContent() {
     getMobileSyncSnapshot,
     getMobileSyncSnapshot,
   );
+  const sidebarPreferences = useSidebarItemPreferences();
 
   const planLabel = auth.bypass
     ? "Local dev"
@@ -42,6 +49,18 @@ export function SettingsContent() {
         ? "Pro"
         : "Free";
   const presentation = syncStatusPresentation(sync);
+
+  const updateSidebarPreference = (
+    key: "sidebar_show_folder" | "sidebar_show_tags",
+    value: boolean,
+  ) => {
+    void setSidebarItemPreference(key, value).catch((error) => {
+      captureOperationalError(error, {
+        operation: "sidebar_preference_update",
+        tags: { key },
+      });
+    });
+  };
 
   const renderStatusActions = () => {
     if (auth.bypass || sync.phase === "inactive") return null;
@@ -117,6 +136,54 @@ export function SettingsContent() {
           </View>
           <View style={styles.planChip}>
             <Text style={styles.planLabel}>{planLabel}</Text>
+          </View>
+        </View>
+
+        <View style={styles.notesListCard}>
+          <Text style={styles.eyebrow}>Notes list</Text>
+          <Text style={styles.notesListDescription}>
+            Choose extra details to show on each note.
+          </Text>
+          <View style={styles.preferenceGroup}>
+            <View>
+              <Host
+                matchContents={{ vertical: true }}
+                seedColor={Colors.primary}
+                style={styles.preferenceControl}
+              >
+                <Switch
+                  label="Folder"
+                  value={sidebarPreferences.showFolder}
+                  onValueChange={(value) =>
+                    updateSidebarPreference("sidebar_show_folder", value)
+                  }
+                  testID="sidebar-show-folder"
+                />
+              </Host>
+              <Text style={styles.preferenceDescription}>
+                Show the folder above the title.
+              </Text>
+            </View>
+            <View style={styles.preferenceDivider} />
+            <View>
+              <Host
+                matchContents={{ vertical: true }}
+                seedColor={Colors.primary}
+                style={styles.preferenceControl}
+              >
+                <Switch
+                  label="Tags"
+                  value={sidebarPreferences.showTags}
+                  onValueChange={(value) =>
+                    updateSidebarPreference("sidebar_show_tags", value)
+                  }
+                  testID="sidebar-show-tags"
+                />
+              </Host>
+              <Text style={styles.preferenceDescription}>
+                Show tags under the date and time.
+              </Text>
+            </View>
           </View>
         </View>
 
@@ -209,6 +276,36 @@ const styles = StyleSheet.create({
     borderCurve: CornerCurve.squircle,
     backgroundColor: Colors.surface,
     padding: Spacing.md,
+  },
+  notesListCard: {
+    marginTop: Spacing.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+    borderRadius: Radius.card,
+    borderCurve: CornerCurve.squircle,
+    backgroundColor: Colors.surface,
+    padding: Spacing.md,
+  },
+  notesListDescription: {
+    marginTop: Spacing.xs,
+    ...Typography.body,
+    color: Colors.muted,
+  },
+  preferenceGroup: {
+    marginTop: Spacing.md,
+    gap: Spacing.md,
+  },
+  preferenceControl: {
+    width: "100%",
+  },
+  preferenceDescription: {
+    marginTop: Spacing.xs,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  preferenceDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: Colors.border,
   },
   statusHeading: {
     flexDirection: "row",

--- a/apps/mobile/src/components/session-card.tsx
+++ b/apps/mobile/src/components/session-card.tsx
@@ -109,7 +109,7 @@ const styles = StyleSheet.create({
   cardContent: {
     minHeight: 64,
     justifyContent: "center",
-    paddingLeft: Spacing.compact,
+    paddingHorizontal: Spacing.compact,
     paddingVertical: Spacing.sm,
   },
   cardPressed: {

--- a/apps/mobile/src/components/session-card.tsx
+++ b/apps/mobile/src/components/session-card.tsx
@@ -12,19 +12,33 @@ import { relativeLabel, type TimelineSession } from "@/data/timeline";
 
 export function SessionCard({
   session,
+  showFolder,
+  showTags,
   onPress,
   onDelete,
 }: {
   session: TimelineSession;
+  showFolder: boolean;
+  showTags: boolean;
   onPress: () => void;
   onDelete?: () => void;
 }) {
   const title = session.title || "Untitled";
+  const folder = showFolder ? session.folderPath : "";
+  const tags = showTags ? session.tags.map((tag) => `#${tag}`).join(" ") : "";
+  const accessibilityLabel = [
+    title,
+    folder ? `Folder ${folder}` : "",
+    relativeLabel(session.startedAt),
+    tags,
+  ]
+    .filter(Boolean)
+    .join(", ");
 
   return (
     <View style={styles.card}>
       <Pressable
-        accessibilityLabel={`${title}, ${relativeLabel(session.startedAt)}`}
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
         onPress={onPress}
         style={({ pressed }) => [
@@ -32,6 +46,14 @@ export function SessionCard({
           pressed && styles.cardPressed,
         ]}
       >
+        {folder && (
+          <View style={styles.folderRow}>
+            <Ionicons name="folder-outline" size={12} color={Colors.muted} />
+            <Text style={styles.folder} numberOfLines={1}>
+              {folder}
+            </Text>
+          </View>
+        )}
         <Text
           style={[styles.title, !session.title && styles.titleEmpty]}
           numberOfLines={1}
@@ -39,6 +61,11 @@ export function SessionCard({
           {title}
         </Text>
         <Text style={styles.subtitle}>{relativeLabel(session.startedAt)}</Text>
+        {tags && (
+          <Text style={styles.tags} numberOfLines={1}>
+            {tags}
+          </Text>
+        )}
       </Pressable>
       {onDelete && (
         <Pressable
@@ -84,6 +111,17 @@ const styles = StyleSheet.create({
     ...Typography.bodyStrong,
     color: Colors.ink,
   },
+  folderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.xs,
+    marginBottom: Spacing.xs,
+  },
+  folder: {
+    flex: 1,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
   titleEmpty: {
     color: Colors.muted,
   },
@@ -100,6 +138,11 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.accentSurface,
   },
   subtitle: {
+    marginTop: Spacing.xs,
+    ...Typography.caption,
+    color: Colors.muted,
+  },
+  tags: {
     marginTop: Spacing.xs,
     ...Typography.caption,
     color: Colors.muted,

--- a/apps/mobile/src/components/session-card.tsx
+++ b/apps/mobile/src/components/session-card.tsx
@@ -1,3 +1,4 @@
+import MenuView, { type MenuAction } from "@expo/ui/community/menu";
 import { Ionicons } from "@expo/vector-icons";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
@@ -9,6 +10,15 @@ import {
   Typography,
 } from "@/constants/theme";
 import { relativeLabel, type TimelineSession } from "@/data/timeline";
+
+const DELETE_ACTIONS: MenuAction[] = [
+  {
+    id: "delete",
+    title: "Delete",
+    image: "trash",
+    attributes: { destructive: true },
+  },
+];
 
 export function SessionCard({
   session,
@@ -35,61 +45,59 @@ export function SessionCard({
     .filter(Boolean)
     .join(", ");
 
-  return (
-    <View style={styles.card}>
-      <Pressable
-        accessibilityLabel={accessibilityLabel}
-        accessibilityRole="button"
-        onPress={onPress}
-        style={({ pressed }) => [
-          styles.cardContent,
-          pressed && styles.cardPressed,
-        ]}
-      >
-        {folder && (
-          <View style={styles.folderRow}>
-            <Ionicons name="folder-outline" size={12} color={Colors.muted} />
-            <Text style={styles.folder} numberOfLines={1}>
-              {folder}
-            </Text>
-          </View>
-        )}
-        <Text
-          style={[styles.title, !session.title && styles.titleEmpty]}
-          numberOfLines={1}
-        >
-          {title}
-        </Text>
-        <Text style={styles.subtitle}>{relativeLabel(session.startedAt)}</Text>
-        {tags && (
-          <Text style={styles.tags} numberOfLines={1}>
-            {tags}
+  const content = (
+    <Pressable
+      accessibilityHint={onDelete ? "Long press for actions" : undefined}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.cardContent,
+        pressed && styles.cardPressed,
+      ]}
+    >
+      {folder && (
+        <View style={styles.folderRow}>
+          <Ionicons name="folder-outline" size={12} color={Colors.muted} />
+          <Text style={styles.folder} numberOfLines={1}>
+            {folder}
           </Text>
-        )}
-      </Pressable>
-      {onDelete && (
-        <Pressable
-          accessibilityLabel={`Delete ${title}`}
-          accessibilityRole="button"
-          hitSlop={4}
-          onPress={onDelete}
-          style={({ pressed }) => [
-            styles.moreButton,
-            pressed && styles.moreButtonPressed,
-          ]}
-        >
-          <Ionicons name="ellipsis-horizontal" size={17} color={Colors.muted} />
-        </Pressable>
+        </View>
       )}
-    </View>
+      <Text
+        style={[styles.title, !session.title && styles.titleEmpty]}
+        numberOfLines={1}
+      >
+        {title}
+      </Text>
+      <Text style={styles.subtitle}>{relativeLabel(session.startedAt)}</Text>
+      {tags && (
+        <Text style={styles.tags} numberOfLines={1}>
+          {tags}
+        </Text>
+      )}
+    </Pressable>
+  );
+
+  if (!onDelete) return <View style={styles.card}>{content}</View>;
+
+  return (
+    <MenuView
+      actions={DELETE_ACTIONS}
+      onPressAction={({ nativeEvent }) => {
+        if (nativeEvent.event === "delete") onDelete();
+      }}
+      shouldOpenOnLongPress
+      style={styles.card}
+    >
+      {content}
+    </MenuView>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
     minHeight: 64,
-    flexDirection: "row",
-    alignItems: "stretch",
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: Colors.border,
     borderRadius: Radius.card,
@@ -99,7 +107,7 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   cardContent: {
-    flex: 1,
+    minHeight: 64,
     justifyContent: "center",
     paddingLeft: Spacing.compact,
     paddingVertical: Spacing.sm,
@@ -124,18 +132,6 @@ const styles = StyleSheet.create({
   },
   titleEmpty: {
     color: Colors.muted,
-  },
-  moreButton: {
-    width: 32,
-    alignSelf: "stretch",
-    alignItems: "center",
-    justifyContent: "center",
-    marginHorizontal: Spacing.compact,
-    marginVertical: Spacing.sm,
-    borderRadius: Radius.pill,
-  },
-  moreButtonPressed: {
-    backgroundColor: Colors.accentSurface,
   },
   subtitle: {
     marginTop: Spacing.xs,

--- a/apps/mobile/src/components/ui/icon-button.tsx
+++ b/apps/mobile/src/components/ui/icon-button.tsx
@@ -1,8 +1,8 @@
-import { Ionicons } from "@expo/vector-icons";
-import type { ComponentProps } from "react";
 import { Pressable, StyleSheet } from "react-native";
 
 import { Colors, ControlSize, CornerCurve, Radius } from "@/constants/theme";
+
+import { NativeIcon, type NativeIconName } from "./native-icon";
 
 export function IconButton({
   accessibilityLabel,
@@ -15,7 +15,7 @@ export function IconButton({
 }: {
   accessibilityLabel: string;
   disabled?: boolean;
-  icon: ComponentProps<typeof Ionicons>["name"];
+  icon: NativeIconName;
   iconSize?: number;
   onPress: () => void;
   tone?: "default" | "muted" | "destructive";
@@ -33,7 +33,6 @@ export function IconButton({
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
       disabled={disabled}
-      hitSlop={4}
       onPress={onPress}
       style={({ pressed }) => [
         styles.button,
@@ -42,15 +41,15 @@ export function IconButton({
         disabled && styles.disabled,
       ]}
     >
-      <Ionicons name={icon} size={iconSize} color={color} />
+      <NativeIcon name={icon} size={iconSize} color={color} />
     </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
   button: {
-    width: ControlSize.compact,
-    height: ControlSize.compact,
+    width: ControlSize.default,
+    height: ControlSize.default,
     alignItems: "center",
     justifyContent: "center",
     borderRadius: Radius.pill,

--- a/apps/mobile/src/components/ui/native-icon.tsx
+++ b/apps/mobile/src/components/ui/native-icon.tsx
@@ -1,0 +1,47 @@
+import { Host, Icon } from "@expo/ui";
+import type { ColorValue } from "react-native";
+
+const nativeIcons = {
+  back: Icon.select({
+    ios: "chevron.left",
+    android: import("@expo/material-symbols/arrow_back.xml"),
+  }),
+  close: Icon.select({
+    ios: "xmark",
+    android: import("@expo/material-symbols/close.xml"),
+  }),
+  more: Icon.select({
+    ios: "ellipsis",
+    android: import("@expo/material-symbols/more_horiz.xml"),
+  }),
+  "new-note": Icon.select({
+    ios: "square.and.pencil",
+    android: import("@expo/material-symbols/edit_square.xml"),
+  }),
+  profile: Icon.select({
+    ios: "person",
+    android: import("@expo/material-symbols/person.xml"),
+  }),
+  search: Icon.select({
+    ios: "magnifyingglass",
+    android: import("@expo/material-symbols/search.xml"),
+  }),
+} as const;
+
+export type NativeIconName = keyof typeof nativeIcons;
+
+export function NativeIcon({
+  color,
+  name,
+  size,
+}: {
+  color: ColorValue;
+  name: NativeIconName;
+  size: number;
+}) {
+  return (
+    <Host matchContents>
+      <Icon color={color} name={nativeIcons[name]} size={size} />
+    </Host>
+  );
+}

--- a/apps/mobile/src/components/user-avatar.tsx
+++ b/apps/mobile/src/components/user-avatar.tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from "@expo/vector-icons";
 import type { User } from "@supabase/supabase-js";
 import { Image } from "expo-image";
 import { useState } from "react";
@@ -9,7 +8,14 @@ import {
   getProviderProfileName,
 } from "@anlg/supabase/profile";
 
-import { Colors, CornerCurve, Radius, Typography } from "@/constants/theme";
+import { NativeIcon } from "@/components/ui/native-icon";
+import {
+  Colors,
+  ControlSize,
+  CornerCurve,
+  Radius,
+  Typography,
+} from "@/constants/theme";
 
 function profileInitials(name: string | null): string {
   if (!name) return "";
@@ -47,7 +53,7 @@ export function UserAvatar({
           {initials}
         </Text>
       ) : (
-        <Ionicons name="person-outline" size={size * 0.55} color={Colors.ink} />
+        <NativeIcon name="profile" size={size * 0.55} color={Colors.ink} />
       )}
       {imageUrl ? <ProviderImage key={imageUrl} imageUrl={imageUrl} /> : null}
     </View>
@@ -82,7 +88,6 @@ export function UserAvatarButton({
     <Pressable
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"
-      hitSlop={4}
       onPress={onPress}
       style={({ pressed }) => [styles.button, pressed && styles.pressed]}
     >
@@ -106,6 +111,10 @@ const styles = StyleSheet.create({
     color: Colors.ink,
   },
   button: {
+    width: ControlSize.default,
+    height: ControlSize.default,
+    alignItems: "center",
+    justifyContent: "center",
     borderRadius: Radius.pill,
     borderCurve: CornerCurve.squircle,
   },

--- a/apps/mobile/src/data/search.ts
+++ b/apps/mobile/src/data/search.ts
@@ -6,7 +6,25 @@ import {
 import { useLiveQuery } from "@/db";
 
 const SEARCH_SQL = `
-SELECT DISTINCT sessions.id, sessions.title, sessions.created_at, sessions.event_json
+SELECT DISTINCT
+  sessions.id,
+  sessions.title,
+  sessions.created_at,
+  sessions.event_json,
+  sessions.folder_path,
+  COALESCE((
+    SELECT json_group_array(name)
+    FROM (
+      SELECT DISTINCT tags.name AS name
+      FROM session_tags
+      JOIN tags ON tags.id = session_tags.tag_id
+      WHERE session_tags.session_id = sessions.id
+        AND session_tags.deleted_at IS NULL
+        AND tags.deleted_at IS NULL
+        AND trim(tags.name) <> ''
+      ORDER BY tags.name COLLATE NOCASE
+    )
+  ), '[]') AS tags_json
 FROM sessions
 LEFT JOIN session_documents AS note
   ON note.session_id = sessions.id AND note.kind = 'note' AND note.deleted_at IS NULL

--- a/apps/mobile/src/data/sidebar-preferences-model.ts
+++ b/apps/mobile/src/data/sidebar-preferences-model.ts
@@ -1,0 +1,33 @@
+export type SidebarItemPreferences = {
+  showFolder: boolean;
+  showTags: boolean;
+};
+
+export type SidebarPreferenceRow = {
+  id: string;
+  value_json: string;
+  source_rank: number;
+};
+
+export const DEFAULT_SIDEBAR_ITEM_PREFERENCES: SidebarItemPreferences = {
+  showFolder: true,
+  showTags: false,
+};
+
+export function parseSidebarPreferences(
+  rows: SidebarPreferenceRow[],
+): SidebarItemPreferences {
+  const preferences = { ...DEFAULT_SIDEBAR_ITEM_PREFERENCES };
+  for (const row of rows) {
+    let value: unknown;
+    try {
+      value = JSON.parse(row.value_json);
+    } catch {
+      continue;
+    }
+    if (typeof value !== "boolean") continue;
+    if (row.id === "sidebar_show_folder") preferences.showFolder = value;
+    if (row.id === "sidebar_show_tags") preferences.showTags = value;
+  }
+  return preferences;
+}

--- a/apps/mobile/src/data/sidebar-preferences.test.mjs
+++ b/apps/mobile/src/data/sidebar-preferences.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSidebarPreferences } from "./sidebar-preferences-model.ts";
+
+test("uses the desktop notes-list defaults", () => {
+  assert.deepEqual(parseSidebarPreferences([]), {
+    showFolder: true,
+    showTags: false,
+  });
+});
+
+test("prefers synced notes-list settings over device values", () => {
+  assert.deepEqual(
+    parseSidebarPreferences([
+      {
+        id: "sidebar_show_folder",
+        value_json: "false",
+        source_rank: 0,
+      },
+      {
+        id: "sidebar_show_folder",
+        value_json: "true",
+        source_rank: 1,
+      },
+      {
+        id: "sidebar_show_tags",
+        value_json: "true",
+        source_rank: 1,
+      },
+    ]),
+    { showFolder: true, showTags: true },
+  );
+});
+
+test("ignores malformed notes-list settings", () => {
+  assert.deepEqual(
+    parseSidebarPreferences([
+      {
+        id: "sidebar_show_folder",
+        value_json: '"false"',
+        source_rank: 1,
+      },
+      {
+        id: "sidebar_show_tags",
+        value_json: "not-json",
+        source_rank: 1,
+      },
+    ]),
+    { showFolder: true, showTags: false },
+  );
+});

--- a/apps/mobile/src/data/sidebar-preferences.ts
+++ b/apps/mobile/src/data/sidebar-preferences.ts
@@ -16,9 +16,13 @@ SELECT id, value_json, 0 AS source_rank
 FROM app_settings
 WHERE id IN ('sidebar_show_folder', 'sidebar_show_tags')
 UNION ALL
-SELECT id, value_json, 1 AS source_rank
-FROM synced_preferences
-WHERE id IN ('sidebar_show_folder', 'sidebar_show_tags')
+SELECT preferences.id, preferences.value_json, 1 AS source_rank
+FROM synced_preferences AS preferences
+JOIN app_settings AS binding ON binding.id = 'cloudsync_workspace_binding'
+WHERE preferences.id IN ('sidebar_show_folder', 'sidebar_show_tags')
+  AND json_type(binding.value_json, '$.workspace_id') = 'text'
+  AND preferences.workspace_id = json_extract(binding.value_json, '$.workspace_id')
+  AND preferences.workspace_id <> ''
 ORDER BY id, source_rank
 `;
 

--- a/apps/mobile/src/data/sidebar-preferences.ts
+++ b/apps/mobile/src/data/sidebar-preferences.ts
@@ -1,0 +1,69 @@
+import { useLiveQuery, executeTransaction } from "@/db";
+
+import {
+  DEFAULT_SIDEBAR_ITEM_PREFERENCES,
+  parseSidebarPreferences,
+  type SidebarItemPreferences,
+  type SidebarPreferenceRow,
+} from "./sidebar-preferences-model";
+
+export * from "./sidebar-preferences-model";
+
+export type SidebarPreferenceKey = "sidebar_show_folder" | "sidebar_show_tags";
+
+const SIDEBAR_PREFERENCES_SQL = `
+SELECT id, value_json, 0 AS source_rank
+FROM app_settings
+WHERE id IN ('sidebar_show_folder', 'sidebar_show_tags')
+UNION ALL
+SELECT id, value_json, 1 AS source_rank
+FROM synced_preferences
+WHERE id IN ('sidebar_show_folder', 'sidebar_show_tags')
+ORDER BY id, source_rank
+`;
+
+export function useSidebarItemPreferences(): SidebarItemPreferences {
+  const { data } = useLiveQuery<SidebarPreferenceRow, SidebarItemPreferences>({
+    sql: SIDEBAR_PREFERENCES_SQL,
+    mapRows: parseSidebarPreferences,
+  });
+  return data ?? DEFAULT_SIDEBAR_ITEM_PREFERENCES;
+}
+
+export async function setSidebarItemPreference(
+  key: SidebarPreferenceKey,
+  value: boolean,
+): Promise<void> {
+  const valueJson = JSON.stringify(value);
+  const updatedAt = new Date().toISOString();
+  await executeTransaction([
+    {
+      sql: `
+        INSERT INTO app_settings (id, value_json, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          value_json = excluded.value_json,
+          updated_at = excluded.updated_at
+      `,
+      params: [key, valueJson, updatedAt],
+    },
+    {
+      sql: `
+        INSERT INTO synced_preferences (id, workspace_id, value_json, updated_at)
+        SELECT
+          ?,
+          json_extract(value_json, '$.workspace_id'),
+          ?,
+          ?
+        FROM app_settings
+        WHERE id = 'cloudsync_workspace_binding'
+          AND COALESCE(json_extract(value_json, '$.workspace_id'), '') <> ''
+        ON CONFLICT(id) DO UPDATE SET
+          workspace_id = excluded.workspace_id,
+          value_json = excluded.value_json,
+          updated_at = excluded.updated_at
+      `,
+      params: [key, valueJson, updatedAt],
+    },
+  ]);
+}

--- a/apps/mobile/src/data/timeline-model.test.mjs
+++ b/apps/mobile/src/data/timeline-model.test.mjs
@@ -41,7 +41,7 @@ test("uses readable relative units instead of unbounded hours", () => {
   );
 });
 
-test("groups upcoming meetings nearest-first and past meetings newest-first", () => {
+test("orders meetings without generic past or upcoming headers", () => {
   const now = new Date(2026, 7, 17, 12).getTime();
   const iso = (offsetHours) =>
     new Date(now + offsetHours * 60 * 60 * 1000).toISOString();
@@ -55,9 +55,13 @@ test("groups upcoming meetings nearest-first and past meetings newest-first", ()
     now,
   );
 
+  assert.equal(
+    items.some((item) => item.type === "group"),
+    false,
+  );
   assert.deepEqual(
-    items.filter((item) => item.type === "group").map((item) => item.label),
-    ["Upcoming", "Past"],
+    items.filter((item) => item.type === "header").map((item) => item.label),
+    ["Today", "Tomorrow", "Today", "Yesterday"],
   );
   assert.deepEqual(
     items
@@ -67,7 +71,7 @@ test("groups upcoming meetings nearest-first and past meetings newest-first", ()
   );
 });
 
-test("omits empty timeline groups", () => {
+test("uses only day headers for a past-only timeline", () => {
   const now = new Date(2026, 7, 17, 12).getTime();
   const items = buildSessionList(
     [
@@ -81,8 +85,8 @@ test("omits empty timeline groups", () => {
   );
 
   assert.deepEqual(
-    items.filter((item) => item.type === "group").map((item) => item.label),
-    ["Past"],
+    items.filter((item) => item.type === "header").map((item) => item.label),
+    ["Today"],
   );
 });
 
@@ -94,6 +98,8 @@ test("prefers canonical event start time and falls back to creation time", () =>
         title: "Scheduled",
         created_at: "2026-08-17T00:00:00.000Z",
         event_json: JSON.stringify({ started_at: "2026-08-18T01:00:00.000Z" }),
+        folder_path: "Work/Planning",
+        tags_json: '["roadmap","planning","roadmap"]',
       },
       {
         id: "local",
@@ -113,31 +119,33 @@ test("prefers canonical event start time and falls back to creation time", () =>
         id: "scheduled",
         title: "Scheduled",
         startedAt: "2026-08-18T01:00:00.000Z",
+        folderPath: "Work/Planning",
+        tags: ["planning", "roadmap"],
       },
       {
         id: "local",
         title: "Local",
         startedAt: "2026-08-17T02:00:00.000Z",
+        folderPath: "",
+        tags: [],
       },
       {
         id: "malformed-event",
         title: "Malformed event",
         startedAt: "2026-08-17T03:00:00.000Z",
+        folderPath: "",
+        tags: [],
       },
     ],
   );
 });
 
-test("retains a session with an invalid date in the past group", () => {
+test("retains a session with an invalid date in the timeline", () => {
   const items = buildSessionList(
     [{ id: "invalid", title: "Invalid", startedAt: "not-a-date" }],
     Date.now(),
   );
 
-  assert.deepEqual(
-    items.filter((item) => item.type === "group").map((item) => item.label),
-    ["Past"],
-  );
   assert.equal(
     items.find((item) => item.type === "header")?.label,
     "Date unavailable",

--- a/apps/mobile/src/data/timeline-model.ts
+++ b/apps/mobile/src/data/timeline-model.ts
@@ -2,10 +2,11 @@ export type TimelineSession = {
   id: string;
   title: string;
   startedAt: string;
+  folderPath: string;
+  tags: string[];
 };
 
 export type SessionListItem =
-  | { type: "group"; key: string; label: "Upcoming" | "Past" }
   | { type: "header"; key: string; label: string }
   | { type: "session"; key: string; session: TimelineSession };
 
@@ -14,6 +15,8 @@ export type TimelineRow = {
   title: string;
   created_at: string;
   event_json: string;
+  folder_path?: string;
+  tags_json?: string;
 };
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -71,20 +74,14 @@ export function buildSessionList(
   now = Date.now(),
 ): SessionListItem[] {
   const items: SessionListItem[] = [];
-  const appendGroup = (
-    label: "Upcoming" | "Past",
-    group: TimelineSession[],
-  ) => {
-    if (group.length === 0) return;
-    const groupKey = label.toLowerCase();
-    items.push({ type: "group", key: `group-${groupKey}`, label });
+  const appendSessions = (keyPrefix: string, group: TimelineSession[]) => {
     let currentLabel: string | null = null;
     for (const session of group) {
       const sessionDayLabel = dayLabel(session.startedAt, now);
       if (sessionDayLabel !== currentLabel) {
         items.push({
           type: "header",
-          key: `header-${groupKey}-${sessionDayLabel}`,
+          key: `header-${keyPrefix}-${sessionDayLabel}`,
           label: sessionDayLabel,
         });
         currentLabel = sessionDayLabel;
@@ -112,8 +109,8 @@ export function buildSessionList(
     .sort((a, b) => (b.timestamp ?? -Infinity) - (a.timestamp ?? -Infinity))
     .map((item) => item.session);
 
-  appendGroup("Upcoming", upcoming);
-  appendGroup("Past", past);
+  appendSessions("upcoming", upcoming);
+  appendSessions("past", past);
   return items;
 }
 
@@ -158,5 +155,25 @@ export function mapTimelineRows(rows: TimelineRow[]): TimelineSession[] {
     id: row.id,
     title: row.title,
     startedAt: sessionStartedAt(row),
+    folderPath: row.folder_path?.trim() ?? "",
+    tags: parseTagNames(row.tags_json),
   }));
+}
+
+function parseTagNames(value: string | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return [
+      ...new Set(
+        parsed
+          .filter((tag): tag is string => typeof tag === "string")
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+      ),
+    ].sort((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
 }

--- a/apps/mobile/src/data/timeline.ts
+++ b/apps/mobile/src/data/timeline.ts
@@ -14,10 +14,28 @@ import {
 export * from "./timeline-model";
 
 const TIMELINE_SQL = `
-SELECT id, title, created_at, event_json
+SELECT
+  sessions.id,
+  sessions.title,
+  sessions.created_at,
+  sessions.event_json,
+  sessions.folder_path,
+  COALESCE((
+    SELECT json_group_array(name)
+    FROM (
+      SELECT DISTINCT tags.name AS name
+      FROM session_tags
+      JOIN tags ON tags.id = session_tags.tag_id
+      WHERE session_tags.session_id = sessions.id
+        AND session_tags.deleted_at IS NULL
+        AND tags.deleted_at IS NULL
+        AND trim(tags.name) <> ''
+      ORDER BY tags.name COLLATE NOCASE
+    )
+  ), '[]') AS tags_json
 FROM sessions
-WHERE deleted_at IS NULL
-ORDER BY created_at DESC
+WHERE sessions.deleted_at IS NULL
+ORDER BY sessions.created_at DESC
 `;
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@anlg/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
+      '@expo/material-symbols':
+        specifier: ^0.1.1
+        version: 0.1.1
       '@expo/metro-runtime':
         specifier: ^57.0.14
         version: 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -3768,6 +3771,10 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  '@expo/material-symbols@0.1.1':
+    resolution: {integrity: sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==}
+    hasBin: true
 
   '@expo/metro-config@57.0.12':
     resolution: {integrity: sha512-S62Lrq35HZqBFD55423pmWb8PjaiR/W02zQC1uECBmw1vTN8WZaFz4TJ0i21EeJzwfebMb9MLxL8JZ102Z6VbA==}
@@ -20338,6 +20345,8 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.0)(@react-native/metro-config@0.86.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       stacktrace-parser: 0.1.11
+
+  '@expo/material-symbols@0.1.1': {}
 
   '@expo/metro-config@57.0.12(expo@57.0.18)(typescript@6.0.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- animate the compact logo into the Anarlog wordmark and clarify the login call to action
- simplify the home timeline around prominent day headers and add sidebar display preferences to settings
- standardize home header hit areas and use native SF Symbols or Material Symbols for mobile actions

## Validation

- pnpm exec dprint fmt
- pnpm fmt:check
- pnpm -F @anlg/mobile typecheck
- pnpm -F @anlg/mobile test
- visually verified the updated screens in the iPhone Simulator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, preferences, and build metadata; preference writes are local DB transactions with optional sync—no auth or payment logic changes.
> 
> **Overview**
> **Onboarding and launch:** The root layout now plays an optional **animated splash** (logo → wordmark type-reveal with reduced-motion fallback) before the main app, and the sign-in primary CTA label changes from **Sign in** to **Get started**.
> 
> **Home and notes list:** The timeline drops **Upcoming/Past** section groups in favor of **day headers only** (with updated section styling). **Session cards** can show **folder** and **tags** driven by new **Notes list** toggles in settings; preferences use the same keys as desktop (`sidebar_show_folder` / `sidebar_show_tags`), read from local `app_settings` with **synced workspace preferences** winning when bound. Timeline and search queries now load `folder_path` and tag names; delete moves from an inline control to a **long-press native menu**.
> 
> **Chrome and icons:** Header controls use **`ControlSize.default`** hit targets. **`IconButton`** and the avatar fallback switch from Ionicons to a **`NativeIcon`** layer (SF Symbols on iOS, Material Symbols on Android via `@expo/material-symbols`).
> 
> **Release tooling:** iOS **`ITSAppUsesNonExemptEncryption: false`**, EAS **`projectId`** / **`owner`**, and **stable** submit metadata (`appleId`, `ascAppId`) are added for App Store builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21abab48b893482dd15daeb9f95021ba5d2e392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->