### PR TITLE
Refresh desktop 1.4.17 release notes

### DIFF
--- a/packages/changelog/content/1.4.17.md
+++ b/packages/changelog/content/1.4.17.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-09-02"
-summary: "Anarlog 1.4.17 adds nested folders and workspace management, improves recording resilience, and speeds up large database migrations."
+date: "2026-09-03"
+summary: "Anarlog 1.4.17 adds nested folders and workspace management, on-device speaker diarization, and more reliable recording and transcription."
 ---
 
 ## Folders and notes
@@ -14,11 +14,17 @@ summary: "Anarlog 1.4.17 adds nested folders and workspace management, improves 
 
 ## Recording and transcription
 
-- Start scheduled recordings even when live transcription is not ready, and
-  keep an active meeting recording through brief microphone or browser-state
-  changes
+- Start scheduled recordings only after transcription is ready, and keep an
+  active meeting recording through brief microphone or browser-state changes
+- Separate speakers during on-device batch transcription, with more resilient
+  diarization and automatic recovery from damaged Core ML model caches
+- Keep you signed in across app restarts unless you explicitly log out, and
+  refresh cloud credentials before batch transcription starts
 - Use live OpenAI and Gemini transcription with corrected provider requests,
   and keep the floating-bar waveform visible while transcription falls back
+- Keep the speaker selector open while assigning consecutive transcript
+  segments, let live recording interrupt an in-progress batch transcription,
+  and hide obsolete stop controls after a meeting ends
 - Delete a recording while it is still finalizing without seeing obsolete
   failure alerts or losing recovery when you undo the deletion
 


### PR DESCRIPTION
Correct the scheduled recording note and document on-device diarization, persistent sign-in, and batch transcription recovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only edits with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates **`packages/changelog/content/1.4.17.md`** for the 1.4.17 desktop release: bumps the entry date to **2026-09-03** and rewrites the top-line summary to highlight **on-device speaker diarization** and clearer recording/transcription reliability wording.
> 
> Under **Recording and transcription**, it **corrects** scheduled recordings to start **only after transcription is ready** (replacing the prior “even when live transcription is not ready” note) and **adds** bullets for on-device diarization with Core ML cache recovery, persistent sign-in with credential refresh before batch transcription, and UX fixes (speaker selector during consecutive assignments, live recording interrupting batch jobs, hiding stale stop controls after meetings end).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43023e49ddd6c8d3e45a3031e50d43b41023403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->