### PR TITLE
Refresh desktop 1.4.16 release notes

### DIFF
--- a/packages/changelog/content/1.4.16.md
+++ b/packages/changelog/content/1.4.16.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-08-30"
+date: "2026-09-02"
 summary: "Anarlog 1.4.16 clarifies on-device model labels and fixes downloads for Whisper Large Turbo."
 ---
 
@@ -15,3 +15,34 @@ summary: "Anarlog 1.4.16 clarifies on-device model labels and fixes downloads fo
 - Read the four on-device paths — Soniqo, Apple Speech, an on-device `.bin`,
   and a local Deepgram-compatible server — in the
   [on-device models FAQ](https://docs.anarlog.so/help#use-on-device-models)
+
+## Folders and notes
+
+- Organize notes in nested folders, group the sidebar by date or folder, sort
+  newest or oldest first, and show folder and tag context above note titles
+- Add PDFs and other reference files to a folder, give chat folder-specific
+  instructions, and let chat use those materials; folder materials remain on
+  this device for now
+- Delete a folder without deleting its notes — they return to **All notes**
+
+## Recording and transcription
+
+- Start scheduled recordings even when live transcription is not ready, and
+  keep an active meeting recording through brief microphone or browser-state
+  changes
+- Use live OpenAI and Gemini transcription with corrected provider requests,
+  and keep the floating-bar waveform visible while transcription falls back
+- Delete a recording while it is still finalizing without seeing obsolete
+  failure alerts or losing recovery when you undo the deletion
+
+## Performance and polish
+
+- Open large encrypted local databases without spending minutes stalled on
+  **Migrating your local database**
+- See chat replies appear word by word, keep update progress visible through
+  download and install, and reconnect Outlook when its authorization expires
+
+## Teams
+
+- Switch between teams in Settings, add a workspace logo, and manage members,
+  policies, billing, and other controls from one workspace-focused view

--- a/packages/changelog/content/1.4.16.md
+++ b/packages/changelog/content/1.4.16.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-09-02"
+date: "2026-08-30"
 summary: "Anarlog 1.4.16 clarifies on-device model labels and fixes downloads for Whisper Large Turbo."
 ---
 
@@ -15,34 +15,3 @@ summary: "Anarlog 1.4.16 clarifies on-device model labels and fixes downloads fo
 - Read the four on-device paths — Soniqo, Apple Speech, an on-device `.bin`,
   and a local Deepgram-compatible server — in the
   [on-device models FAQ](https://docs.anarlog.so/help#use-on-device-models)
-
-## Folders and notes
-
-- Organize notes in nested folders, group the sidebar by date or folder, sort
-  newest or oldest first, and show folder and tag context above note titles
-- Add PDFs and other reference files to a folder, give chat folder-specific
-  instructions, and let chat use those materials; folder materials remain on
-  this device for now
-- Delete a folder without deleting its notes — they return to **All notes**
-
-## Recording and transcription
-
-- Start scheduled recordings even when live transcription is not ready, and
-  keep an active meeting recording through brief microphone or browser-state
-  changes
-- Use live OpenAI and Gemini transcription with corrected provider requests,
-  and keep the floating-bar waveform visible while transcription falls back
-- Delete a recording while it is still finalizing without seeing obsolete
-  failure alerts or losing recovery when you undo the deletion
-
-## Performance and polish
-
-- Open large encrypted local databases without spending minutes stalled on
-  **Migrating your local database**
-- See chat replies appear word by word, keep update progress visible through
-  download and install, and reconnect Outlook when its authorization expires
-
-## Teams
-
-- Switch between teams in Settings, add a workspace logo, and manage members,
-  policies, billing, and other controls from one workspace-focused view

--- a/packages/changelog/content/1.4.17.md
+++ b/packages/changelog/content/1.4.17.md
@@ -1,0 +1,35 @@
+---
+date: "2026-09-02"
+summary: "Anarlog 1.4.17 adds nested folders and workspace management, improves recording resilience, and speeds up large database migrations."
+---
+
+## Folders and notes
+
+- Organize notes in nested folders, group the sidebar by date or folder, sort
+  newest or oldest first, and show folder and tag context above note titles
+- Add PDFs and other reference files to a folder, give chat folder-specific
+  instructions, and let chat use those materials; folder materials remain on
+  this device for now
+- Delete a folder without deleting its notes — they return to **All notes**
+
+## Recording and transcription
+
+- Start scheduled recordings even when live transcription is not ready, and
+  keep an active meeting recording through brief microphone or browser-state
+  changes
+- Use live OpenAI and Gemini transcription with corrected provider requests,
+  and keep the floating-bar waveform visible while transcription falls back
+- Delete a recording while it is still finalizing without seeing obsolete
+  failure alerts or losing recovery when you undo the deletion
+
+## Performance and polish
+
+- Open large encrypted local databases without spending minutes stalled on
+  **Migrating your local database**
+- See chat replies appear word by word, keep update progress visible through
+  download and install, and reconnect Outlook when its authorization expires
+
+## Teams
+
+- Switch between teams in Settings, add a workspace logo, and manage members,
+  policies, billing, and other controls from one workspace-focused view


### PR DESCRIPTION
Expand the changelog to cover folders, capture reliability, performance, chat, updater, Outlook, and Teams changes shipping since 1.4.15.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or product code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.17.md`** (dated 2026-09-02) as the desktop **1.4.17** release entry, with a front-matter summary and four sections: **Folders and notes** (nested folders, sidebar grouping/sorting, folder materials and chat context, non-destructive folder delete), **Recording and transcription** (scheduled start without live transcription, resilience through mic/browser blips, OpenAI/Gemini live transcription and fallback UX, delete-while-finalizing behavior), **Performance and polish** (faster encrypted DB migration, streaming chat replies, updater progress through install, Outlook re-auth), and **Teams** (team switching, workspace logo, unified workspace admin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 796a6d31cfaccb384ae26c617f6e5f3077b0fe14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->