### PR TITLE
Show transcript find and stop clipping the speaker picker

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -15,6 +15,7 @@ const hoisted = vi.hoisted(() => ({
   onBeforeTabChange: vi.fn(),
   rawEditorProps: [] as Record<string, unknown>[],
   registerCanonicalSessionEditor: vi.fn(),
+  searchVisible: false,
   sessionMode: "inactive",
   unregisterCanonicalSessionEditor: vi.fn(),
   updateSessionTabState: vi.fn(),
@@ -93,7 +94,13 @@ vi.mock("./search/bar", () => ({
 }));
 
 vi.mock("./search/context", () => ({
-  useSearch: () => null,
+  useSearch: () =>
+    hoisted.searchVisible
+      ? {
+          isVisible: true,
+          close: vi.fn(),
+        }
+      : null,
 }));
 
 vi.mock("./transcript", () => ({
@@ -217,6 +224,7 @@ describe("NoteInput tab selection", () => {
     hoisted.onBeforeTabChange.mockClear();
     hoisted.rawEditorProps = [];
     hoisted.registerCanonicalSessionEditor.mockClear();
+    hoisted.searchVisible = false;
     hoisted.sessionMode = "inactive";
     hoisted.unregisterCanonicalSessionEditor.mockClear();
     hoisted.updateSessionTabState.mockClear();
@@ -439,5 +447,19 @@ describe("NoteInput tab selection", () => {
 
     expect(wasNotCancelled).toBe(true);
     expect(hoisted.focusAtTrailingEmptyLine).not.toHaveBeenCalled();
+  });
+
+  it("shows the keyword search bar on the transcript tab", () => {
+    hoisted.searchVisible = true;
+
+    renderNoteInput({ currentTab: { type: "transcript" } });
+
+    expect(screen.getByTestId("search-bar")).toBeTruthy();
+  });
+
+  it("hides the search bar until find is opened", () => {
+    renderNoteInput({ currentTab: { type: "transcript" } });
+
+    expect(screen.queryByTestId("search-bar")).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -271,6 +271,8 @@ const NoteInputContent = forwardRef<
     const isEditableTab =
       renderedCurrentTab.type === "enhanced" ||
       renderedCurrentTab.type === "raw";
+    const isSearchableTab =
+      isEditableTab || renderedCurrentTab.type === "transcript";
 
     useEffect(() => {
       search?.close();
@@ -345,9 +347,12 @@ const NoteInputContent = forwardRef<
           </div>
         )}
 
-        {showSearchBar && isEditableTab && (
+        {showSearchBar && isSearchableTab && (
           <div className="px-3 pt-1">
-            <SearchBar editorRef={internalEditorRef} />
+            <SearchBar
+              editorRef={internalEditorRef}
+              allowReplace={isEditableTab}
+            />
           </div>
         )}
 

--- a/apps/desktop/src/session/components/note-input/search/bar.test.tsx
+++ b/apps/desktop/src/session/components/note-input/search/bar.test.tsx
@@ -89,4 +89,11 @@ describe("SearchBar", () => {
 
     expect(container.textContent).toContain("Ctrl H");
   });
+
+  it("hides replace controls for find-only surfaces", () => {
+    const { container } = render(<SearchBar allowReplace={false} />);
+
+    expect(container.textContent).not.toContain("Replace");
+    expect(container.textContent).not.toContain("⌘ H");
+  });
 });

--- a/apps/desktop/src/session/components/note-input/search/bar.tsx
+++ b/apps/desktop/src/session/components/note-input/search/bar.tsx
@@ -97,8 +97,10 @@ function IconButton({
 
 export function SearchBar({
   editorRef,
+  allowReplace = true,
 }: {
-  editorRef: React.RefObject<NoteEditorRef | null>;
+  editorRef?: React.RefObject<NoteEditorRef | null>;
+  allowReplace?: boolean;
 }) {
   const { t } = useLingui();
   const search = useSearch();
@@ -109,15 +111,15 @@ export function SearchBar({
   useMountEffect(() => {
     searchInputRef.current?.focus();
 
-    const editor = editorRef.current;
+    const editor = editorRef?.current;
     return () => editor?.commands.setSearch("", false);
   });
 
   useEffect(() => {
-    if (search?.showReplace) {
+    if (allowReplace && search?.showReplace) {
       replaceInputRef.current?.focus();
     }
-  }, [search?.showReplace]);
+  }, [allowReplace, search?.showReplace]);
 
   if (!search) {
     return null;
@@ -138,7 +140,7 @@ export function SearchBar({
     setReplaceQuery,
   } = search;
 
-  const commands = editorRef.current?.commands;
+  const commands = editorRef?.current?.commands;
 
   const setQuery = (q: string) => {
     search.setQuery(q);
@@ -231,20 +233,22 @@ export function SearchBar({
           >
             <Textbox className="size-3.5" />
           </ToggleButton>
-          <ToggleButton
-            active={showReplace}
-            onClick={toggleReplace}
-            tooltip={
-              <>
-                <span>
-                  <Trans>Replace</Trans>
-                </span>
-                <Kbd className="animate-kbd-press">{primaryModifier} H</Kbd>
-              </>
-            }
-          >
-            <Swap className="size-3.5" />
-          </ToggleButton>
+          {allowReplace && (
+            <ToggleButton
+              active={showReplace}
+              onClick={toggleReplace}
+              tooltip={
+                <>
+                  <span>
+                    <Trans>Replace</Trans>
+                  </span>
+                  <Kbd className="animate-kbd-press">{primaryModifier} H</Kbd>
+                </>
+              }
+            >
+              <Swap className="size-3.5" />
+            </ToggleButton>
+          )}
         </div>
         <span className="text-muted-foreground text-[10px] whitespace-nowrap tabular-nums">
           {displayCount}
@@ -294,7 +298,7 @@ export function SearchBar({
         </IconButton>
       </div>
 
-      {showReplace && (
+      {allowReplace && showReplace && (
         <div className="bg-muted flex h-7 items-center gap-1.5 rounded-lg px-2">
           <input
             ref={replaceInputRef}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -224,6 +224,11 @@ describe("SpeakerAssignPopover", () => {
     }).parentElement;
     expect(footer?.className).toContain("py-1");
     expect(footer?.className).not.toContain("pb-3");
+    const list = screen.getByRole("button", {
+      name: "Create new speaker",
+    }).parentElement;
+    expect(list?.className).toContain("py-1");
+    expect(list?.className).toContain("pb-3");
     const aliceOption = screen.getByRole("button", { name: "Alice" });
     expect(aliceOption.querySelector("img")?.getAttribute("src")).toBe(
       "data:image/jpeg;base64,alice",

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -111,7 +111,7 @@ export function SpeakerAssignPopover({
         align="start"
         sideOffset={8}
         collisionPadding={16}
-        className="max-h-[min(var(--radix-popover-content-available-height),28rem)] w-80"
+        className="w-80"
       >
         <SpeakerParticipantPicker
           sessionId={sessionId}
@@ -500,62 +500,64 @@ export function SpeakerParticipantPicker({
             />
           </div>
         </div>
-        <div className="min-h-0 flex-1 overflow-auto py-1">
-          {groups.map((group) => (
-            <div key={group.title}>
-              <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
-                {group.title === "Participants" ? (
-                  <Trans>Participants</Trans>
-                ) : (
-                  <Trans>People</Trans>
-                )}
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div className="py-1 pb-3">
+            {groups.map((group) => (
+              <div key={group.title}>
+                <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
+                  {group.title === "Participants" ? (
+                    <Trans>Participants</Trans>
+                  ) : (
+                    <Trans>People</Trans>
+                  )}
+                </div>
+                {group.options.map((option) => (
+                  <ParticipantOptionButton
+                    key={option.id}
+                    option={option}
+                    selected={selectedOption === option}
+                    onSelect={handleSelect}
+                  />
+                ))}
               </div>
-              {group.options.map((option) => (
+            ))}
+
+            {createOption && (
+              <div>
+                {!hasPeopleGroup && (
+                  <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
+                    <Trans>People</Trans>
+                  </div>
+                )}
                 <ParticipantOptionButton
-                  key={option.id}
-                  option={option}
-                  selected={selectedOption === option}
+                  option={createOption}
+                  selected={selectedOption === createOption}
                   onSelect={handleSelect}
                 />
-              ))}
-            </div>
-          ))}
+              </div>
+            )}
 
-          {createOption && (
-            <div>
-              {!hasPeopleGroup && (
-                <div className="text-muted-foreground px-3 pt-2 pb-1 text-[11px] font-medium uppercase">
-                  <Trans>People</Trans>
-                </div>
-              )}
-              <ParticipantOptionButton
-                option={createOption}
-                selected={selectedOption === createOption}
-                onSelect={handleSelect}
-              />
-            </div>
-          )}
+            {!createOption && groups.length === 0 && (
+              <p className="text-muted-foreground px-3 py-2 text-xs">
+                {query.trim() ? (
+                  <Trans>No matching people</Trans>
+                ) : (
+                  <Trans>No people</Trans>
+                )}
+              </p>
+            )}
 
-          {!createOption && groups.length === 0 && (
-            <p className="text-muted-foreground px-3 py-2 text-xs">
-              {query.trim() ? (
-                <Trans>No matching people</Trans>
-              ) : (
-                <Trans>No people</Trans>
-              )}
-            </p>
-          )}
-
-          {!query.trim() && (
-            <button
-              type="button"
-              className="hover:bg-accent flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
-              onClick={() => searchInputRef.current?.focus()}
-            >
-              <Plus className="size-4" />
-              <Trans>Create new speaker</Trans>
-            </button>
-          )}
+            {!query.trim() && (
+              <button
+                type="button"
+                className="hover:bg-accent flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
+                onClick={() => searchInputRef.current?.focus()}
+              >
+                <Plus className="size-4" />
+                <Trans>Create new speaker</Trans>
+              </button>
+            )}
+          </div>
         </div>
       </AppFloatingPanel>
       <div className="flex items-center justify-end gap-3 py-1 pl-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Cmd+F on the transcript tab did nothing visible, even though summary and memos already open a keyword search bar. The speaker picker also cut off the last person in Chromium because list padding sat on an `overflow-auto` flex child, which Chrome does not include in scroll height.

**Fix:** Open the existing find bar on transcript (find-only, no replace). Move the participant list’s extra bottom padding onto an inner wrapper so the last row can scroll fully above the panel edge, and stop stacking the same max-height on the popover chrome so the footer is not clipped.

## Verification

- `pnpm exec dprint fmt` / `dprint check` on the changed files
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop exec vitest run src/session/components/note-input/index.test.tsx src/session/components/note-input/search/bar.test.tsx src/session/components/note-input/transcript/renderer/speaker-assign.test.ts`
- `pnpm -F desktop test` (full desktop suite)

Could not interactively verify the picker or Cmd+F in Chrome here; this environment’s desktop shell is WebKitGTK, and the session UI is not on the web app.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c4ef65a-6c7c-432e-9b39-fcd6c7a8cd2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c4ef65a-6c7c-432e-9b39-fcd6c7a8cd2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

