### PR TITLE
Show a DEV/STAGING bar and React Scan at the bottom

### DIFF
--- a/apps/desktop/src/devtools-panel/mode-bar.test.tsx
+++ b/apps/desktop/src/devtools-panel/mode-bar.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  showDevtool: vi.fn(),
+  getIdentifier: vi.fn(),
+  getVersion: vi.fn(),
+  devtoolsPanelShow: vi.fn(),
+}));
+
+vi.mock("~/types/tauri.gen", () => ({
+  commands: {
+    showDevtool: mocks.showDevtool,
+  },
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getIdentifier: mocks.getIdentifier,
+  getVersion: mocks.getVersion,
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  commands: {
+    devtoolsPanelShow: mocks.devtoolsPanelShow,
+  },
+}));
+
+import { EnvironmentModeBar } from "./mode-bar";
+
+function renderBar() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EnvironmentModeBar />
+    </QueryClientProvider>,
+  );
+}
+
+describe("EnvironmentModeBar", () => {
+  afterEach(() => {
+    cleanup();
+    delete document.documentElement.dataset.devtoolsChannel;
+  });
+
+  beforeEach(() => {
+    mocks.showDevtool.mockReset();
+    mocks.getIdentifier.mockReset();
+    mocks.getVersion.mockReset();
+    mocks.devtoolsPanelShow.mockReset();
+    mocks.showDevtool.mockResolvedValue(true);
+    mocks.getIdentifier.mockResolvedValue("com.hyprnote.dev");
+    mocks.getVersion.mockResolvedValue("0.1.0");
+    mocks.devtoolsPanelShow.mockResolvedValue({ status: "ok" });
+  });
+
+  it("does not render on stable builds", async () => {
+    mocks.showDevtool.mockResolvedValue(false);
+
+    renderBar();
+
+    await waitFor(() => expect(mocks.showDevtool).toHaveBeenCalled());
+    expect(screen.queryByTestId("environment-mode-bar")).toBeNull();
+  });
+
+  it("shows the DEV channel and version", async () => {
+    renderBar();
+
+    const bar = await screen.findByTestId("environment-mode-bar");
+    expect(bar.dataset.channel).toBe("dev");
+    expect(bar.textContent).toContain("DEV");
+    expect(bar.textContent).toContain("v0.1.0");
+    expect(document.documentElement.dataset.devtoolsChannel).toBe("dev");
+  });
+
+  it("shows the STAGING channel for staging identifiers", async () => {
+    mocks.getIdentifier.mockResolvedValue("com.hyprnote.staging");
+
+    renderBar();
+
+    const bar = await screen.findByTestId("environment-mode-bar");
+    expect(bar.dataset.channel).toBe("staging");
+    expect(bar.textContent).toContain("STAGING");
+    expect(document.documentElement.dataset.devtoolsChannel).toBe("staging");
+  });
+
+  it("opens the Devtools panel from the mode label", async () => {
+    renderBar();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Open Devtools panel (DEV v0.1.0)",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.devtoolsPanelShow).toHaveBeenCalledTimes(1),
+    );
+  });
+});

--- a/apps/desktop/src/devtools-panel/mode-bar.tsx
+++ b/apps/desktop/src/devtools-panel/mode-bar.tsx
@@ -1,0 +1,95 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getIdentifier, getVersion } from "@tauri-apps/api/app";
+import { useEffect } from "react";
+
+import { commands as windowsCommands } from "@anlg/plugin-windows";
+import { cn } from "@anlg/utils";
+
+import { getDevtoolsChannel } from "~/shared/utils";
+import { commands } from "~/types/tauri.gen";
+
+export function EnvironmentModeBar() {
+  const enabledQuery = useQuery({
+    queryKey: ["devtools-panel", "enabled"],
+    queryFn: commands.showDevtool,
+    staleTime: Infinity,
+  });
+  const identityQuery = useQuery({
+    queryKey: ["devtools-panel", "identity"],
+    queryFn: loadDevtoolsIdentity,
+    enabled: enabledQuery.data === true,
+    staleTime: Infinity,
+  });
+  const openMutation = useMutation({
+    mutationFn: async () => {
+      const result = await windowsCommands.devtoolsPanelShow();
+      if (result.status === "error") {
+        throw new Error(result.error);
+      }
+    },
+  });
+
+  const identity = identityQuery.data;
+
+  useEffect(() => {
+    if (!identity) {
+      return;
+    }
+
+    document.documentElement.dataset.devtoolsChannel = identity.channel;
+    return () => {
+      delete document.documentElement.dataset.devtoolsChannel;
+    };
+  }, [identity]);
+
+  if (enabledQuery.data !== true || !identity) {
+    return null;
+  }
+
+  const label = identity.channel === "staging" ? "STAGING" : "DEV";
+
+  return (
+    <div
+      className={cn([
+        "border-border bg-muted/80 text-muted-foreground",
+        "flex h-8 shrink-0 items-center gap-3 border-t px-2.5",
+      ])}
+      data-channel={identity.channel}
+      data-testid="environment-mode-bar"
+    >
+      <button
+        type="button"
+        aria-label={`Open Devtools panel (${label} v${identity.version})`}
+        className={cn([
+          "flex min-w-0 items-center gap-1.5 text-[11px] leading-none tracking-wide",
+          "hover:text-foreground outline-hidden",
+        ])}
+        disabled={openMutation.isPending}
+        onClick={() => openMutation.mutate()}
+      >
+        <span
+          aria-hidden
+          className={cn([
+            "size-1.5 shrink-0 rounded-full",
+            identity.channel === "staging" ? "bg-sky-500" : "bg-amber-500",
+          ])}
+        />
+        <span className="text-foreground font-medium">{label}</span>
+        <span>v{identity.version}</span>
+      </button>
+      <div className="min-w-0 flex-1" aria-hidden />
+    </div>
+  );
+}
+
+async function loadDevtoolsIdentity() {
+  const [identifier, version] = await Promise.all([
+    getIdentifier(),
+    getVersion(),
+  ]);
+
+  return {
+    channel: getDevtoolsChannel(identifier),
+    version,
+  };
+}

