### PR TITLE
Fix tray main-thread handle ownership

### DIFF
--- a/plugins/tray/src/macos_position.rs
+++ b/plugins/tray/src/macos_position.rs
@@ -58,12 +58,12 @@ pub fn apply_autosave_name(app: &tauri::AppHandle<tauri::Wry>, autosave_name: &'
         tracing::warn!(%error, "failed to set tray status item autosave name");
     }
 
-    let app = app.clone();
+    let app_for_callback = app.clone();
     if let Err(error) = app.run_on_main_thread(move || {
         if !wanted_visible() {
             return;
         }
-        if let Some(tray) = app.tray_by_id(autosave_name) {
+        if let Some(tray) = app_for_callback.tray_by_id(autosave_name) {
             let _ = tray.set_visible(true);
         }
     }) {


### PR DESCRIPTION
Use a dedicated AppHandle clone inside the deferred tray callback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow macOS tray ownership fix with no auth, data, or API behavior changes beyond correct compilation and safe deferred visibility restore.
> 
> **Overview**
> Fixes **main-thread handle ownership** in `apply_autosave_name` when forcing the tray visible after AppKit autosave restore.
> 
> The deferred `run_on_main_thread` closure now uses a dedicated **`app_for_callback`** clone instead of reusing the same owned `AppHandle` as the call receiver, so the callback can look up the tray by id without moving the handle needed to schedule the work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0c0a5913b2bc08c963c87c98495247ed62b0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->