### PR TITLE
Keep transcription readiness warnings accurate

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -492,12 +492,17 @@ function clearTranscriptionLanguageWarningToast() {
 }
 
 function useTranscriptionLanguageWarning() {
-  const { current_stt_provider, current_stt_model, spoken_languages } =
-    useConfigValues([
-      "current_stt_provider",
-      "current_stt_model",
-      "spoken_languages",
-    ] as const);
+  const {
+    ai_language,
+    current_stt_provider,
+    current_stt_model,
+    spoken_languages,
+  } = useConfigValues([
+    "ai_language",
+    "current_stt_provider",
+    "current_stt_model",
+    "spoken_languages",
+  ] as const);
   const health = useConnectionHealth();
 
   const selectedSttModel = isConfiguredSttModel(
@@ -531,6 +536,7 @@ function useTranscriptionLanguageWarning() {
       current_stt_provider,
       selectedSttModel,
       useLiveMode,
+      ai_language,
       spoken_languages,
     ],
     queryFn: async () => {
@@ -547,12 +553,13 @@ function useTranscriptionLanguageWarning() {
               languages,
             );
 
-      return await getLanguageSupportIssue(spoken_languages ?? [], isSupported);
+      return await getLanguageSupportIssue(
+        ai_language,
+        spoken_languages,
+        isSupported,
+      );
     },
-    enabled:
-      isConfigured &&
-      liveSupport.data !== undefined &&
-      !!spoken_languages?.length,
+    enabled: isConfigured && liveSupport.data !== undefined && !!ai_language,
   });
 
   if (
@@ -568,6 +575,7 @@ function useTranscriptionLanguageWarning() {
     key: [
       current_stt_provider,
       selectedSttModel,
+      ai_language,
       ...(spoken_languages ?? []),
     ].join(":"),
     model: selectedSttModel,

--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -190,7 +190,8 @@ describe("getDefaultSttSelection", () => {
 describe("getLanguageSupportIssue", () => {
   test("returns the languages the model cannot transcribe", async () => {
     const issue = await getLanguageSupportIssue(
-      ["en", "ko", "ja"],
+      "en",
+      ["ko", "ja"],
       async (languages) => !languages.includes("ko"),
     );
 
@@ -199,7 +200,8 @@ describe("getLanguageSupportIssue", () => {
 
   test("distinguishes an unsupported combination from unsupported languages", async () => {
     const issue = await getLanguageSupportIssue(
-      ["en", "ko"],
+      "en",
+      ["ko"],
       async (languages) => languages.length === 1,
     );
 
@@ -207,7 +209,7 @@ describe("getLanguageSupportIssue", () => {
   });
 
   test("returns no issue when the full selection is supported", async () => {
-    const issue = await getLanguageSupportIssue(["en", "ko"], async () => true);
+    const issue = await getLanguageSupportIssue("en", ["ko"], async () => true);
 
     expect(issue).toBeNull();
   });

--- a/apps/desktop/src/settings/ai/stt/selection.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.ts
@@ -1,3 +1,4 @@
+import { getTranscriptionLanguages } from "~/stt/capabilities";
 import {
   getDefaultSttModel,
   getPreferredProviderModel,
@@ -6,9 +7,11 @@ import {
 export { getDefaultSttModel, getPreferredProviderModel };
 
 export async function getLanguageSupportIssue(
-  languages: readonly string[],
+  mainLanguage: string | null | undefined,
+  spokenLanguages: readonly string[] | null | undefined,
   isSupported: (languages: readonly string[]) => Promise<boolean>,
 ) {
+  const languages = getTranscriptionLanguages(mainLanguage, spokenLanguages);
   if (await isSupported(languages)) {
     return null;
   }

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -478,6 +478,7 @@ describe("getLiveTranscriptionConfig", () => {
       }),
     ).resolves.toEqual({
       languages: ["en"],
+      omittedLanguages: ["ko"],
       transcriptionMode: undefined,
     });
   });

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -6,6 +6,7 @@ import {
 
 type LiveTranscriptionConfig = {
   languages: string[];
+  omittedLanguages?: string[];
   transcriptionMode?: TranscriptionMode;
 };
 
@@ -413,6 +414,7 @@ export async function getLiveTranscriptionConfig({
     return {
       ...config,
       languages: [primaryLanguage],
+      omittedLanguages: languages.slice(1),
     };
   }
 

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -359,6 +359,7 @@ export function useCaptureLifecycle(sessionId: string) {
         requestRecoveryOnFailure: boolean,
       ) => {
         sonnerToast.dismiss("recording-without-transcription");
+        sonnerToast.dismiss("recording-with-limited-transcription-languages");
         sonnerToast.dismiss("live-transcription-stalled");
         sonnerToast.dismiss("meeting-disclosure-send-failed");
         const sessionWasDeleted = async () => {

--- a/apps/desktop/src/stt/useSTTConnection.test.ts
+++ b/apps/desktop/src/stt/useSTTConnection.test.ts
@@ -36,7 +36,7 @@ vi.mock("~/settings/providers", () => ({
   useAiProvider: () => ({
     type: "stt",
     base_url: "   ",
-    api_key: "",
+    api_key: "test-key",
   }),
 }));
 
@@ -77,6 +77,25 @@ describe("useSTTConnection", () => {
       model: "cloud",
       baseUrl: "https://api.anarlog.so/stt",
       apiKey: "access-token",
+    });
+  });
+
+  it("uses the provider endpoint when only a Deepgram API key is stored", () => {
+    config.current_stt_provider = "deepgram";
+    config.current_stt_model = "nova-3-general";
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useSTTConnection(), { wrapper });
+
+    expect(result.current.conn).toEqual({
+      provider: "deepgram",
+      model: "nova-3-general",
+      baseUrl: "https://api.deepgram.com/v1",
+      apiKey: "test-key",
     });
   });
 

--- a/apps/desktop/src/stt/useSTTConnection.ts
+++ b/apps/desktop/src/stt/useSTTConnection.ts
@@ -7,7 +7,7 @@ import type { AIProviderStorage } from "@anlg/store";
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { env } from "~/env";
-import { type ProviderId } from "~/settings/ai/stt/shared";
+import { type ProviderId, PROVIDERS } from "~/settings/ai/stt/shared";
 import { useAiProvider } from "~/settings/providers";
 import { useConfigValues } from "~/shared/config";
 import {
@@ -130,7 +130,10 @@ export const useSTTConnection = () => {
     },
   });
 
-  const baseUrl = providerConfig?.base_url?.trim();
+  const defaultBaseUrl = PROVIDERS.find(
+    (provider) => provider.id === current_stt_provider,
+  )?.baseUrl;
+  const baseUrl = providerConfig?.base_url?.trim() || defaultBaseUrl?.trim();
   const apiKey = providerConfig?.api_key?.trim();
 
   const connection = useMemo(() => {

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -3376,6 +3376,24 @@ describe("useStartListening", () => {
       languages: ["en"],
       transcription_mode: undefined,
     });
+    expect(sonnerToastWarningMock).toHaveBeenCalledWith(
+      "Live transcription is using English",
+      expect.objectContaining({
+        id: "recording-with-limited-transcription-languages",
+        description:
+          "Live transcription won't include Korean. Audio is still being saved.",
+        action: expect.objectContaining({ label: "Change" }),
+      }),
+    );
+
+    const warningCalls = sonnerToastWarningMock.mock.calls;
+    const warningOptions = warningCalls[warningCalls.length - 1]?.[1];
+    warningOptions?.action.onClick();
+
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "settings",
+      state: { tab: "transcription" },
+    });
   });
 
   test("does not send the recording disclosure when auto-post is disabled", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -14,6 +14,7 @@ import {
 import { trackAnalyticsEvent } from "~/analytics";
 import { useShell } from "~/contexts/shell";
 import { getSessionEvent } from "~/session/utils";
+import { getBaseLanguageDisplayName } from "~/settings/general/language";
 import { useConfigValue } from "~/shared/config";
 import { useTabs } from "~/store/zustand/tabs";
 import {
@@ -199,7 +200,34 @@ export function useStartListening(sessionId: string) {
       return;
     }
 
-    if (!conn) {
+    const openTranscriptionSettings = () => {
+      openNew({
+        type: "settings",
+        state: { tab: "transcription" },
+      });
+    };
+
+    const primaryLanguage = liveTranscriptionConfig.languages[0];
+    const omittedLanguages = liveTranscriptionConfig.omittedLanguages ?? [];
+    if (conn && primaryLanguage && omittedLanguages.length > 0) {
+      const primaryLanguageName = getBaseLanguageDisplayName(primaryLanguage);
+      const omittedLanguageNames = omittedLanguages
+        .map((language) => getBaseLanguageDisplayName(language))
+        .join(", ");
+
+      sonnerToast.warning(
+        `Live transcription is using ${primaryLanguageName}`,
+        {
+          id: "recording-with-limited-transcription-languages",
+          duration: Infinity,
+          description: `Live transcription won't include ${omittedLanguageNames}. Audio is still being saved.`,
+          action: {
+            label: "Change",
+            onClick: openTranscriptionSettings,
+          },
+        },
+      );
+    } else if (!conn) {
       sonnerToast.warning("Live transcription is not configured", {
         id: "recording-without-transcription",
         duration: Infinity,
@@ -207,12 +235,7 @@ export function useStartListening(sessionId: string) {
           "Audio is being saved. Choose a transcription provider to ensure this recording can be transcribed.",
         action: {
           label: "Configure",
-          onClick: () => {
-            openNew({
-              type: "settings",
-              state: { tab: "transcription" },
-            });
-          },
+          onClick: openTranscriptionSettings,
         },
       });
     }


### PR DESCRIPTION
Use provider default endpoints at runtime and validate the full spoken-language selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live capture startup, STT connection resolution, and language fallback behavior; user-visible toasts and endpoint selection could affect recording if misconfigured.
> 
> **Overview**
> Improves **transcription readiness** by validating the same language set used at record time (`ai_language` plus spoken languages via `getTranscriptionLanguages`) in STT settings warnings, and by surfacing when live STT **drops** extra languages.
> 
> When a live model cannot handle every selected language together but can transcribe the primary language, `getLiveTranscriptionConfig` now returns **`omittedLanguages`** and recording start shows a persistent toast (e.g. live uses English only; Korean omitted) with a **Change** shortcut to transcription settings. That toast is cleared when capture stops.
> 
> **BYOK / external providers:** `useSTTConnection` uses each provider’s **default base URL** when the saved URL is blank, so a stored API key alone (e.g. Deepgram) still yields a working connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9266da87c3dfd53e3508b5cc1aa02cad55a8ff6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->