### PR TITLE
Update founder booking link

### DIFF
--- a/apps/web/src/lib/enterprise.ts
+++ b/apps/web/src/lib/enterprise.ts
@@ -1,4 +1,4 @@
-export const BOOK_CALL_URL = "https://cal.com/team/fastrepl/hi";
+export const BOOK_CALL_URL = "https://cal.com/john.jeong/yo";
 export const SECURITY_REPORT_EMAIL = "founders@fastrepl.com";
 export const SECURITY_ADVISORY_URL =
   "https://github.com/fastrepl/anarlog/security/advisories/new";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single marketing/scheduling URL change with no auth, data, or business-logic impact.
> 
> **Overview**
> Updates the shared **`BOOK_CALL_URL`** constant from the team Cal.com page (`fastrepl/hi`) to **`https://cal.com/john.jeong/yo`**.
> 
> Enterprise and founder “book a call” CTAs that use this constant (e.g. **`book-founder-call`**) will send users to the new scheduling link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a223b864023d8ea0a18cf97a5990a781b6aec596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->