--- a/apps/desktop/src/devtools-panel/react-scan.test.ts
+++ b/apps/desktop/src/devtools-panel/react-scan.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const scan = vi.fn();
+
+vi.mock("react-scan", () => ({
+  scan,
+}));
+
+import { enableReactScan } from "./react-scan";
+
+describe("enableReactScan", () => {
+  beforeEach(() => {
+    scan.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does nothing when disabled", async () => {
+    await enableReactScan(false);
+
+    expect(scan).not.toHaveBeenCalled();
+  });
+
+  it("starts the toolbar when enabled", async () => {
+    await enableReactScan(true);
+
+    expect(scan).toHaveBeenCalledWith({
+      enabled: true,
+      showToolbar: true,
+      dangerouslyForceRunInProduction: !import.meta.env.DEV,
+    });
+  });
+});

--- a/apps/desktop/src/devtools-panel/react-scan.ts
+++ b/apps/desktop/src/devtools-panel/react-scan.ts
@@ -1,0 +1,16 @@
+export async function enableReactScan(enabled: boolean) {
+  if (!enabled) {
+    return;
+  }
+
+  try {
+    const { scan } = await import("react-scan");
+    scan({
+      enabled: true,
+      showToolbar: true,
+      dangerouslyForceRunInProduction: !import.meta.env.DEV,
+    });
+  } catch (error) {
+    console.warn("Failed to start React Scan:", error);
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -17,6 +17,7 @@ import { Toaster } from "@anlg/ui/components/ui/toast";
 import { AITaskWindowSyncBridge } from "./ai/task-window-sync";
 import { trackAnalyticsEvent } from "./analytics";
 import { createToolRegistry } from "./contexts/tool-registry/core";
+import { enableReactScan } from "./devtools-panel/react-scan";
 import {
   captureOperationalError,
   initializeErrorReporting,
@@ -49,6 +50,7 @@ import { AppThemeProvider } from "./shared/theme/provider";
 import type { ThemePreference } from "./shared/theme/resolve";
 import { createAITaskStore } from "./store/zustand/ai-task";
 import { listenerStore } from "./store/zustand/listener/instance";
+import { commands } from "./types/tauri.gen";
 
 const toolRegistry = createToolRegistry();
 const queryClient = new QueryClient({
@@ -156,25 +158,19 @@ if (isMainWindow) {
 
 const rootElement = document.getElementById("root")!;
 
-async function enableReactScanInDev() {
-  if (!import.meta.env.DEV) {
-    return;
-  }
+async function enableDevtoolsInstrumentation() {
+  const enabled = await commands.showDevtool().catch(() => import.meta.env.DEV);
+  await enableReactScan(enabled);
 
-  try {
-    const { scan } = await import("react-scan");
-    scan({ enabled: true });
-  } catch (error) {
-    console.warn("Failed to start React Scan:", error);
+  if (import.meta.env.DEV) {
+    startInteractionProfiler();
   }
-
-  startInteractionProfiler();
 }
 
 async function renderApp() {
   await Promise.all([
     bootstrapThemeFromSettings(),
-    enableReactScanInDev(),
+    enableDevtoolsInstrumentation(),
     initializeAppStoreBuild(),
   ]);
   const root = ReactDOM.createRoot(rootElement);

--- a/apps/desktop/src/shared/main-app-layout.test.tsx
+++ b/apps/desktop/src/shared/main-app-layout.test.tsx
@@ -39,6 +39,10 @@ vi.mock("~/devtools-panel/host", () => ({
   DevtoolsFloatingPanelHost: () => null,
 }));
 
+vi.mock("~/devtools-panel/mode-bar", () => ({
+  EnvironmentModeBar: () => <div data-testid="environment-mode-bar" />,
+}));
+
 vi.mock("~/enterprise-capture/lifecycle", () => ({
   EnterpriseCaptureSync: () => <div data-testid="enterprise-capture-sync" />,
 }));
@@ -87,6 +91,9 @@ describe("MainAppLayout", () => {
     expect(
       authProvider.contains(screen.getByTestId("enterprise-capture-sync")),
     ).toBe(true);
+    expect(
+      authProvider.contains(screen.getByTestId("environment-mode-bar")),
+    ).toBe(true);
   });
 
   it("does not mount connected import sync in secondary windows", () => {
@@ -96,5 +103,6 @@ describe("MainAppLayout", () => {
 
     expect(screen.queryByTestId("meeting-import-sync")).toBeNull();
     expect(screen.queryByTestId("enterprise-capture-sync")).toBeNull();
+    expect(screen.queryByTestId("environment-mode-bar")).toBeNull();
   });
 });

--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -15,6 +15,7 @@ import {
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
 import { DevtoolsFloatingPanelHost } from "~/devtools-panel/host";
+import { EnvironmentModeBar } from "~/devtools-panel/mode-bar";
 import { EnterpriseCaptureSync } from "~/enterprise-capture/lifecycle";
 import { MeetingImportSync } from "~/services/meeting-import-sync";
 import { getOrCreateSessionForEventId } from "~/session/queries";
@@ -41,7 +42,12 @@ function MainAppContent() {
 
   return (
     <>
-      <Outlet />
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <Outlet />
+        </div>
+        {isMainWindow ? <EnvironmentModeBar /> : null}
+      </div>
       {isMainWindow ? <MeetingImportSync /> : null}
       {isMainWindow ? <EnterpriseCaptureSync /> : null}
       <UndoDeleteToast />

--- a/apps/desktop/src/shared/utils.test.ts
+++ b/apps/desktop/src/shared/utils.test.ts
@@ -8,7 +8,7 @@ vi.mock("@tauri-apps/api/app", () => ({
   getIdentifier: mocks.getIdentifier,
 }));
 
-import { getScheme } from "./utils";
+import { getDevtoolsChannel, getScheme } from "./utils";
 
 describe("getScheme", () => {
   beforeEach(() => {
@@ -26,5 +26,17 @@ describe("getScheme", () => {
     mocks.getIdentifier.mockResolvedValue(identifier);
 
     await expect(getScheme()).resolves.toBe(scheme);
+  });
+});
+
+describe("getDevtoolsChannel", () => {
+  it.each([
+    ["com.hyprnote.staging", "staging"],
+    ["com.anarlog.staging", "staging"],
+    ["com.hyprnote.dev", "dev"],
+    ["com.anarlog.dev", "dev"],
+    ["com.hyprnote.stable", "dev"],
+  ])("maps %s to %s", (identifier, channel) => {
+    expect(getDevtoolsChannel(identifier)).toBe(channel);
   });
 });

--- a/apps/desktop/src/shared/utils.ts
+++ b/apps/desktop/src/shared/utils.ts
@@ -25,6 +25,13 @@ export const getScheme = async (): Promise<DesktopScheme> => {
   return schemes[id] ?? "anarlog";
 };
 
+export function getDevtoolsChannel(identifier: string): "dev" | "staging" {
+  return identifier === "com.hyprnote.staging" ||
+    identifier === "com.anarlog.staging"
+    ? "staging"
+    : "dev";
+}
+
 type DesktopFlowPath =
   | "/auth"
   | "/app/account"

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -327,3 +327,7 @@ html[data-live-caption] #root {
   border-radius: calc(infinity * 1px);
   corner-shape: round;
 }
+
+html[data-devtools-channel] #react-scan-root {
+  inset: auto 8px 4px auto !important;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Dev and staging desktop builds look like production unless you check the tray menu, so it is easy to mix them up. React Scan also only started in local Vite DEV, not in staging.

**Fix:** Reserve a slim footer in the main window for non-production builds. It shows `DEV` or `STAGING` plus the app version (click opens the existing Devtools panel). React Scan now starts whenever `show_devtool` is true, including staging, and its toolbar is pinned into that footer.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed non-Swift files
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop test` (3688 passed)
- Skipped `pnpm -F desktop i18n:check` — no Lingui strings were added
- Desktop UI not yet exercised in `tauri dev` (first compile is the full Rust workspace)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7e3c062-13e6-44ae-ac48-9af6f7032909?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7e3c062-13e6-44ae-ac48-9af6f7032909&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

