### PR TITLE
Format repository documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,21 +55,21 @@ The Supabase stack requires Docker. Provider credentials and service-specific co
 
 ## Find the right code
 
-| Path | Scope |
-| --- | --- |
-| `apps/desktop` | React desktop UI and Tauri application |
-| `apps/web` | Marketing site, account portal, and shared-note pages |
-| `apps/api` | Hosted API routes |
-| `apps/cli` | CLI and MCP server |
-| `apps/mobile` | Expo mobile client |
-| `plugins/*` | Tauri plugin boundaries |
-| `crates/*` | Rust libraries and services |
-| `packages/*` | Shared TypeScript packages |
-| `crates/db-app` | SQLite schema and migrations |
-| `supabase` | Hosted database schema, functions, and tests |
-| `skills/anarlog` | Published CLI and MCP agent skill |
-| `enterprise` | Commercially licensed capture and deployment components |
-| `docs` | Mintlify product and reference documentation |
+| Path             | Scope                                                   |
+| ---------------- | ------------------------------------------------------- |
+| `apps/desktop`   | React desktop UI and Tauri application                  |
+| `apps/web`       | Marketing site, account portal, and shared-note pages   |
+| `apps/api`       | Hosted API routes                                       |
+| `apps/cli`       | CLI and MCP server                                      |
+| `apps/mobile`    | Expo mobile client                                      |
+| `plugins/*`      | Tauri plugin boundaries                                 |
+| `crates/*`       | Rust libraries and services                             |
+| `packages/*`     | Shared TypeScript packages                              |
+| `crates/db-app`  | SQLite schema and migrations                            |
+| `supabase`       | Hosted database schema, functions, and tests            |
+| `skills/anarlog` | Published CLI and MCP agent skill                       |
+| `enterprise`     | Commercially licensed capture and deployment components |
+| `docs`           | Mintlify product and reference documentation            |
 
 Sessions are the core data entity. Notes, transcripts, and summaries are all backed by sessions. ProseMirror documents use the TipTap JSON dialect.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -6,10 +6,10 @@ This is path-based mixed licensing, not a choice between two licenses for the sa
 
 ## License scope
 
-| Path | License |
-| --- | --- |
+| Path            | License                                                                                                                     |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `enterprise/**` | [Anarlog Enterprise Commercial License Notice](enterprise/LICENSE) and the applicable written agreement with Fastrepl, Inc. |
-| Everything else | [MIT License](LICENSE), unless a nearer license or third-party notice says otherwise |
+| Everything else | [MIT License](LICENSE), unless a nearer license or third-party notice says otherwise                                        |
 
 The nearest license file controls. Moving code across the `enterprise/` boundary requires an explicit licensing review; a file does not keep its previous license merely because it was moved.
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-  <img width="110" src="apps/desktop/src-tauri/icons/stable/128x128@2x.png" alt="anarlog icon" />
+<img width="110" src="apps/desktop/src-tauri/icons/stable/128x128@2x.png" alt="anarlog icon" />
 
-  <h1>anarlog</h1>
+<h1>anarlog</h1>
 
-  <p>
+<p>
     <b>The privacy-first AI meeting notepad.</b>
     <br />
     Open source, local-first, and yours to fork. Granola, rearranged.
   </p>
 
-  <p>
+<p>
     <a href="https://anarlog.so">Website</a>
     &nbsp;•&nbsp;
     <a href="https://docs.anarlog.so">Docs</a>
@@ -28,14 +28,14 @@
     <a href="https://status.anarlog.so">Status</a>
   </p>
 
-  <p>
+<p>
     <a href="https://github.com/fastrepl/anarlog/stargazers"><img src="https://img.shields.io/github/stars/fastrepl/anarlog?style=flat&color=ffe09d" alt="GitHub stars" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-black" alt="MIT license" /></a>
     <a href="https://anarlog.so/discord"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
     <a href="https://deepwiki.com/fastrepl/anarlog"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
   </p>
 
