### PR TITLE
Keep floating bar waveform during fallback

### DIFF
--- a/apps/desktop/src/meeting-float/overlay/bar.test.tsx
+++ b/apps/desktop/src/meeting-float/overlay/bar.test.tsx
@@ -63,6 +63,18 @@ describe("FloatingBarOverlay", () => {
     expect(screen.getByTestId("waveform")).toBeTruthy();
   });
 
+  it("keeps showing the waveform when live transcription is degraded", () => {
+    render(
+      <FloatingBarOverlay
+        state={state({ status: "error" })}
+        onStop={vi.fn()}
+        onToggleExpanded={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("waveform")).toBeTruthy();
+  });
+
   it("expands to the live transcript and can collapse again", () => {
     const onToggleExpanded = vi.fn();
 

--- a/apps/desktop/src/meeting-float/overlay/bar.tsx
+++ b/apps/desktop/src/meeting-float/overlay/bar.tsx
@@ -3,7 +3,6 @@ import {
   ArrowsOutSimple,
   CaretDown,
   Square,
-  Warning,
 } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 
@@ -287,8 +286,6 @@ function StopControl({
           <Square size={9} weight="fill" />
           Stop
         </span>
-      ) : state.status === "error" ? (
-        <Warning size={16} weight="fill" />
       ) : (
         <DancingSticks
           color={colors.accent}


### PR DESCRIPTION
Remove the degraded-state warning icon and cover the persistent waveform behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to error-state affordance on the meeting float bar, covered by a new test.
> 
> **Overview**
> When live transcription enters a **degraded/error** state (`status: "error"`), the compact floating bar **stop** control no longer swaps the animated waveform for a warning icon—it always shows **`DancingSticks`** when not hovered (hover still shows “Stop”).
> 
> A unit test asserts the waveform remains visible under `status: "error"`, and the unused **`Warning`** icon import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808ff1b6bd7e40f816dc4c906935255f2ab105fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->