### PR TITLE
Hide Sign in with Apple on Android

### DIFF
--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -3,6 +3,7 @@ import { Image } from "expo-image";
 import * as WebBrowser from "expo-web-browser";
 import { useState } from "react";
 import {
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -16,7 +17,7 @@ import {
   buildMobileBillingReturnUrl,
   parseBillingCallbackUrl,
 } from "@/auth/billing-handoff";
-import type { SignInMethod } from "@/auth/sign-in";
+import { isAppleSignInAvailable, type SignInMethod } from "@/auth/sign-in";
 import { Button } from "@/components/ui/button";
 import {
   Colors,
@@ -72,14 +73,16 @@ export function SignInScreen({
       >
         <RNHostView matchContents>
           <View style={[styles.signInMethodList, { width }]}>
-            <SignInMethodButton
-              method="apple"
-              label="Sign in with Apple"
-              onSignIn={onSignIn}
-              disabled={busy}
-              iconSource={require("../../assets/images/auth/apple.svg")}
-              lastSignInMethod={lastSignInMethod}
-            />
+            {isAppleSignInAvailable(Platform.OS) && (
+              <SignInMethodButton
+                method="apple"
+                label="Sign in with Apple"
+                onSignIn={onSignIn}
+                disabled={busy}
+                iconSource={require("../../assets/images/auth/apple.svg")}
+                lastSignInMethod={lastSignInMethod}
+              />
+            )}
             <SignInMethodButton
               method="google"
               label="Sign in with Google"

--- a/apps/mobile/src/auth/sign-in.test.mjs
+++ b/apps/mobile/src/auth/sign-in.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildSignInUrl,
+  isAppleSignInAvailable,
   parseAuthCallbackSignInMethod,
   parseLastSignInMethod,
 } from "./sign-in.ts";
@@ -31,6 +32,12 @@ for (const view of ["email", "sso"]) {
     assert.equal(url.searchParams.has("provider"), false);
   });
 }
+
+test("hides Sign in with Apple on Android", () => {
+  assert.equal(isAppleSignInAvailable("android"), false);
+  assert.equal(isAppleSignInAvailable("ios"), true);
+  assert.equal(isAppleSignInAvailable("web"), true);
+});
 
 test("accepts only supported last-used sign-in methods", () => {
   for (const method of ["apple", "google", "azure", "github", "email", "sso"]) {

--- a/apps/mobile/src/auth/sign-in.ts
+++ b/apps/mobile/src/auth/sign-in.ts
@@ -6,6 +6,10 @@ export type SignInMethod =
   | "email"
   | "sso";
 
+export function isAppleSignInAvailable(os: string) {
+  return os !== "android";
+}
+
 export const lastSignInMethodStorageKey = "anarlog:auth:last-sign-in-method";
 
 export function parseLastSignInMethod(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** The mobile sign-in sheet always showed Sign in with Apple, including on Android where that method is not offered.

**Fix:** Skip the Apple button when `Platform.OS` is `android`. iOS (and other non-Android platforms) still show it.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed files
- `pnpm -F @anlg/mobile typecheck`
- `pnpm -F @anlg/mobile test` (126 passing, including a new `isAppleSignInAvailable` case)

Could not run the Expo Android app in this environment to confirm the sheet visually.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a41b371-195d-4570-a06c-d71dc2d9a684?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a41b371-195d-4570-a06c-d71dc2d9a684&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