-  <img width="100%" src="apps/web/public/og.jpg" alt="anarlog" />
+<img width="100%" src="apps/web/public/og.jpg" alt="anarlog" />
 
 </div>
 
@@ -57,22 +57,22 @@ It is built for people who want AI meeting notes without handing their conversat
 
 ## What runs where
 
-| Part of the workflow | Where it happens |
-| --- | --- |
-| Audio capture and recording | Your device |
-| Transcription | Your device with an on-device model, or the provider you select |
-| Notes and transcript storage | Local SQLite plus local files |
-| AI summaries and chat | Your choice: local model, your own API key, or optional hosted AI |
-| Sync and sharing | Off by default, opt-in encrypted CloudSync |
+| Part of the workflow         | Where it happens                                                  |
+| ---------------------------- | ----------------------------------------------------------------- |
+| Audio capture and recording  | Your device                                                       |
+| Transcription                | Your device with an on-device model, or the provider you select   |
+| Notes and transcript storage | Local SQLite plus local files                                     |
+| AI summaries and chat        | Your choice: local model, your own API key, or optional hosted AI |
+| Sync and sharing             | Off by default, opt-in encrypted CloudSync                        |
 
 ## How AI works
 
 anarlog keeps audio transcription separate from the language model used for summaries and chat. You can change either one without changing the other.
 
