### PR TITLE
Move AI above Workspace in settings sidebar

### DIFF
--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -144,6 +144,10 @@ describe("SettingsNav", () => {
       "Account",
       "Teams",
       "Notifications",
+      "AI",
+      "Transcription",
+      "Intelligence",
+      "Dictionary",
       "Workspace",
       "Meetings",
       "Folders",
@@ -151,10 +155,6 @@ describe("SettingsNav", () => {
       "Contacts",
       "Templates",
       "Automations",
-      "AI",
-      "Transcription",
-      "Intelligence",
-      "Dictionary",
       "Data",
       "Sync",
       "Imports",
@@ -165,6 +165,22 @@ describe("SettingsNav", () => {
     ].forEach((label) => {
       expect(screen.getByText(label)).toBeTruthy();
     });
+  });
+
+  it("places the AI section above Workspace", () => {
+    const { container } = render(<SettingsNav />);
+
+    const sectionLabels = Array.from(
+      container.querySelectorAll("span.uppercase"),
+    ).map((node) => node.textContent);
+
+    expect(sectionLabels).toEqual([
+      "App",
+      "AI",
+      "Workspace",
+      "Data",
+      "Advanced",
+    ]);
   });
 
   it.each([

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -93,6 +93,19 @@ export function SettingsNav() {
       ],
     },
     {
+      label: "AI",
+      items: [
+        { id: "transcription", label: t`Transcription`, icon: Sparkle },
+        { id: "intelligence", label: t`Intelligence`, icon: Sparkle },
+        {
+          id: "dictionary",
+          label: t`Dictionary`,
+          icon: BookOpen,
+          requiresPro: true,
+        },
+      ],
+    },
+    {
       label: t`Workspace`,
       items: [
         { id: "meetings", label: t`Meetings`, icon: VideoCamera },
@@ -125,19 +138,6 @@ export function SettingsNav() {
           label: t`Automations`,
           icon: Lightning,
           destination: { type: "automations" },
-          requiresPro: true,
-        },
-      ],
-    },
-    {
-      label: "AI",
-      items: [
-        { id: "transcription", label: t`Transcription`, icon: Sparkle },
-        { id: "intelligence", label: t`Intelligence`, icon: Sparkle },
-        {
-          id: "dictionary",
-          label: t`Dictionary`,
-          icon: BookOpen,
           requiresPro: true,
         },
       ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** In settings, the AI section sat below Workspace in the left sidebar, so transcription and intelligence were farther down than they needed to be.

**Fix:** Reorder the settings nav groups so AI appears immediately after App and before Workspace. Section destinations and items are unchanged.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed files
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/sidebar/settings.tsx apps/desktop/src/sidebar/settings.test.tsx`
- `pnpm -F desktop typecheck`
- `pnpm -F desktop exec vitest run src/sidebar/settings.test.tsx` (29 tests)
- Skipped `pnpm -F desktop i18n:check`: no translatable copy was added or changed
- Did not launch the desktop app: this is a nav-group reorder covered by a unit test that asserts section header order

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c102a7df-f7d7-49f9-b7e0-781481b61eff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c102a7df-f7d7-49f9-b7e0-781481b61eff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

