### PR TITLE
Monitor sync, transcription, and LLM APIs

### DIFF
--- a/openstatus.yaml
+++ b/openstatus.yaml
@@ -66,3 +66,84 @@
     url: https://docs.anarlog.so
   retry: 3
   timeout: 45000
+"anarlog-sync-api":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+  description: Verifies the production sync route and authentication layer.
+  frequency: 1m
+  kind: http
+  name: Anarlog Sync API
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://api.anarlog.so/sync/devices
+  retry: 3
+  timeout: 45000
+"anarlog-transcription-api":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+  description: Verifies the production transcription route and authentication layer.
+  frequency: 1m
+  kind: http
+  name: Anarlog Transcription API
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://api.anarlog.so/stt/status/openstatus-probe
+  retry: 3
+  timeout: 45000
+"anarlog-llm-api":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+  description: Verifies the production LLM route and authentication layer.
+  frequency: 1m
+  kind: http
+  name: Anarlog LLM API
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    body: "{}"
+    headers:
+      Content-Type: application/json
+    method: POST
+    url: https://api.anarlog.so/llm/chat/completions
+  retry: 3
+  timeout: 45000


### PR DESCRIPTION
## Summary
- add dedicated route-level monitors for sync, transcription, and LLM
- assert both the expected 401 status and exact authentication response
- keep the existing API health monitor for process-level coverage

## Verified
- all three production routes returned the expected response
- YAML parses with all six monitors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to external uptime monitoring; no runtime or auth logic is modified.
> 
> **Overview**
> Adds **three route-level OpenStatus HTTP monitors** in `openstatus.yaml` for production **sync** (`GET /sync/devices`), **transcription** (`GET /stt/status/openstatus-probe`), and **LLM** (`POST /llm/chat/completions`). Each runs every minute across the same six regions as the existing checks.
> 
> Unlike the existing **Anarlog API** health probe (expects **200**), these unauthenticated requests intentionally assert **401** and a body of **`missing_authorization_header`**, so alerts fire if a route is down or stops enforcing auth. The LLM probe sends an empty JSON POST with `Content-Type: application/json`; sync and transcription use GET.
> 
> The prior process-level **`/health`** monitor and web/docs checks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c7a890a0eb196f20f58a84bf3b877e40cf4409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->