### PR TITLE
Expose API subsystem readiness checks

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 
-use axum::{Router, body::Body, extract::MatchedPath, http::HeaderMap, http::Request, middleware};
+use axum::{
+    Json, Router, body::Body, extract::MatchedPath, http::HeaderMap, http::Request,
+    http::StatusCode, middleware,
+};
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
 use sentry::protocol::{Context, Value};
 use tokio_util::sync::CancellationToken;
@@ -265,6 +268,13 @@ async fn app_with_session_gate(
         &env.supabase.supabase_service_role_key,
     )
     .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
+    let subsystem_health_state = SubsystemHealthState {
+        cloudsync_configured: sync_config.is_some(),
+        transcription_configured: !stt_config.api_keys.is_empty(),
+        llm_configured: !llm_config.api_key.is_empty(),
+        session_gate: session_gate.clone(),
+    };
+
     let shared_notes_config = anlg_api_sync::SharedNotesConfig::new(
         &env.supabase.supabase_url,
         &env.supabase.supabase_service_role_key,
@@ -460,6 +470,14 @@ async fn app_with_session_gate(
             auth::require_auth,
         ));
 
+    let subsystem_health_routes = Router::new()
+        .route("/health/sync", axum::routing::get(sync_health))
+        .route(
+            "/health/transcription",
+            axum::routing::get(transcription_health),
+        )
+        .route("/health/llm", axum::routing::get(llm_health))
+        .with_state(subsystem_health_state);
     let drain_routes = Router::new()
         .route("/drain", axum::routing::get(drain_status))
         .with_state(session_gate);
@@ -467,6 +485,7 @@ async fn app_with_session_gate(
     Router::new()
         .route("/health", axum::routing::get(version))
         .route("/openapi.json", axum::routing::get(openapi_json))
+        .merge(subsystem_health_routes)
         .merge(drain_routes)
         .merge(webhook_routes)
         .merge(paid_routes)
@@ -568,7 +587,8 @@ async fn app_with_session_gate(
                             span
                         })
                         .on_request(|request: &Request<Body>, span: &tracing::Span| {
-                            // Skip logging for health checks
+                            // Skip logging for liveness and drain checks. Subsystem readiness
+                            // checks remain traced so failures have debugging context.
                             if request.uri().path() == "/health" || request.uri().path() == "/drain"
                             {
                                 return;
@@ -764,6 +784,64 @@ fn main() -> std::io::Result<()> {
     observability.shutdown();
 
     Ok(())
+}
+
+#[derive(Clone)]
+struct SubsystemHealthState {
+    cloudsync_configured: bool,
+    transcription_configured: bool,
+    llm_configured: bool,
+    session_gate: anlg_transcribe_proxy::SessionGate,
+}
+
+fn subsystem_health_response(
+    ok: bool,
+    body: serde_json::Value,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let status = if ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(body))
+}
+
+async fn sync_health(
+    axum::extract::State(state): axum::extract::State<SubsystemHealthState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    subsystem_health_response(
+        state.cloudsync_configured,
+        serde_json::json!({
+            "status": if state.cloudsync_configured { "ok" } else { "not_configured" },
+            "configured": state.cloudsync_configured,
+        }),
+    )
+}
+
+async fn transcription_health(
+    axum::extract::State(state): axum::extract::State<SubsystemHealthState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let draining = state.session_gate.is_draining();
+    subsystem_health_response(
+        state.transcription_configured && !draining,
+        serde_json::json!({
+            "status": if state.transcription_configured && !draining { "ok" } else { "unavailable" },
+            "configured": state.transcription_configured,
+            "draining": draining,
+        }),
+    )
+}
+
+async fn llm_health(
+    axum::extract::State(state): axum::extract::State<SubsystemHealthState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    subsystem_health_response(
+        state.llm_configured,
+        serde_json::json!({
+            "status": if state.llm_configured { "ok" } else { "not_configured" },
+            "configured": state.llm_configured,
+        }),
+    )
 }
 
 const TERM_DRAIN_TIMEOUT: Duration = Duration::from_secs(270);

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -1,6 +1,7 @@
 use axum::{
     body::{Body, to_bytes},
     http::{Method, Request, StatusCode, header},
+    routing::get,
 };
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde_json::{Value, json};
@@ -130,6 +131,18 @@ fn api_env(with_hosted_integrations: bool) -> &'static crate::env::RuntimeConfig
     Box::leak(Box::new(config))
 }
 
+fn api_env_with_subsystems() -> &'static crate::env::RuntimeConfig {
+    let env = deserialize_api_env([
+        ("SQLITECLOUD_PROJECT_URL", "https://test.sqlite.cloud"),
+        ("SQLITECLOUD_TOKEN_ISSUER_API_KEY", "issuer-key"),
+        ("ANARLOG_CLOUDSYNC_E2EE_DATABASE_ID", "database-id"),
+        ("DEEPGRAM_API_KEY", "deepgram-key"),
+    ]);
+    let config = crate::env::RuntimeConfig::resolve(env)
+        .unwrap_or_else(|error| panic!("environment should validate: {error}"));
+    Box::leak(Box::new(config))
+}
+
 async fn request_status(app: &Router, method: Method, path: &str) -> StatusCode {
     app.clone()
         .oneshot(
@@ -142,6 +155,41 @@ async fn request_status(app: &Router, method: Method, path: &str) -> StatusCode 
         .await
         .unwrap()
         .status()
+}
+
+async fn request_json(app: &Router, path: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = serde_json::from_slice(&response_bytes(response).await).unwrap();
+    (status, body)
+}
+
+fn subsystem_health_app(
+    cloudsync_configured: bool,
+    transcription_configured: bool,
+    llm_configured: bool,
+    session_gate: anlg_transcribe_proxy::SessionGate,
+) -> Router {
+    Router::new()
+        .route("/health/sync", get(sync_health))
+        .route("/health/transcription", get(transcription_health))
+        .route("/health/llm", get(llm_health))
+        .with_state(SubsystemHealthState {
+            cloudsync_configured,
+            transcription_configured,
+            llm_configured,
+            session_gate,
+        })
 }
 
 #[tokio::test]
@@ -185,6 +233,87 @@ async fn boots_with_minimal_self_hosted_configuration() {
             "optional route should not be mounted: {path}"
         );
     }
