### PR TITLE
Fix recording startup configuration

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -21,6 +21,7 @@
     "core:window:allow-is-maximized",
     "core:window:allow-toggle-maximize",
     "core:window:allow-set-theme",
+    "core:window:allow-request-user-attention",
     "calendar:default",
     "audio-priority:default",
     "auth:default",

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -100,12 +100,14 @@ describe("SQLite AI providers", () => {
       wrapper,
     });
 
+    expect(result.current.isLoading).toBe(true);
     expect(result.current.isReady).toBe(false);
 
     await waitFor(() => expect(mocks.getSecret).toHaveBeenCalledTimes(1));
     resolveSecret({ status: "ok", data: "deepgram-key" });
 
     await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.providers["stt:deepgram"]?.api_key).toBe(
       "deepgram-key",
     );

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -30,9 +30,10 @@ export function useAiProviders(
 
 export function useAiProvidersState(type: AiProviderType): {
   providers: Record<string, AiProviderConfig>;
+  isLoading: boolean;
   isReady: boolean;
 } {
-  const { data: rows = EMPTY_ROWS, isLoading } = useLiveQuery<
+  const { data: rows = EMPTY_ROWS, isLoading: rowsLoading } = useLiveQuery<
     AppSettingRow,
     AppSettingRow[]
   >({
@@ -44,7 +45,7 @@ export function useAiProvidersState(type: AiProviderType): {
   const secureApiKeysQuery = useQuery({
     queryKey: ["ai-provider-api-keys", type, providerIds],
     queryFn: () => loadSecureAiProviderApiKeys(providerIds, type),
-    enabled: !isLoading,
+    enabled: !rowsLoading,
     staleTime: Infinity,
   });
   const secureApiKeys = secureApiKeysQuery.data ?? EMPTY_PROVIDER_API_KEYS;
@@ -59,7 +60,8 @@ export function useAiProvidersState(type: AiProviderType): {
         },
       ]),
     ),
-    isReady: !isLoading && secureApiKeysQuery.data !== undefined,
+    isLoading: rowsLoading || secureApiKeysQuery.isPending,
+    isReady: !rowsLoading && secureApiKeysQuery.data !== undefined,
   };
 }
 

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -164,7 +164,11 @@ export function useCaptureLifecycle(sessionId: string) {
     useConfigValue("audio_retention"),
   );
   const rememberSpeakers = useConfigValue("remember_speakers") === true;
