### PR TITLE
Update CLI, MCP, API, and agent plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,15 +7,15 @@
   },
   "metadata": {
     "description": "Official plugins from Fastrepl",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "anarlog",
       "displayName": "Anarlog",
       "source": "./agent-plugins/anarlog",
-      "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
-      "version": "1.0.0",
+      "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
+      "version": "1.1.0",
       "author": {
         "name": "Fastrepl",
         "email": "founders@anarlog.so",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official plugins from Fastrepl",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "anarlog",
       "source": "./agent-plugins/anarlog",
-      "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
-      "version": "1.0.0",
+      "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
+      "version": "1.1.0",
       "category": "Productivity",
       "tags": ["meetings", "notes", "transcripts", "mcp", "oauth"]
     }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official plugins from Fastrepl",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "anarlog",
       "source": "./agent-plugins/anarlog",
-      "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
-      "version": "1.0.0",
+      "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
+      "version": "1.1.0",
       "author": {
         "name": "Fastrepl",
         "email": "founders@anarlog.so",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "tokio",
  "url",
  "user-error",
+ "wiremock",
 ]
 
 [[package]]

--- a/agent-plugins/anarlog/.claude-plugin/plugin.json
+++ b/agent-plugins/anarlog/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "anarlog",
   "displayName": "Anarlog",
-  "version": "1.0.0",
-  "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
+  "version": "1.1.0",
+  "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",
     "email": "founders@anarlog.so",

--- a/agent-plugins/anarlog/.codex-plugin/plugin.json
+++ b/agent-plugins/anarlog/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anarlog",
-  "version": "1.0.0",
-  "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
+  "version": "1.1.0",
+  "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",
     "email": "founders@anarlog.so",
@@ -16,14 +16,15 @@
   "interface": {
     "displayName": "Anarlog",
     "shortDescription": "Query your meetings from anywhere",
-    "longDescription": "Connect your Anarlog account with OAuth, then find meetings and read notes, summaries, participants, action items, bounded transcript excerpts, and recurring history. Cloud MCP is read-only hosted snapshots. When a meeting is missing there, the bundled skill fills the gap from the local Anarlog CLI.",
+    "longDescription": "Connect your Anarlog account with OAuth, then find meetings and read notes, summaries, participants, action items, bounded transcript excerpts, recurring history, and complete exports when explicitly needed. Cloud MCP is read-only hosted snapshots. The bundled skill can also use authenticated Cloud reads or local data through the Anarlog CLI.",
     "developerName": "Fastrepl",
     "category": "Productivity",
     "capabilities": [
       "Find meetings",
       "Read notes and summaries",
       "Read bounded transcript excerpts",
-      "Review recurring meeting history"
+      "Review recurring meeting history",
+      "Export complete meeting records"
     ],
     "websiteURL": "https://anarlog.so",
     "privacyPolicyURL": "https://anarlog.so/privacy",

--- a/agent-plugins/anarlog/.cursor-plugin/plugin.json
+++ b/agent-plugins/anarlog/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anarlog",
-  "version": "1.0.0",
-  "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
+  "version": "1.1.0",
+  "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",
     "email": "founders@anarlog.so"

--- a/agent-plugins/anarlog/README.md
+++ b/agent-plugins/anarlog/README.md
@@ -1,6 +1,6 @@
 # Anarlog agent plugin
 
-Query Anarlog meetings through hosted Cloud MCP and a bundled skill. The plugin finds meetings and reads notes, summaries, participants, action items, bounded transcript excerpts, and recurring history. When Cloud has no snapshot for a meeting, the skill fills the gap from the local `anarlog` CLI.
+Query Anarlog meetings through hosted Cloud MCP and a bundled skill. The plugin finds meetings and reads notes, summaries, participants, action items, bounded transcript excerpts, recurring history, and complete exports when explicitly needed. When Cloud has no snapshot for a meeting, the skill fills the gap from the local `anarlog` CLI.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ Query Anarlog meetings through hosted Cloud MCP and a bundled skill. The plugin 
 
 On first use, the host discovers Anarlog's authorization server from `https://api.anarlog.so/mcp`, then opens the Anarlog sign-in and consent flow. No cloud API key is required.
 
-If a meeting is missing from Cloud, install the [Anarlog CLI](https://docs.anarlog.so/installation) so the skill can read the local database.
+If a meeting is missing from Cloud, install the [Anarlog CLI](https://docs.anarlog.so/installation) so the skill can read the local database. The CLI can also read hosted snapshots with `anarlog meetings --source cloud ...` after login.
 
 If you previously installed **Anarlog Cloud**, replace it with this plugin.
 

--- a/agent-plugins/anarlog/llms-install.md
+++ b/agent-plugins/anarlog/llms-install.md
@@ -2,7 +2,7 @@
 
 1. Confirm the user has Anarlog Pro and has enabled **Settings → Developers → Cloud API & Connectors**.
 2. Configure an HTTP MCP server named `anarlog` at `https://api.anarlog.so/mcp`. The host should discover OAuth from that endpoint. Do not paste a cloud API key unless the host cannot complete MCP OAuth.
-3. Start the server and confirm it lists `list_meetings`, `get_meeting`, `get_meeting_transcript`, and `get_recurring_meeting_history`.
+3. Start the server and confirm it lists `list_meetings`, `get_meeting`, `get_meeting_transcript`, `get_recurring_meeting_history`, and `export_meeting`.
 4. If Cloud returns no meetings the user expects, check whether `anarlog` is on `PATH` with `anarlog --version` and fill the gap with `anarlog --json`. If the CLI is missing, ask the user to install it from **Anarlog → Settings → Developers** or follow <https://docs.anarlog.so/installation>. Do not install software or search the filesystem without permission.
 5. Never query or modify Anarlog's SQLite database directly.
 

--- a/agent-plugins/anarlog/plugin.json
+++ b/agent-plugins/anarlog/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "anarlog",
-  "version": "1.0.0",
-  "description": "Query Anarlog meetings through Cloud MCP, and fill gaps from the local CLI.",
+  "version": "1.1.0",
+  "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",
     "email": "founders@anarlog.so",

--- a/agent-plugins/anarlog/skills/anarlog/SKILL.md
+++ b/agent-plugins/anarlog/skills/anarlog/SKILL.md
@@ -10,9 +10,10 @@ Use hosted Cloud MCP as the default. Fill gaps from the local `anarlog` CLI when
 ## Choose a source
 
 1. If Cloud MCP tools are connected, call them first: `list_meetings`, `get_meeting`, `get_meeting_transcript`, and `get_recurring_meeting_history`.
-2. If Cloud returns no match, snapshots are disabled, or the user is asking about a meeting that only exists on this machine, use `anarlog --json` against the local database.
-3. Use a local `anarlog mcp` stdio server only to fill those same gaps. Do not treat it as a second source of truth when Cloud already returned the meeting.
-4. If neither Cloud nor the local CLI is available, direct the user to enable **Cloud API & Connectors** and [installation](https://docs.anarlog.so/installation). Do not install software unless the user asks.
+2. If MCP is unavailable but CLI login is available, use `anarlog --json meetings --source cloud ...` for the same hosted snapshots.
+3. If Cloud returns no match, snapshots are disabled, or the user is asking about a meeting that only exists on this machine, use local `anarlog --json meetings ...` commands.
+4. Use a local `anarlog mcp` stdio server only to fill those same gaps. Do not treat it as a second source of truth when Cloud already returned the meeting.
+5. If neither Cloud nor the local CLI is available, direct the user to enable **Cloud API & Connectors** and [installation](https://docs.anarlog.so/installation). Do not install software unless the user asks.
 
 Never query or modify Anarlog's SQLite database directly. The CLI and MCP servers handle application-schema compatibility.
 

--- a/agent-plugins/anarlog/skills/anarlog/references/cli.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/cli.md
@@ -19,6 +19,8 @@ On Linux, sessions use Secret Service when available and otherwise use the deskt
 ```bash
 anarlog --json doctor
 anarlog --json meetings list --query "planning" --limit 20 --offset 0
+anarlog --json meetings --source cloud list --query "planning" --limit 20 --offset 0
+anarlog --json meetings --source auto get MEETING_ID
 anarlog --json meetings get MEETING_ID
 anarlog --json meetings note MEETING_ID --kind note
 anarlog --json meetings note MEETING_ID --kind summary
@@ -30,6 +32,8 @@ anarlog --json proposals decline PROPOSAL_ID
 ```
 
 `proposals create` stages a pending edit. Do not claim the meeting changed. A human applies or declines it in the Anarlog desktop app.
+
+Meeting commands default to `--source local`. `--source cloud` reads hosted snapshots using `anarlog auth login`; `--source auto` uses Cloud only when the local database is absent. Cloud access is read-only, so proposals remain local.
 
 `doctor` exits with status 1 when its response contains `ready: false`.
 

--- a/agent-plugins/anarlog/skills/anarlog/references/errors.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/errors.md
@@ -16,6 +16,10 @@ Run `anarlog --json doctor`. Ask the user to open Anarlog once if the database d
 
 Confirm the desktop app and CLI come from compatible revisions. Do not run migrations or write SQL from the agent.
 
+## Cloud command failed
+
+Preserve the CLI's hosted error code. Run `anarlog auth login` again for `unauthorized`, ask the user to enable **Cloud API & Connectors** for `cloud_api_not_enabled`, and wait for the reported retry delay after `rate_limited`. Do not silently switch a user-requested `--source cloud` read to local data.
+
 ## Export output exists
 
 Choose a new path. Pass `--force` only when the user explicitly approves replacing that exact file.

--- a/agent-plugins/anarlog/skills/anarlog/references/mcp.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/mcp.md
@@ -8,6 +8,7 @@ Cloud MCP is read-only. Local MCP adds proposal tools, which insert or decline s
 | `get_meeting`                   | Read metadata, canonical note, summaries, participants, and action items.                                                  |
 | `get_meeting_transcript`        | Read a transcript page. Start with `limit: 200`; continue from `pagination.next_offset` only as needed.                    |
 | `get_recurring_meeting_history` | Find meetings from the same recurring series as a known meeting.                                                           |
+| `export_meeting`                | Read the complete meeting record including transcripts. Use only when smaller reads are insufficient.                      |
 | `propose_summary_edit`          | Stage a complete summary replacement. Pass `target_id` when multiple summaries exist.                                      |
 | `propose_memo_edit`             | Stage a complete memo replacement.                                                                                         |
 | `list_proposals`                | List staged proposals. Defaults to `status: pending`.                                                                      |

--- a/agent-plugins/anarlog/skills/anarlog/references/setup.md
+++ b/agent-plugins/anarlog/skills/anarlog/references/setup.md
@@ -34,6 +34,8 @@ Run the Anarlog desktop app once so its local database exists. The CLI works whi
 
 Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`. With `--json`, the login URL is printed to stderr and the callback is read from stdin.
 
+After login, `anarlog --json meetings --source cloud list` reads the same hosted snapshots as Cloud MCP. `--source auto` uses the local database when it exists and Cloud only when it does not.
+
 On Flatpak, the host command is `anarlog-cli`. On DEB, AppImage, macOS, Windows, and Settings-installed builds, the command is `anarlog`.
 
 Homebrew, standalone release binaries, and Windows package-manager distribution are not yet available.

--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -4515,6 +4515,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4551,12 +4561,42 @@
               }
             }
           },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
           "404": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -4608,12 +4648,42 @@
               }
             }
           },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
           "404": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -4673,12 +4743,42 @@
               }
             }
           },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
           "404": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -4738,12 +4838,42 @@
               }
             }
           },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
           "404": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -18,7 +18,7 @@ anlg-user-error = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 dirs = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["json", "query"] }
 rmcp = { workspace = true, features = ["server", "transport-io"] }
 rpassword = { workspace = true }
 schemars = { workspace = true }
@@ -38,3 +38,4 @@ insta = { workspace = true, features = ["json"] }
 rmcp = { workspace = true, features = ["client"] }
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
 tempfile = { workspace = true }
+wiremock = { workspace = true }

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -45,7 +45,7 @@ impl Args {
                 AuthCommand::Logout => "auth_logout",
             },
             Command::Doctor => "doctor",
-            Command::Meetings { command } => match command {
+            Command::Meetings { command, .. } => match command {
                 MeetingCommand::List { .. } => "meetings_list",
                 MeetingCommand::Get { .. } => "meetings_get",
                 MeetingCommand::Note { .. } => "meetings_note",
@@ -84,6 +84,9 @@ pub enum Command {
     Doctor,
     /// Browse and export meetings
     Meetings {
+        /// Choose local data, hosted Cloud snapshots, or Cloud only when no local database exists
+        #[arg(long, env = "ANARLOG_SOURCE", value_enum, default_value_t = MeetingSource::Local)]
+        source: MeetingSource,
         #[command(subcommand)]
         command: MeetingCommand,
     },
@@ -151,6 +154,14 @@ pub enum AuthCommand {
     Status,
     /// Remove the locally stored account session
     Logout,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum MeetingSource {
+    #[default]
+    Local,
+    Cloud,
+    Auto,
 }
 
 #[derive(Debug, Subcommand)]
@@ -229,7 +240,7 @@ mod tests {
         ]);
 
         assert!(args.json);
-        let Command::Meetings { command } = args.command else {
+        let Command::Meetings { command, .. } = args.command else {
             panic!("expected meetings command");
         };
         let MeetingCommand::List { query, limit, .. } = command else {
@@ -248,7 +259,7 @@ mod tests {
         assert!(help.contains("doctor"));
         assert!(help.contains("proposals"));
 
-        let Command::Meetings { command } = Args::parse_from([
+        let Command::Meetings { command, .. } = Args::parse_from([
             "anarlog",
             "meetings",
             "export",
@@ -293,7 +304,7 @@ mod tests {
 
     #[test]
     fn parses_transcript_and_history_pagination() {
-        let Command::Meetings { command } = Args::parse_from([
+        let Command::Meetings { command, .. } = Args::parse_from([
             "anarlog",
             "meetings",
             "transcript",
@@ -316,7 +327,7 @@ mod tests {
             }
         ));
 
-        let Command::Meetings { command } = Args::parse_from([
+        let Command::Meetings { command, .. } = Args::parse_from([
             "anarlog",
             "meetings",
             "history",
@@ -340,6 +351,23 @@ mod tests {
             Args::try_parse_from(["anarlog", "meetings", "export", "meeting-1", "--force"])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn parses_cloud_and_auto_meeting_sources() {
+        let Command::Meetings { source, .. } =
+            Args::parse_from(["anarlog", "meetings", "--source", "cloud", "list"]).command
+        else {
+            panic!("expected meetings command");
+        };
+        assert_eq!(source, MeetingSource::Cloud);
+
+        let Command::Meetings { source, .. } =
+            Args::parse_from(["anarlog", "meetings", "--source", "auto", "list"]).command
+        else {
+            panic!("expected meetings command");
+        };
+        assert_eq!(source, MeetingSource::Auto);
     }
 
     #[test]

--- a/apps/cli/src/cloud.rs
+++ b/apps/cli/src/cloud.rs
@@ -1,0 +1,375 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anlg_agent_access::{
+    GetMeetingInput, GetMeetingTranscriptInput, GetRecurringMeetingHistoryInput, ListMeetingsInput,
+    Meeting, MeetingExport, MeetingPage, TranscriptPage,
+};
+use anlg_supabase_auth::session::Session;
+use reqwest::{Response, StatusCode};
+use serde::de::DeserializeOwned;
+
+use crate::{Error, Result, commands::auth};
+
+const API_URL: &str = "https://api.anarlog.so";
+
+pub(crate) struct CloudClient {
+    base_url: String,
+    access_token: String,
+    client: reqwest::Client,
+}
+
+impl CloudClient {
+    pub(crate) fn current() -> Result<Self> {
+        let session = auth::current_session()?.ok_or_else(|| {
+            Error::cloud(
+                "unauthorized",
+                "Sign in with `anarlog auth login` before using --source cloud.",
+            )
+        })?;
+        Self::from_session(API_URL, session)
+    }
+
+    fn from_session(base_url: &str, session: Session) -> Result<Self> {
+        if session
+            .expires_at
+            .is_none_or(|expires_at| expires_at <= unix_timestamp())
+        {
+            return Err(Error::cloud(
+                "unauthorized",
+                "The Anarlog session has expired; open Anarlog or run `anarlog auth login` again.",
+            ));
+        }
+        Self::new(base_url, session.access_token)
+    }
+
+    fn new(base_url: &str, access_token: String) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .user_agent(format!("anarlog-cli/{}", env!("CARGO_PKG_VERSION")))
+            .build()
+            .map_err(|error| Error::operation("create Cloud API client", error.to_string()))?;
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            access_token,
+            client,
+        })
+    }
+
+    pub(crate) async fn list_meetings(&self, input: ListMeetingsInput) -> Result<MeetingPage> {
+        self.get_json("/v1/meetings", Some(&input), "list Cloud meetings")
+            .await
+    }
+
+    pub(crate) async fn get_meeting(&self, input: GetMeetingInput) -> Result<Meeting> {
+        self.get_json(
+            &format!("/v1/meetings/{}", encode_path(&input.meeting_id)),
+            None::<&()>,
+            "get Cloud meeting",
+        )
+        .await
+    }
+
+    pub(crate) async fn get_meeting_transcript(
+        &self,
+        input: GetMeetingTranscriptInput,
+    ) -> Result<TranscriptPage> {
+        self.get_json(
+            &format!("/v1/meetings/{}/transcript", encode_path(&input.meeting_id)),
+            Some(&TranscriptQuery {
+                offset: input.offset,
+                limit: input.limit,
+            }),
+            "get Cloud transcript",
+        )
+        .await
+    }
+
+    pub(crate) async fn get_recurring_meeting_history(
+        &self,
+        input: GetRecurringMeetingHistoryInput,
+    ) -> Result<MeetingPage> {
+        self.get_json(
+            &format!("/v1/meetings/{}/history", encode_path(&input.meeting_id)),
+            Some(&HistoryQuery {
+                limit: input.limit,
+                offset: input.offset,
+            }),
+            "get Cloud meeting history",
+        )
+        .await
+    }
+
+    pub(crate) async fn get_meeting_export(&self, meeting_id: String) -> Result<MeetingExport> {
+        self.get_json(
+            &format!("/v1/meetings/{}/export", encode_path(&meeting_id)),
+            None::<&()>,
+            "export Cloud meeting",
+        )
+        .await
+    }
+
+    async fn get_json<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: Option<&impl serde::Serialize>,
+        action: &'static str,
+    ) -> Result<T> {
+        let mut request = self
+            .client
+            .get(format!("{}{path}", self.base_url))
+            .bearer_auth(&self.access_token);
+        if let Some(query) = query {
+            request = request.query(query);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|error| Error::operation(action, error.to_string()))?;
+        decode(response, action).await
+    }
+}
+
+#[derive(serde::Serialize)]
+struct TranscriptQuery {
+    offset: Option<u32>,
+    limit: Option<u32>,
+}
+
+#[derive(serde::Serialize)]
+struct HistoryQuery {
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+#[derive(serde::Deserialize)]
+struct ErrorEnvelope {
+    error: ErrorBody,
+}
+
+#[derive(serde::Deserialize)]
+struct ErrorBody {
+    code: String,
+    message: String,
+}
+
+async fn decode<T: DeserializeOwned>(response: Response, action: &'static str) -> Result<T> {
+    let status = response.status();
+    if status.is_success() {
+        return response
+            .json()
+            .await
+            .map_err(|error| Error::operation(action, error.to_string()));
+    }
+
+    let retry_after = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = response.text().await.unwrap_or_default();
+    if let Ok(envelope) = serde_json::from_str::<ErrorEnvelope>(&body) {
+        if envelope.error.code == "not_found" {
+            return Err(Error::NotFound(
+                envelope
+                    .error
+                    .message
+                    .strip_suffix(" not found")
+                    .unwrap_or(&envelope.error.message)
+                    .to_string(),
+            ));
+        }
+        return Err(Error::cloud(
+            cloud_error_code(&envelope.error.code),
+            envelope.error.message,
+        ));
+    }
+
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        let suffix = retry_after
+            .map(|seconds| format!("; retry after {seconds} seconds"))
+            .unwrap_or_default();
+        return Err(Error::cloud(
+            "rate_limited",
+            format!("Cloud API rate limit exceeded{suffix}"),
+        ));
+    }
+
+    Err(Error::cloud(
+        "cloud_api_error",
+        format!("Cloud API returned HTTP {}", status.as_u16()),
+    ))
+}
+
+fn cloud_error_code(code: &str) -> &'static str {
+    match code {
+        "unauthorized" => "unauthorized",
+        "insufficient_scope" => "insufficient_scope",
+        "subscription_required" => "subscription_required",
+        "cloud_api_not_enabled" => "cloud_api_not_enabled",
+        "invalid_request" => "invalid_request",
+        "internal_error" => "internal_error",
+        _ => "cloud_api_error",
+    }
+}
+
+fn encode_path(value: &str) -> String {
+    url::form_urlencoded::byte_serialize(value.as_bytes()).collect()
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path, query_param},
+    };
+
+    #[tokio::test]
+    async fn list_uses_bearer_auth_and_preserves_query_pagination() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/meetings"))
+            .and(header("authorization", "Bearer access-token"))
+            .and(query_param("query", "planning"))
+            .and(query_param("limit", "10"))
+            .and(query_param("offset", "20"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "meetings": [{
+                    "id": "meeting-1",
+                    "title": "Planning",
+                    "kind": "meeting",
+                    "status": "completed",
+                    "created_at": "2026-09-01",
+                    "updated_at": "2026-09-01",
+                    "started_at": "2026-09-01",
+                    "ended_at": "",
+                    "series_id": ""
+                }],
+                "pagination": {
+                    "offset": 20,
+                    "limit": 10,
+                    "returned": 1,
+                    "total": null,
+                    "next_offset": null
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = CloudClient::new(&server.uri(), "access-token".to_string()).unwrap();
+
+        let page = client
+            .list_meetings(ListMeetingsInput {
+                query: Some("planning".to_string()),
+                series_id: None,
+                limit: Some(10),
+                offset: Some(20),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(page.meetings[0].id, "meeting-1");
+        assert_eq!(page.pagination.offset, 20);
+    }
+
+    #[tokio::test]
+    async fn export_reads_the_shared_meeting_export_contract() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/meetings/meeting%2F1/export"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(export_json()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = CloudClient::new(&server.uri(), "access-token".to_string()).unwrap();
+
+        let export = client
+            .get_meeting_export("meeting/1".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(export.meeting.id, "meeting/1");
+        assert_eq!(export.transcripts[0].text, "Launch Friday");
+    }
+
+    #[tokio::test]
+    async fn cloud_errors_keep_stable_codes_and_retry_guidance() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/meetings/missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "error": {
+                    "code": "not_found",
+                    "message": "meeting 'missing' not found"
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/meetings"))
+            .respond_with(
+                ResponseTemplate::new(429)
+                    .insert_header("retry-after", "2")
+                    .set_body_string("rate limit exceeded"),
+            )
+            .mount(&server)
+            .await;
+        let client = CloudClient::new(&server.uri(), "access-token".to_string()).unwrap();
+
+        let missing = client
+            .get_meeting(GetMeetingInput {
+                meeting_id: "missing".to_string(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(missing.code(), "not_found");
+        assert_eq!(missing.to_string(), "meeting 'missing' not found");
+
+        let limited = client
+            .list_meetings(ListMeetingsInput::default())
+            .await
+            .unwrap_err();
+        assert_eq!(limited.code(), "rate_limited");
+        assert!(limited.to_string().contains("retry after 2 seconds"));
+    }
+
+    fn export_json() -> serde_json::Value {
+        serde_json::json!({
+            "id": "meeting/1",
+            "title": "Planning",
+            "kind": "meeting",
+            "status": "completed",
+            "created_at": "2026-09-01",
+            "updated_at": "2026-09-01",
+            "started_at": "2026-09-01",
+            "ended_at": "",
+            "timezone": "Asia/Seoul",
+            "language": "en",
+            "series_id": "",
+            "note": null,
+            "summaries": [],
+            "participants": [],
+            "action_items": [],
+            "transcripts": [{
+                "id": "transcript-1",
+                "source": "mic",
+                "provider": "local",
+                "model": "local",
+                "language": "en",
+                "started_at_ms": 0,
+                "ended_at_ms": null,
+                "memo": "",
+                "text": "Launch Friday",
+                "words": [],
+                "speaker_hints": []
+            }]
+        })
+    }
+}

--- a/apps/cli/src/commands/auth/mod.rs
+++ b/apps/cli/src/commands/auth/mod.rs
@@ -29,6 +29,11 @@ pub async fn run(command: &AuthCommand, json: bool) -> Result<()> {
     }
 }
 
+pub(crate) fn current_session() -> Result<Option<Session>> {
+    let store = AuthStore::new(Environment::current().bundle_id)?;
+    storage::find_session(&store.load()?.data)
+}
+
 async fn login(store: &AuthStore, environment: Environment, json: bool) -> Result<()> {
     let login_url = login_url(environment.scheme)?;
     if json {

--- a/apps/cli/src/commands/meetings.rs
+++ b/apps/cli/src/commands/meetings.rs
@@ -1,12 +1,86 @@
-use crate::cli::{DocumentKind, ExportFormat, MeetingCommand};
-use crate::{Result, output};
+use std::sync::Arc;
+
+use crate::cli::{DocumentKind, ExportFormat, MeetingCommand, MeetingSource};
+use crate::{Args, Error, Result, cloud::CloudClient, db, output};
 use anlg_agent_access::{
     Document, GetMeetingInput, GetMeetingTranscriptInput, GetRecurringMeetingHistoryInput,
-    ListMeetingsInput, MeetingListItem, get_meeting, get_meeting_export, get_meeting_transcript,
-    get_recurring_meeting_history, list_meetings,
+    ListMeetingsInput, Meeting, MeetingExport, MeetingListItem, MeetingPage, TranscriptPage,
 };
 
-pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> Result<()> {
+pub enum DataSource {
+    Local(Arc<anlg_db_core::Db>),
+    Cloud(CloudClient),
+}
+
+impl DataSource {
+    pub async fn open(args: &Args, source: MeetingSource) -> Result<Self> {
+        match source {
+            MeetingSource::Local => db::open(args).await.map(Arc::new).map(Self::Local),
+            MeetingSource::Cloud => CloudClient::current().map(Self::Cloud),
+            MeetingSource::Auto => match db::open(args).await {
+                Ok(db) => Ok(Self::Local(Arc::new(db))),
+                Err(Error::DatabaseNotFound(_)) => CloudClient::current().map(Self::Cloud),
+                Err(error) => Err(error),
+            },
+        }
+    }
+
+    async fn list_meetings(
+        &self,
+        input: anlg_agent_access::ListMeetingsInput,
+    ) -> Result<MeetingPage> {
+        match self {
+            Self::Local(db) => anlg_agent_access::list_meetings(db.pool(), input)
+                .await
+                .map_err(Into::into),
+            Self::Cloud(client) => client.list_meetings(input).await,
+        }
+    }
+
+    async fn get_meeting(&self, input: GetMeetingInput) -> Result<Meeting> {
+        match self {
+            Self::Local(db) => anlg_agent_access::get_meeting(db.pool(), input)
+                .await
+                .map_err(Into::into),
+            Self::Cloud(client) => client.get_meeting(input).await,
+        }
+    }
+
+    async fn get_meeting_transcript(
+        &self,
+        input: GetMeetingTranscriptInput,
+    ) -> Result<TranscriptPage> {
+        match self {
+            Self::Local(db) => anlg_agent_access::get_meeting_transcript(db.pool(), input)
+                .await
+                .map_err(Into::into),
+            Self::Cloud(client) => client.get_meeting_transcript(input).await,
+        }
+    }
+
+    async fn get_recurring_meeting_history(
+        &self,
+        input: GetRecurringMeetingHistoryInput,
+    ) -> Result<MeetingPage> {
+        match self {
+            Self::Local(db) => anlg_agent_access::get_recurring_meeting_history(db.pool(), input)
+                .await
+                .map_err(Into::into),
+            Self::Cloud(client) => client.get_recurring_meeting_history(input).await,
+        }
+    }
+
+    async fn get_meeting_export(&self, meeting_id: String) -> Result<MeetingExport> {
+        match self {
+            Self::Local(db) => anlg_agent_access::get_meeting_export(db.pool(), meeting_id)
+                .await
+                .map_err(Into::into),
+            Self::Cloud(client) => client.get_meeting_export(meeting_id).await,
+        }
+    }
+}
+
+pub async fn run(source: &DataSource, command: MeetingCommand, json: bool) -> Result<()> {
     match command {
         MeetingCommand::List {
             query,
@@ -14,16 +88,14 @@ pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> 
             limit,
             offset,
         } => {
-            let page = list_meetings(
-                db.pool(),
-                ListMeetingsInput {
+            let page = source
+                .list_meetings(ListMeetingsInput {
                     query,
                     series_id,
                     limit: Some(limit),
                     offset: Some(offset),
-                },
-            )
-            .await?;
+                })
+                .await?;
             let rendered = if json {
                 output::json("meetings.list", &page.meetings, Some(&page.pagination))?
             } else {
@@ -33,7 +105,9 @@ pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> 
             Ok(())
         }
         MeetingCommand::Get { id } => {
-            let meeting = get_meeting(db.pool(), GetMeetingInput { meeting_id: id }).await?;
+            let meeting = source
+                .get_meeting(GetMeetingInput { meeting_id: id })
+                .await?;
             let rendered = if json {
                 output::json("meetings.get", &meeting, None)?
             } else {
@@ -43,13 +117,11 @@ pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> 
             Ok(())
         }
         MeetingCommand::Note { id, kind } => {
-            let meeting = get_meeting(
-                db.pool(),
-                GetMeetingInput {
+            let meeting = source
+                .get_meeting(GetMeetingInput {
                     meeting_id: id.clone(),
-                },
-            )
-            .await?;
+                })
+                .await?;
             if json {
                 match kind {
                     DocumentKind::Note => {
@@ -86,15 +158,13 @@ pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> 
             Ok(())
         }
         MeetingCommand::Transcript { id, limit, offset } => {
-            let page = get_meeting_transcript(
-                db.pool(),
-                GetMeetingTranscriptInput {
+            let page = source
+                .get_meeting_transcript(GetMeetingTranscriptInput {
                     meeting_id: id,
                     offset: Some(offset),
                     limit: Some(limit),
-                },
-            )
-            .await?;
+                })
+                .await?;
             let rendered = if json {
                 let content = serde_json::json!({
                     "meeting_id": &page.meeting_id,
@@ -109,15 +179,13 @@ pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> 
             Ok(())
         }
         MeetingCommand::History { id, limit, offset } => {
-            let page = get_recurring_meeting_history(
-                db.pool(),
-                GetRecurringMeetingHistoryInput {
+            let page = source
+                .get_recurring_meeting_history(GetRecurringMeetingHistoryInput {
                     meeting_id: id,
                     limit: Some(limit),
                     offset: Some(offset),
-                },
-            )
-            .await?;
+                })
+                .await?;
             let rendered = if json {
                 output::json("meetings.history", &page.meetings, Some(&page.pagination))?
             } else {
@@ -132,7 +200,7 @@ pub async fn run(db: &anlg_db_core::Db, command: MeetingCommand, json: bool) -> 
             output: path,
             force,
         } => {
-            let meeting = get_meeting_export(db.pool(), id).await?;
+            let meeting = source.get_meeting_export(id).await?;
             let content = match (format, json) {
                 (ExportFormat::Markdown, false) => meeting.to_markdown(),
                 (ExportFormat::Json, false) => output::raw_json(&meeting)?,

--- a/apps/cli/src/error.rs
+++ b/apps/cli/src/error.rs
@@ -6,6 +6,8 @@ pub enum Error {
     DatabaseNotFound(std::path::PathBuf),
     #[error("output file already exists at {0}; pass --force to overwrite it")]
     OutputExists(std::path::PathBuf),
+    #[error("{message}")]
+    Cloud { code: &'static str, message: String },
     #[error("{action} failed: {reason}")]
     Operation {
         action: &'static str,
@@ -40,11 +42,19 @@ impl Error {
         }
     }
 
+    pub fn cloud(code: &'static str, message: impl Into<String>) -> Self {
+        Self::Cloud {
+            code,
+            message: message.into(),
+        }
+    }
+
     pub fn exit_code(&self) -> u8 {
         match self {
             Self::NotFound(_) => 2,
             Self::DatabaseNotFound(_) => 3,
             Self::OutputExists(_) => 4,
+            Self::Cloud { .. } => 1,
             Self::Operation { .. } => 1,
         }
     }
@@ -54,6 +64,7 @@ impl Error {
             Self::NotFound(_) => "not_found",
             Self::DatabaseNotFound(_) => "database_not_found",
             Self::OutputExists(_) => "output_exists",
+            Self::Cloud { code, .. } => code,
             Self::Operation { .. } => "operation_failed",
         }
     }

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod cli;
+mod cloud;
 mod commands;
 mod db;
 mod error;
@@ -11,7 +12,7 @@ pub use cli::Args;
 pub use error::{Error, Result};
 pub use output::JSON_SCHEMA_VERSION;
 
-pub async fn run(args: Args) -> Result<u8> {
+pub async fn run(mut args: Args) -> Result<u8> {
     if let cli::Command::Auth { command } = &args.command {
         commands::auth::run(command, args.json).await?;
         return Ok(0);
@@ -23,22 +24,22 @@ pub async fn run(args: Args) -> Result<u8> {
     }
 
     let json = args.json;
-    let db = std::sync::Arc::new(if args.needs_write() {
-        db::open_write(&args).await?
-    } else {
-        db::open(&args).await?
-    });
-
-    match args.command {
+    let command = std::mem::replace(&mut args.command, cli::Command::Doctor);
+    match command {
         cli::Command::Auth { .. } => unreachable!("auth returns before opening the database"),
         cli::Command::Doctor => unreachable!("doctor returns before opening the database"),
-        cli::Command::Meetings { command } => {
-            commands::meetings::run(db.as_ref(), command, json).await?
+        cli::Command::Meetings { source, command } => {
+            let source = commands::meetings::DataSource::open(&args, source).await?;
+            commands::meetings::run(&source, command, json).await?
         }
         cli::Command::Proposals { command } => {
-            commands::proposals::run(db.as_ref(), command, json).await?
+            let db = db::open_write(&args).await?;
+            commands::proposals::run(&db, command, json).await?
         }
-        cli::Command::Mcp => mcp::serve(db).await?,
+        cli::Command::Mcp => {
+            let db = std::sync::Arc::new(db::open_write(&args).await?);
+            mcp::serve(db).await?
+        }
     }
 
     Ok(0)
@@ -92,6 +93,7 @@ mod tests {
             db_path: Some(db_path),
             json: false,
             command: cli::Command::Meetings {
+                source: cli::MeetingSource::Local,
                 command: cli::MeetingCommand::Export {
                     id: "meeting-1".to_string(),
                     format: cli::ExportFormat::Markdown,

--- a/apps/cli/src/mcp.rs
+++ b/apps/cli/src/mcp.rs
@@ -40,7 +40,9 @@ impl AnarlogMcpServer {
 #[tool_router]
 impl AnarlogMcpServer {
     #[tool(
+        title = "List meetings",
         description = "List recent Anarlog meetings with pagination metadata. Use query to narrow by title or meeting id, then pass next_offset as offset to continue.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingPage>(),
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -59,7 +61,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Get meeting",
         description = "Get one Anarlog meeting with its canonical note, summaries, participants, and action items. Use get_meeting_transcript separately for transcript words.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::Meeting>(),
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -78,7 +82,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Get meeting transcript",
         description = "Get a bounded page of transcript words and readable text for an Anarlog meeting. Pass pagination.next_offset as offset to continue.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::TranscriptPage>(),
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -97,7 +103,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Get recurring meeting history",
         description = "List meetings in the same recurring series as the supplied meeting, newest first, with pagination metadata.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingPage>(),
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -116,7 +124,30 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Export meeting",
+        description = "Get a complete Anarlog meeting export with notes, summaries, participants, action items, and transcripts.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingExport>(),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn export_meeting(
+        &self,
+        Parameters(input): Parameters<access::GetMeetingInput>,
+    ) -> std::result::Result<CallToolResult, McpError> {
+        let export = access::get_meeting_export(self.db.pool(), input.meeting_id)
+            .await
+            .map_err(command_error)?;
+        structured(&export)
+    }
+
+    #[tool(
+        title = "Propose summary edit",
         description = "Propose a complete summary replacement. The proposal stays pending until a human applies it in the Anarlog desktop app. Specify target_id when the meeting has multiple summaries.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::Proposal>(),
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -144,7 +175,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Propose memo edit",
         description = "Propose a complete memo replacement. The proposal stays pending until a human applies it in the Anarlog desktop app.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::Proposal>(),
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -172,7 +205,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "List proposals",
         description = "List staged Anarlog meeting proposals. Defaults to pending proposals. Pass status all to include applied and declined rows, and next_offset as offset to continue.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::ProposalPage>(),
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -191,7 +226,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Get proposal",
         description = "Get one staged Anarlog proposal, including its unified diff. The proposal is not applied.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::Proposal>(),
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -210,7 +247,9 @@ impl AnarlogMcpServer {
     }
 
     #[tool(
+        title = "Decline proposal",
         description = "Decline a pending proposal without changing the meeting. Applied proposals cannot be declined.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::Proposal>(),
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -253,13 +292,13 @@ impl ServerHandler for AnarlogMcpServer {
                 .enable_resources()
                 .build(),
         )
-        .with_protocol_version(ProtocolVersion::V_2024_11_05)
+        .with_protocol_version(ProtocolVersion::LATEST)
         .with_server_info(Implementation::new(
             "anarlog",
             env!("CARGO_PKG_VERSION"),
         ))
         .with_instructions(
-            "Local access to Anarlog meeting data. Start with list_meetings to resolve a meeting_id, then call get_meeting for notes, summaries, participants, and action items. Request transcript pages with get_meeting_transcript and continue with pagination.next_offset; each page is capped at 500 words. Use get_recurring_meeting_history for series context. To persist an edit, call propose_summary_edit or propose_memo_edit; the result stays pending until a human applies it in the desktop app. List or inspect staged work with list_proposals and get_proposal. decline_proposal discards a pending proposal without changing the meeting. Never invent meeting titles, dates, or ids. If list_meetings returns no meetings, say so. Never access SQLite directly, or claim a proposal was applied. Documentation: https://docs.anarlog.so",
+            "Local access to Anarlog meeting data. Start with list_meetings to resolve a meeting_id, then call get_meeting for notes, summaries, participants, and action items. Request transcript pages with get_meeting_transcript and continue with pagination.next_offset; each page is capped at 500 words. Use get_recurring_meeting_history for series context. Use export_meeting only when the task needs the complete record including transcripts. To persist an edit, call propose_summary_edit or propose_memo_edit; the result stays pending until a human applies it in the desktop app. List or inspect staged work with list_proposals and get_proposal. decline_proposal discards a pending proposal without changing the meeting. Never invent meeting titles, dates, or ids. If list_meetings returns no meetings, say so. Never access SQLite directly, or claim a proposal was applied. Documentation: https://docs.anarlog.so",
         )
     }
 
@@ -606,6 +645,7 @@ mod tests {
             tool_names,
             [
                 "decline_proposal",
+                "export_meeting",
                 "get_meeting",
                 "get_meeting_transcript",
                 "get_proposal",
@@ -640,6 +680,13 @@ mod tests {
                     "MCP docs are missing `{parameter}`"
                 );
             }
+            assert_eq!(
+                tool.output_schema
+                    .as_ref()
+                    .and_then(|schema| schema.get("type"))
+                    .and_then(Value::as_str),
+                Some("object")
+            );
             let annotations = tool.annotations.expect("tool annotations");
             let write_tool = matches!(
                 tool.name.as_ref(),

--- a/apps/cli/src/snapshots/anarlog_cli__cli__tests__cli_contract.snap
+++ b/apps/cli/src/snapshots/anarlog_cli__cli__tests__cli_contract.snap
@@ -1,6 +1,5 @@
 ---
 source: apps/cli/src/cli.rs
-assertion_line: 367
 expression: canonicalize_json(contract)
 ---
 {
@@ -111,6 +110,19 @@ expression: canonicalize_json(contract)
       "about": "Browse and export meetings",
       "name": "anarlog meetings",
       "options": [
+        {
+          "default": "local",
+          "flags": "--source",
+          "help": "Choose local data, hosted Cloud snapshots, or Cloud only when no local database exists",
+          "is_flag": false,
+          "possible_values": [
+            "local",
+            "cloud",
+            "auto"
+          ],
+          "required": false,
+          "value_name": "SOURCE"
+        },
         {
           "flags": "-h, --help",
           "help": "Print help",
@@ -323,7 +335,7 @@ expression: canonicalize_json(contract)
           "synopsis": "anarlog meetings export [--format] [-o] [--force] [-h] <id>"
         }
       ],
-      "synopsis": "anarlog meetings [-h] <command>"
+      "synopsis": "anarlog meetings [--source] [-h] <command>"
     },
     {
       "about": "Propose meeting edits for desktop review",

--- a/apps/cli/src/snapshots/anarlog_cli__mcp__tests__mcp_contract.snap
+++ b/apps/cli/src/snapshots/anarlog_cli__mcp__tests__mcp_contract.snap
@@ -1,11 +1,10 @@
 ---
 source: apps/cli/src/mcp.rs
-assertion_line: 589
 expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": info.protocol_version, \"instructions\":\n    info.instructions, \"tools\": tools, \"resource_templates\": templates,\n}))"
 ---
 {
-  "instructions": "Local access to Anarlog meeting data. Start with list_meetings to resolve a meeting_id, then call get_meeting for notes, summaries, participants, and action items. Request transcript pages with get_meeting_transcript and continue with pagination.next_offset; each page is capped at 500 words. Use get_recurring_meeting_history for series context. To persist an edit, call propose_summary_edit or propose_memo_edit; the result stays pending until a human applies it in the desktop app. List or inspect staged work with list_proposals and get_proposal. decline_proposal discards a pending proposal without changing the meeting. Never invent meeting titles, dates, or ids. If list_meetings returns no meetings, say so. Never access SQLite directly, or claim a proposal was applied. Documentation: https://docs.anarlog.so",
-  "protocol_version": "2024-11-05",
+  "instructions": "Local access to Anarlog meeting data. Start with list_meetings to resolve a meeting_id, then call get_meeting for notes, summaries, participants, and action items. Request transcript pages with get_meeting_transcript and continue with pagination.next_offset; each page is capped at 500 words. Use get_recurring_meeting_history for series context. Use export_meeting only when the task needs the complete record including transcripts. To persist an edit, call propose_summary_edit or propose_memo_edit; the result stays pending until a human applies it in the desktop app. List or inspect staged work with list_proposals and get_proposal. decline_proposal discards a pending proposal without changing the meeting. Never invent meeting titles, dates, or ids. If list_meetings returns no meetings, say so. Never access SQLite directly, or claim a proposal was applied. Documentation: https://docs.anarlog.so",
+  "protocol_version": "2025-11-25",
   "resource_templates": [
     {
       "description": "Meeting metadata, note, summaries, people, and action items",
@@ -49,7 +48,348 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "DeclineProposalInput",
         "type": "object"
       },
-      "name": "decline_proposal"
+      "name": "decline_proposal",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "base_updated_at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "current_markdown": {
+            "type": "string"
+          },
+          "diff": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "meeting_id": {
+            "type": "string"
+          },
+          "proposed_markdown": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "meeting_id",
+          "kind",
+          "target_id",
+          "base_updated_at",
+          "current_markdown",
+          "proposed_markdown",
+          "status",
+          "source",
+          "created_at",
+          "updated_at",
+          "diff"
+        ],
+        "title": "Proposal",
+        "type": "object"
+      },
+      "title": "Decline proposal"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get a complete Anarlog meeting export with notes, summaries, participants, action items, and transcripts.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "meeting_id": {
+            "description": "Anarlog meeting id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "meeting_id"
+        ],
+        "title": "GetMeetingInput",
+        "type": "object"
+      },
+      "name": "export_meeting",
+      "outputSchema": {
+        "$defs": {
+          "ActionItem": {
+            "properties": {
+              "assignee_human_id": {
+                "type": "string"
+              },
+              "completed_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "due_at": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "assignee_human_id",
+              "status",
+              "text",
+              "due_at"
+            ],
+            "type": "object"
+          },
+          "Document": {
+            "properties": {
+              "created_at": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "markdown": {
+                "type": "string"
+              },
+              "sort_order": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "template_id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "template_id",
+              "title",
+              "markdown",
+              "sort_order",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "object"
+          },
+          "Participant": {
+            "properties": {
+              "display_name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "human_id": {
+                "type": "string"
+              },
+              "job_title": {
+                "type": "string"
+              },
+              "organization_id": {
+                "type": "string"
+              },
+              "organization_name": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "human_id",
+              "display_name",
+              "email",
+              "role",
+              "job_title",
+              "organization_id",
+              "organization_name"
+            ],
+            "type": "object"
+          },
+          "Transcript": {
+            "properties": {
+              "ended_at_ms": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "memo": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "speaker_hints": {
+                "items": true,
+                "type": "array"
+              },
+              "started_at_ms": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "text": {
+                "type": "string"
+              },
+              "words": {
+                "items": true,
+                "type": "array"
+              }
+            },
+            "required": [
+              "id",
+              "source",
+              "provider",
+              "model",
+              "language",
+              "started_at_ms",
+              "memo",
+              "text",
+              "words",
+              "speaker_hints"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "action_items": {
+            "items": {
+              "$ref": "#/$defs/ActionItem"
+            },
+            "type": "array"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "ended_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Document"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/$defs/Participant"
+            },
+            "type": "array"
+          },
+          "series_id": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summaries": {
+            "items": {
+              "$ref": "#/$defs/Document"
+            },
+            "type": "array"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "transcripts": {
+            "items": {
+              "$ref": "#/$defs/Transcript"
+            },
+            "type": "array"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "kind",
+          "status",
+          "created_at",
+          "updated_at",
+          "started_at",
+          "ended_at",
+          "timezone",
+          "language",
+          "series_id",
+          "summaries",
+          "participants",
+          "action_items",
+          "transcripts"
+        ],
+        "title": "MeetingExport",
+        "type": "object"
+      },
+      "title": "Export meeting"
     },
     {
       "annotations": {
@@ -73,7 +413,202 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "GetMeetingInput",
         "type": "object"
       },
-      "name": "get_meeting"
+      "name": "get_meeting",
+      "outputSchema": {
+        "$defs": {
+          "ActionItem": {
+            "properties": {
+              "assignee_human_id": {
+                "type": "string"
+              },
+              "completed_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "due_at": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "assignee_human_id",
+              "status",
+              "text",
+              "due_at"
+            ],
+            "type": "object"
+          },
+          "Document": {
+            "properties": {
+              "created_at": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "markdown": {
+                "type": "string"
+              },
+              "sort_order": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "template_id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "template_id",
+              "title",
+              "markdown",
+              "sort_order",
+              "created_at",
+              "updated_at"
+            ],
+            "type": "object"
+          },
+          "Participant": {
+            "properties": {
+              "display_name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "human_id": {
+                "type": "string"
+              },
+              "job_title": {
+                "type": "string"
+              },
+              "organization_id": {
+                "type": "string"
+              },
+              "organization_name": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "human_id",
+              "display_name",
+              "email",
+              "role",
+              "job_title",
+              "organization_id",
+              "organization_name"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "action_items": {
+            "items": {
+              "$ref": "#/$defs/ActionItem"
+            },
+            "type": "array"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "ended_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Document"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/$defs/Participant"
+            },
+            "type": "array"
+          },
+          "series_id": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summaries": {
+            "items": {
+              "$ref": "#/$defs/Document"
+            },
+            "type": "array"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "kind",
+          "status",
+          "created_at",
+          "updated_at",
+          "started_at",
+          "ended_at",
+          "timezone",
+          "language",
+          "series_id",
+          "summaries",
+          "participants",
+          "action_items"
+        ],
+        "title": "Meeting",
+        "type": "object"
+      },
+      "title": "Get meeting"
     },
     {
       "annotations": {
@@ -116,7 +651,77 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "GetMeetingTranscriptInput",
         "type": "object"
       },
-      "name": "get_meeting_transcript"
+      "name": "get_meeting_transcript",
+      "outputSchema": {
+        "$defs": {
+          "Pagination": {
+            "properties": {
+              "limit": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "next_offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "returned": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total": {
+                "format": "uint",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "offset",
+              "limit",
+              "returned"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "meeting_id": {
+            "type": "string"
+          },
+          "pagination": {
+            "$ref": "#/$defs/Pagination"
+          },
+          "text": {
+            "type": "string"
+          },
+          "words": {
+            "items": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "meeting_id",
+          "text",
+          "words",
+          "pagination"
+        ],
+        "title": "TranscriptPage",
+        "type": "object"
+      },
+      "title": "Get meeting transcript"
     },
     {
       "annotations": {
@@ -140,7 +745,65 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "GetProposalInput",
         "type": "object"
       },
-      "name": "get_proposal"
+      "name": "get_proposal",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "base_updated_at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "current_markdown": {
+            "type": "string"
+          },
+          "diff": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "meeting_id": {
+            "type": "string"
+          },
+          "proposed_markdown": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "meeting_id",
+          "kind",
+          "target_id",
+          "base_updated_at",
+          "current_markdown",
+          "proposed_markdown",
+          "status",
+          "source",
+          "created_at",
+          "updated_at",
+          "diff"
+        ],
+        "title": "Proposal",
+        "type": "object"
+      },
+      "title": "Get proposal"
     },
     {
       "annotations": {
@@ -183,7 +846,114 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "GetRecurringMeetingHistoryInput",
         "type": "object"
       },
-      "name": "get_recurring_meeting_history"
+      "name": "get_recurring_meeting_history",
+      "outputSchema": {
+        "$defs": {
+          "MeetingListItem": {
+            "properties": {
+              "created_at": {
+                "type": "string"
+              },
+              "ended_at": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "series_id": {
+                "type": "string"
+              },
+              "started_at": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "kind",
+              "status",
+              "created_at",
+              "updated_at",
+              "started_at",
+              "ended_at",
+              "series_id"
+            ],
+            "type": "object"
+          },
+          "Pagination": {
+            "properties": {
+              "limit": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "next_offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "returned": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total": {
+                "format": "uint",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "offset",
+              "limit",
+              "returned"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "meetings": {
+            "items": {
+              "$ref": "#/$defs/MeetingListItem"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/$defs/Pagination"
+          }
+        },
+        "required": [
+          "meetings",
+          "pagination"
+        ],
+        "title": "MeetingPage",
+        "type": "object"
+      },
+      "title": "Get recurring meeting history"
     },
     {
       "annotations": {
@@ -233,7 +1003,114 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "ListMeetingsInput",
         "type": "object"
       },
-      "name": "list_meetings"
+      "name": "list_meetings",
+      "outputSchema": {
+        "$defs": {
+          "MeetingListItem": {
+            "properties": {
+              "created_at": {
+                "type": "string"
+              },
+              "ended_at": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "series_id": {
+                "type": "string"
+              },
+              "started_at": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "kind",
+              "status",
+              "created_at",
+              "updated_at",
+              "started_at",
+              "ended_at",
+              "series_id"
+            ],
+            "type": "object"
+          },
+          "Pagination": {
+            "properties": {
+              "limit": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "next_offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "returned": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total": {
+                "format": "uint",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "offset",
+              "limit",
+              "returned"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "meetings": {
+            "items": {
+              "$ref": "#/$defs/MeetingListItem"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/$defs/Pagination"
+          }
+        },
+        "required": [
+          "meetings",
+          "pagination"
+        ],
+        "title": "MeetingPage",
+        "type": "object"
+      },
+      "title": "List meetings"
     },
     {
       "annotations": {
@@ -283,7 +1160,126 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "ListProposalsInput",
         "type": "object"
       },
-      "name": "list_proposals"
+      "name": "list_proposals",
+      "outputSchema": {
+        "$defs": {
+          "Pagination": {
+            "properties": {
+              "limit": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "next_offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "offset": {
+                "format": "uint32",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "returned": {
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total": {
+                "format": "uint",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "offset",
+              "limit",
+              "returned"
+            ],
+            "type": "object"
+          },
+          "Proposal": {
+            "properties": {
+              "base_updated_at": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "current_markdown": {
+                "type": "string"
+              },
+              "diff": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "meeting_id": {
+                "type": "string"
+              },
+              "proposed_markdown": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "target_id": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "meeting_id",
+              "kind",
+              "target_id",
+              "base_updated_at",
+              "current_markdown",
+              "proposed_markdown",
+              "status",
+              "source",
+              "created_at",
+              "updated_at",
+              "diff"
+            ],
+            "type": "object"
+          }
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "pagination": {
+            "$ref": "#/$defs/Pagination"
+          },
+          "proposals": {
+            "items": {
+              "$ref": "#/$defs/Proposal"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "proposals",
+          "pagination"
+        ],
+        "title": "ProposalPage",
+        "type": "object"
+      },
+      "title": "List proposals"
     },
     {
       "annotations": {
@@ -310,7 +1306,65 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "ProposeMemoInput",
         "type": "object"
       },
-      "name": "propose_memo_edit"
+      "name": "propose_memo_edit",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "base_updated_at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "current_markdown": {
+            "type": "string"
+          },
+          "diff": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "meeting_id": {
+            "type": "string"
+          },
+          "proposed_markdown": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "meeting_id",
+          "kind",
+          "target_id",
+          "base_updated_at",
+          "current_markdown",
+          "proposed_markdown",
+          "status",
+          "source",
+          "created_at",
+          "updated_at",
+          "diff"
+        ],
+        "title": "Proposal",
+        "type": "object"
+      },
+      "title": "Propose memo edit"
     },
     {
       "annotations": {
@@ -343,7 +1397,65 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "title": "ProposeSummaryInput",
         "type": "object"
       },
-      "name": "propose_summary_edit"
+      "name": "propose_summary_edit",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "base_updated_at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "current_markdown": {
+            "type": "string"
+          },
+          "diff": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "meeting_id": {
+            "type": "string"
+          },
+          "proposed_markdown": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "meeting_id",
+          "kind",
+          "target_id",
+          "base_updated_at",
+          "current_markdown",
+          "proposed_markdown",
+          "status",
+          "source",
+          "created_at",
+          "updated_at",
+          "diff"
+        ],
+        "title": "Proposal",
+        "type": "object"
+      },
+      "title": "Propose summary edit"
     }
   ]
 }

--- a/crates/agent-access/src/proposals.rs
+++ b/crates/agent-access/src/proposals.rs
@@ -64,7 +64,9 @@ pub struct DeclineProposalInput {
     pub proposal_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Type, utoipa::ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct Proposal {
     pub id: String,
@@ -81,7 +83,9 @@ pub struct Proposal {
     pub diff: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Type, utoipa::ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct ProposalPage {
     pub proposals: Vec<Proposal>,

--- a/crates/api-cloud/src/auth.rs
+++ b/crates/api-cloud/src/auth.rs
@@ -28,12 +28,29 @@ pub async fn require_cloud_connector_auth(
         return require_api_key(&state, &token, request, next).await;
     }
 
-    let claims = state
-        .verify_oauth_token(&token)
+    let claims = if request.uri().path().starts_with("/mcp") {
+        verify_oauth_token(&state, &token).await?
+    } else {
+        match state.verify_session_token(&token).await {
+            Ok(claims) => claims,
+            Err(_) => verify_oauth_token(&state, &token).await?,
+        }
+    };
+    enforce_user_status(&state, &claims.sub).await?;
+    request
+        .extensions_mut()
+        .insert(AuthContext { token, claims });
+
+    Ok(next.run(request).await)
+}
+
+async fn verify_oauth_token(state: &AppState, token: &str) -> Result<Claims, CloudApiError> {
+    state
+        .verify_oauth_token(token)
         .await
         .map_err(|error| match error {
             OAuthTokenError::Invalid => unauthorized(
-                &state,
+                state,
                 Some(("invalid_token", "Access token is invalid or expired")),
             ),
             OAuthTokenError::InsufficientScope => {
@@ -42,13 +59,7 @@ pub async fn require_cloud_connector_auth(
                     "Access token is missing a required scope",
                 ))))
             }
-        })?;
-    enforce_user_status(&state, &claims.sub).await?;
-    request
-        .extensions_mut()
-        .insert(AuthContext { token, claims });
-
-    Ok(next.run(request).await)
+        })
 }
 
 async fn require_api_key(

--- a/crates/api-cloud/src/mcp.rs
+++ b/crates/api-cloud/src/mcp.rs
@@ -145,6 +145,32 @@ impl CloudMcpServer {
         .map_err(command_error)?;
         structured(&page)
     }
+
+    #[tool(
+        title = "Export meeting",
+        description = "Get a complete Anarlog meeting export with notes, summaries, participants, action items, and transcripts.",
+        output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingExport>(),
+        meta = oauth_security_meta(),
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn export_meeting(
+        &self,
+        McpAuth(auth): McpAuth,
+        Parameters(input): Parameters<access::GetMeetingInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let Some(user_id) = user_id(auth) else {
+            return Ok(authentication_required(&self.state));
+        };
+        let export = read_export(&self.state, &user_id, &input.meeting_id)
+            .await
+            .map_err(command_error)?;
+        structured(&export)
+    }
 }
 
 #[tool_handler]
@@ -157,7 +183,7 @@ impl ServerHandler for CloudMcpServer {
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions(
-                "Read-only hosted access to the user's opted-in Anarlog meeting data. Start with list_meetings, then use get_meeting, get_meeting_transcript, and get_recurring_meeting_history. Every tool is idempotent and performs no writes. Report only meetings these tools return. If list_meetings is empty, say there are no opted-in Cloud snapshots. Never invent titles, dates, or ids.",
+                "Read-only hosted access to the user's opted-in Anarlog meeting data. Start with list_meetings, then use get_meeting, get_meeting_transcript, and get_recurring_meeting_history. Use export_meeting only when the task needs the complete record including transcripts. Every tool is idempotent and performs no writes. Report only meetings these tools return. If list_meetings is empty, say there are no opted-in Cloud snapshots. Never invent titles, dates, or ids.",
             )
     }
 }
@@ -233,6 +259,7 @@ mod tests {
             CloudMcpServer::get_meeting_tool_attr(),
             CloudMcpServer::get_meeting_transcript_tool_attr(),
             CloudMcpServer::get_recurring_meeting_history_tool_attr(),
+            CloudMcpServer::export_meeting_tool_attr(),
         ] {
             assert_eq!(
                 tool.meta.unwrap().get("securitySchemes"),

--- a/crates/api-cloud/src/routes.rs
+++ b/crates/api-cloud/src/routes.rs
@@ -316,7 +316,8 @@ pub(crate) async fn delete_snapshot(
     responses(
         (status = 200, body = access::MeetingPage),
         (status = 401, body = crate::error::ErrorEnvelope),
-        (status = 403, body = crate::error::ErrorEnvelope)
+        (status = 403, body = crate::error::ErrorEnvelope),
+        (status = 429, body = String, description = "Cloud API rate limit exceeded")
     )
 )]
 pub(crate) async fn list_meetings(
@@ -375,7 +376,10 @@ pub(crate) async fn list_meetings_for_user(
     params(("meeting_id" = String, Path)),
     responses(
         (status = 200, body = access::Meeting),
-        (status = 404, body = crate::error::ErrorEnvelope)
+        (status = 401, body = crate::error::ErrorEnvelope),
+        (status = 403, body = crate::error::ErrorEnvelope),
+        (status = 404, body = crate::error::ErrorEnvelope),
+        (status = 429, body = String, description = "Cloud API rate limit exceeded")
     )
 )]
 pub(crate) async fn get_meeting(
@@ -399,7 +403,10 @@ pub(crate) async fn get_meeting(
     ),
     responses(
         (status = 200, body = access::TranscriptPage),
-        (status = 404, body = crate::error::ErrorEnvelope)
+        (status = 401, body = crate::error::ErrorEnvelope),
+        (status = 403, body = crate::error::ErrorEnvelope),
+        (status = 404, body = crate::error::ErrorEnvelope),
+        (status = 429, body = String, description = "Cloud API rate limit exceeded")
     )
 )]
 pub(crate) async fn get_transcript(
@@ -428,7 +435,10 @@ pub(crate) async fn get_transcript(
     ),
     responses(
         (status = 200, body = access::MeetingPage),
-        (status = 404, body = crate::error::ErrorEnvelope)
+        (status = 401, body = crate::error::ErrorEnvelope),
+        (status = 403, body = crate::error::ErrorEnvelope),
+        (status = 404, body = crate::error::ErrorEnvelope),
+        (status = 429, body = String, description = "Cloud API rate limit exceeded")
     )
 )]
 pub(crate) async fn get_history(
@@ -490,7 +500,10 @@ pub(crate) async fn history_for_user(
     responses(
         (status = 200, description = "Meeting export"),
         (status = 400, body = crate::error::ErrorEnvelope),
-        (status = 404, body = crate::error::ErrorEnvelope)
+        (status = 401, body = crate::error::ErrorEnvelope),
+        (status = 403, body = crate::error::ErrorEnvelope),
+        (status = 404, body = crate::error::ErrorEnvelope),
+        (status = 429, body = String, description = "Cloud API rate limit exceeded")
     )
 )]
 pub(crate) async fn export_meeting(
@@ -631,6 +644,27 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
         .unwrap()
     }
 
+    fn session_token(issuer: &str) -> String {
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(TEST_KEY_ID.to_string());
+        let expires_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3_600;
+        encode(
+            &header,
+            &serde_json::json!({
+                "sub": "00000000-0000-0000-0000-000000000001",
+                "iss": issuer,
+                "aud": "authenticated",
+                "exp": expires_at,
+            }),
+            &EncodingKey::from_ec_pem(TEST_PRIVATE_KEY.as_bytes()).unwrap(),
+        )
+        .unwrap()
+    }
+
     fn export() -> access::MeetingExport {
         access::MeetingExport {
             meeting: access::Meeting {
@@ -733,13 +767,96 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
         );
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let body = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
-        assert_eq!(body["result"]["tools"].as_array().unwrap().len(), 4);
+        assert_eq!(body["result"]["tools"].as_array().unwrap().len(), 5);
         assert!(
             body["result"]["tools"]
                 .as_array()
                 .unwrap()
                 .iter()
                 .any(|tool| tool["name"] == "list_meetings")
+        );
+        assert!(
+            body["result"]["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tool| tool["name"] == "export_meeting")
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_export_tool_returns_the_complete_snapshot() {
+        let server = MockServer::start().await;
+        let key = format!("anl_{}", "d".repeat(64));
+        let key_hash = Sha256::digest(key.as_bytes())
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/verify_cloud_api_key"))
+            .and(body_json(serde_json::json!({ "p_key_hash": key_hash })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                    "user_id": "00000000-0000-0000-0000-000000000001",
+                    "status": "ok",
+                }])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_cloud_api_snapshot"))
+            .and(body_json(serde_json::json!({
+                "p_user_id": "00000000-0000-0000-0000-000000000001",
+                "p_session_id": "meeting-1",
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                    "content_json": export(),
+                }])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let state =
+            AppState::new(crate::CloudApiConfig::new(server.uri(), "service-role-key").unwrap());
+        let app = connector_router(state.clone()).route_layer(middleware::from_fn_with_state(
+            state,
+            crate::require_cloud_connector_auth,
+        ));
+
+        let response = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "api.anarlog.so")
+                    .header("authorization", format!("Bearer {key}"))
+                    .header("content-type", "application/json")
+                    .header("accept", "application/json, text/event-stream")
+                    .header("mcp-protocol-version", "2025-11-25")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "tools/call",
+                            "params": {
+                                "name": "export_meeting",
+                                "arguments": { "meeting_id": "meeting-1" },
+                            },
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(body["result"]["structuredContent"]["id"], "meeting-1");
+        assert_eq!(
+            body["result"]["structuredContent"]["transcripts"][0]["text"],
+            "hello"
         );
     }
 
@@ -889,7 +1006,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(serde_json::json!([{ "status": "ok" }])),
             )
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
@@ -899,7 +1016,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                     "content_json": export(),
                 }])),
             )
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         let state =
@@ -930,6 +1047,31 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                 .unwrap()
                 .contains("error=\"invalid_token\"")
         );
+
+        let session = session_token(&issuer);
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/v1/meetings")
+                    .header("authorization", format!("Bearer {session}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/mcp")
+                    .header("authorization", format!("Bearer {session}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
         let response = app
             .oneshot(

--- a/crates/api-cloud/src/state.rs
+++ b/crates/api-cloud/src/state.rs
@@ -97,6 +97,13 @@ impl AppState {
             .await
     }
 
+    pub(crate) async fn verify_session_token(
+        &self,
+        token: &str,
+    ) -> Result<anlg_api_auth::Claims, anlg_api_auth::AuthError> {
+        self.auth.verify_token(token).await
+    }
+
     async fn rpc<T: DeserializeOwned>(
         &self,
         function: &str,

--- a/docs/agents/cli.mdx
+++ b/docs/agents/cli.mdx
@@ -7,11 +7,14 @@ Use the global `--json` flag whenever an agent consumes CLI output.
 
 A successful response contains `schema_version`, `command`, `data`, and optional `pagination`. Read results from `data`. Follow `pagination.next_offset` only when you need another page.
 
+Meeting reads default to the local database. Use `meetings --source cloud` after `anarlog auth login` to read opted-in Cloud snapshots, or `meetings --source auto` to use Cloud only when the local database is absent.
+
 ## Resolve meeting context
 
 ```bash
 anarlog --json meetings list --query "weekly planning" --limit 10
 anarlog --json meetings get MEETING_ID
+anarlog --json meetings --source cloud list --query "weekly planning" --limit 10
 ```
 
 Search is case-insensitive across meeting titles and IDs. If several meetings match, ask the user to choose one.
@@ -60,6 +63,7 @@ Only export a complete meeting when the user explicitly requests a file:
 ```bash
 anarlog meetings export MEETING_ID --format markdown --output meeting.md
 anarlog meetings export MEETING_ID --format json --output meeting.json
+anarlog meetings --source cloud export MEETING_ID --format json --output meeting.json
 ```
 
 Export refuses to replace an existing file. Use `--force` only after the user explicitly approves overwriting that exact path.

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -63,7 +63,7 @@ Start with `list_meetings`, then pass a returned `id` to `get_meeting`. Call `ge
 
 Transcript pages default to 200 words and cap at 500. Follow `pagination.next_offset` only when you need more context.
 
-Use `get_recurring_meeting_history` with a known meeting ID when a task depends on earlier meetings in the same series.
+Use `get_recurring_meeting_history` with a known meeting ID when a task depends on earlier meetings in the same series. Use `export_meeting` only when the task explicitly needs the complete record including transcripts.
 
 Cloud MCP is read-only. To persist an edit, use the local CLI or local MCP `propose_summary_edit` or `propose_memo_edit`. The tool returns a pending proposal. Do not claim the meeting changed. Use `list_proposals` and `get_proposal` to inspect staged work. `decline_proposal` discards a pending proposal; applied or already-declined proposals cannot be declined.
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -8,7 +8,7 @@ Anarlog gives agents three ways to access meeting context. The Anarlog plugin us
 | Transport | Choose it when | Output |
 | --- | --- | --- |
 | Cloud MCP | The default Anarlog plugin, or any remote agent with OAuth | Hosted snapshots; requires Anarlog Pro and explicit opt-in |
-| CLI | Cloud has no snapshot, or the agent only has shell access | JSON with `--json`, or Markdown for people |
+| CLI | Cloud has no snapshot, or the agent only has shell access | Local or authenticated Cloud reads; JSON with `--json`, or Markdown for people |
 | Local MCP | A fully local agent that should not use Cloud | Structured tool results and contextual resources |
 
 ## Recommended agent flow

--- a/docs/reference/api-cloud.mdx
+++ b/docs/reference/api-cloud.mdx
@@ -69,12 +69,13 @@ The Streamable HTTP endpoint is:
 https://api.anarlog.so/mcp
 ```
 
-It exposes the same four read-only tools as the local MCP server:
+It exposes the same five meeting-read tools as the local MCP server:
 
 - `list_meetings`
 - `get_meeting`
 - `get_meeting_transcript`
 - `get_recurring_meeting_history`
+- `export_meeting`
 
 Hosts that support MCP OAuth 2.1 connect your Anarlog account without a cloud API key. The host discovers Anarlog's authorization server from the MCP endpoint, opens the Anarlog sign-in and consent flow, and stores the resulting connection.
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -35,6 +35,19 @@ On Linux, the CLI uses Secret Service when it is available. Headless systems wit
 
 `auth status` reports the signed-in account and whether the current access token has expired. The stored refresh token lets the desktop app refresh an expired access token when it starts.
 
+## Meeting data sources
+
+Meeting commands accept `--source local|cloud|auto` before their subcommand:
+
+```bash
+anarlog meetings --source cloud list
+anarlog meetings --source auto get MEETING_ID
+```
+
+`local` is the default and reads Anarlog's database on this computer. `cloud` reads the opted-in hosted snapshots using the account saved by `anarlog auth login`. `auto` uses the local database when it exists and falls back to Cloud when it does not. Set `ANARLOG_SOURCE` to choose the same behavior without a flag.
+
+All meeting read commands support all three sources. `--base`, `--db-path`, and `doctor` apply only to local data. Proposals and `anarlog mcp` remain local because hosted Cloud access is read-only.
+
 ## Meeting commands
 
 | Command | Options | Result |

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -8,12 +8,14 @@ Without `--json`, CLI errors are written to standard error as human-readable tex
 | Exit code | Meaning | Recovery |
 | --- | --- | --- |
 | `0` | Success | Consume stdout. |
-| `1` | Database or operation failure, or an unhealthy `doctor` report | Read the reported action. For `doctor`, inspect the JSON report and confirm app and CLI compatibility. |
+| `1` | Database, Cloud API, or operation failure, or an unhealthy `doctor` report | Read the reported action. For `doctor`, inspect the JSON report and confirm app and CLI compatibility. |
 | `2` | Meeting, note, or other requested data not found | List meetings again and use a returned ID. |
 | `3` | Database file not found | Open Anarlog once to create it, or provide the correct database path. |
 | `4` | Export output already exists | Choose another path or explicitly pass `--force` to replace the file. |
 
 Invalid arguments use the `invalid_arguments` error code with Clap's nonzero exit code.
+
+Cloud meeting commands preserve hosted error codes: `unauthorized`, `insufficient_scope`, `subscription_required`, `cloud_api_not_enabled`, `invalid_request`, `internal_error`, and `rate_limited`. Re-run `anarlog auth login` for an expired session, enable **Cloud API & Connectors** for `cloud_api_not_enabled`, and follow the retry delay for `rate_limited`.
 
 MCP maps missing meetings and proposals to invalid parameters. Validation and conflict failures—such as empty proposal content, multiple summaries without `target_id`, or declining a non-pending proposal—are reported as internal MCP errors. Database and serialization failures are also internal errors.
 

--- a/docs/reference/mcp.mdx
+++ b/docs/reference/mcp.mdx
@@ -3,7 +3,7 @@ title: "MCP reference"
 description: "Tools, resources, limits, and transport details exposed by Anarlog MCP."
 ---
 
-Run the server with `anarlog mcp`. It uses the MCP `2024-11-05` protocol over stdio. Meeting reads are local and idempotent. Proposal tools can insert or decline staged edits; they never apply those edits. The desktop app only needs to have created the database once. Open it to review and apply pending proposals.
+Run the server with `anarlog mcp`. It uses the MCP `2025-11-25` protocol over stdio. Meeting reads are local and idempotent. Proposal tools can insert or decline staged edits; they never apply those edits. The desktop app only needs to have created the database once. Open it to review and apply pending proposals.
 
 ## Tools
 
@@ -33,6 +33,10 @@ The result includes `meeting_id`, `text`, `words`, and a `pagination` object. Pa
 ### `get_recurring_meeting_history`
 
 Accepts required string `meeting_id` plus optional integer `limit` and `offset`. The limit defaults to 20 and is clamped to `1..200`; the offset defaults to 0. Results are newest first. When the meeting has no recurring series, `meetings` is empty.
+
+### `export_meeting`
+
+Accepts required string `meeting_id`. Returns the complete structured meeting record, including metadata, notes, summaries, participants, action items, and transcripts. Prefer the smaller detail or transcript tools unless the task explicitly needs a full export.
 
 ### `propose_summary_edit`
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -10,9 +10,10 @@ Use hosted Cloud MCP as the default. Fill gaps from the local `anarlog` CLI when
 ## Choose a source
 
 1. If Cloud MCP tools are connected, call them first: `list_meetings`, `get_meeting`, `get_meeting_transcript`, and `get_recurring_meeting_history`.
-2. If Cloud returns no match, snapshots are disabled, or the user is asking about a meeting that only exists on this machine, use `anarlog --json` against the local database.
-3. Use a local `anarlog mcp` stdio server only to fill those same gaps. Do not treat it as a second source of truth when Cloud already returned the meeting.
-4. If neither Cloud nor the local CLI is available, direct the user to enable **Cloud API & Connectors** and [installation](https://docs.anarlog.so/installation). Do not install software unless the user asks.
+2. If MCP is unavailable but CLI login is available, use `anarlog --json meetings --source cloud ...` for the same hosted snapshots.
+3. If Cloud returns no match, snapshots are disabled, or the user is asking about a meeting that only exists on this machine, use local `anarlog --json meetings ...` commands.
+4. Use a local `anarlog mcp` stdio server only to fill those same gaps. Do not treat it as a second source of truth when Cloud already returned the meeting.
+5. If neither Cloud nor the local CLI is available, direct the user to enable **Cloud API & Connectors** and [installation](https://docs.anarlog.so/installation). Do not install software unless the user asks.
 
 Never query or modify Anarlog's SQLite database directly. The CLI and MCP servers handle application-schema compatibility.
 

--- a/scripts/publish-anarlog-skill.test.mjs
+++ b/scripts/publish-anarlog-skill.test.mjs
@@ -42,7 +42,7 @@ test("plugin manifests use one stable identity and version", async () => {
   for (const manifestPath of PLUGIN_MANIFESTS) {
     const manifest = await readJson(manifestPath);
     assert.equal(manifest.name, "anarlog");
-    assert.equal(manifest.version, "1.0.0");
+    assert.equal(manifest.version, "1.1.0");
     assert.equal(manifest.license, "MIT");
   }
 

--- a/skills/anarlog/SKILL.md
+++ b/skills/anarlog/SKILL.md
@@ -10,9 +10,10 @@ Use hosted Cloud MCP as the default. Fill gaps from the local `anarlog` CLI when
 ## Choose a source
 
 1. If Cloud MCP tools are connected, call them first: `list_meetings`, `get_meeting`, `get_meeting_transcript`, and `get_recurring_meeting_history`.
-2. If Cloud returns no match, snapshots are disabled, or the user is asking about a meeting that only exists on this machine, use `anarlog --json` against the local database.
-3. Use a local `anarlog mcp` stdio server only to fill those same gaps. Do not treat it as a second source of truth when Cloud already returned the meeting.
-4. If neither Cloud nor the local CLI is available, direct the user to enable **Cloud API & Connectors** and [installation](https://docs.anarlog.so/installation). Do not install software unless the user asks.
+2. If MCP is unavailable but CLI login is available, use `anarlog --json meetings --source cloud ...` for the same hosted snapshots.
+3. If Cloud returns no match, snapshots are disabled, or the user is asking about a meeting that only exists on this machine, use local `anarlog --json meetings ...` commands.
+4. Use a local `anarlog mcp` stdio server only to fill those same gaps. Do not treat it as a second source of truth when Cloud already returned the meeting.
+5. If neither Cloud nor the local CLI is available, direct the user to enable **Cloud API & Connectors** and [installation](https://docs.anarlog.so/installation). Do not install software unless the user asks.
 
 Never query or modify Anarlog's SQLite database directly. The CLI and MCP servers handle application-schema compatibility.
 

--- a/skills/anarlog/references/cli.md
+++ b/skills/anarlog/references/cli.md
@@ -19,6 +19,8 @@ On Linux, sessions use Secret Service when available and otherwise use the deskt
 ```bash
 anarlog --json doctor
 anarlog --json meetings list --query "planning" --limit 20 --offset 0
+anarlog --json meetings --source cloud list --query "planning" --limit 20 --offset 0
+anarlog --json meetings --source auto get MEETING_ID
 anarlog --json meetings get MEETING_ID
 anarlog --json meetings note MEETING_ID --kind note
 anarlog --json meetings note MEETING_ID --kind summary
@@ -30,6 +32,8 @@ anarlog --json proposals decline PROPOSAL_ID
 ```
 
 `proposals create` stages a pending edit. Do not claim the meeting changed. A human applies or declines it in the Anarlog desktop app.
+
+Meeting commands default to `--source local`. `--source cloud` reads hosted snapshots using `anarlog auth login`; `--source auto` uses Cloud only when the local database is absent. Cloud access is read-only, so proposals remain local.
 
 `doctor` exits with status 1 when its response contains `ready: false`.
 

--- a/skills/anarlog/references/errors.md
+++ b/skills/anarlog/references/errors.md
@@ -16,6 +16,10 @@ Run `anarlog --json doctor`. Ask the user to open Anarlog once if the database d
 
 Confirm the desktop app and CLI come from compatible revisions. Do not run migrations or write SQL from the agent.
 
+## Cloud command failed
+
+Preserve the CLI's hosted error code. Run `anarlog auth login` again for `unauthorized`, ask the user to enable **Cloud API & Connectors** for `cloud_api_not_enabled`, and wait for the reported retry delay after `rate_limited`. Do not silently switch a user-requested `--source cloud` read to local data.
+
 ## Export output exists
 
 Choose a new path. Pass `--force` only when the user explicitly approves replacing that exact file.

--- a/skills/anarlog/references/mcp.md
+++ b/skills/anarlog/references/mcp.md
@@ -8,6 +8,7 @@ Cloud MCP is read-only. Local MCP adds proposal tools, which insert or decline s
 | `get_meeting`                   | Read metadata, canonical note, summaries, participants, and action items.                                                  |
 | `get_meeting_transcript`        | Read a transcript page. Start with `limit: 200`; continue from `pagination.next_offset` only as needed.                    |
 | `get_recurring_meeting_history` | Find meetings from the same recurring series as a known meeting.                                                           |
+| `export_meeting`                | Read the complete meeting record including transcripts. Use only when smaller reads are insufficient.                      |
 | `propose_summary_edit`          | Stage a complete summary replacement. Pass `target_id` when multiple summaries exist.                                      |
 | `propose_memo_edit`             | Stage a complete memo replacement.                                                                                         |
 | `list_proposals`                | List staged proposals. Defaults to `status: pending`.                                                                      |

--- a/skills/anarlog/references/setup.md
+++ b/skills/anarlog/references/setup.md
@@ -34,6 +34,8 @@ Run the Anarlog desktop app once so its local database exists. The CLI works whi
 
 Cloud sign-in does not require a graphical session on the Anarlog machine. Run `anarlog auth login`, open the printed URL in any browser, and paste the copied callback URL into the CLI prompt. Confirm the session with `anarlog auth status`. With `--json`, the login URL is printed to stderr and the callback is read from stdin.
 
+After login, `anarlog --json meetings --source cloud list` reads the same hosted snapshots as Cloud MCP. `--source auto` uses the local database when it exists and Cloud only when it does not.
+
 On Flatpak, the host command is `anarlog-cli`. On DEB, AppImage, macOS, Windows, and Settings-installed builds, the command is `anarlog`.
 
 Homebrew, standalone release binaries, and Windows package-manager distribution are not yet available.


### PR DESCRIPTION
Add authenticated Cloud reads, complete MCP exports, shared contracts, and plugin 1.1.0 documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cloud API authentication and adds a new authenticated HTTP client for meeting data; scope is read-only but spans auth and external API behavior.
> 
> **Overview**
> Ships **Anarlog agent plugin 1.1.0** with updated marketplace copy emphasizing query **and export** via Cloud MCP or the CLI, plus aligned skills and docs.
> 
> The CLI gains **`meetings --source local|cloud|auto`** (and `ANARLOG_SOURCE`), routing list/get/transcript/history/export through a new **`CloudClient`** that calls hosted `/v1/...` with the session from **`anarlog auth login`**. **`--source auto`** uses the local DB when present and Cloud only when the database is missing. Cloud failures surface stable codes (`unauthorized`, `rate_limited`, etc.) without silently falling back when the user asked for Cloud.
> 
> **Hosted and local MCP** add read-only **`export_meeting`**, bump protocol to **2025-11-25**, and attach **output schemas** on tools. **Cloud REST auth** now accepts Supabase **session tokens** on `/v1/*` (OAuth still required on `/mcp`). OpenAPI documents **401/403/429** on meeting routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d913e260e7d78671be621f445040c5b734cf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->