### PR TITLE
Unify Windows toolbar and sidebar surface

### DIFF
--- a/apps/desktop/src/main/windows-title-bar.test.tsx
+++ b/apps/desktop/src/main/windows-title-bar.test.tsx
@@ -95,9 +95,16 @@ describe("WindowsTitleBar", () => {
     render(<WindowsTitleBar />);
 
     const titleBar = screen.getByTestId("windows-title-bar");
+    const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
 
     expect(titleBar.hasAttribute("data-tauri-drag-region")).toBe(true);
-    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(titleBar.className).toContain("bg-background");
+    expect(titleBar.className).not.toContain("border-b");
+    expect(
+      sidebarToggle.compareDocumentPosition(
+        screen.getByRole("menuitem", { name: "File" }),
+      ),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getByRole("menuitem", { name: "File" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Edit" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "View" })).toBeTruthy();

--- a/apps/desktop/src/main/windows-title-bar.tsx
+++ b/apps/desktop/src/main/windows-title-bar.tsx
@@ -103,7 +103,7 @@ export function WindowsTitleBar() {
     <header
       data-tauri-drag-region
       data-testid="windows-title-bar"
-      className="border-border/60 bg-background flex h-10 shrink-0 items-stretch border-b"
+      className="bg-background flex h-10 shrink-0 items-stretch"
     >
       <div
         data-tauri-drag-region

--- a/apps/desktop/src/shared/main/shell-scaffold.test.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.test.tsx
@@ -64,12 +64,12 @@ describe("MainShellScaffold", () => {
   });
 
   it.each([
-    ["windows", "left", "rounded-l-xl"],
-    ["windows", "top", "rounded-t-xl"],
-    ["linux", "left", "rounded-l-xl"],
-    ["linux", "top", "rounded-t-xl"],
+    ["windows", "left", "[&_[data-chat-floating-anchor]]:rounded-tl-xl"],
+    ["windows", "top", "[&_[data-chat-floating-anchor]]:rounded-t-xl"],
+    ["linux", "left", "[&_[data-chat-floating-anchor]]:rounded-tl-xl"],
+    ["linux", "top", "[&_[data-chat-floating-anchor]]:rounded-t-xl"],
   ] as const)(
-    "does not add %s main surface rounding for %s chrome",
+    "adds %s main surface rounding for %s chrome",
     (currentPlatform, mainSurfaceChrome, roundedClass) => {
       mocks.platform = currentPlatform;
 
@@ -79,7 +79,7 @@ describe("MainShellScaffold", () => {
         </MainShellScaffold>,
       );
 
-      expect(screen.getByTestId("main-app-shell").className).not.toContain(
+      expect(screen.getByTestId("main-app-shell").className).toContain(
         roundedClass,
       );
     },

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -44,11 +44,15 @@ export function MainShellScaffold({
           ],
           resolvedMainSurfaceChrome === "left" && [
             isMacos && "[&_[data-chat-floating-anchor]]:rounded-l-xl",
+            !isMacos && "[&_[data-chat-floating-anchor]]:rounded-tl-xl",
             "[&_[data-chat-floating-anchor]]:rounded-r-none",
             "[&_[data-chat-floating-anchor]]:border-y-0",
             "[&_[data-chat-floating-anchor]]:border-r-0",
             "[&_[data-chat-floating-anchor]]:border-l",
           ],
+          hasTopMainSurfaceChrome &&
+            !isMacos &&
+            "[&_[data-chat-floating-anchor]]:rounded-t-xl",
         ])}
         data-testid="main-app-shell"
       >


### PR DESCRIPTION
Blend the title bar and sidebar into one surface while keeping sidebar actions in their own top row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only Tailwind class and test updates; no behavior, auth, or data changes.
> 
> **Overview**
> **Unifies the Windows/Linux chrome** so the custom title bar reads as one continuous surface with the sidebar and main content, instead of a separated strip with a bottom border.
> 
> The Windows title bar drops its bottom border (`border-b` / `border-border/60`) while keeping the same draggable layout; tests now assert that styling and that the sidebar toggle still precedes the app menus in the DOM.
> 
> **Main shell rounding** moves onto the chat floating anchor for non-macOS: left chrome gets top-left rounding, and top/top-borderless chrome gets top rounding—matching the blended toolbar look. Shell scaffold tests flip from expecting no Windows/Linux rounding to expecting those descendant selector classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5f1e06712377b6bc50671d50cb916e7a51892e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->