### PR TITLE
Suppress errors after deleting a recording

### DIFF
--- a/apps/desktop/src/session/queries.test.ts
+++ b/apps/desktop/src/session/queries.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { trackPendingSoftDelete } from "./pending-soft-deletes";
+
 const mocks = vi.hoisted(() => ({
   analyticsEventFireAndForget: vi.fn(() => Promise.resolve()),
   execute: vi.fn(),
@@ -34,6 +36,7 @@ import {
   declineSessionProposal,
   deleteEnhancedNote,
   getOrCreateSessionForEventId,
+  isSessionDeleted,
   isSessionEmpty,
   loadSessionEvent,
   persistChatSessionProposal,
@@ -392,6 +395,31 @@ describe("session SQLite operations", () => {
     mocks.executeTransaction.mockResolvedValueOnce([0, 0, 0, 0, 0, 0, 0, 0]);
 
     await expect(softDeleteSession("session-1")).resolves.toBeNull();
+  });
+
+  it("reports whether a session has been deleted", async () => {
+    mocks.execute
+      .mockResolvedValueOnce([{ id: "session-1" }])
+      .mockResolvedValueOnce([]);
+
+    await expect(isSessionDeleted("session-1")).resolves.toBe(false);
+    await expect(isSessionDeleted("session-1")).resolves.toBe(true);
+  });
+
+  it("waits for an in-flight soft delete before checking the session", async () => {
+    let finishDelete = () => {};
+    const deleteWrite = new Promise<void>((resolve) => {
+      finishDelete = resolve;
+    });
+    trackPendingSoftDelete("pending-session", deleteWrite);
+
+    const deleted = isSessionDeleted("pending-session");
+    await Promise.resolve();
+    expect(mocks.execute).not.toHaveBeenCalled();
+
+    mocks.execute.mockResolvedValueOnce([]);
+    finishDelete();
+    await expect(deleted).resolves.toBe(true);
   });
 
   it("recognizes a blank SQLite session", async () => {

--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -1,6 +1,7 @@
 export {
   buildSessionTombstoneStatements,
   finalizeSessionDeletion,
+  isSessionDeleted,
   isSessionEmpty,
   restoreDeletedSession,
   softDeleteSession,

--- a/apps/desktop/src/session/queries/deletion.ts
+++ b/apps/desktop/src/session/queries/deletion.ts
@@ -41,6 +41,15 @@ export async function softDeleteSession(
   };
 }
 
+export async function isSessionDeleted(sessionId: string): Promise<boolean> {
+  await waitForPendingSoftDelete(sessionId);
+  const [session] = await liveQueryClient.execute<SessionIdentitySqlRow>(
+    `SELECT id FROM sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
+    [sessionId],
+  );
+  return !session;
+}
+
 export async function isSessionEmpty(sessionId: string): Promise<boolean> {
   const [row] = await liveQueryClient.execute<SessionEmptySqlRow>(
     `

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -361,18 +361,16 @@ export function useCaptureLifecycle(sessionId: string) {
         sonnerToast.dismiss("recording-without-transcription");
         sonnerToast.dismiss("live-transcription-stalled");
         sonnerToast.dismiss("meeting-disclosure-send-failed");
-        let sessionDeleted = false;
         const sessionWasDeleted = async () => {
-          if (sessionDeleted) return true;
           try {
-            sessionDeleted = await isSessionDeleted(sessionId);
+            return await isSessionDeleted(sessionId);
           } catch (error) {
             console.warn(
               "[listener] failed to check whether the session was deleted",
               error,
             );
+            return false;
           }
-          return sessionDeleted;
         };
         const notifyFailure = async (message: string, id: string) => {
           if (requestRecoveryOnFailure && !(await sessionWasDeleted())) {

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -31,7 +31,11 @@ import {
   markSessionAudioTranscriptionComplete,
 } from "~/session/attachments";
 import { enqueueSessionAudioOperation } from "~/session/audio-operations";
-import { useSession, useSessionTranscriptExistence } from "~/session/queries";
+import {
+  isSessionDeleted,
+  useSession,
+  useSessionTranscriptExistence,
+} from "~/session/queries";
 import { requestAppAttention } from "~/shared/app-attention";
 import { useConfigValue } from "~/shared/config";
 import { id } from "~/shared/utils";
@@ -357,13 +361,44 @@ export function useCaptureLifecycle(sessionId: string) {
         sonnerToast.dismiss("recording-without-transcription");
         sonnerToast.dismiss("live-transcription-stalled");
         sonnerToast.dismiss("meeting-disclosure-send-failed");
-        const notifyFailure = (message: string, id: string) => {
-          if (requestRecoveryOnFailure) {
+        let sessionDeleted = false;
+        const sessionWasDeleted = async () => {
+          if (sessionDeleted) return true;
+          try {
+            sessionDeleted = await isSessionDeleted(sessionId);
+          } catch (error) {
+            console.warn(
+              "[listener] failed to check whether the session was deleted",
+              error,
+            );
+          }
+          return sessionDeleted;
+        };
+        const notifyFailure = async (message: string, id: string) => {
+          if (requestRecoveryOnFailure && !(await sessionWasDeleted())) {
             sonnerToast.error(message, { id });
           }
         };
         const requestRecovery = async () => {
           recoveryPending = true;
+          if (await sessionWasDeleted()) {
+            try {
+              await persistTranscriptWrite(() =>
+                clearCaptureLifecycleMarker(sessionId, transcriptId),
+              );
+              recoveryPending = false;
+              recoveryStateCleared = true;
+            } catch (error) {
+              console.error(
+                "[listener] failed to clear deleted session capture state",
+                error,
+              );
+              if (requestRecoveryOnFailure) {
+                await requestCaptureRecoverySafely(sessionId);
+              }
+            }
+            return;
+          }
           if (requestRecoveryOnFailure) {
             await requestCaptureRecoverySafely(sessionId);
           }
@@ -492,12 +527,12 @@ export function useCaptureLifecycle(sessionId: string) {
               failure_stage: "batch_repair",
             });
             if (transcriptWriteError || !details.liveTranscriptionActive) {
-              notifyFailure(
+              await notifyFailure(
                 "Anarlog could not finish saving the transcript. The recording was kept so you can try again.",
                 "post-capture-transcript-incomplete",
               );
             } else {
-              notifyFailure(
+              await notifyFailure(
                 "Post-meeting transcription failed. The recording was kept so you can try again.",
                 "post-capture-batch-failed",
               );
@@ -525,7 +560,7 @@ export function useCaptureLifecycle(sessionId: string) {
           transcriptWriteError &&
           postCaptureAction !== "batch_then_enhance"
         ) {
-          notifyFailure(
+          await notifyFailure(
             details.audioPath
               ? "Anarlog could not finish saving the transcript. The recording was kept so you can try again."
               : "Anarlog could not save part of the live transcript.",
@@ -609,7 +644,7 @@ export function useCaptureLifecycle(sessionId: string) {
                 "[listener] failed to persist summary recovery state",
                 error,
               );
-              notifyFailure(
+              await notifyFailure(
                 "The transcript was saved, but Anarlog could not start the summary. Try generating it again.",
                 "post-capture-summary-failed",
               );
@@ -627,7 +662,7 @@ export function useCaptureLifecycle(sessionId: string) {
           } catch (error) {
             summaryScheduled = false;
             console.error("[listener] failed to schedule summary", error);
-            notifyFailure(
+            await notifyFailure(
               "The transcript was saved, but Anarlog could not start the summary. Try generating it again.",
               "post-capture-summary-failed",
             );

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -31,6 +31,7 @@ const {
   setBatchTranscriptionPendingMock,
   runBatchMock,
   useListenerMock,
+  isSessionDeletedMock,
   useSessionMock,
   useSessionHasTranscriptMock,
   useSessionParticipantHumanIdsMock,
@@ -83,6 +84,7 @@ const {
   setBatchTranscriptionPendingMock: vi.fn(),
   runBatchMock: vi.fn(),
   useListenerMock: vi.fn(),
+  isSessionDeletedMock: vi.fn(),
   useSessionMock: vi.fn(),
   useSessionHasTranscriptMock: vi.fn(),
   useSessionParticipantHumanIdsMock: vi.fn(),
@@ -231,6 +233,7 @@ vi.mock("~/session/utils", () => ({
 }));
 
 vi.mock("~/session/queries", () => ({
+  isSessionDeleted: isSessionDeletedMock,
   useSession: useSessionMock,
   useSessionTranscriptExistence: useSessionHasTranscriptMock,
 }));
@@ -464,6 +467,7 @@ describe("useStartListening", () => {
     beginCaptureRecoveryFinalizationMock.mockReturnValue(true);
     canStartLiveSessionMock.mockReturnValue(true);
     getSessionModeMock.mockReturnValue("active");
+    isSessionDeletedMock.mockResolvedValue(false);
     useSessionMock.mockReturnValue({
       id: "session-1",
       user_id: "user-1",
@@ -3026,6 +3030,49 @@ describe("useStartListening", () => {
     expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
     expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+    consoleError.mockRestore();
+  });
+
+  test("does not surface a summary scheduling failure after the session is deleted", async () => {
+    useSessionHasTranscriptMock.mockReturnValue(true);
+    isSessionDeletedMock.mockResolvedValue(true);
+    queueAutoEnhanceIfSummaryEmptyMock.mockRejectedValueOnce(
+      new Error("Session session-1 no longer exists"),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+        needsBatchRepair: false,
+      });
+    });
+
+    expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledOnce();
+    expect(sonnerToastErrorMock).not.toHaveBeenCalled();
+    expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledWith(
+      "session-1",
+      "generated-id",
+    );
+    expect(requestCaptureRecoveryMock).not.toHaveBeenCalled();
+    expect(endCloudsyncActivityMock).toHaveBeenCalledWith(
+      "capture",
+      "session-1:generated-id",
+    );
+    expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
+    expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -3076,6 +3076,42 @@ describe("useStartListening", () => {
     consoleError.mockRestore();
   });
 
+  test("requests recovery when the deleted session is restored during finalization", async () => {
+    useSessionHasTranscriptMock.mockReturnValue(true);
+    isSessionDeletedMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    queueAutoEnhanceIfSummaryEmptyMock.mockRejectedValueOnce(
+      new Error("constraint failed"),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 42,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+        needsBatchRepair: false,
+      });
+    });
+
+    expect(isSessionDeletedMock).toHaveBeenCalledTimes(2);
+    expect(sonnerToastErrorMock).not.toHaveBeenCalled();
+    expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+    expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+    consoleError.mockRestore();
+  });
+
   test("regenerates the summary after resumed batch capture completes", async () => {
     useSessionHasTranscriptMock.mockReturnValue(true);
 


### PR DESCRIPTION
Wait for the note tombstone before post-capture alerts and clear obsolete recovery state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-capture failure handling and recovery paths in capture lifecycle; incorrect deleted detection could hide real errors or leave stale recovery state, but behavior is covered by new tests.
> 
> **Overview**
> Adds **`isSessionDeleted`**, which waits for an in-flight soft delete to finish before checking whether the session row is tombstoned, and exports it from session queries.
> 
> Post-capture finalization in **`capture-lifecycle`** uses that check so failure toasts and capture recovery are skipped when the user deleted the recording mid-finalization; instead it clears the capture lifecycle marker and releases sync. **`notifyFailure`** and **`requestRecovery`** are async so those checks run before showing errors or re-queueing recovery.
> 
> Tests cover tombstone timing, summary scheduling after delete, and the case where the session is restored while finalization is still running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67bd10407a8cf5cff67cb2bee47c56f6dd0b57c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->