### PR TITLE
Monitor billing and cloud service health

### DIFF
--- a/openstatus.yaml
+++ b/openstatus.yaml
@@ -71,11 +71,11 @@
   assertions:
     - compare: eq
       kind: statusCode
-      target: 401
-    - compare: eq
+      target: 200
+    - compare: contains
       kind: textBody
-      target: missing_authorization_header
-  description: Verifies the production sync route and authentication layer.
+      target: '"status":"ok"'
+  description: Checks that production CloudSync is configured and ready.
   frequency: 1m
   kind: http
   name: Anarlog Sync API
@@ -89,7 +89,7 @@
     - jnb
   request:
     method: GET
-    url: https://api.anarlog.so/sync/devices
+    url: https://api.anarlog.so/health/sync
   retry: 3
   timeout: 45000
 "anarlog-transcription-api":
@@ -97,11 +97,11 @@
   assertions:
     - compare: eq
       kind: statusCode
-      target: 401
-    - compare: eq
+      target: 200
+    - compare: contains
       kind: textBody
-      target: missing_authorization_header
-  description: Verifies the production transcription route and authentication layer.
+      target: '"status":"ok"'
+  description: Checks transcription-provider configuration and stream readiness.
   frequency: 1m
   kind: http
   name: Anarlog Transcription API
@@ -115,10 +115,88 @@
     - jnb
   request:
     method: GET
-    url: https://api.anarlog.so/stt/status/openstatus-probe
+    url: https://api.anarlog.so/health/transcription
   retry: 3
   timeout: 45000
 "anarlog-llm-api":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: '"status":"ok"'
+  description: Checks that the production LLM provider is configured and ready.
+  frequency: 1m
+  kind: http
+  name: Anarlog LLM API
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://api.anarlog.so/health/llm
+  retry: 3
+  timeout: 45000
+"anarlog-cloud-api-mcp":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: https://api.anarlog.so/mcp
+  description: Verifies Cloud API and MCP OAuth discovery metadata.
+  frequency: 1m
+  kind: http
+  name: Anarlog Cloud API & MCP
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://api.anarlog.so/.well-known/oauth-protected-resource/mcp
+  retry: 3
+  timeout: 45000
+"anarlog-billing":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: '"status":"ok"'
+  description: Verifies the production Stripe webhook and billing service.
+  frequency: 1m
+  kind: http
+  name: Anarlog Billing
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://hyprnote-stripe.fly.dev/health
+  retry: 3
+  timeout: 45000
+"anarlog-sync-auth-guard":
   active: true
   assertions:
     - compare: eq
@@ -127,10 +205,62 @@
     - compare: eq
       kind: textBody
       target: missing_authorization_header
-  description: Verifies the production LLM route and authentication layer.
+  description: Verifies that the production sync route remains protected.
   frequency: 1m
   kind: http
-  name: Anarlog LLM API
+  name: Anarlog Sync Auth Guard
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://api.anarlog.so/sync/devices
+  retry: 3
+  timeout: 45000
+"anarlog-transcription-auth-guard":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+  description: Verifies that the production transcription route remains protected.
+  frequency: 1m
+  kind: http
+  name: Anarlog Transcription Auth Guard
+  openTelemetry: {}
+  regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+  request:
+    method: GET
+    url: https://api.anarlog.so/stt/status/openstatus-probe
+  retry: 3
+  timeout: 45000
+"anarlog-llm-auth-guard":
+  active: true
+  assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+  description: Verifies that the production LLM route remains protected.
+  frequency: 1m
+  kind: http
+  name: Anarlog LLM Auth Guard
   openTelemetry: {}
   regions:
     - iad


### PR DESCRIPTION
Complete Anarlog production monitoring

## What

- point the public Sync, Transcription, and LLM monitors at their dedicated readiness endpoints
- add private Billing and Cloud API/MCP monitors
- preserve protected-route auth coverage with three private 401 auth guards
- keep the existing process-level API, Web, and Docs monitors

This brings the workspace to 11 production monitors. Billing, Cloud API/MCP, and auth guards stay off the public status page.

## Rollout

Merge only after the subsystem health endpoint PR has deployed successfully. The existing OpenStatus GitHub Action will apply the config from `main`.

## Validation

- YAML parses with 11 unique monitor keys
- Billing `/health` returns 200 with `status: ok`
- Cloud API/MCP OAuth metadata currently returns the expected MCP resource URL
- existing protected Sync, Transcription, and LLM routes return 401 with `missing_authorization_header`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to external uptime checks; no app logic, but failed rollout if health endpoints are not live yet.
> 
> **Overview**
> **Expands `openstatus.yaml` to 11 production HTTP monitors** so readiness and auth coverage are split instead of overloading the same routes.
> 
> Sync, Transcription, and LLM **public-style monitors** now call dedicated readiness URLs (`/health/sync`, `/health/transcription`, `/health/llm`) and assert **200** plus a body containing `"status":"ok"`. **New monitors** cover billing (`hyprnote-stripe.fly.dev/health`) and Cloud API/MCP OAuth discovery (`/.well-known/oauth-protected-resource/mcp`).
> 
> The previous **401 probes** on those API routes are preserved as separate **auth guard** monitors (`anarlog-sync-auth-guard`, etc.) with updated names and descriptions. Existing API/Web/Docs monitors are unchanged.
> 
> **Rollout note:** this config assumes the subsystem health endpoints are already deployed; otherwise the new readiness checks will fail until that ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430be6adb79b603ac2f123e452461bf6b1206195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->