### PR TITLE
Fix auth invalidation during batch transcription

### DIFF
--- a/apps/desktop/src/auth/auth-context.ts
+++ b/apps/desktop/src/auth/auth-context.ts
@@ -12,6 +12,7 @@ type AuthActions = {
   signIn: () => Promise<void>;
   signOut: () => Promise<void>;
   refreshSession: () => Promise<Session | null>;
+  getSessionForRequest: () => Promise<Session | null>;
 };
 
 type AuthTokenHandlers = {

--- a/apps/desktop/src/auth/client.test.ts
+++ b/apps/desktop/src/auth/client.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  removeItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+vi.mock("@anlg/plugin-auth", () => ({
+  commands: {
+    getItem: mocks.getItem,
+    removeItem: mocks.removeItem,
+    setItem: mocks.setItem,
+  },
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({})),
+  processLock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: vi.fn() }));
+
+vi.mock("~/env", () => ({
+  env: {
+    VITE_SUPABASE_ANON_KEY: "anon-key",
+    VITE_SUPABASE_URL: "https://project.supabase.co",
+  },
+}));
+
+import { readPersistedAuthSession, tauriStorage } from "./client";
+
+const authStorageKey = "sb-project-auth-token";
+
+function serializedSession(accessToken: string) {
+  return JSON.stringify({
+    access_token: accessToken,
+    refresh_token: "refresh-token",
+    token_type: "bearer",
+    user: { id: "user-id" },
+  });
+}
+
+describe("auth storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getItem.mockResolvedValue({ status: "ok", data: null });
+    mocks.removeItem.mockResolvedValue({ status: "ok", data: null });
+    mocks.setItem.mockResolvedValue({ status: "ok", data: null });
+  });
+
+  test("does not let the SDK clear the persisted session", async () => {
+    await tauriStorage.removeItem(authStorageKey);
+
+    expect(mocks.removeItem).not.toHaveBeenCalled();
+  });
+
+  test("persists the session once", async () => {
+    await tauriStorage.setItem(authStorageKey, "serialized-session");
+
+    expect(mocks.setItem).toHaveBeenCalledOnce();
+    expect(mocks.setItem).toHaveBeenCalledWith(
+      authStorageKey,
+      "serialized-session",
+    );
+  });
+
+  test("still removes auxiliary auth values", async () => {
+    await tauriStorage.removeItem("pkce-code-verifier");
+
+    expect(mocks.removeItem).toHaveBeenCalledWith("pkce-code-verifier");
+  });
+
+  test("loads the persisted session after a cold start", async () => {
+    mocks.getItem.mockImplementation(async (key: string) => ({
+      status: "ok",
+      data:
+        key === authStorageKey ? serializedSession("persisted-token") : null,
+    }));
+
+    await expect(readPersistedAuthSession()).resolves.toEqual({
+      access_token: "persisted-token",
+      refresh_token: "refresh-token",
+      token_type: "bearer",
+      user: { id: "user-id" },
+    });
+  });
+});

--- a/apps/desktop/src/auth/client.ts
+++ b/apps/desktop/src/auth/client.ts
@@ -11,6 +11,10 @@ import { commands as authCommands } from "@anlg/plugin-auth";
 
 import { env } from "~/env";
 
