### PR TITLE
Route Windows downloads through Microsoft Store

### DIFF
--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -35,14 +35,15 @@ test("offers macOS, Windows, and Linux downloads", () => {
     macosDownloads[0].url,
     /^https:\/\/desktop\.anarlog\.so\/download\/latest\/platform\/dmg-aarch64\?/,
   );
-  assert.equal(windowsDownloads.length, 1);
-  assert.equal(windowsDownloads[0].name, "Microsoft Store");
-  assert.equal(windowsDownloads[0].url, windowsStoreDownloadUrl);
-  assert.equal(windowsDownloads[0].actionLabel, "Get from Store");
-  assert.equal(
-    windowsDownloads.some((download) => download.url.includes("nsis-x86_64")),
-    false,
+  assert.equal(windowsDownloads.length, 2);
+  assert.equal(windowsDownloads[0].name, "Windows x64");
+  assert.match(
+    windowsDownloads[0].url,
+    /^https:\/\/desktop\.anarlog\.so\/download\/latest\/platform\/nsis-x86_64\?/,
   );
+  assert.equal(windowsDownloads[1].name, "Microsoft Store");
+  assert.equal(windowsDownloads[1].url, windowsStoreDownloadUrl);
+  assert.equal(windowsDownloads[1].actionLabel, "Get from Store");
   assert.deepEqual(
     linuxDownloads.map((download) =>
       new URL(download.url).pathname.split("/").at(-1),

--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -6,6 +6,7 @@ import {
   desktopDownloadSections,
   detectDesktopPlatform,
   getOrderedDesktopDownloadSections,
+  windowsStoreDownloadUrl,
 } from "./download.ts";
 
 test("offers macOS, Windows, and Linux downloads", () => {
@@ -34,9 +35,13 @@ test("offers macOS, Windows, and Linux downloads", () => {
     macosDownloads[0].url,
     /^https:\/\/desktop\.anarlog\.so\/download\/latest\/platform\/dmg-aarch64\?/,
   );
-  assert.match(
-    windowsDownloads[0].url,
-    /^https:\/\/desktop\.anarlog\.so\/download\/latest\/platform\/nsis-x86_64\?/,
+  assert.equal(windowsDownloads.length, 1);
+  assert.equal(windowsDownloads[0].name, "Microsoft Store");
+  assert.equal(windowsDownloads[0].url, windowsStoreDownloadUrl);
+  assert.equal(windowsDownloads[0].actionLabel, "Get from Store");
+  assert.equal(
+    windowsDownloads.some((download) => download.url.includes("nsis-x86_64")),
+    false,
   );
   assert.deepEqual(
     linuxDownloads.map((download) =>

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -44,8 +44,14 @@ export const desktopDownloadSections = [
     platform: "windows",
     name: "Windows",
     status: "Beta",
-    description: "Install Anarlog through the Microsoft Store.",
+    description: "Choose a direct download or install from Microsoft Store.",
     downloads: [
+      {
+        name: "Windows x64",
+        detail: "Signed EXE installer",
+        url: getStableDownloadUrl("nsis-x86_64"),
+        showInMenu: true,
+      },
       {
         name: "Microsoft Store",
         detail: "Windows 10 and 11",

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -9,6 +9,8 @@ export type DesktopPlatform = "linux" | "macos" | "windows";
 
 export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
+export const windowsStoreDownloadUrl =
+  "https://apps.microsoft.com/detail/XPDLN196NKSW10";
 
 export const comingSoonPlatforms = [
   "iOS",
@@ -42,12 +44,13 @@ export const desktopDownloadSections = [
     platform: "windows",
     name: "Windows",
     status: "Beta",
-    description: "Beta installer for 64-bit Windows PCs.",
+    description: "Install Anarlog through the Microsoft Store.",
     downloads: [
       {
-        name: "Windows x64",
-        detail: "NSIS installer · EXE",
-        url: getStableDownloadUrl("nsis-x86_64"),
+        name: "Microsoft Store",
+        detail: "Windows 10 and 11",
+        url: windowsStoreDownloadUrl,
+        actionLabel: "Get from Store",
         showInMenu: true,
       },
     ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing/download metadata only; no auth or backend changes, and the direct EXE path is unchanged.
> 
> **Overview**
> Windows desktop downloads now offer **two choices**: the existing stable **Windows x64** direct EXE (copy updated to “Signed EXE installer”) and a new **Microsoft Store** entry that links to the published store listing with a **“Get from Store”** action label.
> 
> The Windows section copy now tells users they can pick a direct download or install from the Store. A shared `windowsStoreDownloadUrl` constant holds the Store URL, and unit tests assert both Windows download rows and the Store link/label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c7e86decec249828947a9948419726ab14538b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->