### PR TITLE
Keep speaker selector open during live transcription

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-hooks.ts
@@ -29,7 +29,14 @@ export function createSegmentKey(
   transcriptId: string,
   fallbackIndex: number,
 ) {
-  return segment.id || `${transcriptId}-segment-${fallbackIndex}`;
+  const firstWord = segment.words[0];
+  return [
+    transcriptId,
+    segment.key.channel,
+    segment.key.speaker_index ?? "speaker-none",
+    segment.key.speaker_human_id ?? "human-none",
+    firstWord ? `start-${firstWord.start_ms}` : `index-${fallbackIndex}`,
+  ].join(":");
 }
 
 function segmentsEqual(a: Segment, b: Segment) {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.test.tsx
@@ -354,6 +354,73 @@ describe("RenderTranscript", () => {
     ).toBe(first);
     expect(document.querySelectorAll("section").length).toBeLessThanOrEqual(30);
   });
+
+  it("preserves an active live segment while trailing words update", () => {
+    const initial = createSegment("live-start:live-end", 0);
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest([initial]),
+      segments: [],
+    });
+    const rendered = render(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive
+        liveSegments={[initial]}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+    const initialNode = document.querySelector(
+      "section[data-transcript-segment-id='segment-live-start:live-end']",
+    );
+    const nextWord = {
+      id: "word-live-next",
+      text: " next",
+      start_ms: 100,
+      end_ms: 200,
+      channel: "MixedCapture" as const,
+      is_final: false,
+    };
+    const updated = {
+      ...initial,
+      id: "segment-live-start:live-next",
+      end_ms: nextWord.end_ms,
+      text: `${initial.text}${nextWord.text}`,
+      words: [...initial.words, nextWord],
+    };
+    mocks.useRenderedTranscriptData.mockReturnValue({
+      maxSpeakerNumber: undefined,
+      request: createRenderRequest([updated]),
+      segments: [],
+    });
+
+    rendered.rerender(
+      <RenderTranscript
+        scrollElement={null}
+        isLastTranscript
+        shouldScrollToEnd={false}
+        transcriptId="transcript-1"
+        currentActive
+        liveSegments={[updated]}
+        currentMs={0}
+        seek={vi.fn()}
+        startPlayback={vi.fn()}
+        audioExists
+      />,
+    );
+
+    expect(
+      document.querySelector(
+        "section[data-transcript-segment-id='segment-live-start:live-next']",
+      ),
+    ).toBe(initialNode);
+  });
 });
 
 function renderTranscript(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized change to transcript segment key generation plus a unit test; low blast radius outside live transcript rendering.
> 
> **Overview**
> Fixes live transcription UI remounting segments (and closing the speaker selector) when trailing words append and the segment `id` changes.
> 
> **`createSegmentKey`** no longer prefers `segment.id`; it builds a stable key from `transcriptId`, channel, speaker fields, and the first word’s `start_ms` (with an index fallback when there are no words). Virtualized transcript rows keep the same React key across incremental live updates, so the underlying DOM node is preserved.
> 
> Adds a **`RenderTranscript`** test that rerenders a growing live segment with a new `id` and asserts the same `section` element is reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e30a1605a771026745e9e10e5f2809f7608f2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->