### PR TITLE
Prefer the macOS tray icon next to system extras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17341,6 +17341,8 @@ dependencies = [
  "host",
  "intercept",
  "libloading 0.8.9",
+ "objc2-app-kit",
+ "objc2-foundation",
  "open",
  "serde",
  "serde_json",
@@ -17357,6 +17359,7 @@ dependencies = [
  "tauri-specta",
  "tokio",
  "tracing",
+ "tray-icon",
  "unicode-width 0.2.2",
 ]
 

--- a/plugins/tray/Cargo.toml
+++ b/plugins/tray/Cargo.toml
@@ -40,3 +40,8 @@ unicode-width = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { workspace = true, features = ["NSStatusItem"] }
+objc2-foundation = { workspace = true, features = ["NSString", "NSUserDefaults"] }
+tray-icon = { version = "0.21.3", default-features = false }

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -229,6 +229,7 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
 
     pub fn set_visible(&self, visible: bool) -> Result<()> {
         let app = self.manager.app_handle();
+        crate::macos_position::set_wanted_visible(visible);
 
         if visible {
             if let Some(tray) = app.tray_by_id(TRAY_ID) {

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -213,7 +213,12 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
                 }
             })
         };
+        #[cfg(target_os = "macos")]
+        crate::macos_position::seed_default_position(TRAY_ID);
+
         builder.build(app)?;
+        #[cfg(target_os = "macos")]
+        crate::macos_position::apply_autosave_name(app, TRAY_ID);
         #[cfg(target_os = "macos")]
         MENU_DIRTY.store(false, Ordering::SeqCst);
 

--- a/plugins/tray/src/lib.rs
+++ b/plugins/tray/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod ext;
+mod macos_position;
 mod menu_items;
 mod schedule;
 mod tray_icon;

--- a/plugins/tray/src/macos_position.rs
+++ b/plugins/tray/src/macos_position.rs
@@ -1,9 +1,21 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static WANTED_VISIBLE: AtomicBool = AtomicBool::new(true);
+
 pub fn preferred_position_key(autosave_name: &str) -> String {
     format!("NSStatusItem Preferred Position {autosave_name}")
 }
 
 pub fn visibility_key(autosave_name: &str) -> String {
     format!("NSStatusItem Visible {autosave_name}")
+}
+
+pub fn set_wanted_visible(visible: bool) {
+    WANTED_VISIBLE.store(visible, Ordering::SeqCst);
+}
+
+pub fn wanted_visible() -> bool {
+    WANTED_VISIBLE.load(Ordering::SeqCst)
 }
 
 #[cfg(target_os = "macos")]