-  const { conn, localBatchDiarizationAvailable } = useSTTConnection();
+  const {
+    conn,
+    isReady: connectionReady,
+    localBatchDiarizationAvailable,
+  } = useSTTConnection();
   const runBatch = useRunBatch(sessionId);
   const setBatchTranscriptionPending = useListener(
     (state) => state.setBatchTranscriptionPending,
@@ -829,6 +833,7 @@ export function useCaptureLifecycle(sessionId: string) {
 
   return {
     conn,
+    connectionReady,
     createCaptureLifecycle,
     session,
     setStopMeetingChatCapture,

--- a/apps/desktop/src/stt/scheduled-session-auto-start.test.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   canStart: true,
   finishScheduledAutoStart: vi.fn(),
   openUrl: vi.fn(),
+  providerConfigLoading: false,
   session: {
     id: "session-1",
     user_id: "user-1",
@@ -66,6 +67,14 @@ vi.mock("~/session/queries", () => ({
   useSession: () => mocks.session,
 }));
 
+vi.mock("~/settings/providers", () => ({
+  useAiProvidersState: () => ({
+    isLoading: mocks.providerConfigLoading,
+    isReady: !mocks.providerConfigLoading,
+    providers: {},
+  }),
+}));
+
 vi.mock("~/stt/scheduled-auto-start-state", async () => {
   const actual = await vi.importActual<
     typeof import("./scheduled-auto-start-state")
@@ -101,6 +110,7 @@ beforeEach(() => {
   mocks.beginScheduledAutoStart.mockReset();
   mocks.finishScheduledAutoStart.mockReset();
   mocks.openUrl.mockReset();
+  mocks.providerConfigLoading = false;
   mocks.startListening.mockReset().mockResolvedValue(undefined);
   mocks.updateSessionTabState.mockReset();
   takeScheduledAutoJoin("session-1");
@@ -169,6 +179,18 @@ test("starts when the session record becomes available", () => {
     raw_template_id: "",
     locked: false,
   };
+  view.rerender(<ScheduledSessionAutoStart sessionId="session-1" />);
+
+  expect(mocks.startListening).toHaveBeenCalledTimes(1);
+});
+
+test("waits for secure provider credentials before auto-starting", () => {
+  mocks.providerConfigLoading = true;
+  const view = render(<ScheduledSessionAutoStart sessionId="session-1" />);
+
+  expect(mocks.startListening).not.toHaveBeenCalled();
+
+  mocks.providerConfigLoading = false;
   view.rerender(<ScheduledSessionAutoStart sessionId="session-1" />);
 
   expect(mocks.startListening).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/stt/scheduled-session-auto-start.test.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   canStart: true,
   finishScheduledAutoStart: vi.fn(),
   openUrl: vi.fn(),
-  providerConfigLoading: false,
+  connectionReady: true,
   session: {
     id: "session-1",
     user_id: "user-1",
@@ -67,14 +67,6 @@ vi.mock("~/session/queries", () => ({
   useSession: () => mocks.session,
 }));
 
-vi.mock("~/settings/providers", () => ({
-  useAiProvidersState: () => ({
-    isLoading: mocks.providerConfigLoading,
-    isReady: !mocks.providerConfigLoading,
-    providers: {},
-  }),
-}));
-
 vi.mock("~/stt/scheduled-auto-start-state", async () => {
   const actual = await vi.importActual<
     typeof import("./scheduled-auto-start-state")
@@ -87,7 +79,10 @@ vi.mock("~/stt/scheduled-auto-start-state", async () => {
 });
 
 vi.mock("~/stt/useStartListening", () => ({
-  useStartListening: () => mocks.startListening,
+  useStartListeningState: () => ({
+    connectionReady: mocks.connectionReady,
+    startListening: mocks.startListening,
+  }),
 }));
 
 vi.mock("@anlg/plugin-opener2", () => ({
@@ -110,7 +105,7 @@ beforeEach(() => {
   mocks.beginScheduledAutoStart.mockReset();
   mocks.finishScheduledAutoStart.mockReset();
   mocks.openUrl.mockReset();
-  mocks.providerConfigLoading = false;
+  mocks.connectionReady = true;
   mocks.startListening.mockReset().mockResolvedValue(undefined);
   mocks.updateSessionTabState.mockReset();
   takeScheduledAutoJoin("session-1");
@@ -121,7 +116,7 @@ afterEach(() => {
   cleanup();
 });
 
-test("starts scheduled recording without waiting for transcription", async () => {
+test("starts scheduled recording when its connection state is ready", async () => {
   render(<ScheduledSessionAutoStart sessionId="session-1" />);
 
   expect(mocks.startListening).toHaveBeenCalledTimes(1);
@@ -184,16 +179,34 @@ test("starts when the session record becomes available", () => {
   expect(mocks.startListening).toHaveBeenCalledTimes(1);
 });
 
-test("waits for secure provider credentials before auto-starting", () => {
-  mocks.providerConfigLoading = true;
+test("waits for the recording hook's connection before auto-starting", () => {
+  mocks.connectionReady = false;
   const view = render(<ScheduledSessionAutoStart sessionId="session-1" />);
 
   expect(mocks.startListening).not.toHaveBeenCalled();
 
-  mocks.providerConfigLoading = false;
+  mocks.connectionReady = true;
   view.rerender(<ScheduledSessionAutoStart sessionId="session-1" />);
 
   expect(mocks.startListening).toHaveBeenCalledTimes(1);
+});
+
+test("abandons when the recording connection never becomes ready", async () => {
+  vi.useFakeTimers();
+  mocks.connectionReady = false;
+
+  try {
+    render(<ScheduledSessionAutoStart sessionId="session-1" />);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(mocks.startListening).not.toHaveBeenCalled();
+    expect(mocks.updateSessionTabState).toHaveBeenCalledWith(tab, {
+      view: null,
+      autoStart: null,
+    });
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("abandons a scheduled start that never becomes ready", async () => {

--- a/apps/desktop/src/stt/scheduled-session-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.tsx
@@ -5,6 +5,7 @@ import { commands as openerCommands } from "@anlg/plugin-opener2";
 import { isLockedFlag } from "~/lock/flag";
 import { useAppLock } from "~/lock/store";
 import { useSession } from "~/session/queries";
+import { useAiProvidersState } from "~/settings/providers";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
@@ -25,6 +26,7 @@ export function ScheduledSessionAutoStart({
     state.canStartLiveSession(sessionId),
   );
   const session = useSession(sessionId);
+  const { isLoading: providerConfigLoading } = useAiProvidersState("stt");
   const revealed = useAppLock((state) =>
     Boolean(state.revealedNoteIds[sessionId]),
   );
@@ -34,7 +36,7 @@ export function ScheduledSessionAutoStart({
     return <AbandonedScheduledSessionAutoStart sessionId={sessionId} />;
   }
 
-  return canStartLiveSession && session ? (
+  return canStartLiveSession && session && !providerConfigLoading ? (
     <ReadyScheduledSessionAutoStart sessionId={sessionId} />
   ) : (
     <PendingScheduledSessionAutoStart sessionId={sessionId} />

--- a/apps/desktop/src/stt/scheduled-session-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 
@@ -68,11 +68,35 @@ function PendingScheduledSessionAutoStart({
 
 function ReadyScheduledSessionAutoStart({ sessionId }: { sessionId: string }) {
   const { connectionReady, startListening } = useStartListeningState(sessionId);
-  const startListeningRef = useLatestRef(startListening);
   const attemptedRef = useRef(false);
 
-  useEffect(() => {
-    if (!connectionReady || attemptedRef.current) {
+  useMountEffect(() => {
+    const timeout = setTimeout(() => clearPendingAutoStart(sessionId), 30_000);
+    return () => clearTimeout(timeout);
+  });
+
+  return connectionReady ? (
+    <StartScheduledSessionAutoStart
+      attemptedRef={attemptedRef}
+      sessionId={sessionId}
+      startListening={startListening}
+    />
+  ) : null;
+}
+
+function StartScheduledSessionAutoStart({
+  attemptedRef,
+  sessionId,
+  startListening,
+}: {
+  attemptedRef: { current: boolean };
+  sessionId: string;
+  startListening: () => Promise<void>;
+}) {
+  const startListeningRef = useLatestRef(startListening);
+
+  useMountEffect(() => {
+    if (attemptedRef.current) {
       return;
     }
     attemptedRef.current = true;
@@ -94,11 +118,6 @@ function ReadyScheduledSessionAutoStart({ sessionId }: { sessionId: string }) {
       .finally(() => {
         finishScheduledAutoStart(sessionId);
       });
-  }, [connectionReady, sessionId, startListeningRef]);
-
-  useMountEffect(() => {
-    const timeout = setTimeout(() => clearPendingAutoStart(sessionId), 30_000);
-    return () => clearTimeout(timeout);
   });
 
   return null;

--- a/apps/desktop/src/stt/scheduled-session-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.tsx
@@ -1,11 +1,10 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import { commands as openerCommands } from "@anlg/plugin-opener2";
 
 import { isLockedFlag } from "~/lock/flag";
 import { useAppLock } from "~/lock/store";
 import { useSession } from "~/session/queries";
-import { useAiProvidersState } from "~/settings/providers";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
@@ -15,7 +14,7 @@ import {
   finishScheduledAutoStart,
   takeScheduledAutoJoin,
 } from "~/stt/scheduled-auto-start-state";
-import { useStartListening } from "~/stt/useStartListening";
+import { useStartListeningState } from "~/stt/useStartListening";
 
 export function ScheduledSessionAutoStart({
   sessionId,
@@ -26,7 +25,6 @@ export function ScheduledSessionAutoStart({
     state.canStartLiveSession(sessionId),
   );
   const session = useSession(sessionId);
-  const { isLoading: providerConfigLoading } = useAiProvidersState("stt");
   const revealed = useAppLock((state) =>
     Boolean(state.revealedNoteIds[sessionId]),
   );
@@ -36,7 +34,7 @@ export function ScheduledSessionAutoStart({
     return <AbandonedScheduledSessionAutoStart sessionId={sessionId} />;
   }
 
-  return canStartLiveSession && session && !providerConfigLoading ? (
+  return canStartLiveSession && session ? (
     <ReadyScheduledSessionAutoStart sessionId={sessionId} />
   ) : (
     <PendingScheduledSessionAutoStart sessionId={sessionId} />
@@ -69,12 +67,12 @@ function PendingScheduledSessionAutoStart({
 }
 
 function ReadyScheduledSessionAutoStart({ sessionId }: { sessionId: string }) {
-  const startListening = useStartListening(sessionId);
+  const { connectionReady, startListening } = useStartListeningState(sessionId);
   const startListeningRef = useLatestRef(startListening);
   const attemptedRef = useRef(false);
 
-  useMountEffect(() => {
-    if (attemptedRef.current) {
+  useEffect(() => {
+    if (!connectionReady || attemptedRef.current) {
       return;
     }
     attemptedRef.current = true;
@@ -96,6 +94,11 @@ function ReadyScheduledSessionAutoStart({ sessionId }: { sessionId: string }) {
       .finally(() => {
         finishScheduledAutoStart(sessionId);
       });
+  }, [connectionReady, sessionId, startListeningRef]);
+
+  useMountEffect(() => {
+    const timeout = setTimeout(() => clearPendingAutoStart(sessionId), 30_000);
+    return () => clearTimeout(timeout);
   });
 
   return null;

--- a/apps/desktop/src/stt/useSTTConnection.test.ts
+++ b/apps/desktop/src/stt/useSTTConnection.test.ts
@@ -3,11 +3,15 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { config, startServerForPathMock } = vi.hoisted(() => ({
+const { config, readiness, startServerForPathMock } = vi.hoisted(() => ({
   config: {
     current_stt_provider: "anarlog",
     current_stt_model: "cloud",
     local_stt_model_path: "",
+  },
+  readiness: {
+    provider: true,
+    settings: true,
   },
   startServerForPathMock: vi.fn(),
 }));
@@ -33,11 +37,25 @@ vi.mock("~/env", () => ({
 }));
 
 vi.mock("~/settings/providers", () => ({
-  useAiProvider: () => ({
-    type: "stt",
-    base_url: "   ",
-    api_key: "test-key",
+  useAiProvidersState: () => ({
+    isReady: readiness.provider,
+    providers: {
+      "stt:anarlog": {
+        type: "stt",
+        base_url: "   ",
+        api_key: "test-key",
+      },
+      "stt:deepgram": {
+        type: "stt",
+        base_url: "   ",
+        api_key: "test-key",
+      },
+    },
   }),
+}));
+
+vi.mock("~/settings/queries", () => ({
+  useSettingsReady: () => readiness.settings,
 }));
 
 vi.mock("~/shared/config", () => ({
@@ -60,6 +78,8 @@ describe("useSTTConnection", () => {
     config.current_stt_provider = "anarlog";
     config.current_stt_model = "cloud";
     config.local_stt_model_path = "";
+    readiness.provider = true;
+    readiness.settings = true;
     startServerForPathMock.mockReset();
   });
 
@@ -78,6 +98,7 @@ describe("useSTTConnection", () => {
       baseUrl: "https://api.anarlog.so/stt",
       apiKey: "access-token",
     });
+    expect(result.current.isReady).toBe(true);
   });
 
   it("uses the provider endpoint when only a Deepgram API key is stored", () => {
@@ -97,6 +118,28 @@ describe("useSTTConnection", () => {
       baseUrl: "https://api.deepgram.com/v1",
       apiKey: "test-key",
     });
+  });
+
+  it("waits for stored settings and secure provider configuration", () => {
+    config.current_stt_provider = "deepgram";
+    config.current_stt_model = "nova-3-general";
+    readiness.provider = false;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const providerPending = renderHook(() => useSTTConnection(), { wrapper });
+
+    expect(providerPending.result.current.isReady).toBe(false);
+
+    providerPending.unmount();
+    readiness.provider = true;
+    readiness.settings = false;
+    const settingsPending = renderHook(() => useSTTConnection(), { wrapper });
+
+    expect(settingsPending.result.current.isReady).toBe(false);
   });
 
   it("starts a selected local model file and exposes its local URL", async () => {

--- a/apps/desktop/src/stt/useSTTConnection.test.ts
+++ b/apps/desktop/src/stt/useSTTConnection.test.ts
@@ -3,12 +3,32 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { config, readiness, startServerForPathMock } = vi.hoisted(() => ({
+const {
+  authState,
+  billingState,
+  config,
+  getServerForModelMock,
+  isModelDownloadedMock,
+  readiness,
+  startServerForPathMock,
+} = vi.hoisted(() => ({
+  authState: {
+    session: { access_token: "access-token" } as
+      | { access_token: string }
+      | null
+      | undefined,
+  },
+  billingState: {
+    isPaid: true,
+    isReady: true,
+  },
   config: {
     current_stt_provider: "anarlog",
     current_stt_model: "cloud",
     local_stt_model_path: "",
   },
+  getServerForModelMock: vi.fn(),
+  isModelDownloadedMock: vi.fn(),
   readiness: {
     provider: true,
     settings: true,
@@ -18,18 +38,18 @@ const { config, readiness, startServerForPathMock } = vi.hoisted(() => ({
 
 vi.mock("@anlg/plugin-local-stt", () => ({
   commands: {
-    getServerForModel: vi.fn(),
-    isModelDownloaded: vi.fn(),
+    getServerForModel: getServerForModelMock,
+    isModelDownloaded: isModelDownloadedMock,
     startServerForPath: startServerForPathMock,
   },
 }));
 
 vi.mock("~/auth", () => ({
-  useAuth: () => ({ session: { access_token: "access-token" } }),
+  useAuth: () => ({ session: authState.session }),
 }));
 
 vi.mock("~/auth/billing-context", () => ({
-  useBillingAccess: () => ({ isPaid: true }),
+  useBillingAccess: () => billingState,
 }));
 
 vi.mock("~/env", () => ({
@@ -67,8 +87,10 @@ vi.mock("~/stt/capabilities", () => ({
     provider === "anarlog" && model === "cloud",
   isLocalFileSttModel: (provider: string, model: string) =>
     provider === "local_file" && model === "local-file",
-  isOnDeviceSttModel: () => false,
-  isRealtimeLocalModel: () => false,
+  isOnDeviceSttModel: (provider: string, model: string) =>
+    provider === "soniqo" && model === "soniqo-parakeet-streaming",
+  isRealtimeLocalModel: (model: string) =>
+    model === "soniqo-parakeet-streaming",
 }));
 
 import { useSTTConnection } from "./useSTTConnection";
@@ -78,8 +100,13 @@ describe("useSTTConnection", () => {
     config.current_stt_provider = "anarlog";
     config.current_stt_model = "cloud";
     config.local_stt_model_path = "";
+    authState.session = { access_token: "access-token" };
+    billingState.isPaid = true;
+    billingState.isReady = true;
     readiness.provider = true;
     readiness.settings = true;
+    getServerForModelMock.mockReset();
+    isModelDownloadedMock.mockReset();
     startServerForPathMock.mockReset();
   });
 
@@ -140,6 +167,49 @@ describe("useSTTConnection", () => {
     const settingsPending = renderHook(() => useSTTConnection(), { wrapper });
 
     expect(settingsPending.result.current.isReady).toBe(false);
+  });
+
+  it("waits for cloud authentication and billing access", () => {
+    billingState.isReady = false;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const billingPending = renderHook(() => useSTTConnection(), { wrapper });
+
+    expect(billingPending.result.current.isReady).toBe(false);
+
+    billingPending.unmount();
+    billingState.isReady = true;
+    authState.session = undefined;
+    const authPending = renderHook(() => useSTTConnection(), { wrapper });
+
+    expect(authPending.result.current.conn).toBeNull();
+    expect(authPending.result.current.isReady).toBe(false);
+  });
+
+  it("waits for an on-device model server to become ready", async () => {
+    config.current_stt_provider = "soniqo";
+    config.current_stt_model = "soniqo-parakeet-streaming";
+    isModelDownloadedMock.mockResolvedValue({ status: "ok", data: true });
+    getServerForModelMock.mockResolvedValue({
+      status: "ok",
+      data: { status: "loading" },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useSTTConnection(), { wrapper });
+
+    await waitFor(() => expect(result.current.local.isPending).toBe(false));
+    expect(result.current.conn).toBeNull();
+    expect(result.current.local.data?.status).toBe("loading");
+    expect(result.current.isReady).toBe(false);
   });
 
   it("starts a selected local model file and exposes its local URL", async () => {

--- a/apps/desktop/src/stt/useSTTConnection.ts
+++ b/apps/desktop/src/stt/useSTTConnection.ts
@@ -8,7 +8,8 @@ import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { env } from "~/env";
 import { type ProviderId, PROVIDERS } from "~/settings/ai/stt/shared";
-import { useAiProvider } from "~/settings/providers";
+import { useAiProvidersState } from "~/settings/providers";
+import { useSettingsReady } from "~/settings/queries";
 import { useConfigValues } from "~/shared/config";
 import {
   isAnarlogCloudSttModel,
@@ -21,6 +22,7 @@ import { localSttQueries } from "~/stt/useLocalSttModel";
 export const useSTTConnection = () => {
   const auth = useAuth();
   const billing = useBillingAccess();
+  const settingsReady = useSettingsReady();
   const { current_stt_provider, current_stt_model, local_stt_model_path } =
     useConfigValues([
       "current_stt_provider",
@@ -32,9 +34,11 @@ export const useSTTConnection = () => {
       local_stt_model_path: string | undefined;
     };
 
-  const providerConfig = useAiProvider("stt", current_stt_provider) as
-    | AIProviderStorage
-    | undefined;
+  const { providers, isReady: providerConfigReady } =
+    useAiProvidersState("stt");
+  const providerConfig = (
+    current_stt_provider ? providers[`stt:${current_stt_provider}`] : undefined
+  ) as AIProviderStorage | undefined;
 
   const localModel = isOnDeviceSttModel(current_stt_provider, current_stt_model)
     ? current_stt_model
@@ -183,6 +187,9 @@ export const useSTTConnection = () => {
 
   return {
     conn: connection,
+    isReady:
+      settingsReady &&
+      (isLocalModel ? !local.isPending : isCloudModel || providerConfigReady),
     local,
     localBatchDiarizationAvailable: localBatchModel.data === true,
     isLocalModel,

--- a/apps/desktop/src/stt/useSTTConnection.ts
+++ b/apps/desktop/src/stt/useSTTConnection.ts
@@ -189,7 +189,12 @@ export const useSTTConnection = () => {
     conn: connection,
     isReady:
       settingsReady &&
-      (isLocalModel ? !local.isPending : isCloudModel || providerConfigReady),
+      connection !== null &&
+      (isLocalModel
+        ? !local.isPending
+        : isCloudModel
+          ? billing.isReady
+          : providerConfigReady),
     local,
     localBatchDiarizationAvailable: localBatchModel.data === true,
     isLocalModel,

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -35,8 +35,13 @@ export {
 export { useResumeListeningLifecycle } from "./resume-listening";
 
 export function useStartListening(sessionId: string) {
+  return useStartListeningState(sessionId).startListening;
+}
+
+export function useStartListeningState(sessionId: string) {
   const {
     conn,
+    connectionReady,
     createCaptureLifecycle,
     session,
     setStopMeetingChatCapture,
@@ -297,5 +302,5 @@ export function useStartListening(sessionId: string) {
     stopMeetingChatTasks,
   ]);
 
-  return startListening;
+  return { connectionReady, startListening };
 }


### PR DESCRIPTION
Wait for secure STT credentials before shortcut auto-start and allow app attention requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when live recording and scheduled auto-start begin relative to auth, billing, and secure STT credentials—core capture paths with timing-sensitive behavior.
> 
> **Overview**
> Fixes a race where **scheduled / shortcut auto-start** could begin recording before STT configuration and credentials were loaded, leading to misconfigured or failed capture.
> 
> **`useSTTConnection`** now exposes **`isReady`**, which stays false until app settings are loaded, secure provider API keys are available (via expanded **`useAiProvidersState`** with **`isLoading`**), and provider-specific prerequisites are met (billing/auth for cloud Anarlog, local model server readiness for on-device STT). That readiness flows through **`useCaptureLifecycle`** / **`useStartListeningState`** as **`connectionReady`**.
> 
> **`ScheduledSessionAutoStart`** only calls **`startListening`** once **`connectionReady`** is true; if the connection never becomes ready within the existing 30s abandon window, auto-start is cleared without starting recording.
> 
> Also grants the desktop app **`core:window:allow-request-user-attention`** so the shell can request user attention when needed during startup flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e474fc7dca8e4936f82c39ab257ff1386d4eb512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->