-| Stage | App setting | Anarlog Cloud | Local or bring your own |
-| --- | --- | --- | --- |
-| Audio → transcript | **Transcription** | Managed **Pro (Cloud)** chooses by language and live or batch mode. Current primary paths include Deepgram Nova, Soniox 5, and AssemblyAI Universal 3.5. | Soniqo or Apple Speech when available, or your selected transcription provider and model |
-| Transcript + memo → summary, title, or chat | **Intelligence** | Managed **Auto** (also shown as Pro (Cloud)) currently uses the latest Claude Sonnet alias through OpenRouter. | Your selected API, subscription, OpenAI-compatible server, or eligible Apple Intelligence |
+| Stage                                       | App setting       | Anarlog Cloud                                                                                                                                            | Local or bring your own                                                                   |
+| ------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Audio → transcript                          | **Transcription** | Managed **Pro (Cloud)** chooses by language and live or batch mode. Current primary paths include Deepgram Nova, Soniox 5, and AssemblyAI Universal 3.5. | Soniqo or Apple Speech when available, or your selected transcription provider and model  |
+| Transcript + memo → summary, title, or chat | **Intelligence**  | Managed **Auto** (also shown as Pro (Cloud)) currently uses the latest Claude Sonnet alias through OpenRouter.                                           | Your selected API, subscription, OpenAI-compatible server, or eligible Apple Intelligence |
 
 The active provider and model are always visible under **Settings → Transcription** and **Settings → Intelligence**. Read [Models and providers](https://docs.anarlog.so/models-and-providers) for the current routes, local model list, and privacy boundaries.
 
@@ -87,21 +87,21 @@ Product docs live at [docs.anarlog.so](https://docs.anarlog.so). To build the de
 
 ## Repository map
 
-| Path | What lives there |
-| --- | --- |
-| `apps/desktop` | Tauri v2 desktop app: React and TypeScript UI, Rust backend |
-| `apps/web` | anarlog.so website, account portal, and shared-note pages; not the desktop notepad |
-| `apps/api` | Optional hosted services for AI, sync, sharing, and integrations |
-| `apps/cli` | Local CLI and MCP server |
-| `apps/mobile` | Mobile client source; no mobile app is currently distributed |
-| `apps/stripe` | Billing integration |
-| `apps/watch/apple` | watchOS companion source built with the mobile app |
-| `plugins/*` | Tauri capabilities such as local STT, database access, calendar, export, and notifications |
-| `crates/*` | Rust libraries for audio capture, transcription, diarization, storage, and services |
-| `packages/*` | Shared TypeScript packages for the editor, database, UI, and plugin SDK |
-| `supabase/` | Hosted authentication, sharing, sync, billing, and Cloud API data |
-| `skills/anarlog` | Published agent skill for the CLI and MCP server |
-| `enterprise/` | Source-visible enterprise components, commercially licensed |
+| Path               | What lives there                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `apps/desktop`     | Tauri v2 desktop app: React and TypeScript UI, Rust backend                                |
+| `apps/web`         | anarlog.so website, account portal, and shared-note pages; not the desktop notepad         |
+| `apps/api`         | Optional hosted services for AI, sync, sharing, and integrations                           |
+| `apps/cli`         | Local CLI and MCP server                                                                   |
+| `apps/mobile`      | Mobile client source; no mobile app is currently distributed                               |
+| `apps/stripe`      | Billing integration                                                                        |
+| `apps/watch/apple` | watchOS companion source built with the mobile app                                         |
+| `plugins/*`        | Tauri capabilities such as local STT, database access, calendar, export, and notifications |
+| `crates/*`         | Rust libraries for audio capture, transcription, diarization, storage, and services        |
+| `packages/*`       | Shared TypeScript packages for the editor, database, UI, and plugin SDK                    |
+| `supabase/`        | Hosted authentication, sharing, sync, billing, and Cloud API data                          |
+| `skills/anarlog`   | Published agent skill for the CLI and MCP server                                           |
+| `enterprise/`      | Source-visible enterprise components, commercially licensed                                |
 
 ## Local development
 

--- a/enterprise/Cargo.lock
+++ b/enterprise/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "tiptap",
  "tokio",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -12,4 +12,3 @@ Customer configuration, credentials, license-signing keys, and confidential depl
 - Zoom RTMS: `docs/zoom-rtms.md`
 - Teams connector: `docs/teams-capture.md`
 - Owned-stack planning: `docs/planning/`
-

--- a/enterprise/control-plane/README.md
+++ b/enterprise/control-plane/README.md
@@ -54,17 +54,17 @@ See the official [`infisical run` documentation](https://infisical.com/docs/cli/
 
 ## Configuration
 
-| Variable | Required | Purpose |
-| --- | --- | --- |
-| `ANARLOG_ENTERPRISE_DATABASE_URL` | Yes | PostgreSQL connection URL. Startup fails if the database is unavailable or migrations fail. |
-| `ANARLOG_ENTERPRISE_WORKSPACE_TOKENS` | Yes | JSON object mapping workspace IDs to bearer tokens. At least one unique token of 32–512 bytes is required. |
-| `ANARLOG_ENTERPRISE_BIND_ADDRESS` | No | Listener address. Defaults to `0.0.0.0:8080`; the image sets the same value. |
-| `ANARLOG_ENTERPRISE_DATABASE_MAX_CONNECTIONS` | No | PostgreSQL pool size from 1–100. Defaults to `10`. |
-| `ANARLOG_ENTERPRISE_ZOOM_CLIENT_ID` | Together | Zoom RTMS app client ID. |
-| `ANARLOG_ENTERPRISE_ZOOM_CLIENT_SECRET` | Together | Zoom RTMS app client secret. |
-| `ANARLOG_ENTERPRISE_ZOOM_WEBHOOK_SECRET` | Together | Zoom webhook secret used to verify signed request bodies. |
-| `ANARLOG_ENTERPRISE_ZOOM_ACCOUNT_WORKSPACES` | Together | JSON object mapping signed Zoom account IDs to configured workspace IDs. |
-| `RUST_LOG` | No | Standard tracing filter. Defaults to request and service information. No telemetry is exported. |
+| Variable                                      | Required | Purpose                                                                                                    |
+| --------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `ANARLOG_ENTERPRISE_DATABASE_URL`             | Yes      | PostgreSQL connection URL. Startup fails if the database is unavailable or migrations fail.                |
+| `ANARLOG_ENTERPRISE_WORKSPACE_TOKENS`         | Yes      | JSON object mapping workspace IDs to bearer tokens. At least one unique token of 32–512 bytes is required. |
+| `ANARLOG_ENTERPRISE_BIND_ADDRESS`             | No       | Listener address. Defaults to `0.0.0.0:8080`; the image sets the same value.                               |
+| `ANARLOG_ENTERPRISE_DATABASE_MAX_CONNECTIONS` | No       | PostgreSQL pool size from 1–100. Defaults to `10`.                                                         |
+| `ANARLOG_ENTERPRISE_ZOOM_CLIENT_ID`           | Together | Zoom RTMS app client ID.                                                                                   |
+| `ANARLOG_ENTERPRISE_ZOOM_CLIENT_SECRET`       | Together | Zoom RTMS app client secret.                                                                               |
+| `ANARLOG_ENTERPRISE_ZOOM_WEBHOOK_SECRET`      | Together | Zoom webhook secret used to verify signed request bodies.                                                  |
+| `ANARLOG_ENTERPRISE_ZOOM_ACCOUNT_WORKSPACES`  | Together | JSON object mapping signed Zoom account IDs to configured workspace IDs.                                   |
+| `RUST_LOG`                                    | No       | Standard tracing filter. Defaults to request and service information. No telemetry is exported.            |
 
 `GET /health/live` is process-only liveness. `GET /health/ready` checks PostgreSQL. Capture and delivery routes require `Authorization: Bearer <token>` and reject a token used against any workspace other than its configured workspace.
 

--- a/enterprise/deploy/docs/operations.md
+++ b/enterprise/deploy/docs/operations.md
@@ -4,11 +4,11 @@ This is the customer-hosted meeting capture distribution. Evaluation Compose doe
 
 ## Layout
 
-| Mode | Manifest | License | Typical use |
-| --- | --- | --- | --- |
-| Evaluation | `enterprise/control-plane/compose.yaml` | optional | Single-box soak of the control plane |
-| Production Compose | `enterprise/deploy/compose.prod.yaml` | required | Compose on customer VMs |
-| Production Helm | `enterprise/deploy/helm/anarlog-capture` | required | Kubernetes |
+| Mode               | Manifest                                 | License  | Typical use                          |
+| ------------------ | ---------------------------------------- | -------- | ------------------------------------ |
+| Evaluation         | `enterprise/control-plane/compose.yaml`  | optional | Single-box soak of the control plane |
+| Production Compose | `enterprise/deploy/compose.prod.yaml`    | required | Compose on customer VMs              |
+| Production Helm    | `enterprise/deploy/helm/anarlog-capture` | required | Kubernetes                           |
 
 Pinned images live in the Compose files and Helm `values.yaml`. Do not float untagged `latest`.
 

--- a/enterprise/docs/planning/consent-model.md
+++ b/enterprise/docs/planning/consent-model.md
@@ -14,12 +14,12 @@ Posting a recording/transcription disclosure is an opt-in transport. A sent disc
 
 ## Evidence vs consent
 
-| Event | Product meaning |
-| --- | --- |
-| `session_disclosure_attempts` row with `delivery = sent` | Transport evidence only |
-| `session_participant_consent.status = unknown` | Default, including late joiners |
-| `status = consented` with `source` in `explicit_chat_reply` / `explicit_ui` | That participant answered; not legal consent for the room |
-| `status = declined` | Stop listening. Still not a legal record of anyone else's choice |
+| Event                                                                       | Product meaning                                                  |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `session_disclosure_attempts` row with `delivery = sent`                    | Transport evidence only                                          |
+| `session_participant_consent.status = unknown`                              | Default, including late joiners                                  |
+| `status = consented` with `source` in `explicit_chat_reply` / `explicit_ui` | That participant answered; not legal consent for the room        |
+| `status = declined`                                                         | Stop listening. Still not a legal record of anyone else's choice |
 
 `sessionHasLegalConsent()` is always false. Schema CHECK constraints reject a `disclosure_sent` consent source. These tables are local-only and are not in CloudSync or the E2EE domain.
 

--- a/enterprise/docs/planning/owned-stack-roadmap.md
+++ b/enterprise/docs/planning/owned-stack-roadmap.md
@@ -18,15 +18,15 @@ Later: SOC 2 / ISO 27001 / AIUC-1 / HIPAA programs, certified-cloud SKU, Teams G
 
 ## Workstreams
 
-| Workstream | Tickets | v1 vs later |
-| --- | --- | --- |
-| Capture data plane | ANLG-223 and children | Meet + Zoom v1; Teams after Meet reliability |
-| Inference routing | ANLG-132 | Policy model v1; certified-cloud providers later |
-| Admin / deletion | ANLG-133, 216, 217, 218 | Policies + SSO/SCIM + analytics v1; MDM later |
-| Disclosure / consent | ANLG-134, 135 | Slack huddle transport v1; virtual camera later |
-| Trust / procurement | ANLG-136 | Questionnaires and DPA v1; certifications later |
-| Deployment SKUs | ANLG-137, 233 | Customer-hosted data plane v1; certified cloud later |
-| No lock-in | ANLG-138 | CLI/MCP/export v1; public HTTP API later |
+| Workstream           | Tickets                 | v1 vs later                                          |
+| -------------------- | ----------------------- | ---------------------------------------------------- |
+| Capture data plane   | ANLG-223 and children   | Meet + Zoom v1; Teams after Meet reliability         |
+| Inference routing    | ANLG-132                | Policy model v1; certified-cloud providers later     |
+| Admin / deletion     | ANLG-133, 216, 217, 218 | Policies + SSO/SCIM + analytics v1; MDM later        |
+| Disclosure / consent | ANLG-134, 135           | Slack huddle transport v1; virtual camera later      |
+| Trust / procurement  | ANLG-136                | Questionnaires and DPA v1; certifications later      |
+| Deployment SKUs      | ANLG-137, 233           | Customer-hosted data plane v1; certified cloud later |
+| No lock-in           | ANLG-138                | CLI/MCP/export v1; public HTTP API later             |
 
 ## Platform constraints
 

--- a/enterprise/docs/teams-capture.md
+++ b/enterprise/docs/teams-capture.md
@@ -20,20 +20,20 @@ This is **not** deployable on Linux-only clusters or a fully air-gapped network 
 
 Replay fixtures in `enterprise/meeting-sdk-bridge-worker/tests/teams_reliability.rs` cover:
 
-| Scenario | Terminal reason |
-| --- | --- |
-| Admitted then capturing | (non-terminal) |
-| Lobby timeout | `admission_timeout` |
-| Organizer denied | `admission_denied` |
-| Removed by organizer | `removed_from_meeting` |
-| Meeting ended | `meeting_ended` |
+| Scenario                              | Terminal reason              |
+| ------------------------------------- | ---------------------------- |
+| Admitted then capturing               | (non-terminal)               |
+| Lobby timeout                         | `admission_timeout`          |
+| Organizer denied                      | `admission_denied`           |
+| Removed by organizer                  | `removed_from_meeting`       |
+| Meeting ended                         | `meeting_ended`              |
 | Participant upsert / leave / captions | non-terminal until host ends |
 
 ## Deployment modes
 
-| Mode | Supported |
-| --- | --- |
-| Customer Azure + Windows Server sidecar | yes |
-| Linux-only Helm capture chart | no (Meet/Zoom only) |
-| Air-gapped / no Graph | no |
-| Browser worker against teams.microsoft.com | no |
+| Mode                                       | Supported           |
+| ------------------------------------------ | ------------------- |
+| Customer Azure + Windows Server sidecar    | yes                 |
+| Linux-only Helm capture chart              | no (Meet/Zoom only) |
+| Air-gapped / no Graph                      | no                  |
+| Browser worker against teams.microsoft.com | no                  |

--- a/enterprise/google-meet-worker/fixtures/vexa-v0.12.18/MATRIX.md
+++ b/enterprise/google-meet-worker/fixtures/vexa-v0.12.18/MATRIX.md
@@ -3,34 +3,34 @@
 Pinned reference: Vexa `v0.12.18`, commit `1b62993e7e97c6ee04a5dcb116f7749ec74169df`.
 These fixtures are replayable snapshots of normalized Anarlog admission/runtime classifiers. They do not require Vexa internals at test time.
 
-| Fixture | Vexa module | Anarlog outcome | Terminal reason | Retryable |
-| --- | --- | --- | --- | --- |
-| `admission/host-denied.json` | `join/src/googlemeet/admission.ts` | Rejected HostDenied | `admission_denied` | no |
-| `admission/waiting-room.json` | `join/src/googlemeet/admission.ts` | WaitingForAdmission | — | — |
-| `admission/admitted.json` | `join/src/googlemeet/join.ts` | Admitted | — | — |
-| `admission/captcha-unsolved.json` | `join/src/googlemeet/admission.ts` | Rejected CaptchaUnsolved | `authentication_failed` | no |
-| `admission/error-page.json` | `join/src/googlemeet/admission.ts` | Rejected ErrorPage | `provider_error` | no |
-| `admission/consent.json` | `join/src/googlemeet/admission.ts` | ConsentRequired | — | — |
-| `runtime/removed.json` | `join/src/googlemeet/removal.ts` | Removed | `removed_from_meeting` | no |
-| `runtime/meeting-ended.json` | `join/src/googlemeet/removal.ts` | MeetingEnded | `meeting_ended` | no |
-| `runtime/network-lost.json` | `join/src/googlemeet/removal.ts` | NetworkLost after grace | `network_lost` | yes |
-| `runtime/active.json` | `gmeet-capture/src/gmeet-capture.ts` | Active | — | — |
-| `runtime/silence.json` | `gmeet-capture/src/pcm-capture.ts` | Active (no tiles besides bot) | `no_one_joined` after grace | yes |
-| `runtime/nobody-joined.json` | `gmeet-capture/src/pcm-capture.ts` | Active until empty-room grace | `no_one_joined` | yes |
-| `runtime/overlapping-speakers.json` | `gmeet-capture/src/gmeet-speakers.ts` | Active with two named tiles | — | — |
-| `runtime/speaker-renamed.json` | `gmeet-capture/src/gmeet-speakers.ts` | Active with renamed tile | — | — |
-| `runtime/unresolved-speaker.json` | `gmeet-capture/src/gmeet-speakers.ts` | Active with chrome chrome-ui tile | — | — |
-| `runtime/long-duration.json` | `gmeet-capture/src/gmeet-capture.ts` | Active after two hours | — | — |
+| Fixture                             | Vexa module                           | Anarlog outcome                   | Terminal reason             | Retryable |
+| ----------------------------------- | ------------------------------------- | --------------------------------- | --------------------------- | --------- |
+| `admission/host-denied.json`        | `join/src/googlemeet/admission.ts`    | Rejected HostDenied               | `admission_denied`          | no        |
+| `admission/waiting-room.json`       | `join/src/googlemeet/admission.ts`    | WaitingForAdmission               | —                           | —         |
+| `admission/admitted.json`           | `join/src/googlemeet/join.ts`         | Admitted                          | —                           | —         |
+| `admission/captcha-unsolved.json`   | `join/src/googlemeet/admission.ts`    | Rejected CaptchaUnsolved          | `authentication_failed`     | no        |
+| `admission/error-page.json`         | `join/src/googlemeet/admission.ts`    | Rejected ErrorPage                | `provider_error`            | no        |
+| `admission/consent.json`            | `join/src/googlemeet/admission.ts`    | ConsentRequired                   | —                           | —         |
+| `runtime/removed.json`              | `join/src/googlemeet/removal.ts`      | Removed                           | `removed_from_meeting`      | no        |
+| `runtime/meeting-ended.json`        | `join/src/googlemeet/removal.ts`      | MeetingEnded                      | `meeting_ended`             | no        |
+| `runtime/network-lost.json`         | `join/src/googlemeet/removal.ts`      | NetworkLost after grace           | `network_lost`              | yes       |
+| `runtime/active.json`               | `gmeet-capture/src/gmeet-capture.ts`  | Active                            | —                           | —         |
+| `runtime/silence.json`              | `gmeet-capture/src/pcm-capture.ts`    | Active (no tiles besides bot)     | `no_one_joined` after grace | yes       |
+| `runtime/nobody-joined.json`        | `gmeet-capture/src/pcm-capture.ts`    | Active until empty-room grace     | `no_one_joined`             | yes       |
+| `runtime/overlapping-speakers.json` | `gmeet-capture/src/gmeet-speakers.ts` | Active with two named tiles       | —                           | —         |
+| `runtime/speaker-renamed.json`      | `gmeet-capture/src/gmeet-speakers.ts` | Active with renamed tile          | —                           | —         |
+| `runtime/unresolved-speaker.json`   | `gmeet-capture/src/gmeet-speakers.ts` | Active with chrome chrome-ui tile | —                           | —         |
+| `runtime/long-duration.json`        | `gmeet-capture/src/gmeet-capture.ts`  | Active after two hours            | —                           | —         |
 
 Scenarios in `scenarios.json` replay the same snapshots through `WorkerLifecycle` and assert the provider-neutral terminal reason.
 
 Additional lifecycle scenarios (not a new classifier snapshot):
 
-| Scenario | Terminal reason | Retryable |
-| --- | --- | --- |
-| `everyone-left-after-participants` | `everyone_left` | no |
-| `silence-then-nobody-joined` | `no_one_joined` | yes |
-| `host-ended-after-long-capture` | `meeting_ended` | no |
-| `captcha-unsolved` | `authentication_failed` | no |
-| `error-page-before-join` | `provider_error` | no |
-| `stopped-by-request` | `stopped_by_request` | no |
+| Scenario                           | Terminal reason         | Retryable |
+| ---------------------------------- | ----------------------- | --------- |
+| `everyone-left-after-participants` | `everyone_left`         | no        |
+| `silence-then-nobody-joined`       | `no_one_joined`         | yes       |
+| `host-ended-after-long-capture`    | `meeting_ended`         | no        |
+| `captcha-unsolved`                 | `authentication_failed` | no        |
+| `error-page-before-join`           | `provider_error`        | no        |
+| `stopped-by-request`               | `stopped_by_request`    | no        |

--- a/packages/changelog/content/1.4.9.md
+++ b/packages/changelog/content/1.4.9.md
@@ -22,6 +22,7 @@ summary: "Anarlog 1.4.9 adds Team workspace management, relationship briefs, exa
 - Avoid failures from unsupported temperature settings on newer models, and
   stop automatic summary retries after a bounded backoff instead of retrying
   forever
+
 ## Teams and contacts
 
 ![Teams](/api/assets/changelog/1.4-team.jpg)


### PR DESCRIPTION
Apply dprint formatting to Markdown tables and layout across repository documentation and the current changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and lockfile-only edits with no runtime or product behavior changes.
> 
> **Overview**
> Applies **dprint** formatting across repo documentation so Markdown tables use aligned columns and consistent spacing, and tightens **README** centered-block HTML indentation.
> 
> Touched files include root **CONTRIBUTING**, **LICENSING**, and **README**; enterprise ops/planning docs (control plane config table, capture operations, consent model, roadmap, Teams capture, Google Meet fixture matrix); a trailing newline trim in **enterprise/README**; and a blank line before the Teams section in the **1.4.9** changelog.
> 
> **enterprise/Cargo.lock** also lists an added `uuid` dependency on one workspace crate—likely incidental lockfile refresh, with no accompanying source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 031453aa10aca31ef6d8a679c2baf24dc3df3051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->