@@ -48,6 +60,9 @@ pub fn apply_autosave_name(app: &tauri::AppHandle<tauri::Wry>, autosave_name: &'
 
     let app = app.clone();
     if let Err(error) = app.run_on_main_thread(move || {
+        if !wanted_visible() {
+            return;
+        }
         if let Some(tray) = app.tray_by_id(autosave_name) {
             let _ = tray.set_visible(true);
         }
@@ -74,5 +89,14 @@ mod tests {
             visibility_key("anlg-tray"),
             "NSStatusItem Visible anlg-tray"
         );
+    }
+
+    #[test]
+    fn deferred_show_respects_a_later_hide() {
+        super::set_wanted_visible(true);
+        assert!(super::wanted_visible());
+        super::set_wanted_visible(false);
+        assert!(!super::wanted_visible());
+        super::set_wanted_visible(true);
     }
 }

--- a/plugins/tray/src/macos_position.rs
+++ b/plugins/tray/src/macos_position.rs
@@ -1,0 +1,50 @@
+pub fn preferred_position_key(autosave_name: &str) -> String {
+    format!("NSStatusItem Preferred Position {autosave_name}")
+}
+
+#[cfg(target_os = "macos")]
+pub fn seed_default_position(autosave_name: &str) {
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let key = NSString::from_str(&preferred_position_key(autosave_name));
+    if defaults.objectForKey(&key).is_some() {
+        return;
+    }
+
+    // AppKit treats this as distance from the right edge of the status area.
+    // 0 claims the rightmost third-party slot, just left of system extras.
+    // Only seed when unset so a user ⌘-drag keeps winning on later launches.
+    defaults.setDouble_forKey(0.0, &key);
+}
+
+#[cfg(target_os = "macos")]
+pub fn apply_autosave_name(app: &tauri::AppHandle<tauri::Wry>, autosave_name: &'static str) {
+    use objc2_foundation::NSString;
+
+    let Some(tray) = app.tray_by_id(autosave_name) else {
+        return;
+    };
+
+    if let Err(error) = tray.with_inner_tray_icon(move |inner: &tray_icon::TrayIcon| {
+        let Some(item) = inner.ns_status_item() else {
+            return;
+        };
+        item.setAutosaveName(Some(&NSString::from_str(autosave_name)));
+    }) {
+        tracing::warn!(%error, "failed to set tray status item autosave name");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preferred_position_key;
+
+    #[test]
+    fn preferred_position_key_matches_appkit_convention() {
+        assert_eq!(
+            preferred_position_key("anlg-tray"),
+            "NSStatusItem Preferred Position anlg-tray"
+        );
+    }
+}

--- a/plugins/tray/src/macos_position.rs
+++ b/plugins/tray/src/macos_position.rs
@@ -2,6 +2,10 @@ pub fn preferred_position_key(autosave_name: &str) -> String {
     format!("NSStatusItem Preferred Position {autosave_name}")
 }
 
+pub fn visibility_key(autosave_name: &str) -> String {
+    format!("NSStatusItem Visible {autosave_name}")
+}
+
 #[cfg(target_os = "macos")]
 pub fn seed_default_position(autosave_name: &str) {
     use objc2_foundation::{NSString, NSUserDefaults};
@@ -20,7 +24,13 @@ pub fn seed_default_position(autosave_name: &str) {
 
 #[cfg(target_os = "macos")]
 pub fn apply_autosave_name(app: &tauri::AppHandle<tauri::Wry>, autosave_name: &'static str) {
-    use objc2_foundation::NSString;
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    // Visibility is owned by show_tray_icon. setAutosaveName also restores
+    // `NSStatusItem Visible`, so a prior set_visible(false) would hide the
+    // item we just created to show.
+    defaults.removeObjectForKey(&NSString::from_str(&visibility_key(autosave_name)));
 
     let Some(tray) = app.tray_by_id(autosave_name) else {
         return;
@@ -31,20 +41,38 @@ pub fn apply_autosave_name(app: &tauri::AppHandle<tauri::Wry>, autosave_name: &'
             return;
         };
         item.setAutosaveName(Some(&NSString::from_str(autosave_name)));
+        item.setVisible(true);
     }) {
         tracing::warn!(%error, "failed to set tray status item autosave name");
+    }
+
+    let app = app.clone();
+    if let Err(error) = app.run_on_main_thread(move || {
+        if let Some(tray) = app.tray_by_id(autosave_name) {
+            let _ = tray.set_visible(true);
+        }
+    }) {
+        tracing::warn!(%error, "failed to force tray icon visible after autosave restore");
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::preferred_position_key;
+    use super::{preferred_position_key, visibility_key};
 
     #[test]
     fn preferred_position_key_matches_appkit_convention() {
         assert_eq!(
             preferred_position_key("anlg-tray"),
             "NSStatusItem Preferred Position anlg-tray"
+        );
+    }
+
+    #[test]
+    fn visibility_key_matches_appkit_convention() {
+        assert_eq!(
+            visibility_key("anlg-tray"),
+            "NSStatusItem Visible anlg-tray"
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** The `a_` menu bar icon lands among other third-party status items instead of at the right end of that group, just left of the system extras (battery, Wi‑Fi, Control Center, clock). Apple does not expose a public API to pin `NSStatusItem` in that slot.

**Fix:** Use AppKit’s supported placement hint. Before creating the tray, seed `NSStatusItem Preferred Position anlg-tray` to `0` (right edge of the status area) **only if unset**, then set `autosaveName` on the status item so a user ⌘-drag is remembered across launches.

`setAutosaveName` also restores `NSStatusItem Visible`. After `set_visible(false)`, a later `create_tray_menu` would reapply the name and could leave the icon hidden. Visibility stays owned by `show_tray_icon`: we drop the Visible defaults key before assigning the name, then force the item visible.

The AppKit follow-up `set_visible(true)` now checks the latest wanted visibility, so an ON-then-OFF toggle cannot be overwritten by that deferred callback.

This cannot jump over other apps that already claimed a rightward slot, and it cannot sit *inside* the system extra cluster.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed files
- Isolated unit tests for the AppKit defaults keys and the hide-after-show intent flag
- Could not run `cargo test -p tauri-plugin-anlg-tray` in this environment: `gdk-3.0` / `libgtk-3-dev` pkg-config files are not available
- Menu-bar placement itself needs a macOS machine (⌘-drag still works as a manual override)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4689cadf-998c-4011-a759-b1c2823dfbe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4689cadf-998c-4011-a759-b1c2823dfbe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