+const authStorageKey = env.VITE_SUPABASE_URL
+  ? `sb-${new URL(env.VITE_SUPABASE_URL).hostname.split(".")[0]}-auth-token`
+  : null;
+
 export const tauriStorage: SupportedStorage = {
   async getItem(key: string): Promise<string | null> {
     const result = await authCommands.getItem(key);
@@ -26,6 +30,10 @@ export const tauriStorage: SupportedStorage = {
     }
   },
   async removeItem(key: string): Promise<void> {
+    if (key === authStorageKey) {
+      return;
+    }
+
     const result = await authCommands.removeItem(key);
     if (result.status === "error") {
       throw new Error(`auth storage removeItem failed: ${result.error}`);
@@ -33,9 +41,31 @@ export const tauriStorage: SupportedStorage = {
   },
 };
 
-const authStorageKey = env.VITE_SUPABASE_URL
-  ? `sb-${new URL(env.VITE_SUPABASE_URL).hostname.split(".")[0]}-auth-token`
-  : null;
+function parsePersistedSession(value: string | null): Session | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<Session>;
+    return typeof parsed.access_token === "string" &&
+      typeof parsed.refresh_token === "string" &&
+      typeof parsed.token_type === "string" &&
+      typeof parsed.user?.id === "string"
+      ? (parsed as Session)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readPersistedAuthSession(): Promise<Session | null> {
+  if (!authStorageKey) {
+    return null;
+  }
+
+  return parsePersistedSession(await tauriStorage.getItem(authStorageKey));
+}
 
 export async function persistAuthSession(session: Session): Promise<void> {
   if (!authStorageKey) {

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAuth } from "./auth-context";
@@ -25,13 +26,14 @@ const mocks = vi.hoisted(() => ({
   bindCloudsyncAccountForAuth: vi.fn(),
   clearAuthStorage: vi.fn(),
   currentWebviewWindowLabel: "main",
+  emit: vi.fn(),
   emitTo: vi.fn(),
   eventCallbacks: new Map<string, (event: { payload: unknown }) => void>(),
   focusCallback: null as ((event: { payload: boolean }) => void) | null,
   getSession: vi.fn(),
   handleCloudsyncAuthChange: vi.fn(),
-  isFatalSessionError: vi.fn(),
   persistAuthSession: vi.fn(),
+  readPersistedAuthSession: vi.fn(),
   prepareCloudsyncSignOut: vi.fn(),
   refreshCloudsyncForSession: vi.fn(),
   refreshSession: vi.fn(),
@@ -44,6 +46,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./client", () => ({
   persistAuthSession: mocks.persistAuthSession,
+  readPersistedAuthSession: mocks.readPersistedAuthSession,
   supabase: {
     auth: {
       getSession: mocks.getSession,
@@ -79,7 +82,6 @@ vi.mock("./cloudsync", () => ({
 
 vi.mock("./errors", () => ({
   clearAuthStorage: mocks.clearAuthStorage,
-  isFatalSessionError: mocks.isFatalSessionError,
 }));
 
 vi.mock("@anlg/plugin-analytics", () => ({
@@ -130,6 +132,7 @@ vi.mock("@tauri-apps/api/app", () => ({
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
   emitTo: mocks.emitTo,
   listen: vi.fn(
     (event: string, callback: (event: { payload: unknown }) => void) => {
@@ -196,7 +199,9 @@ function makeSession(userId: string): Session {
 }
 
 function SessionProbe() {
-  const { getHeaders, refreshSession, session, signOut } = useAuth();
+  const { getHeaders, getSessionForRequest, refreshSession, session, signOut } =
+    useAuth();
+  const [requestAccessToken, setRequestAccessToken] = useState("none");
   return (
     <>
       <div data-testid="session">{session?.user.id ?? "none"}</div>
@@ -204,8 +209,18 @@ function SessionProbe() {
       <div data-testid="authorization">
         {getHeaders()?.Authorization ?? "none"}
       </div>
+      <div data-testid="request-access-token">{requestAccessToken}</div>
       <button onClick={() => void refreshSession().catch(() => {})}>
         Refresh
+      </button>
+      <button
+        onClick={() =>
+          void getSessionForRequest().then((requestSession) => {
+            setRequestAccessToken(requestSession?.access_token ?? "none");
+          })
+        }
+      >
+        Get request session
       </button>
       <button onClick={() => void signOut().catch(() => {})}>Sign out</button>
     </>
@@ -242,13 +257,14 @@ describe("AuthProvider", () => {
     mocks.bindCloudsyncAccountForAuth.mockReset();
     mocks.clearAuthStorage.mockReset();
     mocks.currentWebviewWindowLabel = "main";
+    mocks.emit.mockReset();
     mocks.emitTo.mockReset();
     mocks.eventCallbacks.clear();
     mocks.focusCallback = null;
     mocks.getSession.mockReset();
     mocks.handleCloudsyncAuthChange.mockReset();
-    mocks.isFatalSessionError.mockReset();
     mocks.persistAuthSession.mockReset();
+    mocks.readPersistedAuthSession.mockReset();
     mocks.prepareCloudsyncSignOut.mockReset();
     mocks.refreshCloudsyncForSession.mockReset();
     mocks.refreshSession.mockReset();
@@ -259,11 +275,12 @@ describe("AuthProvider", () => {
     mocks.toastError.mockReset();
     mocks.bindCloudsyncAccountForAuth.mockResolvedValue(true);
     mocks.clearAuthStorage.mockResolvedValue(undefined);
+    mocks.emit.mockResolvedValue(undefined);
     mocks.emitTo.mockResolvedValue(undefined);
     mocks.getSession.mockImplementation(() => new Promise(() => {}));
     mocks.handleCloudsyncAuthChange.mockResolvedValue("ok");
-    mocks.isFatalSessionError.mockReturnValue(false);
     mocks.persistAuthSession.mockResolvedValue(undefined);
+    mocks.readPersistedAuthSession.mockResolvedValue(null);
     mocks.prepareCloudsyncSignOut.mockResolvedValue(undefined);
     mocks.refreshCloudsyncForSession.mockResolvedValue("ok");
     mocks.refreshSession.mockResolvedValue({
@@ -312,9 +329,7 @@ describe("AuthProvider", () => {
       );
     });
 
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
 
     await waitFor(() => {
       expect(mocks.analyticsClearGroups).toHaveBeenCalledTimes(1);
@@ -340,9 +355,7 @@ describe("AuthProvider", () => {
       expect(mocks.analyticsIdentify).toHaveBeenCalledTimes(1);
     });
 
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
 
     await waitFor(() => {
       expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
@@ -377,9 +390,7 @@ describe("AuthProvider", () => {
       });
     });
 
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
 
     await waitFor(() => {
       expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
@@ -402,7 +413,7 @@ describe("AuthProvider", () => {
       expect(mocks.focusCallback).not.toBeNull();
     });
 
-    mocks.getSession.mockResolvedValueOnce({
+    mocks.getSession.mockResolvedValue({
       data: { session: currentSession },
       error: null,
     });
@@ -510,6 +521,97 @@ describe("AuthProvider", () => {
       );
     });
     expect(mocks.refreshCloudsyncForSession).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an expiring session before an authenticated request", async () => {
+    const staleSession = makeSession("bound-account");
+    staleSession.expires_at = Math.floor(Date.now() / 1000) + 60;
+    const refreshedSession = makeSession("bound-account");
+    mocks.getSession.mockResolvedValue({
+      data: { session: staleSession },
+      error: null,
+    });
+    mocks.refreshSession.mockResolvedValueOnce({
+      data: { session: refreshedSession },
+      error: null,
+    });
+
+    renderAuthProvider();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Get request session" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.refreshSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("uses the current session when the SDK lookup fails", async () => {
+    const currentSession = makeSession("bound-account");
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        currentSession.user.id,
+      );
+    });
+
+    mocks.getSession.mockRejectedValueOnce(new Error("offline"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Get request session" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("request-access-token").textContent).toBe(
+        currentSession.access_token,
+      );
+    });
+  });
+
+  it("uses a still-valid session when proactive refresh fails", async () => {
+    const currentSession = makeSession("bound-account");
+    currentSession.expires_at = Math.floor(Date.now() / 1000) + 60;
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        currentSession.user.id,
+      );
+    });
+
+    mocks.getSession.mockResolvedValueOnce({
+      data: { session: currentSession },
+      error: null,
+    });
+    mocks.refreshSession.mockRejectedValueOnce(new Error("offline"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Get request session" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("request-access-token").textContent).toBe(
+        currentSession.access_token,
+      );
+    });
   });
 
   it("only runs cloudsync from the main window", async () => {
@@ -676,128 +778,7 @@ describe("AuthProvider", () => {
     expect(mocks.emitTo).toHaveBeenCalledTimes(1);
   });
 
-  it("coordinates spontaneous secondary sign-out with main exactly once", async () => {
-    const currentSession = makeSession("bound-account");
-    mocks.currentWebviewWindowLabel = "note-session-id";
-
-    renderAuthProvider();
-
-    await waitFor(() => {
-      expect(mocks.authCallback).not.toBeNull();
-    });
-
-    act(() => {
-      mocks.authCallback?.("SIGNED_IN", currentSession);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("session").textContent).toBe(
-        currentSession.user.id,
-      );
-    });
-
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-    });
-
-    await waitFor(() => {
-      expect(mocks.emitTo).toHaveBeenCalledWith(
-        "main",
-        "anlg:auth-sign-out-request",
-        {
-          requestId: "request-id",
-          sourceLabel: "note-session-id",
-        },
-      );
-    });
-    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
-    expect(mocks.signOut).not.toHaveBeenCalled();
-
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-      mocks.eventCallbacks.get("anlg:auth-sign-out-result")?.({
-        payload: { requestId: "request-id", completed: true, error: null },
-      });
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("session").textContent).toBe("none");
-      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
-    });
-    expect(mocks.emitTo).toHaveBeenCalledTimes(1);
-    expect(mocks.signOut).not.toHaveBeenCalled();
-  });
-
-  it("hides a spontaneous secondary sign-out while retrying incomplete main coordination", async () => {
-    const currentSession = makeSession("bound-account");
-    mocks.currentWebviewWindowLabel = "note-session-id";
-
-    renderAuthProvider();
-
-    await waitFor(() => {
-      expect(mocks.authCallback).not.toBeNull();
-    });
-
-    act(() => {
-      mocks.authCallback?.("SIGNED_IN", currentSession);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("session").textContent).toBe(
-        currentSession.user.id,
-      );
-      expect(screen.getByTestId("authorization").textContent).toBe(
-        `bearer ${currentSession.access_token}`,
-      );
-    });
-
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-    });
-
-    await waitFor(() => {
-      expect(mocks.emitTo).toHaveBeenCalledTimes(1);
-      expect(screen.getByTestId("session").textContent).toBe("none");
-      expect(screen.getByTestId("authorization").textContent).toBe("none");
-    });
-    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
-    expect(mocks.signOut).not.toHaveBeenCalled();
-
-    act(() => {
-      mocks.eventCallbacks.get("anlg:auth-sign-out-result")?.({
-        payload: { requestId: "request-id", completed: false, error: null },
-      });
-    });
-
-    await waitFor(() => {
-      expect(mocks.eventCallbacks.has("anlg:auth-sign-out-result")).toBe(false);
-    });
-    expect(mocks.analyticsClearGroups).not.toHaveBeenCalled();
-    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
-    expect(screen.getByTestId("session").textContent).toBe("none");
-
-    act(() => {
-      mocks.authCallback?.("SIGNED_OUT", null);
-    });
-
-    await waitFor(() => {
-      expect(mocks.emitTo).toHaveBeenCalledTimes(2);
-    });
-
-    act(() => {
-      mocks.eventCallbacks.get("anlg:auth-sign-out-result")?.({
-        payload: { requestId: "request-id", completed: true, error: null },
-      });
-    });
-
-    await waitFor(() => {
-      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
-    });
-    expect(mocks.signOut).not.toHaveBeenCalled();
-    expect(screen.getByTestId("session").textContent).toBe("none");
-  });
-
-  it("keeps a spontaneous secondary sign-out hidden after rejected coordination and allows recovery", async () => {
+  it("preserves a secondary-window session after an unsolicited SDK sign-out", async () => {
     const currentSession = makeSession("bound-account");
     const recoveredSession = {
       ...makeSession("bound-account"),
@@ -826,29 +807,15 @@ describe("AuthProvider", () => {
       mocks.authCallback?.("SIGNED_OUT", null);
     });
 
-    await waitFor(() => {
-      expect(mocks.emitTo).toHaveBeenCalledTimes(1);
-      expect(screen.getByTestId("session").textContent).toBe("none");
-      expect(screen.getByTestId("authorization").textContent).toBe("none");
-    });
+    expect(screen.getByTestId("session").textContent).toBe(
+      currentSession.user.id,
+    );
+    expect(screen.getByTestId("authorization").textContent).toBe(
+      `bearer ${currentSession.access_token}`,
+    );
+    expect(mocks.emitTo).not.toHaveBeenCalled();
     expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
     expect(mocks.signOut).not.toHaveBeenCalled();
-
-    act(() => {
-      mocks.eventCallbacks.get("anlg:auth-sign-out-result")?.({
-        payload: {
-          requestId: "request-id",
-          completed: false,
-          error: "cloudsync suspension failed",
-        },
-      });
-    });
-
-    await waitFor(() => {
-      expect(mocks.eventCallbacks.has("anlg:auth-sign-out-result")).toBe(false);
-    });
-    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
-    expect(screen.getByTestId("session").textContent).toBe("none");
 
     act(() => {
       mocks.authCallback?.("TOKEN_REFRESHED", recoveredSession);
@@ -863,6 +830,44 @@ describe("AuthProvider", () => {
       );
     });
     expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
+  });
+
+  it("clears a secondary-window session after committed sign-out", async () => {
+    const currentSession = makeSession("bound-account");
+    mocks.currentWebviewWindowLabel = "note-session-id";
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+      expect(mocks.eventCallbacks.has("anlg:auth-sign-out-committed")).toBe(
+        true,
+      );
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        currentSession.user.id,
+      );
+    });
+
+    act(() => {
+      mocks.eventCallbacks.get("anlg:auth-sign-out-committed")?.({
+        payload: { sourceLabel: "main" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe("none");
+    });
+    expect(mocks.stopAutoRefresh).toHaveBeenCalled();
+    expect(mocks.signOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    expect(mocks.emitTo).not.toHaveBeenCalled();
   });
 
   it("keeps the secondary-window session when main sign-out fails", async () => {
@@ -1013,6 +1018,9 @@ describe("AuthProvider", () => {
       expect.any(Function),
     );
     expect(mocks.signOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(mocks.emit).toHaveBeenCalledWith("anlg:auth-sign-out-committed", {
+      sourceLabel: "main",
+    });
     expect(
       mocks.prepareCloudsyncSignOut.mock.invocationCallOrder[0],
     ).toBeLessThan(mocks.signOut.mock.invocationCallOrder[0]);
@@ -1101,15 +1109,15 @@ describe("AuthProvider", () => {
     mocks.prepareCloudsyncSignOut.mockRejectedValueOnce(
       new Error("cloudsync suspension failed"),
     );
+    mocks.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
 
     renderAuthProvider();
 
     await waitFor(() => {
       expect(mocks.authCallback).not.toBeNull();
-    });
-
-    act(() => {
-      mocks.authCallback?.("INITIAL_SESSION", null);
     });
 
     await waitFor(() => {
@@ -1490,7 +1498,7 @@ describe("AuthProvider", () => {
     );
   });
 
-  it("fails closed when the local database account cannot be verified", async () => {
+  it("preserves local auth when the database account cannot be verified", async () => {
     const nextSession = makeSession("unverified-account");
     mocks.bindCloudsyncAccountForAuth.mockRejectedValue(
       new Error("database unavailable"),
@@ -1508,9 +1516,11 @@ describe("AuthProvider", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("session").textContent).toBe(
+        nextSession.user.id,
+      );
     });
-    expect(screen.getByTestId("session").textContent).toBe("none");
+    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
     expect(mocks.persistAuthSession).not.toHaveBeenCalled();
     expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalledWith(
       "SIGNED_IN",
@@ -1738,19 +1748,14 @@ describe("AuthProvider", () => {
     );
   });
 
-  it("does not let delayed fatal initial cleanup erase a newer session", async () => {
+  it("does not let failed initial recovery erase a newer session", async () => {
     const fatalError = new Error("invalid refresh token");
     const initialSession = deferred<{
       data: { session: null };
       error: Error;
     }>();
-    const clear = deferred();
     const newSession = makeSession("new-account");
     mocks.getSession.mockReturnValue(initialSession.promise);
-    mocks.isFatalSessionError.mockImplementation(
-      (error: unknown) => error === fatalError,
-    );
-    mocks.clearAuthStorage.mockReturnValue(clear.promise);
 
     renderAuthProvider();
 
@@ -1766,17 +1771,10 @@ describe("AuthProvider", () => {
       await initialSession.promise;
     });
 
-    await waitFor(() => {
-      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
-    });
+    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
 
     act(() => {
       mocks.authCallback?.("SIGNED_IN", newSession);
-    });
-
-    await act(async () => {
-      clear.resolve();
-      await clear.promise;
     });
 
     await waitFor(() => {
@@ -1785,32 +1783,27 @@ describe("AuthProvider", () => {
       );
     });
 
-    expect(mocks.persistAuthSession).toHaveBeenCalledWith(newSession);
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
     expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalledWith(
       "SIGNED_OUT",
       null,
     );
   });
 
-  it("clears fatal initial storage after the auth subscription initializes", async () => {
+  it("restores stored auth when initial token refresh fails", async () => {
     const fatalError = new Error("invalid refresh token");
     const initialSession = deferred<{
       data: { session: null };
       error: Error;
     }>();
+    const storedSession = makeSession("stored-account");
     mocks.getSession.mockReturnValue(initialSession.promise);
-    mocks.isFatalSessionError.mockImplementation(
-      (error: unknown) => error === fatalError,
-    );
+    mocks.readPersistedAuthSession.mockResolvedValue(storedSession);
 
     renderAuthProvider();
 
     await waitFor(() => {
       expect(mocks.authCallback).not.toBeNull();
-    });
-
-    act(() => {
-      mocks.authCallback?.("INITIAL_SESSION", null);
     });
 
     await act(async () => {
@@ -1822,12 +1815,17 @@ describe("AuthProvider", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("session").textContent).toBe(
+        storedSession.user.id,
+      );
     });
 
+    expect(mocks.clearAuthStorage).not.toHaveBeenCalled();
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
     expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
-      "SIGNED_OUT",
-      null,
+      "INITIAL_SESSION",
+      storedSession,
+      expect.any(Function),
     );
   });
 

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -6,7 +6,7 @@ import {
   type Session,
 } from "@supabase/supabase-js";
 import { useMutation } from "@tanstack/react-query";
-import { emitTo, listen } from "@tauri-apps/api/event";
+import { emit, emitTo, listen } from "@tauri-apps/api/event";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -33,11 +33,14 @@ import {
 import { clearAuthStorage } from "./errors";
 import { loadInitialSession } from "./initial-session";
 import {
+  AUTH_SIGN_OUT_COMMITTED_EVENT,
   AUTH_SIGN_OUT_REQUEST_EVENT,
   AUTH_SIGN_OUT_RESULT_EVENT,
+  type AuthSignOutCommittedPayload,
   type AuthSignOutRequestPayload,
   type AuthSignOutResultPayload,
   getErrorMessage,
+  isAuthSignOutCommittedPayload,
   isAuthSignOutRequestPayload,
   requestMainSignOut,
 } from "./sign-out-coordination";
@@ -63,7 +66,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const initStartedRef = useRef(false);
   const authTransitionRef = useRef(0);
   const authTransitionEventRef = useRef<AuthChangeEvent | null>(null);
-  const nonInitialAuthTransitionRef = useRef(0);
   const authTransitionQueueRef = useRef(Promise.resolve());
   const authAnalyticsQueueRef = useRef(Promise.resolve());
   const authStorageRevisionRef = useRef(0);
@@ -222,8 +224,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         { id: ACCOUNT_MISMATCH_TOAST_ID },
       );
       await rejectAuthChange(transition, true);
+
+      if (managesCloudsync && transition === authTransitionRef.current) {
+        try {
+          await emit(AUTH_SIGN_OUT_COMMITTED_EVENT, {
+            sourceLabel: currentWindowLabel,
+          } satisfies AuthSignOutCommittedPayload);
+        } catch {
+          console.warn("[auth] account rejection could not be synchronized");
+        }
+      }
     },
-    [rejectAuthChange],
+    [currentWindowLabel, managesCloudsync, rejectAuthChange],
   );
 
   const applyAuthChange = useCallback(
@@ -232,13 +244,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       nextSession: Session | null,
       transition: number,
       storageRevision: number,
-      clearStorage: boolean,
     ) => {
       if (transition !== authTransitionRef.current) {
         return;
       }
 
-      if (clearStorage || event === "SIGNED_OUT") {
+      if (event === "SIGNED_OUT") {
         let mainSignOutCompleted = false;
         if (event === "SIGNED_OUT" && !managesCloudsync) {
           resetTrackedAuthIdentity();
@@ -259,11 +270,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           }
         }
 
-        await rejectAuthChange(
-          transition,
-          clearStorage && event !== "SIGNED_OUT",
-          mainSignOutCompleted,
-        );
+        await rejectAuthChange(transition, false, mainSignOutCompleted);
         return;
       }
 
@@ -289,8 +296,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           if (transition !== authTransitionRef.current) {
             return;
           }
-          console.warn("[auth] local database account verification failed");
-          await rejectAuthChange(transition, true);
+          console.warn(
+            "[auth] local database account verification failed; preserving the local session",
+          );
+          setSession(nextSession);
+          void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
           return;
         }
       }
@@ -352,11 +362,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 
   const enqueueAuthChange = useCallback(
-    (
-      event: AuthChangeEvent,
-      nextSession: Session | null,
-      clearStorage = false,
-    ) => {
+    (event: AuthChangeEvent, nextSession: Session | null) => {
       if (event !== "SIGNED_OUT") {
         coordinatedMainSignOutRef.current = null;
       }
@@ -364,13 +370,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const transition = ++authTransitionRef.current;
       const storageRevision = authStorageRevisionRef.current;
       const apply = () =>
-        applyAuthChange(
-          event,
-          nextSession,
-          transition,
-          storageRevision,
-          clearStorage,
-        );
+        applyAuthChange(event, nextSession, transition, storageRevision);
       const queued =
         event === "SIGNED_OUT"
           ? Promise.resolve().then(apply)
@@ -389,19 +389,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!initStartedRef.current) {
       initStartedRef.current = true;
       const initialTransition = authTransitionRef.current;
-      const initialNonInitialTransition = nonInitialAuthTransitionRef.current;
-      void loadInitialSession(supabase).then((initial) => {
-        if (initial.clearStorage) {
-          if (
-            initialNonInitialTransition === nonInitialAuthTransitionRef.current
-          ) {
-            void enqueueAuthChange("INITIAL_SESSION", null, true);
-          }
-          return;
-        }
-
+      void loadInitialSession(supabase).then((initialSession) => {
         if (initialTransition === authTransitionRef.current) {
-          void enqueueAuthChange("INITIAL_SESSION", initial.session);
+          void enqueueAuthChange("INITIAL_SESSION", initialSession);
         }
       });
     }
@@ -409,9 +399,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event !== "INITIAL_SESSION") {
-        nonInitialAuthTransitionRef.current += 1;
+      if (event === "INITIAL_SESSION") {
+        return;
       }
+      if (event === "SIGNED_OUT") {
+        console.warn("[auth] ignoring unsolicited SDK sign-out");
+        return;
+      }
+
       console.log(
         `[auth] onAuthStateChange: ${event}`,
         session ? `expires_at=${session.expires_at}` : "no session",
@@ -619,8 +614,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     await enqueueAuthChange("SIGNED_OUT", null);
+    if (authTransitionEventRef.current !== "SIGNED_OUT") {
+      return false;
+    }
+
+    try {
+      await emit(AUTH_SIGN_OUT_COMMITTED_EVENT, {
+        sourceLabel: currentWindowLabel,
+      } satisfies AuthSignOutCommittedPayload);
+    } catch {
+      console.warn("[auth] sign-out could not be synchronized");
+    }
     return true;
-  }, [enqueueAuthChange, rejectAccountMismatch, session]);
+  }, [currentWindowLabel, enqueueAuthChange, rejectAccountMismatch, session]);
   const signOutFromMainRef = useLatestRef(signOutFromMain);
 
   useMountEffect(() => {
@@ -677,6 +683,43 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   });
 
+  useMountEffect(() => {
+    let active = true;
+    let unlisten: (() => void) | null = null;
+
+    void listen<AuthSignOutCommittedPayload>(
+      AUTH_SIGN_OUT_COMMITTED_EVENT,
+      (event) => {
+        if (
+          !active ||
+          !isAuthSignOutCommittedPayload(event.payload) ||
+          event.payload.sourceLabel === currentWindowLabel
+        ) {
+          return;
+        }
+
+        authTransitionEventRef.current = "SIGNED_OUT";
+        const transition = ++authTransitionRef.current;
+        void rejectAuthChange(transition, true, true);
+      },
+    )
+      .then((fn) => {
+        if (active) {
+          unlisten = fn;
+        } else {
+          fn();
+        }
+      })
+      .catch(() => {
+        console.warn("[auth] sign-out synchronization failed to initialize");
+      });
+
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  });
+
   const signOut = useCallback(async () => {
     if (managesCloudsync) {
       await signOutFromMain();
@@ -714,6 +757,46 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     () => refreshSessionMutation.mutateAsync(),
     [refreshSessionMutation.mutateAsync],
   );
+
+  const getSessionForRequest =
+    useCallback(async (): Promise<Session | null> => {
+      if (!supabase) {
+        return null;
+      }
+
+      let requestSession = session ?? null;
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (!error && data.session) {
+          requestSession = data.session;
+        }
+      } catch {
+        // Fall back to the in-memory session below.
+      }
+
+      if (!requestSession) {
+        return null;
+      }
+
+      const expiresAt = requestSession.expires_at
+        ? requestSession.expires_at * 1000
+        : null;
+      if (!expiresAt || expiresAt > Date.now() + 120_000) {
+        return requestSession;
+      }
+
+      let refreshedSession: Session | null = null;
+      try {
+        refreshedSession = await refreshSession();
+      } catch {
+        // Fall back to the current session while it remains valid.
+      }
+      if (refreshedSession) {
+        return refreshedSession;
+      }
+
+      return expiresAt > Date.now() ? requestSession : null;
+    }, [refreshSession, session]);
 
   const getHeaders = useCallback(() => {
     if (!session) {
@@ -761,6 +844,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       signIn,
       signOut,
       refreshSession,
+      getSessionForRequest,
       isRefreshingSession: refreshSessionMutation.isPending,
       handleAuthCallback,
       setSessionFromTokens,
@@ -772,6 +856,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       signIn,
       signOut,
       refreshSession,
+      getSessionForRequest,
       refreshSessionMutation.isPending,
       handleAuthCallback,
       setSessionFromTokens,

--- a/apps/desktop/src/auth/errors.ts
+++ b/apps/desktop/src/auth/errors.ts
@@ -1,20 +1,4 @@
-import { AuthApiError, AuthSessionMissingError } from "@supabase/supabase-js";
-
 import { commands as authCommands } from "@anlg/plugin-auth";
-
-export const isFatalSessionError = (error: unknown): boolean => {
-  if (error instanceof AuthSessionMissingError) {
-    return true;
-  }
-  if (error instanceof AuthApiError) {
-    const fatalCodes = [
-      "refresh_token_not_found",
-      "refresh_token_already_used",
-    ];
-    return fatalCodes.includes(error.code ?? "");
-  }
-  return false;
-};
 
 export const clearAuthStorage = async (): Promise<void> => {
   try {

--- a/apps/desktop/src/auth/initial-session.test.ts
+++ b/apps/desktop/src/auth/initial-session.test.ts
@@ -1,0 +1,54 @@
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { loadInitialSession } from "./initial-session";
+
+const { readPersistedAuthSessionMock } = vi.hoisted(() => ({
+  readPersistedAuthSessionMock: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  readPersistedAuthSession: readPersistedAuthSessionMock,
+}));
+
+const storedSession = { access_token: "stored" } as Session;
+const refreshedSession = { access_token: "refreshed" } as Session;
+
+function makeClient(getSession: () => unknown) {
+  return {
+    auth: { getSession },
+  } as unknown as SupabaseClient;
+}
+
+describe("loadInitialSession", () => {
+  beforeEach(() => {
+    readPersistedAuthSessionMock.mockResolvedValue(storedSession);
+  });
+
+  test("uses the refreshed session when recovery succeeds", async () => {
+    const client = makeClient(async () => ({
+      data: { session: refreshedSession },
+      error: null,
+    }));
+
+    await expect(loadInitialSession(client)).resolves.toBe(refreshedSession);
+  });
+
+  test("keeps the stored session when refresh fails", async () => {
+    const client = makeClient(async () => ({
+      data: { session: null },
+      error: new Error("refresh token unavailable"),
+    }));
+
+    await expect(loadInitialSession(client)).resolves.toBe(storedSession);
+  });
+
+  test("keeps the stored session when the SDK returns no session", async () => {
+    const client = makeClient(async () => ({
+      data: { session: null },
+      error: null,
+    }));
+
+    await expect(loadInitialSession(client)).resolves.toBe(storedSession);
+  });
+});

--- a/apps/desktop/src/auth/initial-session.ts
+++ b/apps/desktop/src/auth/initial-session.ts
@@ -1,28 +1,21 @@
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 
-import { isFatalSessionError } from "./errors";
+import { readPersistedAuthSession } from "./client";
 
 export async function loadInitialSession(
   client: SupabaseClient,
-): Promise<{ clearStorage: boolean; session: Session | null }> {
+): Promise<Session | null> {
+  const storedSession = await readPersistedAuthSession();
+
   try {
     const { data, error } = await client.auth.getSession();
 
     if (error) {
-      return {
-        clearStorage: isFatalSessionError(error),
-        session: null,
-      };
+      return storedSession;
     }
 
-    return {
-      clearStorage: false,
-      session: data.session ?? null,
-    };
-  } catch (error) {
-    return {
-      clearStorage: isFatalSessionError(error),
-      session: null,
-    };
+    return data.session ?? storedSession;
+  } catch {
+    return storedSession;
   }
 }

--- a/apps/desktop/src/auth/sign-out-coordination.ts
+++ b/apps/desktop/src/auth/sign-out-coordination.ts
@@ -4,6 +4,7 @@ import { id } from "~/shared/utils";
 
 export const AUTH_SIGN_OUT_REQUEST_EVENT = "anlg:auth-sign-out-request";
 export const AUTH_SIGN_OUT_RESULT_EVENT = "anlg:auth-sign-out-result";
+export const AUTH_SIGN_OUT_COMMITTED_EVENT = "anlg:auth-sign-out-committed";
 const AUTH_SIGN_OUT_TIMEOUT_MS = 10_000;
 
 export type AuthSignOutRequestPayload = {
@@ -16,6 +17,24 @@ export type AuthSignOutResultPayload = {
   completed: boolean;
   error: string | null;
 };
+
+export type AuthSignOutCommittedPayload = {
+  sourceLabel: string;
+};
+
+export function isAuthSignOutCommittedPayload(
+  payload: unknown,
+): payload is AuthSignOutCommittedPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const candidate = payload as Partial<AuthSignOutCommittedPayload>;
+  return (
+    typeof candidate.sourceLabel === "string" &&
+    candidate.sourceLabel.length > 0
+  );
+}
 
 export function isAuthSignOutRequestPayload(
   payload: unknown,

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr "Transcription complete"
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr "Transcription failed"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -4969,6 +4969,7 @@ msgid "Transcription complete"
 msgstr ""
 
 #: src/session/components/note-input/transcript/screens/empty.tsx
+#: src/stt/useRunBatch.ts
 msgid "Transcription failed"
 msgstr ""
 

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -22,6 +22,7 @@ const {
   useSessionParticipantsMock,
   useSTTConnectionMock,
   useAuthMock,
+  getSessionForRequestMock,
   refreshSessionMock,
   useBillingAccessMock,
   useConfigValueMock,
@@ -41,6 +42,7 @@ const {
   useSessionParticipantsMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
   useAuthMock: vi.fn(),
+  getSessionForRequestMock: vi.fn(),
   refreshSessionMock: vi.fn(),
   useBillingAccessMock: vi.fn(),
   useConfigValueMock: vi.fn(),
@@ -614,7 +616,11 @@ describe("useRunBatch", () => {
         access_token: "paid-token",
         user: { id: "user-1" },
       },
+      getSessionForRequest: getSessionForRequestMock,
       refreshSession: refreshSessionMock,
+    });
+    getSessionForRequestMock.mockResolvedValue({
+      access_token: "paid-token",
     });
     refreshSessionMock.mockResolvedValue(null);
     useBillingAccessMock.mockReturnValue({
@@ -1198,6 +1204,60 @@ describe("useRunBatch", () => {
     );
   });
 
+  test("uses a request-ready cloud token before transcription starts", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "anarlog",
+        model: "cloud",
+        baseUrl: "https://api.test/stt",
+        apiKey: "stale-token",
+      },
+    });
+    useBillingAccessMock.mockReturnValue({ isPaid: true });
+    getSessionForRequestMock.mockResolvedValue({
+      access_token: "request-ready-token",
+    });
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledTimes(1);
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ api_key: "request-ready-token" }),
+      expect.any(Object),
+    );
+  });
+
+  test("falls back to the current cloud token when refresh is unavailable", async () => {
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "anarlog",
+        model: "cloud",
+        baseUrl: "https://api.test/stt",
+        apiKey: "stale-token",
+      },
+    });
+    useBillingAccessMock.mockReturnValue({ isPaid: true });
+    getSessionForRequestMock.mockRejectedValue(new Error("offline"));
+    startTranscriptionMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRunBatch("session-1"));
+
+    await act(async () => {
+      await result.current("/tmp/session.wav");
+    });
+
+    expect(startTranscriptionMock).toHaveBeenCalledTimes(1);
+    expect(startTranscriptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ api_key: "paid-token" }),
+      expect.any(Object),
+    );
+  });
+
   test("refreshes an expired cloud token and retries transcription once", async () => {
     useSTTConnectionMock.mockReturnValue({
       conn: {
@@ -1212,7 +1272,11 @@ describe("useRunBatch", () => {
         access_token: "stale-token",
         user: { id: "user-1" },
       },
+      getSessionForRequest: getSessionForRequestMock,
       refreshSession: refreshSessionMock,
+    });
+    getSessionForRequestMock.mockResolvedValue({
+      access_token: "stale-token",
     });
     refreshSessionMock.mockResolvedValue({ access_token: "fresh-token" });
     startTranscriptionMock

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -1,3 +1,4 @@
+import { t } from "@lingui/core/macro";
 import { arch, platform } from "@tauri-apps/plugin-os";
 import { useCallback } from "react";
 
@@ -589,9 +590,18 @@ export const useRunBatch = (sessionId: string) => {
               languages,
             )
           : false;
+      const requiresCloudSession =
+        billing.isPaid ||
+        (selectedTarget?.provider === "anarlog" &&
+          selectedTarget.model === "cloud");
+      const requestSession = requiresCloudSession
+        ? await auth.getSessionForRequest().catch(() => null)
+        : null;
+      const cloudAccessToken =
+        requestSession?.access_token ?? auth.session?.access_token;
       const fallbackTarget = getBatchFallbackTarget({
         isPaid: billing.isPaid,
-        accessToken: auth?.session?.access_token,
+        accessToken: cloudAccessToken,
         apiBaseUrl: env.VITE_API_URL,
         currentPlatform,
         currentArch,
@@ -599,7 +609,7 @@ export const useRunBatch = (sessionId: string) => {
       const shouldUseSelectedTarget =
         selectedTargetSupported ||
         (fallbackTarget && sameBatchTarget(selectedTarget, fallbackTarget));
-      const target = shouldUseSelectedTarget
+      let target = shouldUseSelectedTarget
         ? (selectedTarget ?? fallbackTarget)
         : fallbackTarget;
 
@@ -609,6 +619,13 @@ export const useRunBatch = (sessionId: string) => {
             ? `${selectedProviderLabel(conn, selectedModel)} is not available for batch transcription with the selected languages. Choose languages it supports, or configure another speech-to-text provider.`
             : `${selectedProviderLabel(conn, selectedModel)} is not available for batch transcription on this platform. Configure a batch-capable speech-to-text provider.`,
         );
+      }
+
+      if (target.provider === "anarlog" && target.model === "cloud") {
+        if (!cloudAccessToken) {
+          throw new Error(t`Transcription failed`);
+        }
+        target = { ...target, apiKey: cloudAccessToken };
       }
 
       if (!shouldUseSelectedTarget) {
@@ -862,7 +879,7 @@ export const useRunBatch = (sessionId: string) => {
     [
       conn,
       auth,
-      auth?.session?.access_token,
+      auth.session?.access_token,
       aiLanguage,
       audioRetention,
       billing.isPaid,


### PR DESCRIPTION
## Summary

- Preserve the existing persisted session when Supabase refresh or transient account verification fails.
- Synchronize explicit logout across every app window while continuing to ignore unsolicited SDK sign-out events.
- Refresh Anarlog Cloud credentials before batch transcription and fall back to a still-valid current token when lookup or refresh is unavailable.

## Validation

- pnpm -F desktop test (431 files, 3695 tests)
- pnpm -F desktop typecheck
- pnpm fmt:check
- pnpm exec oxlint --quiet --format=github apps/desktop/src/ (0 errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Broad changes to authentication persistence, multi-window sign-out, and when sessions are cleared—security-sensitive behavior with intentional relaxation of SDK-driven logout.
> 
> **Overview**
> Fixes **unexpected logouts** during batch transcription and fragile Supabase refresh by making the desktop app own session persistence and treat SDK sign-out as non-authoritative unless the user (or main window) commits logout.
> 
> **Session storage and startup:** Tauri auth storage **blocks** the Supabase client from removing the primary session key; sessions are **read back** on cold start. Initial load **falls back to the persisted session** when `getSession` fails or returns empty, instead of clearing storage on “fatal” refresh errors (`isFatalSessionError` is removed).
> 
> **Auth provider behavior:** Unsolicited `SIGNED_OUT` from the SDK is **ignored**; explicit sign-out still runs the existing main/secondary coordination and now **broadcasts** `anlg:auth-sign-out-committed` so other windows clear only after a real logout. Transient **cloudsync account verification failures keep the in-memory session** rather than wiping auth.
> 
> **API calls:** New **`getSessionForRequest`** resolves a token for outbound requests (SDK lookup, proactive refresh within ~2 minutes, offline fallbacks). **Batch transcription** uses it for Anarlog Cloud / paid paths so jobs start with a fresh access token (existing 401 retry unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31af0f5951b1709796ffff07554abbfa8778176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->