### PR TITLE
Expand 1.4.17 release notes

### DIFF
--- a/packages/changelog/content/1.4.17.md
+++ b/packages/changelog/content/1.4.17.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-09-03"
-summary: "Anarlog 1.4.17 adds nested folders and workspace management, on-device speaker diarization, and more reliable recording and transcription."
+summary: "Anarlog 1.4.17 adds nested folders, distinct Pro, Team, and Enterprise plans, on-device speaker diarization, and more reliable recording."
 ---
 
 ## Folders and notes
@@ -14,8 +14,11 @@ summary: "Anarlog 1.4.17 adds nested folders and workspace management, on-device
 
 ## Recording and transcription
 
-- Start scheduled recordings only after transcription is ready, and keep an
-  active meeting recording through brief microphone or browser-state changes
+- Fix automatic listening for scheduled meetings and recording shortcuts so
+  capture waits for a usable transcription connection and starts alongside
+  auto-joined meetings
+- Keep an active meeting recording through brief microphone or browser-state
+  changes
 - Separate speakers during on-device batch transcription, with more resilient
   diarization and automatic recovery from damaged Core ML model caches
 - Keep you signed in across app restarts unless you explicitly log out, and
@@ -34,8 +37,18 @@ summary: "Anarlog 1.4.17 adds nested folders and workspace management, on-device
   **Migrating your local database**
 - See chat replies appear word by word, keep update progress visible through
   download and install, and reconnect Outlook when its authorization expires
+- Use a simpler, recording-first session header and scroll every Settings page
+  in smaller windows
+- Get a unified Windows title bar and sidebar, while the macOS menu-bar icon
+  starts near system controls and remembers where you move it
 
-## Teams
+## Plans and workspaces
 
-- Switch between teams in Settings, add a workspace logo, and manage members,
-  policies, billing, and other controls from one workspace-focused view
+- Choose Pro for individual AI and cloud features, the new Team plan for shared
+  workspaces and centralized billing, or Enterprise for advanced security and
+  deployment controls
+- Preview plan-gated Settings before upgrading, with unavailable controls
+  clearly identified instead of hidden
+- Switch between workspaces in Settings, add a workspace logo, and manage
+  members, roles, policies, billing, and other controls from one
+  workspace-focused view

--- a/packages/changelog/content/1.4.17.md
+++ b/packages/changelog/content/1.4.17.md
@@ -35,18 +35,31 @@ summary: "Anarlog 1.4.17 adds nested folders, distinct Pro, Team, and Enterprise
 
 - Open large encrypted local databases without spending minutes stalled on
   **Migrating your local database**
-- See chat replies appear word by word, keep update progress visible through
-  download and install, and reconnect Outlook when its authorization expires
+- See chat replies appear word by word and keep update progress visible through
+  download and install
+- Keep notifications, long chat messages, and calendar details visible instead
+  of clipping at window edges
+- Reconnect Outlook when its authorization expires, and keep Apple Calendar and
+  Reminders loading when macOS returns an unnamed account
 - Use a simpler, recording-first session header and scroll every Settings page
   in smaller windows
 - Get a unified Windows title bar and sidebar, while the macOS menu-bar icon
   starts near system controls and remembers where you move it
+
+## Intelligence and sharing
+
+- Use ChatGPT, Grok, GitHub Copilot, or Kimi Code subscriptions with
+  Intelligence; Claude Pro and Max subscription connections are no longer
+  available, while Anthropic API keys still work
+- Preview sharing controls before signing in instead of being redirected
+  immediately
 
 ## Plans and workspaces
 
 - Choose Pro for individual AI and cloud features, the new Team plan for shared
   workspaces and centralized billing, or Enterprise for advanced security and
   deployment controls
+- Keep plan access in sync after subscription changes
 - Preview plan-gated Settings before upgrading, with unavailable controls
   clearly identified instead of hidden
 - Switch between workspaces in Settings, add a workspace logo, and manage


### PR DESCRIPTION
Document automatic listening fixes, plan tiers, and desktop polish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or security impact.
> 
> **Overview**
> Updates the **1.4.17** changelog so it matches what shipped: the frontmatter summary now highlights **Pro, Team, and Enterprise** plans and tightened recording wording.
> 
> **Recording and transcription** reframes scheduled capture as fixes to automatic listening and shortcuts (wait for a usable transcription connection, start with auto-joined meetings) instead of the earlier “start only after transcription is ready” phrasing.
> 
> **Performance and polish** adds UI and integration bullets (no edge clipping, Outlook reconnect, unnamed Apple accounts, recording-first header, scrollable Settings, Windows title bar / macOS menu-bar behavior) and splits them out from the shorter chat/update list.
> 
> The old **Teams** section becomes **Intelligence and sharing** (subscription providers, Claude Pro/Max removal, sharing preview before sign-in) plus a new **Plans and workspaces** section (plan tiers, gated Settings preview, subscription sync, and the workspace management content that used to live under Teams).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab755d0d4b67c38d6d287f30b2330f1a073b1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->