+}
+
+#[tokio::test]
+async fn subsystem_health_routes_are_mounted_unauthenticated_and_secret_free() {
+    let app = app_with_env(api_env_with_subsystems()).await;
+
+    let (sync_status, sync_body) = request_json(&app, "/health/sync").await;
+    assert_eq!(sync_status, StatusCode::OK);
+    assert_eq!(sync_body, json!({"status": "ok", "configured": true}));
+
+    let (transcription_status, transcription_body) =
+        request_json(&app, "/health/transcription").await;
+    assert_eq!(transcription_status, StatusCode::OK);
+    assert_eq!(
+        transcription_body,
+        json!({"status": "ok", "configured": true, "draining": false})
+    );
+
+    let (llm_status, llm_body) = request_json(&app, "/health/llm").await;
+    assert_eq!(llm_status, StatusCode::OK);
+    assert_eq!(llm_body, json!({"status": "ok", "configured": true}));
+
+    let bodies = format!("{sync_body}{transcription_body}{llm_body}");
+    for secret in [
+        "issuer-key",
+        "database-id",
+        "deepgram-key",
+        "openrouter-key",
+    ] {
+        assert!(!bodies.contains(secret), "health response leaked {secret}");
+    }
+}
+
+#[tokio::test]
+async fn subsystem_health_handlers_report_unavailable_states() {
+    let app = subsystem_health_app(
+        true,
+        false,
+        false,
+        anlg_transcribe_proxy::SessionGate::new(),
+    );
+
+    let (sync_status, sync_body) = request_json(&app, "/health/sync").await;
+    assert_eq!(sync_status, StatusCode::OK);
+    assert_eq!(sync_body, json!({"status": "ok", "configured": true}));
+
+    let (transcription_status, transcription_body) =
+        request_json(&app, "/health/transcription").await;
+    assert_eq!(transcription_status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        transcription_body,
+        json!({"status": "unavailable", "configured": false, "draining": false})
+    );
+
+    let (llm_status, llm_body) = request_json(&app, "/health/llm").await;
+    assert_eq!(llm_status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        llm_body,
+        json!({"status": "not_configured", "configured": false})
+    );
+}
+
+#[tokio::test]
+async fn transcription_health_reflects_drain_state() {
+    let gate = anlg_transcribe_proxy::SessionGate::new();
+    let app = subsystem_health_app(false, true, false, gate.clone());
+
+    let (status, body) = request_json(&app, "/health/transcription").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body,
+        json!({"status": "ok", "configured": true, "draining": false})
+    );
+
+    gate.begin_drain();
+    let (status, body) = request_json(&app, "/health/transcription").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        body,
+        json!({"status": "unavailable", "configured": true, "draining": true})
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add subsystem health endpoints

## What

- add unauthenticated, no-I/O readiness endpoints for Sync, Transcription, and LLM
- return 200 when configured and ready, or 503 when unavailable
- make Transcription readiness reflect drain state
- keep subsystem readiness failures traced for debugging

## Safety

- responses expose only status/configured/draining booleans
- no secret values, provider counts, or provider names are exposed
- no database or provider calls are made by the checks
- existing protected API routes and auth middleware are unchanged

## Validation

- `cargo check -p api`
- `cargo test -p api --no-run`
- integration coverage boots the real app, verifies all three routes are unauthenticated, and checks injected credentials never appear in responses
- production Fly secret names required by the checks were confirmed present for CloudSync, OpenRouter, and STT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only config flags on new public routes; no auth or provider I/O changes to existing APIs.
> 
> **Overview**
> Adds **unauthenticated, no-I/O readiness endpoints** at `/health/sync`, `/health/transcription`, and `/health/llm` so operators can tell whether CloudSync, STT, and LLM are configured and accepting traffic without hitting protected routes.
> 
> Each handler returns JSON with `status` / `configured` (and `draining` for transcription), using **200 when ready** and **503** when not configured or unavailable. Readiness is derived from existing startup config (e.g. sync config present, STT API keys, LLM API key) and, for transcription, **`SessionGate` drain state** so deploys can shed load while streams finish.
> 
> Subsystem routes are merged on the main router **outside auth middleware**. Request tracing still skips only `/health` and `/drain`; **subsystem health checks remain traced** for debugging 503s. Integration tests cover full-app mounting, non-leakage of env secrets in bodies, and unavailable/draining behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b51e2353924e0b16124dd04cdf35e40965a82ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->