### PR TITLE
Use GitHub-hosted macOS runners

### DIFF
--- a/.github/actions/macos_tcc/action.yaml
+++ b/.github/actions/macos_tcc/action.yaml
@@ -6,21 +6,39 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        shopt -s nullglob
-        candidates=(
-          /Users/runner/runners/*/bin/Runner.Listener
-          /Users/runner/runner/bin/Runner.Listener
-        )
         listener=""
-        for candidate in "${candidates[@]}"; do
-          if [[ -f "$candidate" ]]; then
-            listener=$candidate
+        pid=$$
+        while [[ "$pid" -gt 1 ]]; do
+          cmd=$(ps -p "$pid" -o command= 2>/dev/null) || break
+          exe=${cmd%% *}
+          if [[ "$exe" == */Runner.Listener && -f "$exe" ]]; then
+            listener=$exe
             break
           fi
+          next=$(ps -p "$pid" -o ppid= 2>/dev/null) || break
+          next=${next// /}
+          [[ -z "$next" || "$next" == "$pid" ]] && break
+          pid=$next
         done
         if [[ -z "$listener" ]]; then
-          echo "::error::Could not locate Runner.Listener under /Users/runner/runners or /Users/runner/runner"
+          shopt -s nullglob
+          candidates=(
+            /Users/runner/actions-runner/cached/bin/Runner.Listener
+            /Users/runner/actions-runner/cached/*/bin/Runner.Listener
+            /Users/runner/runners/*/bin/Runner.Listener
+            /Users/runner/runner/bin/Runner.Listener
+          )
+          for candidate in "${candidates[@]}"; do
+            if [[ -f "$candidate" ]]; then
+              listener=$candidate
+              break
+            fi
+          done
+        fi
+        if [[ -z "$listener" ]]; then
+          echo "::error::Could not locate Runner.Listener"
           exit 1
         fi
         listener=$(realpath "$listener")
+        echo "Granting AppleEvents (Finder) to $listener"
         sudo sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "INSERT OR IGNORE INTO access VALUES('kTCCServiceAppleEvents','$listener',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL,'UNUSED',1592919552)"

--- a/.github/actions/macos_tcc/action.yaml
+++ b/.github/actions/macos_tcc/action.yaml
@@ -6,22 +6,19 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        listener=$(ps -axo command= | awk '$1 ~ /\/Runner\.Listener$/ { print $1; exit }')
-        if [[ -z "${listener:-}" || ! -f "$listener" ]]; then
-          shopt -s nullglob
-          candidates=(
-            /Users/runner/runners/*/bin/Runner.Listener
-            /Users/runner/runner/bin/Runner.Listener
-          )
-          listener=""
-          for candidate in "${candidates[@]}"; do
-            if [[ -f "$candidate" ]]; then
-              listener=$candidate
-              break
-            fi
-          done
-        fi
-        if [[ -z "${listener:-}" ]]; then
+        shopt -s nullglob
+        candidates=(
+          /Users/runner/runners/*/bin/Runner.Listener
+          /Users/runner/runner/bin/Runner.Listener
+        )
+        listener=""
+        for candidate in "${candidates[@]}"; do
+          if [[ -f "$candidate" ]]; then
+            listener=$candidate
+            break
+          fi
+        done
+        if [[ -z "$listener" ]]; then
           echo "::error::Could not locate Runner.Listener under /Users/runner/runners or /Users/runner/runner"
           exit 1
         fi

--- a/.github/actions/macos_tcc/action.yaml
+++ b/.github/actions/macos_tcc/action.yaml
@@ -5,4 +5,25 @@ runs:
   steps:
     - shell: bash
       run: |
-        sudo sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "INSERT OR IGNORE INTO access VALUES('kTCCServiceAppleEvents','$(realpath /Users/runner/runner)/bin/Runner.Listener',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL,'UNUSED',1592919552)"
+        set -euo pipefail
+        listener=$(ps -axo command= | awk '$1 ~ /\/Runner\.Listener$/ { print $1; exit }')
+        if [[ -z "${listener:-}" || ! -f "$listener" ]]; then
+          shopt -s nullglob
+          candidates=(
+            /Users/runner/runners/*/bin/Runner.Listener
+            /Users/runner/runner/bin/Runner.Listener
+          )
+          listener=""
+          for candidate in "${candidates[@]}"; do
+            if [[ -f "$candidate" ]]; then
+              listener=$candidate
+              break
+            fi
+          done
+        fi
+        if [[ -z "${listener:-}" ]]; then
+          echo "::error::Could not locate Runner.Listener under /Users/runner/runners or /Users/runner/runner"
+          exit 1
+        fi
+        listener=$(realpath "$listener")
+        sudo sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "INSERT OR IGNORE INTO access VALUES('kTCCServiceAppleEvents','$listener',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL,'UNUSED',1592919552)"

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -133,7 +133,7 @@ jobs:
     if: ${{ !cancelled() && (needs.cn-draft.result == 'success' || needs.cn-draft.result == 'skipped') }}
     permissions:
       contents: write
-    runs-on: depot-macos-26
+    runs-on: macos-26
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         include:
           - platform: "macos"
-            runner: "depot-macos-26"
+            runner: "macos-26"
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -612,7 +612,7 @@ jobs:
 
   desktop_swift:
     if: ${{ github.event_name != 'pull_request' && !startsWith(github.head_ref || '', 'blog/') }}
-    runs-on: depot-macos-15
+    runs-on: macos-15
     defaults:
       run:
         shell: bash

--- a/.github/workflows/desktop_e2e.yaml
+++ b/.github/workflows/desktop_e2e.yaml
@@ -31,7 +31,7 @@ jobs:
           target_triple: x86_64-unknown-linux-gnu
 
   e2e-macos:
-    runs-on: depot-macos-14
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -66,7 +66,7 @@ jobs:
 
   watchos_build:
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: depot-macos-26
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
 
   ios_build:
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: depot-macos-26
+    runs-on: macos-26
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Replace Depot runner labels across desktop and mobile workflows with standard GitHub-hosted macOS runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> macOS release builds and TCC setup depend on correct `Runner.Listener` discovery on GitHub-hosted images; mis-detection could break notarization or automation that needs Finder AppleEvents.
> 
> **Overview**
> Moves desktop and mobile CI/CD off **Depot** labels (`depot-macos-*`) onto standard **GitHub-hosted** runners (`macos-14`, `macos-15`, `macos-26`) in `desktop_cd`, `desktop_ci`, `desktop_e2e`, and `mobile_ci`.
> 
> Updates **`macos_tcc`** so AppleEvents TCC grants target the real `Runner.Listener` on hosted runners: walk the process tree, fall back to common install paths under `/Users/runner`, fail fast if missing, then `realpath` before the existing `sqlite3` insert (replacing the fixed `/Users/runner/runner/bin/Runner.Listener` path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d1dcc9eba5f05a96c912349e74ccf511a92d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->