### PR TITLE
Keep local diarization alive, repair the CoreML cache, simplify the diarizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13371,9 +13371,8 @@ dependencies = [
  "onnx",
  "serde",
  "serde_json",
- "specta",
  "thiserror 2.0.18",
- "tracing",
+ "tracing-subscriber",
  "voiceprint",
 ]
 

--- a/crates/listener2-core/src/batch/diarize.rs
+++ b/crates/listener2-core/src/batch/diarize.rs
@@ -2,21 +2,29 @@
 //! providers, which return words without speaker labels. Cloud providers
 //! diarize server-side, so this only runs when a channel came back unlabeled.
 
+use std::cell::Cell;
 use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anlg_pyannote_local::{
     AudioSource, DiarizationConfig, DiarizeRequest, Diarizer, SpeakerBounds, assign_words,
 };
 use owhisper_interface::batch;
+use owhisper_interface::batch_stream::BatchStreamEvent;
 
 use super::simple::{ResampledChannelFile, resample_audio_to_channel_files_until};
 use super::{BatchParams, BatchProvider, BatchRunOutput};
-use crate::BatchRuntime;
+use crate::{BatchEvent, BatchRuntime};
 
 pub(super) const LOCAL_DIARIZATION_PROVIDER: &str = "pyannote-local";
+/// Diarization reports progress from here to 1.0, continuing where local
+/// transcription providers stop.
+pub(super) const DIARIZATION_PROGRESS_START: f64 = 0.95;
+/// Progressive sessions are torn down after 60 s without a streamed event, so
+/// the diarizer emits a progress heartbeat at least this often.
+pub(super) const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 
 /// A participant voiceprint the caller already trusts, forwarded to the
 /// diarizer so fragmented clusters of a known voice can be merged.
@@ -181,6 +189,7 @@ pub(super) async fn apply_local_diarization(
         return;
     }
 
+    let session_id = params.session_id.clone();
     let file_path = params.file_path.clone();
     let listen_params = listen_params.clone();
     let known_speakers: Vec<anlg_pyannote_local::KnownSpeaker> = params
