### PR TITLE
Hide stop control after meetings

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr "Stop response"
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr "Stop transcription"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -4609,7 +4609,6 @@ msgid "Stop response"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
-#: src/session/components/outer-header/index.tsx
 msgid "Stop transcription"
 msgstr ""
 

--- a/apps/desktop/src/session/components/note-input/header-transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/header-transcript.tsx
@@ -24,7 +24,7 @@ import {
   useNativeContextMenu,
 } from "~/shared/hooks/useNativeContextMenu";
 import { useListener } from "~/stt/contexts";
-import { useStartListening } from "~/stt/useStartListening";
+import { useStartListeningWithBatchOverride } from "~/stt/useStartListeningWithBatchOverride";
 import {
   isMainWebviewWindow,
   requestMainListenerControl,
@@ -212,7 +212,7 @@ function HeaderViewTranscriptActive({
   };
 }) {
   const regenerate = useRegenerateTranscript(sessionId);
-  const startListening = useStartListening(sessionId);
+  const startListening = useStartListeningWithBatchOverride(sessionId);
   const sessionEvent = useSessionEvent(sessionId);
   const hasTranscript = useHasTranscript(sessionId);
   const now = useNow();
@@ -289,7 +289,7 @@ function HeaderViewTranscriptActive({
       },
     ];
 
-    if (sessionMode === "inactive") {
+    if (sessionMode === "inactive" || sessionMode === "running_batch") {
       items.push({
         id: `resume-listening-${sessionId}`,
         text: "Resume listening",

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -295,8 +295,8 @@ vi.mock("~/stt/contexts", () => ({
     }),
 }));
 
-vi.mock("~/stt/useStartListening", () => ({
-  useStartListening: () => hoisted.startListening,
+vi.mock("~/stt/useStartListeningWithBatchOverride", () => ({
+  useStartListeningWithBatchOverride: () => hoisted.startListening,
 }));
 
 vi.mock("~/stt/window-control", () => ({
@@ -672,32 +672,61 @@ describe("Header", () => {
     ).toEqual(["Copy", "Resume listening"]);
   });
 
-  it.each(["finalizing", "running_batch"])(
-    "hides re-transcription actions while the session is %s",
-    (sessionMode) => {
-      hoisted.audioExists = false;
-      hoisted.sessionMode = sessionMode;
+  it("hides re-transcription actions while the session is finalizing", () => {
+    hoisted.audioExists = false;
+    hoisted.sessionMode = "finalizing";
 
-      render(
-        <SessionViewSwitcher
-          sessionId="session-1"
-          editorTabs={[
-            { type: "enhanced", id: "note-1" },
-            { type: "raw" },
-            { type: "transcript" },
-          ]}
-          currentTab={{ type: "transcript" }}
-          handleTabChange={vi.fn()}
-        />,
-      );
+    render(
+      <SessionViewSwitcher
+        sessionId="session-1"
+        editorTabs={[
+          { type: "enhanced", id: "note-1" },
+          { type: "raw" },
+          { type: "transcript" },
+        ]}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
 
-      expect(
-        findContextMenu("copy-transcript-session-1").map((item) =>
-          "text" in item ? item.text : "separator",
-        ),
-      ).toEqual(["Copy"]);
-    },
-  );
+    expect(
+      findContextMenu("copy-transcript-session-1").map((item) =>
+        "text" in item ? item.text : "separator",
+      ),
+    ).toEqual(["Copy"]);
+  });
+
+  it("lets transcript menus interrupt batch processing to resume listening", () => {
+    hoisted.audioExists = false;
+    hoisted.sessionMode = "running_batch";
+
+    render(
+      <SessionViewSwitcher
+        sessionId="session-1"
+        editorTabs={[
+          { type: "enhanced", id: "note-1" },
+          { type: "raw" },
+          { type: "transcript" },
+        ]}
+        currentTab={{ type: "transcript" }}
+        handleTabChange={vi.fn()}
+      />,
+    );
+
+    const menu = findContextMenu("copy-transcript-session-1");
+    expect(
+      menu.map((item) => ("text" in item ? item.text : "separator")),
+    ).toEqual(["Copy", "Resume listening"]);
+
+    menu
+      .find(
+        (item): item is Extract<CapturedMenuItem, { id: string }> =>
+          "id" in item && item.id === "resume-listening-session-1",
+      )
+      ?.action();
+
+    expect(hoisted.startListening).toHaveBeenCalledTimes(1);
+  });
 
   it("hides re-transcription while the audio lookup is pending", () => {
     hoisted.audioExists = true;

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -233,6 +233,30 @@ describe("OuterHeader", () => {
     expect(spacer?.className).not.toContain("right-[140px]");
   });
 
+  it("hides the header stop button during post-meeting transcription", () => {
+    mocks.sessionModes = { "session-1": "running_batch" };
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+    mocks.nowMs = new Date("2026-06-05T10:31:00.000Z").getTime();
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "transcript" } as EditorView}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
+  });
+
   it("uses the collapsed sidebar gutter without a title field", () => {
     mocks.leftsidebar.expanded = false;
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -124,7 +124,7 @@ function HeaderMeetingControl({
     ? safeParseDate(sessionEvent.ended_at)
     : null;
   const ended = !!endedAt && endedAt.getTime() <= now.getTime();
-  if (sessionMode === "finalizing") {
+  if (sessionMode === "finalizing" || sessionMode === "running_batch") {
     return null;
   }
 
@@ -165,10 +165,7 @@ function HeaderMeetingActionPill({
   audioExists: boolean;
 }) {
   const startListening = useStartListening(sessionId);
-  const { stop, stopTranscription } = useListener((state) => ({
-    stop: state.stop,
-    stopTranscription: state.stopTranscription,
-  }));
+  const stop = useListener((state) => state.stop);
   const remote = getRemoteMeeting(event?.meeting_link);
   const meetingLink = event?.meeting_link || null;
   const isWelcomeDemo = event?.tracking_id === WELCOME_NOTE_TRACKING_ID;
@@ -252,17 +249,6 @@ function HeaderMeetingActionPill({
         title: t`Stop listening`,
         icon: <Square className="size-3 text-red-500" weight="fill" />,
         onClick: stopListening,
-      };
-    }
-
-    if (sessionMode === "running_batch") {
-      return {
-        label: t`Stop`,
-        title: t`Stop transcription`,
-        icon: <Square className="size-3 text-red-500" weight="fill" />,
-        onClick: () => {
-          void stopTranscription(sessionId);
-        },
       };
     }
 

--- a/apps/desktop/src/session/components/outer-header/overflow/listening.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/listening.test.tsx
@@ -32,8 +32,8 @@ vi.mock("~/stt/contexts", () => ({
   useListener: useListenerMock,
 }));
 
-vi.mock("~/stt/useStartListening", () => ({
-  useStartListening: () => startListeningMock,
+vi.mock("~/stt/useStartListeningWithBatchOverride", () => ({
+  useStartListeningWithBatchOverride: () => startListeningMock,
 }));
 
 vi.mock("~/stt/window-control", () => ({
@@ -74,6 +74,26 @@ describe("Listening", () => {
     expect(requestMainListenerControlMock).not.toHaveBeenCalled();
   });
 
+  it("lets users interrupt batch processing to resume listening", () => {
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "running_batch",
+        stop: stopMock,
+      }),
+    );
+
+    render(<Listening sessionId="session-1" resume />);
+
+    const resumeButton = screen.getByRole("button", {
+      name: "Resume listening",
+    });
+    expect(resumeButton.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(resumeButton);
+
+    expect(startListeningMock).toHaveBeenCalledTimes(1);
+  });
+
   it("delegates standalone start requests to the main window before transcript exists", () => {
     isMainWebviewWindowMock.mockReturnValue(false);
 
@@ -106,5 +126,25 @@ describe("Listening", () => {
       "session-1",
     );
     expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates batch overrides from standalone windows", () => {
+    isMainWebviewWindowMock.mockReturnValue(false);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        getSessionMode: () => "running_batch",
+        stop: stopMock,
+      }),
+    );
+
+    render(<Listening sessionId="session-1" resume />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume listening" }));
+
+    expect(requestMainListenerControlMock).toHaveBeenCalledWith(
+      "start",
+      "session-1",
+    );
+    expect(startListeningMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/outer-header/overflow/listening.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/listening.tsx
@@ -3,7 +3,7 @@ import { Microphone, MicrophoneSlash } from "@phosphor-icons/react";
 import { DropdownMenuItem } from "@anlg/ui/components/ui/dropdown-menu";
 
 import { useListener } from "~/stt/contexts";
-import { useStartListening } from "~/stt/useStartListening";
+import { useStartListeningWithBatchOverride } from "~/stt/useStartListeningWithBatchOverride";
 import {
   isMainWebviewWindow,
   requestMainListenerControl,
@@ -23,13 +23,9 @@ export function Listening({
   const isListening = mode === "active" || mode === "finalizing";
   const isFinalizing = mode === "finalizing";
   const isBatching = mode === "running_batch";
-  const startListening = useStartListening(sessionId);
+  const startListening = useStartListeningWithBatchOverride(sessionId);
 
   const handleToggleListening = () => {
-    if (isBatching) {
-      return;
-    }
-
     if (!isMainWebviewWindow()) {
       void requestMainListenerControl(
         isListening ? "stop" : "start",
@@ -41,26 +37,21 @@ export function Listening({
     if (isListening) {
       stop();
     } else {
-      startListening();
+      void startListening();
     }
   };
 
-  const startLabel = resume ? "Resume listening" : "Start listening";
+  const startLabel =
+    resume || isBatching ? "Resume listening" : "Start listening";
 
   return (
     <DropdownMenuItem
       className="cursor-pointer"
       onClick={handleToggleListening}
-      disabled={isFinalizing || isBatching}
+      disabled={isFinalizing}
     >
       {isListening ? <MicrophoneSlash /> : <Microphone />}
-      <span>
-        {isBatching
-          ? "Batch processing"
-          : isListening
-            ? "Stop listening"
-            : startLabel}
-      </span>
+      <span>{isListening ? "Stop listening" : startLabel}</span>
     </DropdownMenuItem>
   );
 }

--- a/apps/desktop/src/store/zustand/listener/batch.ts
+++ b/apps/desktop/src/store/zustand/listener/batch.ts
@@ -145,6 +145,10 @@ export const createBatchSlice = <T extends BatchState>(
   },
 
   handleBatchResponseStreamed: (sessionId, event) => {
+    if (get().batch[sessionId]?.terminalReason === "stopped") {
+      return;
+    }
+
     const percentage = getBatchStreamPercentage(event);
     const isComplete = event.type === "result" || event.type === "terminal";
     const currentPreview = get().batchPreview[sessionId] ?? {

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -13,6 +13,7 @@ const {
   setRecordingIndicatorMock,
   startCaptureMock,
   stopCaptureMock,
+  stopTranscriptionMock,
   vaultBaseMock,
 } = vi.hoisted(() => ({
   dispatchEventMock: vi.fn(),
@@ -26,6 +27,7 @@ const {
   setRecordingIndicatorMock: vi.fn(),
   startCaptureMock: vi.fn(),
   stopCaptureMock: vi.fn(),
+  stopTranscriptionMock: vi.fn(),
   vaultBaseMock: vi.fn(),
 }));
 
@@ -70,7 +72,7 @@ vi.mock("@anlg/plugin-transcription", () => ({
     startCapture: startCaptureMock,
     startTranscription: vi.fn(),
     stopCapture: stopCaptureMock,
-    stopTranscription: vi.fn(),
+    stopTranscription: stopTranscriptionMock,
     updateCaptureConfig: vi.fn(),
   },
   events: {
@@ -126,6 +128,7 @@ describe("General Listener Slice", () => {
     setRecordingIndicatorMock.mockResolvedValue({ status: "ok", data: null });
     startCaptureMock.mockResolvedValue({ status: "ok", data: null });
     stopCaptureMock.mockResolvedValue({ status: "ok", data: null });
+    stopTranscriptionMock.mockResolvedValue({ status: "ok", data: null });
     dispatchEventMock.mockResolvedValue({ status: "ok", data: 1 });
     vaultBaseMock.mockResolvedValue({ status: "ok", data: "/tmp/anarlog" });
   });
@@ -710,6 +713,18 @@ describe("General Listener Slice", () => {
     test("stop action exists and is callable", () => {
       const stop = store.getState().stop;
       expect(typeof stop).toBe("function");
+    });
+
+    test("marks batch transcription stopped as soon as native cancellation succeeds", async () => {
+      store.getState().handleBatchStarted("session-1");
+
+      await store.getState().stopTranscription("session-1");
+
+      expect(stopTranscriptionMock).toHaveBeenCalledWith("session-1");
+      expect(store.getState().getSessionMode("session-1")).toBe("inactive");
+      expect(store.getState().batch["session-1"]?.terminalReason).toBe(
+        "stopped",
+      );
     });
 
     test("marks the live session finalizing immediately when stop is requested", () => {

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -707,6 +707,28 @@ describe("General Listener Slice", () => {
       });
       expect(getSessionMode(sessionId)).toBe("inactive");
     });
+
+    test("late progress cannot restart a stopped batch", () => {
+      const sessionId = "session-batch-stopped";
+      const { handleBatchResponseStreamed, handleBatchStopped } =
+        store.getState();
+
+      handleBatchStopped(sessionId);
+      handleBatchResponseStreamed(sessionId, {
+        type: "progress",
+        percentage: 0.5,
+        partial_text: "late progress",
+      });
+
+      expect(store.getState().batch[sessionId]).toEqual({
+        percentage: 0,
+        error: "Transcription stopped.",
+        isComplete: false,
+        terminalReason: "stopped",
+        errorCode: undefined,
+      });
+      expect(store.getState().getSessionMode(sessionId)).toBe("inactive");
+    });
   });
 
   describe("Stop Action", () => {

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -233,7 +233,19 @@ export const createGeneralSlice = <
       return;
     }
 
-    await listenerCommands.stopTranscription(sessionId).catch(console.error);
+    try {
+      const result = await listenerCommands.stopTranscription(sessionId);
+      if (result.status === "error") {
+        console.error(result.error);
+        return;
+      }
+
+      if (get().getSessionMode(sessionId) === "running_batch") {
+        get().handleBatchStopped(sessionId);
+      }
+    } catch (error) {
+      console.error(error);
+    }
   },
   canStartLiveSession: (sessionId) => {
     if (!sessionId) {

--- a/apps/desktop/src/stt/useStartListeningWithBatchOverride.test.tsx
+++ b/apps/desktop/src/stt/useStartListeningWithBatchOverride.test.tsx
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSessionMode: vi.fn(),
+  startListening: vi.fn(),
+  stopTranscription: vi.fn(),
+}));
+
+vi.mock("./contexts", () => ({
+  useListener: (selector: (state: unknown) => unknown) =>
+    selector({
+      getSessionMode: mocks.getSessionMode,
+      stopTranscription: mocks.stopTranscription,
+    }),
+}));
+
+vi.mock("./useStartListening", () => ({
+  useStartListening: () => mocks.startListening,
+}));
+
+import { useStartListeningWithBatchOverride } from "./useStartListeningWithBatchOverride";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSessionMode.mockReturnValue("inactive");
+  mocks.stopTranscription.mockResolvedValue(undefined);
+  mocks.startListening.mockResolvedValue(undefined);
+});
+
+test("starts listening without touching inactive transcription", async () => {
+  const { result } = renderHook(() =>
+    useStartListeningWithBatchOverride("session-1"),
+  );
+
+  await act(result.current);
+
+  expect(mocks.stopTranscription).not.toHaveBeenCalled();
+  expect(mocks.startListening).toHaveBeenCalledTimes(1);
+});
+
+test("stops batch transcription before resuming listening", async () => {
+  mocks.getSessionMode.mockReturnValue("running_batch");
+  const { result } = renderHook(() =>
+    useStartListeningWithBatchOverride("session-1"),
+  );
+
+  await act(result.current);
+
+  expect(mocks.stopTranscription).toHaveBeenCalledWith("session-1");
+  expect(mocks.startListening).toHaveBeenCalledTimes(1);
+  expect(mocks.stopTranscription).toHaveBeenCalledBefore(mocks.startListening);
+});

--- a/apps/desktop/src/stt/useStartListeningWithBatchOverride.ts
+++ b/apps/desktop/src/stt/useStartListeningWithBatchOverride.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react";
+
+import { useListener } from "./contexts";
+import { useStartListening } from "./useStartListening";
+
+export function useStartListeningWithBatchOverride(sessionId: string) {
+  const startListening = useStartListening(sessionId);
+  const { getSessionMode, stopTranscription } = useListener((state) => ({
+    getSessionMode: state.getSessionMode,
+    stopTranscription: state.stopTranscription,
+  }));
+
+  return useCallback(async () => {
+    if (getSessionMode(sessionId) === "running_batch") {
+      await stopTranscription(sessionId);
+    }
+
+    await startListening();
+  }, [getSessionMode, sessionId, startListening, stopTranscription]);
+}

--- a/apps/desktop/src/stt/window-control.tsx
+++ b/apps/desktop/src/stt/window-control.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { getCurrentWebviewWindowLabel } from "@anlg/plugin-windows";
 
 import { useListener } from "./contexts";
-import { useStartListening } from "./useStartListening";
+import { useStartListeningWithBatchOverride } from "./useStartListeningWithBatchOverride";
 
 import { listenerStore } from "~/store/zustand/listener/instance";
 
@@ -90,7 +90,7 @@ function MainListenerControlRequestRunner({
   onHandled: (requestId: string) => void;
   request: ListenerControlRequest;
 }) {
-  const startListening = useStartListening(request.sessionId);
+  const startListening = useStartListeningWithBatchOverride(request.sessionId);
   const stop = useListener((state) => state.stop);
   const startListeningRef = useRef(startListening);
   startListeningRef.current = startListening;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes session-mode UI and batch cancellation timing; incorrect handling could leave batch/live capture in a bad state, but behavior is covered by new tests.
> 
> **Overview**
> After a meeting ends, **post-meeting batch transcription** no longer shows a **Stop** control in the session outer header—the pill is hidden for `running_batch` (same as finalizing), and the dedicated “Stop transcription” header action is removed.
> 
> Users can still **resume live listening** while batch runs: transcript header menus, overflow **Listening**, and cross-window listener control use a new **`useStartListeningWithBatchOverride`** hook that cancels batch transcription (`stopTranscription`) before starting capture. Overflow no longer disables or labels batch as “Batch processing.”
> 
> **Listener store** updates make cancellation stick: successful native `stopTranscription` immediately marks the batch **stopped**, and **late batch stream events** are ignored once stopped so the session does not flip back to `running_batch`.
> 
> Locale **`.po`** files drop a stale source reference for “Stop transcription” tied to the removed outer-header string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb3f109f2cb7838cb1ea375f743ae0bb56e899c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->