### PR TITLE
Pin OpenStatus monitor IDs

### DIFF
--- a/openstatus.lock
+++ b/openstatus.lock
@@ -1,4 +1,5 @@
-"11026":
+---
+'11026':
   ID: 11026
   Monitor:
     active: true
@@ -22,7 +23,7 @@
       url: https://api.anarlog.so/health
     retry: 3
     timeout: 45000
-"11027":
+'11027':
   ID: 11027
   Monitor:
     active: true
@@ -46,7 +47,7 @@
       url: https://anarlog.so
     retry: 3
     timeout: 45000
-"11028":
+'11028':
   ID: 11028
   Monitor:
     active: true
@@ -68,5 +69,232 @@
     request:
       method: GET
       url: https://docs.anarlog.so
+    retry: 3
+    timeout: 45000
+'11509':
+  ID: 11509
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: '"status":"ok"'
+    description: Checks that production CloudSync is configured and ready.
+    frequency: 1m
+    kind: http
+    name: Anarlog Sync API
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://api.anarlog.so/health/sync
+    retry: 3
+    timeout: 45000
+'11510':
+  ID: 11510
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: '"status":"ok"'
+    description: Checks transcription-provider configuration and stream readiness.
+    frequency: 1m
+    kind: http
+    name: Anarlog Transcription API
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://api.anarlog.so/health/transcription
+    retry: 3
+    timeout: 45000
+'11511':
+  ID: 11511
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: '"status":"ok"'
+    description: Checks that the production LLM provider is configured and ready.
+    frequency: 1m
+    kind: http
+    name: Anarlog LLM API
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://api.anarlog.so/health/llm
+    retry: 3
+    timeout: 45000
+'11512':
+  ID: 11512
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+    description: Verifies that the production LLM route remains protected.
+    frequency: 1m
+    kind: http
+    name: Anarlog LLM Auth Guard
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      body: "{}"
+      headers:
+        Content-Type: application/json
+      method: POST
+      url: https://api.anarlog.so/llm/chat/completions
+    retry: 3
+    timeout: 45000
+'11514':
+  ID: 11514
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+    description: Verifies that the production transcription route remains protected.
+    frequency: 1m
+    kind: http
+    name: Anarlog Transcription Auth Guard
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://api.anarlog.so/stt/status/openstatus-probe
+    retry: 3
+    timeout: 45000
+'11515':
+  ID: 11515
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: https://api.anarlog.so/mcp
+    description: Verifies Cloud API and MCP OAuth discovery metadata.
+    frequency: 1m
+    kind: http
+    name: Anarlog Cloud API & MCP
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://api.anarlog.so/.well-known/oauth-protected-resource/mcp
+    retry: 3
+    timeout: 45000
+'11518':
+  ID: 11518
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 200
+    - compare: contains
+      kind: textBody
+      target: '"status":"ok"'
+    description: Verifies the production Stripe webhook and billing service.
+    frequency: 1m
+    kind: http
+    name: Anarlog Billing
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://hyprnote-stripe.fly.dev/health
+    retry: 3
+    timeout: 45000
+'11519':
+  ID: 11519
+  Monitor:
+    active: true
+    assertions:
+    - compare: eq
+      kind: statusCode
+      target: 401
+    - compare: eq
+      kind: textBody
+      target: missing_authorization_header
+    description: Verifies that the production sync route remains protected.
+    frequency: 1m
+    kind: http
+    name: Anarlog Sync Auth Guard
+    openTelemetry: {}
+    regions:
+    - iad
+    - arn
+    - sin
+    - syd
+    - gru
+    - jnb
+    request:
+      method: GET
+      url: https://api.anarlog.so/sync/devices
     retry: 3
     timeout: 45000

--- a/openstatus.yaml
+++ b/openstatus.yaml
@@ -66,7 +66,7 @@
     url: https://docs.anarlog.so
   retry: 3
   timeout: 45000
-"anarlog-sync-api":
+"11509":
   active: true
   assertions:
     - compare: eq
@@ -92,7 +92,7 @@
     url: https://api.anarlog.so/health/sync
   retry: 3
   timeout: 45000
-"anarlog-transcription-api":
+"11510":
   active: true
   assertions:
     - compare: eq
@@ -118,7 +118,7 @@
     url: https://api.anarlog.so/health/transcription
   retry: 3
   timeout: 45000
-"anarlog-llm-api":
+"11511":
   active: true
   assertions:
     - compare: eq
@@ -144,7 +144,7 @@
     url: https://api.anarlog.so/health/llm
   retry: 3
   timeout: 45000
-"anarlog-cloud-api-mcp":
+"11515":
   active: true
   assertions:
     - compare: eq
@@ -170,7 +170,7 @@
     url: https://api.anarlog.so/.well-known/oauth-protected-resource/mcp
   retry: 3
   timeout: 45000
-"anarlog-billing":
+"11518":
   active: true
   assertions:
     - compare: eq
@@ -196,7 +196,7 @@
     url: https://hyprnote-stripe.fly.dev/health
   retry: 3
   timeout: 45000
-"anarlog-sync-auth-guard":
+"11519":
   active: true
   assertions:
     - compare: eq
@@ -222,7 +222,7 @@
     url: https://api.anarlog.so/sync/devices
   retry: 3
   timeout: 45000
-"anarlog-transcription-auth-guard":
+"11514":
   active: true
   assertions:
     - compare: eq
@@ -248,7 +248,7 @@
     url: https://api.anarlog.so/stt/status/openstatus-probe
   retry: 3
   timeout: 45000
-"anarlog-llm-auth-guard":
+"11512":
   active: true
   assertions:
     - compare: eq


### PR DESCRIPTION
## What

- replace temporary config keys with the real OpenStatus monitor IDs
- add matching lockfile entries for all 11 managed monitors
- keep the three public subsystem components bound to their original monitor IDs

## Why

The first IaC apply treated the temporary keys as new resources and created three duplicate subsystem monitors instead of updating the existing monitors. Pinning the IDs makes future applies update in place.

## Validation

- `openstatus.yaml` and `openstatus.lock` contain the same 11 IDs
- every lock entry matches its YAML monitor definition
- the three accidental duplicate IDs will be removed from OpenStatus after this apply succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to OpenStatus IaC; risk is limited to apply-time monitor create/update/delete behavior in the external OpenStatus project.
> 
> **Overview**
> Pins all **11** OpenStatus monitors to their real remote IDs in `openstatus.yaml`, replacing temporary slug keys (e.g. `anarlog-sync-api`) with numeric keys (`11509`, etc.) so `openstatus monitors apply` updates existing monitors instead of creating duplicates.
> 
> Expands **`openstatus.lock`** to cover every managed monitor (not just the three public components `11026`–`11028`), with quoted YAML keys normalized and a document header added. Lock entries mirror the YAML definitions for sync, transcription, LLM health checks, auth-guard probes, MCP OAuth discovery, and billing.
> 
> After apply, stray duplicate monitors from the first IaC run should be removable while the three original subsystem IDs stay bound to API, Web, and Docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f97d7e80ce19a3bb17ba73c53c18f7d16609c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->