@@ -195,8 +204,10 @@ pub(super) async fn apply_local_diarization(
     let result = tokio::task::spawn_blocking({
         let runtime = runtime.clone();
         move || {
+            let heartbeat = Heartbeat::new(runtime.as_ref(), session_id);
             diarize_channels(
                 runtime.as_ref(),
+                &heartbeat,
                 &file_path,
                 &listen_params,
                 transcript_channels,
@@ -287,19 +298,66 @@ fn apply_labels(response: &mut batch::Response, labels: &[ChannelLabels]) -> Dia
     summary
 }
 
+/// Streams `Progress` events while the diarizer works. Progressive local
+/// sessions have an idle monitor that aborts the run when nothing has been
+/// streamed for a minute; a long recording spends longer than that here,
+/// after transcription has already finished, so silence would throw away a
+/// completed transcript.
+struct Heartbeat<'a> {
+    runtime: &'a dyn BatchRuntime,
+    session_id: String,
+    last_sent: Cell<Option<Instant>>,
+}
+
+impl<'a> Heartbeat<'a> {
+    fn new(runtime: &'a dyn BatchRuntime, session_id: String) -> Self {
+        Self {
+            runtime,
+            session_id,
+            last_sent: Cell::new(None),
+        }
+    }
+
+    /// Emits unless a heartbeat went out within [`HEARTBEAT_INTERVAL`].
+    fn beat(&self, percentage: f64) {
+        let due = self
+            .last_sent
+            .get()
+            .is_none_or(|last| last.elapsed() >= HEARTBEAT_INTERVAL);
+        if due {
+            self.emit(percentage);
+        }
+    }
+
+    fn emit(&self, percentage: f64) {
+        self.last_sent.set(Some(Instant::now()));
+        self.runtime.emit(BatchEvent::BatchResponseStreamed {
+            session_id: self.session_id.clone(),
+            event: BatchStreamEvent::Progress {
+                percentage: percentage.clamp(DIARIZATION_PROGRESS_START, 1.0),
+                partial_text: None,
+            },
+        });
+    }
+}
+
 fn diarize_channels(
     runtime: &dyn BatchRuntime,
+    heartbeat: &Heartbeat<'_>,
     file_path: &str,
     listen_params: &owhisper_interface::ListenParams,
     transcript_channels: usize,
     unlabeled: &[UnlabeledChannel],
     known_speakers: &[anlg_pyannote_local::KnownSpeaker],
 ) -> Result<Vec<ChannelLabels>, String> {
+    heartbeat.emit(DIARIZATION_PROGRESS_START);
     let source = anlg_audio_utils::source_from_path(file_path).map_err(|e| e.to_string())?;
     // A stereo file whose channels were identical collapses to one file, so
     // the recording layout is only known after resampling.
-    let channel_files =
-        resample_audio_to_channel_files_until(file_path, source, || runtime.is_cancelled())?;
+    let channel_files = resample_audio_to_channel_files_until(file_path, source, || {
+        heartbeat.beat(DIARIZATION_PROGRESS_START);
+        runtime.is_cancelled()
+    })?;
     let plans: Vec<(&UnlabeledChannel, ChannelAudio, SpeakerBounds)> = unlabeled
         .iter()
         .filter_map(|channel| {
@@ -316,16 +374,26 @@ fn diarize_channels(
         return Ok(Vec::new());
     }
 
+    // Loading the models can include an accelerator cache rebuild, which is a
+    // full recompile of both; give it a fresh idle window rather than whatever
+    // the last throttled resample beat left over.
+    heartbeat.emit(DIARIZATION_PROGRESS_START);
     let mut diarizer = Diarizer::new(DiarizationConfig::default()).map_err(|e| e.to_string())?;
     let is_cancelled = || runtime.is_cancelled();
+    let plan_count = plans.len() as f64;
+    let progress_span = 1.0 - DIARIZATION_PROGRESS_START;
 
     let mut labels = Vec::new();
-    for (channel, audio, bounds) in plans {
+    for (plan_index, (channel, audio, bounds)) in plans.into_iter().enumerate() {
         let mut audio = match audio {
             ChannelAudio::File(index) => {
                 MixedAudioSource::open(std::slice::from_ref(&channel_files[index]))?
             }
             ChannelAudio::Mix => MixedAudioSource::open(&channel_files)?,
+        };
+        let on_progress = |fraction: f32| {
+            let done = (plan_index as f64 + f64::from(fraction)) / plan_count;
+            heartbeat.beat(DIARIZATION_PROGRESS_START + progress_span * done);
         };
         let diarization = diarizer
             .diarize(
@@ -334,6 +402,7 @@ fn diarize_channels(
                     bounds,
                     known_speakers,
                     is_cancelled: Some(&is_cancelled),
+                    on_progress: Some(&on_progress),
                 },
             )
             .map_err(|e| e.to_string())?;
@@ -380,9 +449,7 @@ impl WavAudioSource {
         let len = reader.len() as usize;
         Ok(Self { reader, len })
     }
-}
 
-impl WavAudioSource {
     fn read_into(
         &mut self,
         start: usize,
@@ -671,6 +738,71 @@ mod tests {
         fn is_cancelled(&self) -> bool {
             false
         }
+    }
+
+    #[derive(Default)]
+    struct RecordingRuntime {
+        progress: std::sync::Mutex<Vec<f64>>,
+    }
+
+    impl BatchRuntime for RecordingRuntime {
+        fn emit(&self, event: crate::BatchEvent) {
+            if let crate::BatchEvent::BatchResponseStreamed {
+                event: BatchStreamEvent::Progress { percentage, .. },
+                ..
+            } = event
+            {
+                self.progress.lock().unwrap().push(percentage);
+            }
+        }
+    }
+
+    #[test]
+    fn heartbeat_throttles_but_forced_emits_always_go_out() {
+        let runtime = RecordingRuntime::default();
+        let heartbeat = Heartbeat::new(&runtime, "s".to_string());
+
+        heartbeat.beat(0.96);
+        heartbeat.beat(0.97);
+        heartbeat.emit(0.98);
+        heartbeat.beat(0.99);
+
+        assert_eq!(*runtime.progress.lock().unwrap(), vec![0.96, 0.98]);
+    }
+
+    #[tokio::test]
+    async fn diarization_streams_progress_so_idle_monitors_stay_quiet() {
+        let runtime = Arc::new(RecordingRuntime::default());
+        let params = params(
+            BatchProvider::WhisperLocal,
+            "http://localhost:1234",
+            anlg_data::english_1::AUDIO_PATH,
+        );
+        let mut output = unlabeled_output(200, 100.0);
+
+        apply_local_diarization(
+            runtime.clone(),
+            &params,
+            &owhisper_interface::ListenParams::default(),
+            &mut output,
+        )
+        .await;
+
+        let progress = runtime.progress.lock().unwrap();
+        // One forced beat before the resample and one before the models load,
+        // so neither phase starts with a partly spent idle window.
+        let start_beats = progress
+            .iter()
+            .filter(|p| **p == DIARIZATION_PROGRESS_START)
+            .count();
+        assert!(start_beats >= 2, "{progress:?}");
+        assert_eq!(progress[0], DIARIZATION_PROGRESS_START);
+        assert!(
+            progress
+                .iter()
+                .all(|p| (DIARIZATION_PROGRESS_START..=1.0).contains(p)),
+            "{progress:?}"
+        );
     }
 
     fn unlabeled_output(word_count: usize, duration: f64) -> BatchRunOutput {

--- a/crates/onnx/src/lib.rs
+++ b/crates/onnx/src/lib.rs
@@ -20,7 +20,18 @@ pub fn load_model_from_bytes(bytes: &[u8]) -> Result<Session, Error> {
 // live path (e.g. Silero VAD) are faster on plain CPU than through CoreML
 // dispatch, so only batch workloads should ask for acceleration.
 pub fn load_model_from_bytes_accelerated(bytes: &[u8]) -> Result<Session, Error> {
-    match commit_accelerated(bytes) {
+    let result = match commit_accelerated(bytes) {
+        Ok(session) => Ok(session),
+        // A compiled model that no longer loads (a crash or a concurrent
+        // process left it half-written) would otherwise pin every future
+        // load to the CPU path; a rebuild from scratch is cheap by comparison.
+        Err(err) if clear_accelerator_cache() => {
+            tracing::warn!(error = %err, "accelerated session cache rebuilt");
+            commit_accelerated(bytes)
+        }
+        Err(err) => Err(err),
+    };
+    match result {
         Ok(session) => Ok(session),
         // A model the accelerator cannot compile must not take the feature down
         // with it; plain CPU produces the same values, only slower.
@@ -46,6 +57,37 @@ fn session_builder() -> Result<SessionBuilder, Error> {
 #[cfg(feature = "coreml")]
 static COREML_COMPILE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+// Keyed by executable so an installed build and a dev build (or two app
+// versions during an update) never compile into each other's cache; the
+// in-process lock cannot protect against another process.
+#[cfg(feature = "coreml")]
+fn accelerator_cache_dir() -> std::path::PathBuf {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::hash::DefaultHasher::new();
+    std::env::current_exe()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .hash(&mut hasher);
+    std::env::temp_dir()
+        .join("anlg-onnx-coreml-cache")
+        .join(format!("{:016x}", hasher.finish()))
+}
+
+/// Returns whether there was a cache to remove.
+#[cfg(feature = "coreml")]
+fn clear_accelerator_cache() -> bool {
+    let _guard = COREML_COMPILE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::fs::remove_dir_all(accelerator_cache_dir()).is_ok()
+}
+
+#[cfg(not(feature = "coreml"))]
+fn clear_accelerator_cache() -> bool {
+    false
+}
+
 #[cfg(feature = "coreml")]
 fn commit_accelerated(bytes: &[u8]) -> Result<Session, Error> {
     use ort::execution_providers::{
@@ -54,15 +96,14 @@ fn commit_accelerated(bytes: &[u8]) -> Result<Session, Error> {
     };
 
     // MLProgram cannot bound the unbounded input dims these models declare (the
-    // WeSpeaker extractor takes a variable frame count) and returns non-finite
-    // output instead of refusing the graph; the GPU unit fails to resize
-    // dynamically. NeuralNetwork on the ANE is the one combination that both
-    // compiles and matches CPU output, and it runs ~10x faster than CPU.
-    let cache_dir = std::env::temp_dir().join("anlg-onnx-coreml-cache");
+    // speaker embedding extractor takes a variable frame count) and returns
+    // non-finite output instead of refusing the graph; the GPU unit fails to
+    // resize dynamically. NeuralNetwork on the ANE is the one combination that
+    // both compiles and matches CPU output, and it runs ~10x faster than CPU.
     let provider = CoreMLExecutionProvider::default()
         .with_model_format(CoreMLModelFormat::NeuralNetwork)
         .with_compute_units(CoreMLComputeUnits::CPUAndNeuralEngine)
-        .with_model_cache_dir(cache_dir.to_string_lossy());
+        .with_model_cache_dir(accelerator_cache_dir().to_string_lossy());
     let builder = session_builder()?.with_execution_providers([provider.build()])?;
 
     let _guard = COREML_COMPILE_LOCK

--- a/crates/pyannote-local/Cargo.toml
+++ b/crates/pyannote-local/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 default = []
 coreml = ["anlg-onnx/coreml", "anlg-embedding/coreml"]
 directml = ["anlg-onnx/directml", "anlg-embedding/directml"]
-eval = ["dep:hound", "dep:serde_json"]
+eval = ["dep:hound", "dep:serde_json", "dep:tracing-subscriber"]
 
 [[bin]]
 name = "diarization-eval"
@@ -22,9 +22,8 @@ anlg-voiceprint = { workspace = true }
 hound = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
-specta = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-tracing = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }
 
 [dev-dependencies]
 anlg-data = { workspace = true }

--- a/crates/pyannote-local/src/bin/diarization_eval.rs
+++ b/crates/pyannote-local/src/bin/diarization_eval.rs
@@ -172,6 +172,13 @@ fn main() {
 }
 
 fn run() -> Result<(), String> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
     let args = parse_args()?;
     let config = match &args.config {
         Some(path) => serde_json::from_str::<DiarizationConfig>(

--- a/crates/pyannote-local/src/clustering.rs
+++ b/crates/pyannote-local/src/clustering.rs
@@ -252,42 +252,28 @@ pub fn cluster(
     let merges = linkage(embeddings);
     let (min_clusters, max_clusters) = bounds.range();
 
+    let count_at =
+        |merge_count: usize| large_cluster_count(&cut(n, &merges, merge_count), min_cluster_size);
     let threshold_cut = merges
         .iter()
         .position(|merge| merge.distance > threshold)
         .unwrap_or(merges.len());
     let mut chosen = threshold_cut;
-    let mut count = large_cluster_count(&cut(n, &merges, chosen), min_cluster_size);
+    let mut count = count_at(chosen);
     if count < min_clusters || count > max_clusters {
+        // The threshold cut violates the speaker bounds: take the cut whose
+        // large-cluster count is closest to the bounds, preferring the one
+        // nearest the threshold when several tie.
         let target = count.clamp(min_clusters, max_clusters);
-        let mut best: Option<(usize, usize)> = None;
-        for offset in 0..=merges.len() {
-            for candidate in [
-                threshold_cut.checked_sub(offset),
-                Some(threshold_cut + offset),
-            ]
-            .into_iter()
-            .flatten()
-            .filter(|candidate| *candidate <= merges.len())
-            {
-                let candidate_count =
-                    large_cluster_count(&cut(n, &merges, candidate), min_cluster_size);
-                let gap = candidate_count.abs_diff(target);
-                if best.is_none_or(|(_, best_gap)| gap < best_gap) {
-                    best = Some((candidate, gap));
-                }
-                if gap == 0 {
-                    break;
-                }
-            }
-            if best.is_some_and(|(_, gap)| gap == 0) {
-                break;
-            }
-        }
-        if let Some((candidate, _)) = best {
-            chosen = candidate;
-            count = large_cluster_count(&cut(n, &merges, chosen), min_cluster_size);
-        }
+        chosen = (0..=merges.len())
+            .min_by_key(|merge_count| {
+                (
+                    count_at(*merge_count).abs_diff(target),
+                    merge_count.abs_diff(threshold_cut),
+                )
+            })
+            .unwrap_or(threshold_cut);
+        count = count_at(chosen);
     }
 
     let labels = cut(n, &merges, chosen);

--- a/crates/pyannote-local/src/pipeline.rs
+++ b/crates/pyannote-local/src/pipeline.rs
@@ -140,6 +140,9 @@ pub struct DiarizeRequest<'a> {
     pub bounds: SpeakerBounds,
     pub known_speakers: &'a [KnownSpeaker],
     pub is_cancelled: Option<&'a dyn Fn() -> bool>,
+    /// Called after each window with the fraction of windows processed, so
+    /// callers can keep liveness signals flowing during long recordings.
+    pub on_progress: Option<&'a dyn Fn(f32)>,
 }
 
 struct WindowEmbedding {
@@ -223,6 +226,9 @@ impl Diarizer {
                 }
             }
             activities.push(activity);
+            if let Some(on_progress) = request.on_progress {
+                on_progress((index + 1) as f32 / window_count as f32);
+            }
         }
 
         if embeddings.is_empty() {
@@ -238,19 +244,25 @@ impl Diarizer {
             request.bounds,
         );
 
-        let mut diarization = self.reconstruct(total, step, &activities, &embeddings, &labels);
-        diarization.speakers = diarization
-            .speakers
+        let speakers: Vec<DiarizedSpeaker> = centroids
             .into_iter()
-            .map(|speaker| {
-                let original = speaker.index;
-                DiarizedSpeaker {
-                    centroid: centroids[original].clone(),
-                    identity: identities.get(original).cloned().flatten(),
-                    ..speaker
-                }
+            .zip(identities)
+            .enumerate()
+            .map(|(index, (centroid, identity))| DiarizedSpeaker {
+                index,
+                centroid,
+                identity,
             })
             .collect();
+        let mut diarization = reconstruct(
+            &self.config,
+            total,
+            step,
+            &activities,
+            &embeddings,
+            &labels,
+            speakers,
+        );
         renumber_by_first_appearance(&mut diarization);
         Ok(diarization)
     }
@@ -430,76 +442,78 @@ impl Diarizer {
         }
         identities
     }
+}
 
-    fn reconstruct(
-        &self,
-        total: usize,
-        step: usize,
-        activities: &[WindowActivity],
-        embeddings: &[WindowEmbedding],
-        labels: &[usize],
-    ) -> Diarization {
-        let speaker_count = labels.iter().copied().max().map_or(0, |max| max + 1);
-        let frame_count = frames_for_samples(total.max(WINDOW_SAMPLES));
-        let mut votes = vec![vec![0u16; frame_count]; speaker_count];
-        let mut coverage = vec![0u16; frame_count];
+/// Votes every window's local-speaker activity onto the global frame grid
+/// under its cluster label and turns the majority into speaker turns. Speakers
+/// that end up with no turn are dropped.
+fn reconstruct(
+    config: &DiarizationConfig,
+    total: usize,
+    step: usize,
+    activities: &[WindowActivity],
+    embeddings: &[WindowEmbedding],
+    labels: &[usize],
+    speakers: Vec<DiarizedSpeaker>,
+) -> Diarization {
+    let speaker_count = speakers.len();
+    let frame_count = frames_for_samples(total.max(WINDOW_SAMPLES));
+    let mut votes = vec![vec![0u16; frame_count]; speaker_count];
+    let mut coverage = vec![0u16; frame_count];
 
-        for (window, activity) in activities.iter().enumerate() {
-            let offset = window * step / FRAME_SIZE;
-            for frame in 0..activity.frames.len() {
-                if let Some(slot) = coverage.get_mut(offset + frame) {
-                    *slot += 1;
-                }
+    for (window, activity) in activities.iter().enumerate() {
+        let offset = window * step / FRAME_SIZE;
+        for frame in 0..activity.frames.len() {
+            if let Some(slot) = coverage.get_mut(offset + frame) {
+                *slot += 1;
             }
         }
-        for (item, &label) in embeddings.iter().zip(labels) {
-            let activity = &activities[item.window];
-            let offset = item.window * step / FRAME_SIZE;
-            for (frame, active) in activity.frames.iter().enumerate() {
-                if active[item.local_speaker]
-                    && let Some(slot) = votes[label].get_mut(offset + frame)
-                {
-                    *slot += 1;
-                }
-            }
-        }
-
-        let mut segments = Vec::new();
-        for (speaker, track) in votes.iter().enumerate() {
-            let active: Vec<bool> = track
-                .iter()
-                .zip(&coverage)
-                .map(|(votes, coverage)| {
-                    *coverage > 0 && u32::from(*votes) * 2 >= u32::from(*coverage)
-                })
-                .collect();
-            segments.extend(
-                frames_to_segments(
-                    &active,
-                    speaker,
-                    self.config.min_duration_on,
-                    self.config.min_duration_off,
-                )
-                .into_iter()
-                .map(|mut segment| {
-                    segment.end = segment.end.min(total as f64 / SAMPLE_RATE as f64);
-                    segment
-                })
-                .filter(|segment| segment.end > segment.start),
-            );
-        }
-        segments.sort_by(|a, b| a.start.total_cmp(&b.start).then(a.speaker.cmp(&b.speaker)));
-
-        let speakers = (0..speaker_count)
-            .filter(|speaker| segments.iter().any(|segment| segment.speaker == *speaker))
-            .map(|index| DiarizedSpeaker {
-                index,
-                centroid: Vec::new(),
-                identity: None,
-            })
-            .collect();
-        Diarization { segments, speakers }
     }
+    for (item, &label) in embeddings.iter().zip(labels) {
+        let activity = &activities[item.window];
+        let offset = item.window * step / FRAME_SIZE;
+        for (frame, active) in activity.frames.iter().enumerate() {
+            if active[item.local_speaker]
+                && let Some(slot) = votes[label].get_mut(offset + frame)
+            {
+                *slot += 1;
+            }
+        }
+    }
+
+    let mut segments = Vec::new();
+    for (speaker, track) in votes.iter().enumerate() {
+        let active: Vec<bool> = track
+            .iter()
+            .zip(&coverage)
+            .map(|(votes, coverage)| *coverage > 0 && u32::from(*votes) * 2 >= u32::from(*coverage))
+            .collect();
+        segments.extend(
+            frames_to_segments(
+                &active,
+                speaker,
+                config.min_duration_on,
+                config.min_duration_off,
+            )
+            .into_iter()
+            .map(|mut segment| {
+                segment.end = segment.end.min(total as f64 / SAMPLE_RATE as f64);
+                segment
+            })
+            .filter(|segment| segment.end > segment.start),
+        );
+    }
+    segments.sort_by(|a, b| a.start.total_cmp(&b.start).then(a.speaker.cmp(&b.speaker)));
+
+    let speakers = speakers
+        .into_iter()
+        .filter(|speaker| {
+            segments
+                .iter()
+                .any(|segment| segment.speaker == speaker.index)
+        })
+        .collect();
+    Diarization { segments, speakers }
 }
 
 fn seconds_to_frames(seconds: f32) -> usize {
@@ -783,6 +797,28 @@ mod tests {
                 .expect("centroid should match itself");
             assert_eq!(identity.id, format!("human-{}", speaker.index));
         }
+    }
+
+    #[test]
+    fn progress_reaches_one_after_the_last_window() {
+        let audio = pcm_bytes_to_f32(anlg_data::english_1::AUDIO);
+        let seen = std::cell::RefCell::new(Vec::new());
+        let on_progress = |fraction: f32| seen.borrow_mut().push(fraction);
+        let mut diarizer = Diarizer::new(DiarizationConfig::default()).unwrap();
+        diarizer
+            .diarize(
+                &mut audio.as_slice(),
+                &DiarizeRequest {
+                    on_progress: Some(&on_progress),
+                    ..DiarizeRequest::default()
+                },
+            )
+            .unwrap();
+
+        let seen = seen.into_inner();
+        assert!(seen.len() > 1);
+        assert!(seen.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!((seen.last().copied().unwrap() - 1.0).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Problem:** Follow-ups from #7244 after verifying the local diarizer on a real Mac.
1. Progressive local batches (whisper.cpp, Argmax) are torn down after 60 s without a streamed event. Diarization runs after the provider finishes and is silent, so any meeting longer than a few minutes lost its finished transcript to a `TimedOut` (Bugbot 0c6455ae).
2. On this machine every accelerated ONNX session was silently running on the CPU: a half-written compiled model in the shared temp cache made `MLModel` refuse to load, `crates/onnx` fell back to CPU, and nothing ever cleared the cache. Diarization ran at RTF 0.20 instead of 0.03; the voiceprint extractor in the installed app has the same problem.
3. A couple of places in the diarizer were more elaborate than they needed to be.

**Fix:**
1. The diarizer reports per-window progress; the batch layer streams it as `Progress` heartbeats from 0.95 to 1.0 (continuing where Soniqo's own progress stops), throttled to 5 s, starting before the resample. Progressive sessions stay alive and the UI shows work continuing instead of freezing at 100%.
2. `load_model_from_bytes_accelerated` clears the cache and retries once when the accelerated commit fails, then falls back to CPU as before. The cache is keyed by executable path so an installed build and a dev build stop compiling into each other's directory (the in-process compile lock never protected across processes).
3. The speaker-bound cut search is one `min_by_key` over (count gap, distance from threshold); speakers are built once with centroid and identity instead of being patched after reconstruction; `specta`/`tracing` are dropped from `pyannote-local`; the eval binary prints tracing warnings so accelerator fallbacks are visible.

Numbers on an M5 Max (`diarization-eval`, two fixtures vs `precision-2`): DER 4.4% unchanged; RTF 0.207 with the broken cache → 0.034 after the repair (6x). Reproduced the production failure by truncating `compiled_model.mlmodelc` and confirmed the rebuild path recovers at full speed.

## Verification

- `cargo test -p listener2-core batch::diarize` (14, incl. new heartbeat throttle test and an end-to-end test asserting progress is streamed within [0.95, 1.0])
- `cargo test -p pyannote-local --features eval` (24, incl. new progress callback test)
- `cargo test -p embedding --features coreml`, `cargo test -p onnx --features coreml`
- `cargo clippy` on `pyannote-local` (eval), `onnx` (coreml), `listener2-core`: clean
- `cargo check -p desktop`
- `cargo fmt`, `pnpm exec dprint check` on changed paths
- Manual: `diarization-eval --features eval,coreml` before/after corrupting the cache (see numbers above)
- Not run: the desktop UI end to end; the word→`provider_speaker_index`→"Speaker N" path is unchanged from cloud providers and covered by existing TS tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch session liveness, CoreML ONNX loading/caching used by diarization and embeddings, and diarizer clustering/reconstruction paths; behavior is covered by new tests but affects long-running local batch workflows on macOS.
> 
> **Overview**
> Fixes progressive local batches **timing out after transcription** when on-device diarization runs silently for long meetings. The batch layer now streams **`Progress` heartbeats from 0.95 to 1.0** (throttled to every 5s, including during resample and model load), driven by a new **`on_progress`** callback on the pyannote diarizer.
> 
> **ONNX CoreML acceleration** no longer stays stuck on CPU when a corrupted compiled cache fails to load: **`load_model_from_bytes_accelerated`** clears the cache and retries once, and the cache directory is **hashed per executable** so dev and installed builds do not share the same temp folder.
> 
> Minor **pyannote-local** refactors: simpler speaker-bound cluster cut selection, speaker metadata assembled before reconstruction, **`specta`/`tracing` dropped** from the crate, and **`diarization-eval`** initializes **`tracing-subscriber`** so accelerator fallbacks show up in stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 177f9f7ce13eb8b48f3e8f3c9082690bceb487e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->