### PR TITLE
Migrate model downloads from AWS to R2

### DIFF
--- a/crates/am/src/model.rs
+++ b/crates/am/src/model.rs
@@ -96,14 +96,10 @@ impl AmModel {
 
     pub fn tar_url(&self) -> &str {
         match self {
-            AmModel::ParakeetV2 => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/nvidia_parakeet-v2_476MB.tar"
-            }
-            AmModel::ParakeetV3 => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/nvidia_parakeet-v3_494MB.tar"
-            }
+            AmModel::ParakeetV2 => "https://models.anarlog.so/v0/nvidia_parakeet-v2_476MB.tar",
+            AmModel::ParakeetV3 => "https://models.anarlog.so/v0/nvidia_parakeet-v3_494MB.tar",
             AmModel::WhisperLargeV3 => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/openai_whisper-large-v3-v20240930_626MB.tar"
+                "https://models.anarlog.so/v0/openai_whisper-large-v3-v20240930_626MB.tar"
             }
         }
     }
@@ -155,6 +151,17 @@ fn extract_tar_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn model_urls_use_anarlog_domain() {
+        for model in [
+            AmModel::ParakeetV2,
+            AmModel::ParakeetV3,
+            AmModel::WhisperLargeV3,
+        ] {
+            assert!(model.tar_url().starts_with("https://models.anarlog.so/v0/"));
+        }
+    }
 
     #[test]
     fn tar_unpack_and_cleanup_skips_checksum_verification() {

--- a/crates/local-model/src/lib.rs
+++ b/crates/local-model/src/lib.rs
@@ -28,13 +28,13 @@ impl GgufLlmModel {
     pub fn model_url(&self) -> &str {
         match self {
             GgufLlmModel::Llama3p2_3bQ4 => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/lmstudio-community/Llama-3.2-3B-Instruct-GGUF/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+                "https://models.anarlog.so/v0/lmstudio-community/Llama-3.2-3B-Instruct-GGUF/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
             }
             GgufLlmModel::AnarlogLLM => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/yujonglee/hypr-llm-sm/model_q4_k_m.gguf"
+                "https://models.anarlog.so/v0/yujonglee/hypr-llm-sm/model_q4_k_m.gguf"
             }
             GgufLlmModel::Gemma3_4bQ4 => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/unsloth/gemma-3-4b-it-GGUF/gemma-3-4b-it-Q4_K_M.gguf"
+                "https://models.anarlog.so/v0/unsloth/gemma-3-4b-it-GGUF/gemma-3-4b-it-Q4_K_M.gguf"
             }
         }
     }
@@ -382,6 +382,21 @@ impl DownloadableModel for LocalModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn model_urls_use_anarlog_domain() {
+        for model in [
+            GgufLlmModel::Llama3p2_3bQ4,
+            GgufLlmModel::AnarlogLLM,
+            GgufLlmModel::Gemma3_4bQ4,
+        ] {
+            assert!(
+                model
+                    .model_url()
+                    .starts_with("https://models.anarlog.so/v0/")
+            );
+        }
+    }
 
     #[test]
     fn anarlog_llm_accepts_legacy_serialized_name() {

--- a/crates/whisper-local-model/src/lib.rs
+++ b/crates/whisper-local-model/src/lib.rs
@@ -56,25 +56,25 @@ impl WhisperModel {
     pub fn model_url(&self) -> &str {
         match self {
             WhisperModel::QuantizedTiny => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-tiny-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-tiny-q8_0.bin"
             }
             WhisperModel::QuantizedTinyEn => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-tiny.en-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-tiny.en-q8_0.bin"
             }
             WhisperModel::QuantizedBase => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-base-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-base-q8_0.bin"
             }
             WhisperModel::QuantizedBaseEn => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-base.en-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-base.en-q8_0.bin"
             }
             WhisperModel::QuantizedSmall => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-small-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-small-q8_0.bin"
             }
             WhisperModel::QuantizedSmallEn => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-small.en-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-small.en-q8_0.bin"
             }
             WhisperModel::QuantizedLargeTurbo => {
-                "https://hyprnote.s3.us-east-1.amazonaws.com/v0/ggerganov/whisper.cpp/main/ggml-large-v3-turbo-q8_0.bin"
+                "https://models.anarlog.so/v0/ggerganov/whisper.cpp/main/ggml-large-v3-turbo-q8_0.bin"
             }
         }
     }
@@ -121,6 +121,30 @@ impl WhisperModel {
             | WhisperModel::QuantizedBase
             | WhisperModel::QuantizedSmall
             | WhisperModel::QuantizedLargeTurbo => anlg_language::whisper_multilingual(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_urls_use_anarlog_domain() {
+        for model in [
+            WhisperModel::QuantizedTiny,
+            WhisperModel::QuantizedTinyEn,
+            WhisperModel::QuantizedBase,
+            WhisperModel::QuantizedBaseEn,
+            WhisperModel::QuantizedSmall,
+            WhisperModel::QuantizedSmallEn,
+            WhisperModel::QuantizedLargeTurbo,
+        ] {
+            assert!(
+                model
+                    .model_url()
+                    .starts_with("https://models.anarlog.so/v0/")
+            );
         }
     }
 }

--- a/packages/changelog/content/1.4.16.md
+++ b/packages/changelog/content/1.4.16.md
@@ -1,10 +1,11 @@
 ---
 date: "2026-08-30"
-summary: "Anarlog 1.4.16 labels on-device model files more clearly so you can tell a whisper.cpp .bin apart from built-in Soniqo and Apple Speech."
+summary: "Anarlog 1.4.16 clarifies on-device model labels and fixes downloads for Whisper Large Turbo."
 ---
 
 ## Transcription
 
+- Download Whisper, Parakeet, and local LLM models from Anarlog's own model host; this also fixes the broken Whisper Large Turbo download
 - See **On-device file** in Settings → Transcription when you want to use a
   whisper.cpp `.bin` model you already have, instead of the older **Local
   file** label


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Every client-side model fetch now depends on the new host; misconfiguration or outage would block downloads, though verification logic is unchanged.
> 
> **Overview**
> **On-device model downloads** now use `https://models.anarlog.so/v0/...` instead of `hyprnote.s3.us-east-1.amazonaws.com`, with the same `/v0/` object paths and unchanged checksums.
> 
> This applies to **AM** Parakeet/Whisper tarballs (`tar_url`), **whisper.cpp** `.bin` variants (`model_url`), and **GGUF** local LLMs. Each crate adds a test that every model URL starts with the Anarlog host.
> 
> The **1.4.16** changelog notes the new model host and that the move fixes the broken **Whisper Large Turbo** download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b32997b4b93b5e511969a11c4a99e67c9a75b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->