### PR TITLE
Add VS Code-style developer status bar to dev and staging builds

### DIFF
--- a/apps/desktop/src/devtools-bar/index.test.tsx
+++ b/apps/desktop/src/devtools-bar/index.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  identifier: "com.hyprnote.staging",
+  reactScanAvailable: false,
+  outlinesEnabled: true,
+  toolbarVisible: false,
+  setReactScanOutlinesEnabled: vi.fn(),
+  setReactScanToolbarVisible: vi.fn(),
+  devtoolsPanelShow: vi.fn().mockResolvedValue({ status: "ok", data: null }),
+  startDevtoolsMetrics: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getIdentifier: vi.fn(() => Promise.resolve(mocks.identifier)),
+  getVersion: vi.fn(() => Promise.resolve("1.2.3")),
+}));
+
+vi.mock("@anlg/plugin-misc", () => ({
+  commands: {
+    getGitHash: vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: "abcdef1234567890" }),
+    getProcessMemoryBytes: vi.fn(),
+  },
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  commands: {
+    devtoolsPanelShow: mocks.devtoolsPanelShow,
+  },
+}));
+
+vi.mock("./react-scan", () => ({
+  isReactScanAvailable: () => mocks.reactScanAvailable,
+  subscribeReactScanAvailability: () => () => {},
+  areReactScanOutlinesEnabled: () => mocks.outlinesEnabled,
+  isReactScanToolbarVisible: () => mocks.toolbarVisible,
+  setReactScanOutlinesEnabled: mocks.setReactScanOutlinesEnabled,
+  setReactScanToolbarVisible: mocks.setReactScanToolbarVisible,
+}));
+
+vi.mock("./metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./metrics")>();
+  return {
+    ...actual,
+    startDevtoolsMetrics: mocks.startDevtoolsMetrics,
+  };
+});
+
+import { DevtoolsStatusBar } from "./index";
+import { useDevtoolsMetrics } from "./metrics";
+
+import { commands } from "~/types/tauri.gen";
+
+function renderBar() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DevtoolsStatusBar />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DevtoolsStatusBar", () => {
+  beforeEach(() => {
+    mocks.identifier = "com.hyprnote.staging";
+    mocks.reactScanAvailable = false;
+    mocks.outlinesEnabled = true;
+    mocks.toolbarVisible = false;
+    vi.mocked(commands.showDevtool).mockResolvedValue(true);
+    useDevtoolsMetrics.setState({
+      fps: [58, 60],
+      invokes: [3, 12],
+      callbacks: [4, 15],
+      renders: [10, 41],
+      memoryBytes: [300 * 1024 ** 2, 312 * 1024 ** 2],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when devtools are disabled", async () => {
+    vi.mocked(commands.showDevtool).mockResolvedValue(false);
+
+    renderBar();
+
+    await vi.waitFor(() => expect(commands.showDevtool).toHaveBeenCalled());
+    expect(screen.queryByTestId("devtools-status-bar")).toBeNull();
+    expect(mocks.startDevtoolsMetrics).not.toHaveBeenCalled();
+  });
+
+  it("shows the build channel, version, hash and live metrics", async () => {
+    renderBar();
+
+    const bar = await screen.findByTestId("devtools-status-bar");
+    await screen.findByText("1.2.3 abcdef1");
+
+    expect(bar.textContent).toContain("staging");
+    expect(bar.className).toContain("bg-amber-900");
+    expect(bar.textContent).toContain("FPS60");
+    expect(bar.textContent).toContain("↑12 ↓15");
+    expect(bar.textContent).toContain("MEM312MB");
+    expect(screen.queryByText("renders")).toBeNull();
+    expect(mocks.startDevtoolsMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the dev palette for local builds", async () => {
+    mocks.identifier = "com.hyprnote.dev";
+
+    renderBar();
+
+    const bar = await screen.findByTestId("devtools-status-bar");
+    await vi.waitFor(() => expect(bar.className).toContain("bg-blue-900"));
+    expect(bar.textContent).toContain("dev");
+  });
+
+  it("opens the devtools panel from the channel badge", async () => {
+    renderBar();
+
+    fireEvent.click(await screen.findByTitle("Open Devtools panel"));
+
+    expect(mocks.devtoolsPanelShow).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes react-scan controls when it is running", async () => {
+    mocks.reactScanAvailable = true;
+
+    renderBar();
+
+    const bar = await screen.findByTestId("devtools-status-bar");
+    expect(bar.textContent).toContain("renders41");
+
+    fireEvent.click(
+      screen.getByTitle("React Scan: outlining re-renders (click to pause)"),
+    );
+    expect(mocks.setReactScanOutlinesEnabled).toHaveBeenCalledWith(false);
+
+    fireEvent.click(
+      screen.getByTitle(
+        "Toggle the React Scan toolbar (inspector, slowdown notifications)",
+      ),
+    );
+    expect(mocks.setReactScanToolbarVisible).toHaveBeenCalledWith(true);
+  });
+
+  it("shows renders as off while outlines are paused", async () => {
+    mocks.reactScanAvailable = true;
+    mocks.outlinesEnabled = false;
+
+    renderBar();
+
+    const bar = await screen.findByTestId("devtools-status-bar");
+    expect(bar.textContent).toContain("rendersoff");
+  });
+});

--- a/apps/desktop/src/devtools-bar/index.test.tsx
+++ b/apps/desktop/src/devtools-bar/index.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@anlg/plugin-windows", () => ({
 }));
 
 vi.mock("./react-scan", () => ({
+  ignoreReactScan: vi.fn(),
   isReactScanAvailable: () => mocks.reactScanAvailable,
   subscribeReactScanAvailability: () => () => {},
   areReactScanOutlinesEnabled: () => mocks.outlinesEnabled,

--- a/apps/desktop/src/devtools-bar/index.test.tsx
+++ b/apps/desktop/src/devtools-bar/index.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getIdentifier } from "@tauri-apps/api/app";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -71,6 +72,9 @@ function renderBar() {
 describe("DevtoolsStatusBar", () => {
   beforeEach(() => {
     mocks.identifier = "com.hyprnote.staging";
+    vi.mocked(getIdentifier).mockImplementation(() =>
+      Promise.resolve(mocks.identifier),
+    );
     mocks.reactScanAvailable = false;
     mocks.outlinesEnabled = true;
     mocks.toolbarVisible = false;
@@ -112,6 +116,26 @@ describe("DevtoolsStatusBar", () => {
     expect(bar.textContent).toContain("MEM312MB");
     expect(screen.queryByText("renders")).toBeNull();
     expect(mocks.startDevtoolsMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for build info before rendering the channel", async () => {
+    let resolveIdentifier: (identifier: string) => void = () => {};
+    vi.mocked(getIdentifier).mockReturnValue(
+      new Promise((resolve) => {
+        resolveIdentifier = resolve;
+      }),
+    );
+
+    renderBar();
+
+    await vi.waitFor(() => expect(getIdentifier).toHaveBeenCalled());
+    expect(screen.queryByTestId("devtools-status-bar")).toBeNull();
+
+    resolveIdentifier("com.hyprnote.staging");
+
+    const bar = await screen.findByTestId("devtools-status-bar");
+    expect(bar.textContent).toContain("staging");
+    expect(bar.className).toContain("bg-amber-900");
   });
 
   it("uses the dev palette for local builds", async () => {

--- a/apps/desktop/src/devtools-bar/index.tsx
+++ b/apps/desktop/src/devtools-bar/index.tsx
@@ -1,0 +1,326 @@
+import { useQuery } from "@tanstack/react-query";
+import { getIdentifier, getVersion } from "@tauri-apps/api/app";
+import { useEffect, useReducer, useSyncExternalStore } from "react";
+
+import { commands as miscCommands } from "@anlg/plugin-misc";
+import { commands as windowsCommands } from "@anlg/plugin-windows";
+import { cn } from "@anlg/utils";
+
+import {
+  formatBytes,
+  HISTORY_LENGTH,
+  startDevtoolsMetrics,
+  useDevtoolsMetrics,
+} from "./metrics";
+import {
+  areReactScanOutlinesEnabled,
+  isReactScanAvailable,
+  isReactScanToolbarVisible,
+  setReactScanOutlinesEnabled,
+  setReactScanToolbarVisible,
+  subscribeReactScanAvailability,
+} from "./react-scan";
+
+import { commands } from "~/types/tauri.gen";
+
+export type BuildChannel = "dev" | "staging" | "stable";
+
+export function resolveBuildChannel(identifier: string): BuildChannel {
+  if (identifier.endsWith(".staging")) return "staging";
+  if (identifier.endsWith(".dev")) return "dev";
+  return "stable";
+}
+
+const CHANNEL_CLASSES: Record<BuildChannel, string> = {
+  dev: "bg-blue-900 text-blue-50",
+  staging: "bg-amber-900 text-amber-50",
+  stable: "bg-neutral-800 text-neutral-100",
+};
+
+/**
+ * VS Code-style status bar for dev and staging builds. Stable builds never
+ * render it (`show_devtool` is false there), so copy stays English-only.
+ */
+export function DevtoolsStatusBar() {
+  const enabledQuery = useQuery({
+    queryKey: ["devtools-panel", "enabled"],
+    queryFn: commands.showDevtool,
+    staleTime: Infinity,
+  });
+
+  if (enabledQuery.data !== true) {
+    return null;
+  }
+
+  return <DevtoolsStatusBarContent />;
+}
+
+function DevtoolsStatusBarContent() {
+  useEffect(() => startDevtoolsMetrics(), []);
+
+  const metrics = useDevtoolsMetrics();
+  const build = useBuildInfo();
+  const reactScanAvailable = useSyncExternalStore(
+    subscribeReactScanAvailability,
+    isReactScanAvailable,
+  );
+  const [, refresh] = useReducer((tick: number) => tick + 1, 0);
+
+  const channel = build?.channel ?? "stable";
+  const fps = last(metrics.fps);
+  const invokes = last(metrics.invokes) ?? 0;
+  const callbacks = last(metrics.callbacks) ?? 0;
+  const renders = last(metrics.renders) ?? 0;
+  const memoryBytes = last(metrics.memoryBytes);
+  const outlinesEnabled = reactScanAvailable && areReactScanOutlinesEnabled();
+  const toolbarVisible = reactScanAvailable && isReactScanToolbarVisible();
+
+  return (
+    <footer
+      aria-label="Developer status bar"
+      data-testid="devtools-status-bar"
+      className={cn([
+        "flex h-6 shrink-0 items-stretch overflow-hidden select-none",
+        "font-mono text-[11px] leading-none",
+        CHANNEL_CLASSES[channel],
+      ])}
+    >
+      <BarButton
+        title="Open Devtools panel"
+        onClick={() => void openDevtoolsPanel()}
+      >
+        <span className="font-semibold tracking-wider uppercase">
+          {channel}
+        </span>
+        {build ? (
+          <span className="opacity-70">
+            {build.version}
+            {build.hash ? ` ${build.hash}` : ""}
+          </span>
+        ) : null}
+      </BarButton>
+
+      <Segment
+        label="FPS"
+        title={`Frames per second (avg ${average(metrics.fps)} over ${metrics.fps.length}s)`}
+      >
+        <Value>{fps ?? "–"}</Value>
+        <Sparkline values={metrics.fps} floor={60} />
+      </Segment>
+
+      <Segment
+        label="IPC"
+        title="Tauri IPC per second: ↑ invokes, ↓ callbacks (responses, events, channels)"
+      >
+        <Value>
+          ↑{invokes} ↓{callbacks}
+        </Value>
+        <Sparkline
+          values={metrics.invokes.map(
+            (value, index) => value + (metrics.callbacks[index] ?? 0),
+          )}
+        />
+      </Segment>
+
+      {reactScanAvailable ? (
+        <BarButton
+          title={
+            outlinesEnabled
+              ? "React Scan: outlining re-renders (click to pause)"
+              : "React Scan: outlines paused (click to resume)"
+          }
+          onClick={() => {
+            setReactScanOutlinesEnabled(!outlinesEnabled);
+            refresh();
+          }}
+        >
+          <Label>renders</Label>
+          <Value>{outlinesEnabled ? renders : "off"}</Value>
+          <Sparkline values={metrics.renders} />
+        </BarButton>
+      ) : null}
+
+      <Segment
+        label="MEM"
+        title="Host process resident memory (WebKit content process is separate on macOS)"
+      >
+        <Value>
+          {memoryBytes === undefined ? "–" : formatBytes(memoryBytes)}
+        </Value>
+        <Sparkline values={metrics.memoryBytes} relative />
+      </Segment>
+
+      <div className="flex-1" />
+
+      {reactScanAvailable ? (
+        <BarButton
+          title="Toggle the React Scan toolbar (inspector, slowdown notifications)"
+          onClick={() => {
+            setReactScanToolbarVisible(!toolbarVisible);
+            refresh();
+          }}
+        >
+          <Value className={cn([!toolbarVisible && "opacity-70"])}>
+            {toolbarVisible ? "◉" : "○"} react scan
+          </Value>
+        </BarButton>
+      ) : null}
+    </footer>
+  );
+}
+
+function useBuildInfo() {
+  return useQuery({
+    queryKey: ["devtools-bar", "build"],
+    staleTime: Infinity,
+    queryFn: async () => {
+      const [identifier, version, hash] = await Promise.all([
+        getIdentifier(),
+        getVersion(),
+        miscCommands.getGitHash(),
+      ]);
+
+      return {
+        channel: resolveBuildChannel(identifier),
+        version,
+        hash: hash.status === "ok" ? hash.data.slice(0, 7) : null,
+      };
+    },
+  }).data;
+}
+
+async function openDevtoolsPanel() {
+  const result = await windowsCommands.devtoolsPanelShow();
+  if (result.status === "error") {
+    console.error("Failed to show Devtools panel:", result.error);
+  }
+}
+
+function Segment({
+  children,
+  label,
+  title,
+}: {
+  children: React.ReactNode;
+  label: string;
+  title: string;
+}) {
+  return (
+    <div
+      title={title}
+      className="flex items-center gap-1.5 border-l border-white/15 px-2"
+    >
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function BarButton({
+  children,
+  onClick,
+  title,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  title: string;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className={cn([
+        "flex items-center gap-1.5 border-l border-white/15 px-2 first:border-l-0",
+        "hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-hidden",
+      ])}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return <span className="uppercase opacity-60">{children}</span>;
+}
+
+function Value({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <span className={cn(["tabular-nums", className])}>{children}</span>;
+}
+
+const SPARKLINE_WIDTH = 36;
+const SPARKLINE_HEIGHT = 10;
+
+/**
+ * `floor` pins the top of the chart to at least that value (e.g. 60 fps).
+ * `relative` scales between the window's min and max so slow drifts such as
+ * memory growth stay visible instead of flattening against zero.
+ */
+function Sparkline({
+  values,
+  floor = 1,
+  relative = false,
+}: {
+  values: number[];
+  floor?: number;
+  relative?: boolean;
+}) {
+  if (values.length < 2) {
+    return (
+      <svg
+        aria-hidden
+        width={SPARKLINE_WIDTH}
+        height={SPARKLINE_HEIGHT}
+        className="shrink-0"
+      />
+    );
+  }
+
+  const min = relative ? Math.min(...values) : 0;
+  const max = relative ? Math.max(...values) : Math.max(floor, ...values);
+  const range = max - min;
+  const step = SPARKLINE_WIDTH / (HISTORY_LENGTH - 1);
+  const offset = SPARKLINE_WIDTH - (values.length - 1) * step;
+  const points = values
+    .map((value, index) => {
+      const x = offset + index * step;
+      const ratio = range === 0 ? 0.5 : (value - min) / range;
+      const y = SPARKLINE_HEIGHT - 0.5 - ratio * (SPARKLINE_HEIGHT - 1);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      aria-hidden
+      width={SPARKLINE_WIDTH}
+      height={SPARKLINE_HEIGHT}
+      className="shrink-0 opacity-80"
+    >
+      <polyline
+        fill="none"
+        points={points}
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1"
+      />
+    </svg>
+  );
+}
+
+function last(values: number[]): number | undefined {
+  return values.length ? values[values.length - 1] : undefined;
+}
+
+function average(values: number[]): number {
+  if (!values.length) return 0;
+  return Math.round(
+    values.reduce((sum, value) => sum + value, 0) / values.length,
+  );
+}

--- a/apps/desktop/src/devtools-bar/index.tsx
+++ b/apps/desktop/src/devtools-bar/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getIdentifier, getVersion } from "@tauri-apps/api/app";
-import { useEffect, useReducer, useSyncExternalStore } from "react";
+import { useReducer, useSyncExternalStore } from "react";
 
 import { commands as miscCommands } from "@anlg/plugin-misc";
 import { commands as windowsCommands } from "@anlg/plugin-windows";
@@ -22,6 +22,7 @@ import {
   subscribeReactScanAvailability,
 } from "./react-scan";
 
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { commands } from "~/types/tauri.gen";
 
 export type BuildChannel = "dev" | "staging" | "stable";
@@ -63,7 +64,7 @@ export function DevtoolsStatusBar(props: Record<never, never>) {
 
 function DevtoolsStatusBarContent(props: Record<never, never>) {
   ignoreReactScan(props);
-  useEffect(() => startDevtoolsMetrics(), []);
+  useMountEffect(() => startDevtoolsMetrics());
 
   const metrics = useDevtoolsMetrics();
   const build = useBuildInfo();
@@ -73,7 +74,6 @@ function DevtoolsStatusBarContent(props: Record<never, never>) {
   );
   const [, refresh] = useReducer((tick: number) => tick + 1, 0);
 
-  const channel = build?.channel ?? "stable";
   const fps = last(metrics.fps);
   const invokes = last(metrics.invokes) ?? 0;
   const callbacks = last(metrics.callbacks) ?? 0;
@@ -81,6 +81,12 @@ function DevtoolsStatusBarContent(props: Record<never, never>) {
   const memoryBytes = last(metrics.memoryBytes);
   const outlinesEnabled = reactScanAvailable && areReactScanOutlinesEnabled();
   const toolbarVisible = reactScanAvailable && isReactScanToolbarVisible();
+
+  if (!build) {
+    return null;
+  }
+
+  const channel = build.channel;
 
   return (
     <footer
@@ -99,12 +105,10 @@ function DevtoolsStatusBarContent(props: Record<never, never>) {
         <span className="font-semibold tracking-wider uppercase">
           {channel}
         </span>
-        {build ? (
-          <span className="opacity-70">
-            {build.version}
-            {build.hash ? ` ${build.hash}` : ""}
-          </span>
-        ) : null}
+        <span className="opacity-70">
+          {build.version}
+          {build.hash ? ` ${build.hash}` : ""}
+        </span>
       </BarButton>
 
       <Segment

--- a/apps/desktop/src/devtools-bar/index.tsx
+++ b/apps/desktop/src/devtools-bar/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "./metrics";
 import {
   areReactScanOutlinesEnabled,
+  ignoreReactScan,
   isReactScanAvailable,
   isReactScanToolbarVisible,
   setReactScanOutlinesEnabled,
@@ -37,11 +38,16 @@ const CHANNEL_CLASSES: Record<BuildChannel, string> = {
   stable: "bg-neutral-800 text-neutral-100",
 };
 
+const LABEL_CLASS = "uppercase opacity-60";
+const VALUE_CLASS = "tabular-nums";
+
 /**
  * VS Code-style status bar for dev and staging builds. Stable builds never
  * render it (`show_devtool` is false there), so copy stays English-only.
  */
-export function DevtoolsStatusBar() {
+export function DevtoolsStatusBar(props: Record<never, never>) {
+  ignoreReactScan(props);
+
   const enabledQuery = useQuery({
     queryKey: ["devtools-panel", "enabled"],
     queryFn: commands.showDevtool,
@@ -55,7 +61,8 @@ export function DevtoolsStatusBar() {
   return <DevtoolsStatusBarContent />;
 }
 
-function DevtoolsStatusBarContent() {
+function DevtoolsStatusBarContent(props: Record<never, never>) {
+  ignoreReactScan(props);
   useEffect(() => startDevtoolsMetrics(), []);
 
   const metrics = useDevtoolsMetrics();
@@ -104,7 +111,7 @@ function DevtoolsStatusBarContent() {
         label="FPS"
         title={`Frames per second (avg ${average(metrics.fps)} over ${metrics.fps.length}s)`}
       >
-        <Value>{fps ?? "–"}</Value>
+        <span className={VALUE_CLASS}>{fps ?? "–"}</span>
         <Sparkline values={metrics.fps} floor={60} />
       </Segment>
 
@@ -112,9 +119,9 @@ function DevtoolsStatusBarContent() {
         label="IPC"
         title="Tauri IPC per second: ↑ invokes, ↓ callbacks (responses, events, channels)"
       >
-        <Value>
+        <span className={VALUE_CLASS}>
           ↑{invokes} ↓{callbacks}
-        </Value>
+        </span>
         <Sparkline
           values={metrics.invokes.map(
             (value, index) => value + (metrics.callbacks[index] ?? 0),
@@ -134,8 +141,10 @@ function DevtoolsStatusBarContent() {
             refresh();
           }}
         >
-          <Label>renders</Label>
-          <Value>{outlinesEnabled ? renders : "off"}</Value>
+          <span className={LABEL_CLASS}>renders</span>
+          <span className={VALUE_CLASS}>
+            {outlinesEnabled ? renders : "off"}
+          </span>
           <Sparkline values={metrics.renders} />
         </BarButton>
       ) : null}
@@ -144,9 +153,9 @@ function DevtoolsStatusBarContent() {
         label="MEM"
         title="Host process resident memory (WebKit content process is separate on macOS)"
       >
-        <Value>
+        <span className={VALUE_CLASS}>
           {memoryBytes === undefined ? "–" : formatBytes(memoryBytes)}
-        </Value>
+        </span>
         <Sparkline values={metrics.memoryBytes} relative />
       </Segment>
 
@@ -160,9 +169,9 @@ function DevtoolsStatusBarContent() {
             refresh();
           }}
         >
-          <Value className={cn([!toolbarVisible && "opacity-70"])}>
+          <span className={cn([VALUE_CLASS, !toolbarVisible && "opacity-70"])}>
             {toolbarVisible ? "◉" : "○"} react scan
-          </Value>
+          </span>
         </BarButton>
       ) : null}
     </footer>
@@ -196,62 +205,44 @@ async function openDevtoolsPanel() {
   }
 }
 
-function Segment({
-  children,
-  label,
-  title,
-}: {
+function Segment(props: {
   children: React.ReactNode;
   label: string;
   title: string;
 }) {
+  ignoreReactScan(props);
+
   return (
     <div
-      title={title}
+      title={props.title}
       className="flex items-center gap-1.5 border-l border-white/15 px-2"
     >
-      <Label>{label}</Label>
-      {children}
+      <span className={LABEL_CLASS}>{props.label}</span>
+      {props.children}
     </div>
   );
 }
 
-function BarButton({
-  children,
-  onClick,
-  title,
-}: {
+function BarButton(props: {
   children: React.ReactNode;
   onClick: () => void;
   title: string;
 }) {
+  ignoreReactScan(props);
+
   return (
     <button
       type="button"
-      title={title}
-      onClick={onClick}
+      title={props.title}
+      onClick={props.onClick}
       className={cn([
         "flex items-center gap-1.5 border-l border-white/15 px-2 first:border-l-0",
         "hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-hidden",
       ])}
     >
-      {children}
+      {props.children}
     </button>
   );
-}
-
-function Label({ children }: { children: React.ReactNode }) {
-  return <span className="uppercase opacity-60">{children}</span>;
-}
-
-function Value({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return <span className={cn(["tabular-nums", className])}>{children}</span>;
 }
 
 const SPARKLINE_WIDTH = 36;
@@ -262,15 +253,14 @@ const SPARKLINE_HEIGHT = 10;
  * `relative` scales between the window's min and max so slow drifts such as
  * memory growth stay visible instead of flattening against zero.
  */
-function Sparkline({
-  values,
-  floor = 1,
-  relative = false,
-}: {
+function Sparkline(props: {
   values: number[];
   floor?: number;
   relative?: boolean;
 }) {
+  ignoreReactScan(props);
+  const { values, floor = 1, relative = false } = props;
+
   if (values.length < 2) {
     return (
       <svg

--- a/apps/desktop/src/devtools-bar/metrics.test.ts
+++ b/apps/desktop/src/devtools-bar/metrics.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./react-scan", () => ({
+  drainReactScanRenders: vi.fn(() => 0),
+}));
+
+vi.mock("@anlg/plugin-misc", () => ({
+  commands: {
+    getProcessMemoryBytes: vi.fn(),
+  },
+}));
+
+import { commands as miscCommands } from "@anlg/plugin-misc";
+
+import {
+  formatBytes,
+  HISTORY_LENGTH,
+  installIpcCounters,
+  isTauriIpcUrl,
+  pushSample,
+  startDevtoolsMetrics,
+  useDevtoolsMetrics,
+} from "./metrics";
+
+const internals = () =>
+  (window as unknown as { __TAURI_INTERNALS__: Record<string, unknown> })
+    .__TAURI_INTERNALS__;
+
+describe("pushSample", () => {
+  it("appends and keeps only the most recent samples", () => {
+    const history = Array.from({ length: HISTORY_LENGTH }, (_, i) => i);
+
+    const next = pushSample(history, 99);
+
+    expect(next).toHaveLength(HISTORY_LENGTH);
+    expect(next[0]).toBe(1);
+    expect(next[next.length - 1]).toBe(99);
+    expect(history).toHaveLength(HISTORY_LENGTH);
+  });
+
+  it("grows until the limit is reached", () => {
+    expect(pushSample([], 1)).toEqual([1]);
+    expect(pushSample([1], 2)).toEqual([1, 2]);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats megabytes and gigabytes", () => {
+    expect(formatBytes(36 * 1024 ** 2)).toBe("36MB");
+    expect(formatBytes(1.5 * 1024 ** 3)).toBe("1.50GB");
+  });
+});
+
+describe("isTauriIpcUrl", () => {
+  it("matches the ipc scheme on every platform", () => {
+    expect(isTauriIpcUrl("ipc://localhost/plugin%3Amisc%7Cget_git_hash")).toBe(
+      true,
+    );
+    expect(isTauriIpcUrl("http://ipc.localhost/plugin%3Amisc")).toBe(true);
+    expect(isTauriIpcUrl("https://api.anarlog.so/v1")).toBe(false);
+  });
+});
+
+describe("installIpcCounters", () => {
+  let originalFetch: typeof fetch;
+  let callbacks: Map<number, (payload: unknown) => void>;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    window.fetch = vi.fn().mockResolvedValue(undefined) as typeof fetch;
+    callbacks = new Map();
+    internals().callbacks = callbacks;
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    delete internals().callbacks;
+  });
+
+  it("counts ipc invokes and delivered callbacks", () => {
+    const counters = installIpcCounters();
+
+    void fetch("ipc://localhost/plugin%3Amisc%7Cget_git_hash", {
+      method: "POST",
+    });
+    void fetch("https://api.anarlog.so/v1");
+    callbacks.set(1, () => {});
+    callbacks.get(1);
+    callbacks.get(2);
+
+    expect(counters.drain()).toEqual({ invokes: 1, callbacks: 2 });
+    expect(counters.drain()).toEqual({ invokes: 0, callbacks: 0 });
+
+    counters.restore();
+  });
+
+  it("ignores traffic issued inside ignoring()", () => {
+    const counters = installIpcCounters();
+
+    counters.ignoring(() => {
+      void fetch("ipc://localhost/plugin%3Amisc%7Cget_process_memory_bytes");
+      callbacks.set(10, () => {});
+      callbacks.set(11, () => {});
+    });
+    callbacks.get(10);
+    callbacks.delete(11);
+    callbacks.set(12, () => {});
+    callbacks.get(12);
+
+    expect(counters.drain()).toEqual({ invokes: 0, callbacks: 1 });
+
+    counters.restore();
+  });
+
+  it("restores the original fetch and map methods", () => {
+    const patchedFetch = window.fetch;
+    const counters = installIpcCounters();
+
+    expect(window.fetch).not.toBe(patchedFetch);
+    expect(Object.getOwnPropertyNames(callbacks)).toContain("get");
+
+    counters.restore();
+
+    expect(window.fetch).toBe(patchedFetch);
+    expect(Object.getOwnPropertyNames(callbacks)).not.toContain("get");
+  });
+});
+
+describe("startDevtoolsMetrics", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useDevtoolsMetrics.setState({
+      fps: [],
+      invokes: [],
+      callbacks: [],
+      renders: [],
+      memoryBytes: [],
+    });
+    vi.mocked(miscCommands.getProcessMemoryBytes).mockResolvedValue({
+      status: "ok",
+      data: 512 * 1024 ** 2,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("samples once per second and polls memory", async () => {
+    const stop = startDevtoolsMetrics();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const state = useDevtoolsMetrics.getState();
+    expect(state.fps).toHaveLength(2);
+    expect(state.invokes).toHaveLength(2);
+    expect(state.callbacks).toHaveLength(2);
+    expect(state.renders).toHaveLength(2);
+    expect(state.memoryBytes).toEqual([512 * 1024 ** 2, 512 * 1024 ** 2]);
+    expect(miscCommands.getProcessMemoryBytes).toHaveBeenCalledTimes(2);
+
+    stop();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(useDevtoolsMetrics.getState().fps).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/devtools-bar/metrics.ts
+++ b/apps/desktop/src/devtools-bar/metrics.ts
@@ -1,0 +1,209 @@
+import { create } from "zustand";
+
+import { commands as miscCommands } from "@anlg/plugin-misc";
+
+import { drainReactScanRenders } from "./react-scan";
+
+export const HISTORY_LENGTH = 30;
+const TICK_MS = 1000;
+const MEMORY_POLL_EVERY_TICKS = 2;
+
+export type DevtoolsMetrics = {
+  fps: number[];
+  invokes: number[];
+  callbacks: number[];
+  renders: number[];
+  memoryBytes: number[];
+};
+
+export const useDevtoolsMetrics = create<DevtoolsMetrics>(() => ({
+  fps: [],
+  invokes: [],
+  callbacks: [],
+  renders: [],
+  memoryBytes: [],
+}));
+
+export function pushSample(
+  history: number[],
+  value: number,
+  limit = HISTORY_LENGTH,
+): number[] {
+  const next = history.slice(Math.max(0, history.length - limit + 1));
+  next.push(value);
+  return next;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 ** 3) {
+    return `${(bytes / 1024 ** 3).toFixed(2)}GB`;
+  }
+  return `${Math.round(bytes / 1024 ** 2)}MB`;
+}
+
+export function isTauriIpcUrl(input: string): boolean {
+  return /^(?:ipc:\/\/localhost|https?:\/\/ipc\.localhost)\//.test(input);
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+type TauriCallbacks = Map<number, unknown>;
+
+function getTauriCallbacks(): TauriCallbacks | null {
+  const internals = (window as unknown as Record<string, unknown>)
+    .__TAURI_INTERNALS__ as { callbacks?: unknown } | undefined;
+  return internals?.callbacks instanceof Map
+    ? (internals.callbacks as TauriCallbacks)
+    : null;
+}
+
+/**
+ * Tauri freezes `__TAURI_INTERNALS__`, so IPC traffic is observed from the
+ * outside: invokes go through `fetch` against the `ipc` scheme, and every
+ * Rust→JS delivery (invoke responses, events, channel messages) resolves its
+ * callback via `callbacks.get`, which is a plain Map we can shadow.
+ *
+ * Calls made while `ignoring()` runs are excluded so the bar's own memory
+ * polling does not show up as traffic.
+ */
+export function installIpcCounters() {
+  const counters = { invokes: 0, callbacks: 0 };
+  const ignoredIds = new Set<number>();
+  let ignoreDepth = 0;
+  const cleanups: Array<() => void> = [];
+
+  const originalFetch = window.fetch;
+  if (typeof originalFetch === "function") {
+    window.fetch = function countingFetch(
+      this: unknown,
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) {
+      if (ignoreDepth === 0 && isTauriIpcUrl(requestUrl(input))) {
+        counters.invokes += 1;
+      }
+      return originalFetch.call(this, input, init);
+    } as typeof fetch;
+    cleanups.push(() => {
+      window.fetch = originalFetch;
+    });
+  }
+
+  const callbacks = getTauriCallbacks();
+  if (callbacks) {
+    Object.defineProperty(callbacks, "set", {
+      configurable: true,
+      value(this: TauriCallbacks, id: number, callback: unknown) {
+        if (ignoreDepth > 0) {
+          ignoredIds.add(id);
+        }
+        return Map.prototype.set.call(this, id, callback);
+      },
+    });
+    Object.defineProperty(callbacks, "get", {
+      configurable: true,
+      value(this: TauriCallbacks, id: number) {
+        if (!ignoredIds.delete(id)) {
+          counters.callbacks += 1;
+        }
+        return Map.prototype.get.call(this, id);
+      },
+    });
+    Object.defineProperty(callbacks, "delete", {
+      configurable: true,
+      value(this: TauriCallbacks, id: number) {
+        ignoredIds.delete(id);
+        return Map.prototype.delete.call(this, id);
+      },
+    });
+    cleanups.push(() => {
+      delete (callbacks as Partial<TauriCallbacks>).set;
+      delete (callbacks as Partial<TauriCallbacks>).get;
+      delete (callbacks as Partial<TauriCallbacks>).delete;
+    });
+  }
+
+  return {
+    drain() {
+      const snapshot = { ...counters };
+      counters.invokes = 0;
+      counters.callbacks = 0;
+      return snapshot;
+    },
+    ignoring<T>(run: () => T): T {
+      ignoreDepth += 1;
+      try {
+        return run();
+      } finally {
+        ignoreDepth -= 1;
+      }
+    },
+    restore() {
+      cleanups.forEach((cleanup) => cleanup());
+    },
+  };
+}
+
+export function startDevtoolsMetrics(): () => void {
+  const ipc = installIpcCounters();
+  let frames = 0;
+  let frameHandle: number | null = null;
+  if (typeof requestAnimationFrame === "function") {
+    frameHandle = requestAnimationFrame(function countFrame() {
+      frames += 1;
+      frameHandle = requestAnimationFrame(countFrame);
+    });
+  }
+  let lastTick = performance.now();
+  let ticks = 0;
+  let stopped = false;
+
+  const sampleMemory = () => {
+    void ipc
+      .ignoring(() => miscCommands.getProcessMemoryBytes())
+      .then((result) => {
+        if (stopped || result.status !== "ok") return;
+        useDevtoolsMetrics.setState((state) => ({
+          memoryBytes: pushSample(state.memoryBytes, result.data),
+        }));
+      })
+      .catch(() => {});
+  };
+
+  const interval = setInterval(() => {
+    const now = performance.now();
+    const elapsedSeconds = Math.max((now - lastTick) / 1000, 0.001);
+    lastTick = now;
+    const fps = Math.round(frames / elapsedSeconds);
+    frames = 0;
+    const traffic = ipc.drain();
+    const renders = drainReactScanRenders();
+
+    useDevtoolsMetrics.setState((state) => ({
+      fps: pushSample(state.fps, fps),
+      invokes: pushSample(state.invokes, traffic.invokes),
+      callbacks: pushSample(state.callbacks, traffic.callbacks),
+      renders: pushSample(state.renders, renders),
+    }));
+
+    ticks += 1;
+    if (ticks % MEMORY_POLL_EVERY_TICKS === 0) {
+      sampleMemory();
+    }
+  }, TICK_MS);
+
+  sampleMemory();
+
+  return () => {
+    stopped = true;
+    clearInterval(interval);
+    if (frameHandle !== null) {
+      cancelAnimationFrame(frameHandle);
+    }
+    ipc.restore();
+  };
+}

--- a/apps/desktop/src/devtools-bar/react-scan.ts
+++ b/apps/desktop/src/devtools-bar/react-scan.ts
@@ -48,6 +48,15 @@ export function drainReactScanRenders(): number {
   return renders;
 }
 
+/**
+ * Call with a component's props object during render to keep that component
+ * out of React Scan outlines and render counts. The bar re-renders every
+ * second, so without this it would outline and count itself.
+ */
+export function ignoreReactScan(props: object): void {
+  reactScan?.ignoredProps.add(props);
+}
+
 export function areReactScanOutlinesEnabled(): boolean {
   const instrumentation = reactScan?.ReactScanInternals.instrumentation;
   return instrumentation ? !instrumentation.isPaused.value : false;

--- a/apps/desktop/src/devtools-bar/react-scan.ts
+++ b/apps/desktop/src/devtools-bar/react-scan.ts
@@ -1,0 +1,71 @@
+type ReactScanModule = typeof import("react-scan");
+
+let reactScan: ReactScanModule | null = null;
+let pendingRenders = 0;
+const availabilityListeners = new Set<() => void>();
+
+/**
+ * React Scan piggybacks on the devtools hook that React Refresh installs, so it
+ * only works under the Vite dev server. Production bundles (staging included)
+ * evaluate React before any hook exists, and React Scan cannot attach late.
+ */
+export async function startReactScanInDev(): Promise<void> {
+  if (!import.meta.env.DEV || reactScan) {
+    return;
+  }
+
+  try {
+    const module = await import("react-scan");
+    module.scan({
+      enabled: true,
+      showToolbar: false,
+      onRender: (_fiber, renders) => {
+        pendingRenders += renders.length;
+      },
+    });
+    reactScan = module;
+    availabilityListeners.forEach((listener) => listener());
+  } catch (error) {
+    console.warn("Failed to start React Scan:", error);
+  }
+}
+
+export function isReactScanAvailable(): boolean {
+  return reactScan !== null;
+}
+
+export function subscribeReactScanAvailability(listener: () => void) {
+  availabilityListeners.add(listener);
+  return () => {
+    availabilityListeners.delete(listener);
+  };
+}
+
+/** Returns renders observed since the previous call and resets the counter. */
+export function drainReactScanRenders(): number {
+  const renders = pendingRenders;
+  pendingRenders = 0;
+  return renders;
+}
+
+export function areReactScanOutlinesEnabled(): boolean {
+  const instrumentation = reactScan?.ReactScanInternals.instrumentation;
+  return instrumentation ? !instrumentation.isPaused.value : false;
+}
+
+// React Scan skips its onRender hook entirely while outlines are paused, so
+// the render counter only advances when outlines are on.
+export function setReactScanOutlinesEnabled(enabled: boolean): void {
+  const instrumentation = reactScan?.ReactScanInternals.instrumentation;
+  if (instrumentation) {
+    instrumentation.isPaused.value = !enabled;
+  }
+}
+
+export function isReactScanToolbarVisible(): boolean {
+  return reactScan?.getOptions().value.showToolbar === true;
+}
+
+export function setReactScanToolbarVisible(visible: boolean): void {
+  reactScan?.setOptions({ showToolbar: visible });
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -17,6 +17,7 @@ import { Toaster } from "@anlg/ui/components/ui/toast";
 import { AITaskWindowSyncBridge } from "./ai/task-window-sync";
 import { trackAnalyticsEvent } from "./analytics";
 import { createToolRegistry } from "./contexts/tool-registry/core";
+import { startReactScanInDev } from "./devtools-bar/react-scan";
 import {
   captureOperationalError,
   initializeErrorReporting,
@@ -156,25 +157,19 @@ if (isMainWindow) {
 
 const rootElement = document.getElementById("root")!;
 
-async function enableReactScanInDev() {
+async function enableDevInstrumentation() {
   if (!import.meta.env.DEV) {
     return;
   }
 
-  try {
-    const { scan } = await import("react-scan");
-    scan({ enabled: true });
-  } catch (error) {
-    console.warn("Failed to start React Scan:", error);
-  }
-
+  await startReactScanInDev();
   startInteractionProfiler();
 }
 
 async function renderApp() {
   await Promise.all([
     bootstrapThemeFromSettings(),
-    enableReactScanInDev(),
+    enableDevInstrumentation(),
     initializeAppStoreBuild(),
   ]);
   const root = ReactDOM.createRoot(rootElement);

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -54,6 +54,10 @@ vi.mock("~/contexts/shell", () => ({
   }),
 }));
 
+vi.mock("~/devtools-bar", () => ({
+  DevtoolsStatusBar: () => <div data-testid="devtools-status-bar" />,
+}));
+
 vi.mock("~/sidebar/toast", () => ({
   ToastNotifications: () => <div data-testid="toast-notifications" />,
 }));
@@ -99,6 +103,18 @@ describe("ClassicMainShellFrame", () => {
 
     expect(screen.queryByTestId("windows-title-bar")).toBeNull();
     expect(screen.getByTestId("main-shell-scaffold")).toBeTruthy();
+  });
+
+  it("places the devtools status bar below the shell", () => {
+    render(<ClassicMainShellFrame />);
+
+    const scaffold = screen.getByTestId("main-shell-scaffold");
+    const statusBar = screen.getByTestId("devtools-status-bar");
+
+    expect(scaffold.compareDocumentPosition(statusBar)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(statusBar.parentElement?.className).toContain("flex-col");
   });
 
   it("uses left-edge main surface chrome while the sidebar timeline is expanded", () => {

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -5,6 +5,7 @@ import { resolveMainSurfaceChrome } from "./main-surface-chrome";
 import { WindowsTitleBar } from "./windows-title-bar";
 
 import { useShell } from "~/contexts/shell";
+import { DevtoolsStatusBar } from "~/devtools-bar";
 import { usesWindowsStyleTitleBar } from "~/shared/hooks/useWindowControlsGutter";
 import { MainShellBodyFrame, MainShellScaffold } from "~/shared/main";
 import { ToastNotifications } from "~/sidebar/toast";
@@ -45,14 +46,11 @@ export function ClassicMainShellFrame() {
     </MainShellScaffold>
   );
 
-  if (!usesWindowsStyleTitleBar()) {
-    return shell;
-  }
-
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
-      <WindowsTitleBar />
+      {usesWindowsStyleTitleBar() ? <WindowsTitleBar /> : null}
       <div className="min-h-0 flex-1">{shell}</div>
+      <DevtoolsStatusBar />
     </div>
   );
 }

--- a/plugins/misc/build.rs
+++ b/plugins/misc/build.rs
@@ -2,6 +2,7 @@ const COMMANDS: &[&str] = &[
     "get_git_hash",
     "get_fingerprint",
     "get_device_info",
+    "get_process_memory_bytes",
     "opinionated_md_to_html",
     "delete_session_folder",
     "audio_open",

--- a/plugins/misc/js/bindings.gen.ts
+++ b/plugins/misc/js/bindings.gen.ts
@@ -30,6 +30,14 @@ async getDeviceInfo(locale: string | null) : Promise<Result<DeviceInfo, string>>
     else return { status: "error", error: e  as any };
 }
 },
+async getProcessMemoryBytes() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:misc|get_process_memory_bytes") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async opinionatedMdToHtml(text: string) : Promise<Result<string, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:misc|opinionated_md_to_html", { text }) };

--- a/plugins/misc/permissions/autogenerated/commands/get_process_memory_bytes.toml
+++ b/plugins/misc/permissions/autogenerated/commands/get_process_memory_bytes.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-process-memory-bytes"
+description = "Enables the get_process_memory_bytes command without any pre-configured scope."
+commands.allow = ["get_process_memory_bytes"]
+
+[[permission]]
+identifier = "deny-get-process-memory-bytes"
+description = "Denies the get_process_memory_bytes command without any pre-configured scope."
+commands.deny = ["get_process_memory_bytes"]

--- a/plugins/misc/permissions/autogenerated/reference.md
+++ b/plugins/misc/permissions/autogenerated/reference.md
@@ -7,6 +7,7 @@ Default permissions for the plugin
 - `allow-get-git-hash`
 - `allow-get-fingerprint`
 - `allow-get-device-info`
+- `allow-get-process-memory-bytes`
 - `allow-opinionated-md-to-html`
 
 ## Permission Table
@@ -248,6 +249,32 @@ Enables the get_git_hash command without any pre-configured scope.
 <td>
 
 Denies the get_git_hash command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`misc:allow-get-process-memory-bytes`
+
+</td>
+<td>
+
+Enables the get_process_memory_bytes command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`misc:deny-get-process-memory-bytes`
+
+</td>
+<td>
+
+Denies the get_process_memory_bytes command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/misc/permissions/default.toml
+++ b/plugins/misc/permissions/default.toml
@@ -4,5 +4,6 @@ permissions = [
     "allow-get-git-hash",
     "allow-get-fingerprint",
     "allow-get-device-info",
+    "allow-get-process-memory-bytes",
     "allow-opinionated-md-to-html",
 ]

--- a/plugins/misc/permissions/schemas/schema.json
+++ b/plugins/misc/permissions/schemas/schema.json
@@ -403,6 +403,18 @@
           "markdownDescription": "Denies the get_git_hash command without any pre-configured scope."
         },
         {
+          "description": "Enables the get_process_memory_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-process-memory-bytes",
+          "markdownDescription": "Enables the get_process_memory_bytes command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_process_memory_bytes command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-process-memory-bytes",
+          "markdownDescription": "Denies the get_process_memory_bytes command without any pre-configured scope."
+        },
+        {
           "description": "Enables the opinionated_md_to_html command without any pre-configured scope.",
           "type": "string",
           "const": "allow-opinionated-md-to-html",
@@ -427,10 +439,10 @@
           "markdownDescription": "Denies the reveal_session_in_finder command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-git-hash`\n- `allow-get-fingerprint`\n- `allow-get-device-info`\n- `allow-opinionated-md-to-html`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-git-hash`\n- `allow-get-fingerprint`\n- `allow-get-device-info`\n- `allow-get-process-memory-bytes`\n- `allow-opinionated-md-to-html`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-git-hash`\n- `allow-get-fingerprint`\n- `allow-get-device-info`\n- `allow-opinionated-md-to-html`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-get-git-hash`\n- `allow-get-fingerprint`\n- `allow-get-device-info`\n- `allow-get-process-memory-bytes`\n- `allow-opinionated-md-to-html`"
         }
       ]
     }

--- a/plugins/misc/src/commands.rs
+++ b/plugins/misc/src/commands.rs
@@ -25,6 +25,14 @@ pub async fn get_device_info<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn get_process_memory_bytes<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+) -> Result<u64, String> {
+    app.misc().get_process_memory_bytes()
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn opinionated_md_to_html<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     text: String,

--- a/plugins/misc/src/ext.rs
+++ b/plugins/misc/src/ext.rs
@@ -42,6 +42,23 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Misc<'a, R, M> {
         }
     }
 
+    /// Resident set size of the host process. WebKit renders in a separate
+    /// process on macOS, so this reflects the Rust side, not the JS heap.
+    pub fn get_process_memory_bytes(&self) -> Result<u64, String> {
+        let pid = sysinfo::get_current_pid()?;
+        let mut system = sysinfo::System::new();
+        system.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[pid]),
+            false,
+            sysinfo::ProcessRefreshKind::nothing().with_memory(),
+        );
+
+        system
+            .process(pid)
+            .map(|process| process.memory())
+            .ok_or_else(|| "current process not found".to_string())
+    }
+
     pub fn opinionated_md_to_html(&self, text: impl AsRef<str>) -> Result<String, String> {
         anlg_buffer::opinionated_md_to_html(text.as_ref()).map_err(|e| e.to_string())
     }

--- a/plugins/misc/src/lib.rs
+++ b/plugins/misc/src/lib.rs
@@ -12,6 +12,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::get_git_hash::<tauri::Wry>,
             commands::get_fingerprint::<tauri::Wry>,
             commands::get_device_info::<tauri::Wry>,
+            commands::get_process_memory_bytes::<tauri::Wry>,
             commands::opinionated_md_to_html::<tauri::Wry>,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Dev and staging builds have no at-a-glance runtime signal in the window itself. Checking which build you are on, whether the UI is dropping frames, how chatty the frontend is with the Rust side, or whether memory is drifting means opening Web Inspector or the separate Devtools panel window. React Scan runs in dev, but as its own floating toolbar that is disconnected from the rest of the app chrome.

**Fix:** Mount a slim, Linear/VS Code-style status bar at the bottom of the main window whenever `show_devtool` is true (debug builds, `dev`/`devtools` features, and the `com.hyprnote.staging` bundle). Stable builds render nothing and the layout wrapper is the same one the Windows title bar already used. Segments, left to right:

- **Channel badge** — `DEV` / `STAGING` with version and short git hash; whole bar is tinted per channel (blue = dev, amber = staging). Clicking it opens the existing Devtools panel window (macOS-only, same as the Settings → Developers button).
- **FPS** — rAF-based, with a 30s sparkline pinned to 60.
- **IPC** — Tauri traffic per second: `↑` invokes, `↓` callbacks (invoke responses, events, channel messages). Tauri freezes `__TAURI_INTERNALS__`, so this is observed from the outside: invokes are `fetch` calls to the `ipc` scheme, deliveries go through the exposed `callbacks` Map whose `get` we shadow. The bar's own memory poll is excluded.
- **RENDERS** (Vite dev only) — React Scan component renders per second; click toggles re-render outlines. The bar's own components are marked ignored so it does not outline or count itself.
- **MEM** — host process RSS via a new `misc` plugin command `get_process_memory_bytes` (sysinfo); sparkline is min/max scaled so slow growth is visible.
- **react scan** (Vite dev only) — toggles React Scan's own toolbar (inspector, slowdown notifications). The toolbar is now hidden by default since FPS and renders live in the bar.

[Developer status bar in the running dev build](https://cursor.com/agents/bc-35556e70-70c2-4288-81b3-f13214999f71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdev-status-bar-full.png)

[Zoomed status bar: DEV 0.0.0 7df7853, FPS 62, IPC, RENDERS 0, MEM 313MB](https://cursor.com/agents/bc-35556e70-70c2-4288-81b3-f13214999f71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdev-status-bar-crop.png)

React Scan bootstrapping moved out of `main.tsx` into `devtools-bar/react-scan.ts`. Note that React Scan only attaches in Vite dev because it relies on the devtools hook React Refresh installs before React evaluates; staging (production bundle) shows the bar without the React Scan segments. Enabling it there would need `react-scan/install-hook` loaded ahead of React behind a build-time channel flag, which is left as a follow-up.

Copy is English-only on purpose: the bar never ships in stable, so it is kept out of the Lingui catalogs.

## Verification

- `pnpm -F desktop typecheck`, `pnpm -F @anlg/plugin-misc typecheck`
- `pnpm -F desktop test` — 430 files / 3692 tests pass, including new `devtools-bar/metrics.test.ts` and `devtools-bar/index.test.tsx`, and an updated `main/shell-frame.test.tsx`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` — 0 errors
- `pnpm -F desktop i18n:check` — no catalog diff
- `pnpm exec dprint fmt` / `dprint check` on changed files
- `cargo test -p tauri-plugin-misc` (regenerates `bindings.gen.ts` and autogenerated permissions, committed) and `cargo clippy -p tauri-plugin-misc --tests -- -D warnings`
- Manual: ran `turbo dev:desktop` on Linux (WebKitGTK), skipped onboarding, confirmed the bar renders in the main shell, FPS/IPC/MEM update every second, RENDERS toggles to `off` and back, the `react scan` button mounts/unmounts React Scan's toolbar, and the bar no longer outlines itself while idle (RENDERS stays at 0).
- Not run locally: `cargo check -p desktop --features direct-distribution|app-store` (the dev build compiled and ran; only the `misc` plugin's internal surface changed and `init()` is unchanged).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35556e70-70c2-4288-81b3-f13214999f71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35556e70-70c2-4288-81b3-f13214999f71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

