### PR TITLE
Keep chat from crashing the app when a transport rejection is not an Error

### DIFF
--- a/apps/desktop/src/chat/components/message/error.test.tsx
+++ b/apps/desktop/src/chat/components/message/error.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@anlg/plugin-opener2", () => ({
+  commands: { openUrl: vi.fn() },
+}));
+
+vi.mock("~/chat/hooks/use-chat-appearance", () => ({
+  useChatAppearance: () => ({
+    isDarkAppearance: false,
+    toolbarSurface: "light",
+    panelClassName: "",
+    panelBorderClassName: "",
+    elevatedSurfaceClassName: "",
+    inputEditorClassName: "",
+  }),
+}));
+
+vi.mock("~/env", () => ({
+  env: { VITE_APP_URL: "http://localhost:3000" },
+}));
+
+import { ErrorMessage, getChatErrorText } from "./error";
+
+describe("ErrorMessage", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders an Error's message", () => {
+    render(<ErrorMessage error={new Error("model unavailable")} />);
+
+    expect(screen.getByText("model unavailable")).toBeTruthy();
+  });
+
+  it("renders a bare string rejection instead of crashing", () => {
+    // Tauri `invoke` rejects with the serialized Rust error, which is a plain
+    // string; the AI SDK stores it as `useChat().error` as-is.
+    render(<ErrorMessage error="cloudsync_activity_drain_timeout" />);
+
+    expect(screen.getByText("cloudsync_activity_drain_timeout")).toBeTruthy();
+  });
+
+  it("shows context-length help for a string error too", () => {
+    render(<ErrorMessage error="prompt exceeds context length" />);
+
+    expect(screen.getByText("Learn how to fix this")).toBeTruthy();
+  });
+});
+
+describe("getChatErrorText", () => {
+  it("normalizes non-Error values to a string", () => {
+    expect(getChatErrorText(new Error("boom"))).toBe("boom");
+    expect(getChatErrorText("boom")).toBe("boom");
+    expect(getChatErrorText(42)).toBe("42");
+    expect(getChatErrorText(undefined)).toBe("undefined");
+  });
+});

--- a/apps/desktop/src/chat/components/message/error.tsx
+++ b/apps/desktop/src/chat/components/message/error.tsx
@@ -9,6 +9,14 @@ import { env } from "~/env";
 
 const WEB_APP_BASE_URL = env.VITE_APP_URL ?? "http://localhost:3000";
 
+// `useChat().error` is typed as Error but holds whatever the transport threw.
+export function getChatErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === "string" ? error : String(error);
+}
+
 function isContextLengthError(message: string): boolean {
   const lowerMessage = message.toLowerCase();
   return (
@@ -23,11 +31,12 @@ export function ErrorMessage({
   error,
   onRetry,
 }: {
-  error: Error;
+  error: unknown;
   onRetry?: () => void;
 }) {
   const { t } = useLingui();
-  const showContextLengthHelp = isContextLengthError(error.message);
+  const message = getChatErrorText(error);
+  const showContextLengthHelp = isContextLengthError(message);
 
   const handleOpenFaq = () => {
     void openerCommands.openUrl(
@@ -39,7 +48,7 @@ export function ErrorMessage({
   return (
     <MessageContainer align="start">
       <MessageBubble variant="error" withActionButton={!!onRetry}>
-        <p className="text-sm">{error.message}</p>
+        <p className="text-sm">{message}</p>
         {showContextLengthHelp && (
           <button
             onClick={handleOpenFaq}

--- a/apps/desktop/src/chat/store/cloudsync-activity.test.ts
+++ b/apps/desktop/src/chat/store/cloudsync-activity.test.ts
@@ -215,6 +215,64 @@ describe("chat CloudSync activity", () => {
     expect(end).toHaveBeenCalledWith("chat", "turn-1:attempt-1");
   });
 
+  it("wraps a non-Error lease acquisition rejection so useChat gets an Error", async () => {
+    // Tauri `invoke` rejects with the serialized Rust error, a bare string.
+    const begin = vi.fn().mockRejectedValue("cloudsync_activity_drain_timeout");
+    const activity = createChatCloudsyncActivityController({
+      begin,
+      end: vi.fn().mockResolvedValue(undefined),
+      createAttemptKey: sequentialAttemptKeys(),
+    });
+    const transport = guardChatTransport(
+      {
+        sendMessages: vi.fn(),
+        reconnectToStream: vi.fn().mockResolvedValue(null),
+      },
+      activity,
+    );
+
+    const rejection = transport.sendMessages({
+      trigger: "submit-message",
+      chatId: "chat-1",
+      messageId: undefined,
+      messages: [{ id: "turn-1", role: "user", parts: [] }],
+      abortSignal: new AbortController().signal,
+    });
+
+    await expect(rejection).rejects.toBeInstanceOf(Error);
+    await expect(rejection).rejects.toMatchObject({
+      message: "cloudsync_activity_drain_timeout",
+    });
+  });
+
+  it("wraps a non-Error transport rejection so useChat gets an Error", async () => {
+    const activity = createChatCloudsyncActivityController({
+      begin: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      createAttemptKey: sequentialAttemptKeys(),
+    });
+    const transport = guardChatTransport(
+      {
+        sendMessages: vi.fn().mockRejectedValue("template render failed"),
+        reconnectToStream: vi.fn().mockResolvedValue(null),
+      },
+      activity,
+    );
+
+    const rejection = transport.sendMessages({
+      trigger: "submit-message",
+      chatId: "chat-1",
+      messageId: undefined,
+      messages: [{ id: "turn-1", role: "user", parts: [] }],
+      abortSignal: new AbortController().signal,
+    });
+
+    await expect(rejection).rejects.toBeInstanceOf(Error);
+    await expect(rejection).rejects.toMatchObject({
+      message: "template render failed",
+    });
+  });
+
   it("releases the exact attempt when transport rejects before streaming", async () => {
     const transportError = new Error("transport unavailable");
     const end = vi.fn().mockResolvedValue(undefined);

--- a/apps/desktop/src/chat/store/cloudsync-activity.ts
+++ b/apps/desktop/src/chat/store/cloudsync-activity.ts
@@ -622,6 +622,16 @@ export type ChatCloudsyncActivityController = ReturnType<
   typeof createChatCloudsyncActivityController
 >;
 
+// Tauri `invoke` rejects with the serialized Rust error (a bare string), and
+// the AI SDK stores whatever `sendMessages` throws as `useChat().error`
+// without checking it is an Error. Normalize so the UI can rely on `.message`.
+export function toChatTransportError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(typeof error === "string" ? error : String(error));
+}
+
 export function guardChatTransport<UI_MESSAGE extends UIMessage>(
   transport: ChatTransport<UI_MESSAGE>,
   activity: ChatCloudsyncActivityController,
@@ -658,7 +668,7 @@ export function guardChatTransport<UI_MESSAGE extends UIMessage>(
             .runWithLease(key, () => undefined)
             .catch(() => undefined);
         }
-        throw error;
+        throw toChatTransportError(error);
       }
 
       if (!attempt) {
@@ -674,15 +684,10 @@ export function guardChatTransport<UI_MESSAGE extends UIMessage>(
           throw error;
         }
 
-        if (options.abortSignal?.aborted) {
-          const error = new Error("Chat request aborted");
-          error.name = "AbortError";
-          throw error;
-        }
         return await transport.sendMessages(options);
       } catch (error) {
         attempt.finish();
-        throw error;
+        throw toChatTransportError(error);
       }
     },
     reconnectToStream: (options) => transport.reconnectToStream(options),


### PR DESCRIPTION
## Summary

**Problem:** Sending a chat message while CloudSync was busy crashed the whole desktop app to the "Something went wrong" error boundary with `undefined is not an object (evaluating 'e.toLowerCase')`. `beginCloudsyncActivity` hit its 2s drain timeout and the Rust error reached JS via Tauri `invoke` as a bare string (`"cloudsync_activity_drain_timeout"`). The AI SDK stores whatever `sendMessages` throws as `useChat().error` without checking it is an `Error`, so `ErrorMessage` rendered a string and blew up on `error.message.toLowerCase()` during render. A recoverable "request failed" became an app crash.

**Fix:** `guardChatTransport` now normalizes every rejection with `toChatTransportError()` so `useChat().error` is always a real `Error` (real `Error`s pass through untouched; strings and other values are wrapped, preserving the message). This covers both throw sites: lease acquisition and the inner transport. As defense in depth, `ErrorMessage` accepts `error: unknown` and derives display text via `getChatErrorText()` before any string method, so the panel shows the failure in a red bubble with Retry instead of tripping the boundary. Also drops a literally duplicated `abortSignal?.aborted` check in the same block.

This does not fix the underlying trigger: the `e2ee_witness_repair_pending` repair loop is re-running the same ~2.2s query every 2.5s on the same 8 records and never converging, which keeps CloudSync from going idle within the 2s drain window. That is a separate `crates/cloudsync` / `plugins/db` follow-up; with this PR the send fails gracefully instead of crashing.

## Verification

- `pnpm -F desktop exec vitest run src/chat/components/message/error.test.tsx src/chat/store/cloudsync-activity.test.ts` — 42/42 pass, including new regression cases: string rejection from `begin` and from the inner transport surface as `Error` instances; `ErrorMessage` renders a bare string error without throwing and still shows context-length help for string errors.
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` — 0 errors
- `pnpm -F desktop i18n:check` — catalogs stable (no copy changed)
- `pnpm exec dprint fmt` + `dprint check` on changed files
- Root-caused against `~/Library/Logs/com.hyprnote.stable/app.log` from stable 1.4.17: `CloudSync activity could not drain the in-flight operation activity="chat" ... timeout_ms=2000` at 02:37:41.319Z, followed by the boundary's `[Object {}]` console error at 02:37:41.665Z.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat error normalization and UI display; no auth, sync logic, or happy-path transport changes beyond ensuring rejections are `Error` instances.
> 
> **Overview**
> Fixes a desktop crash when chat fails with a **non-`Error` rejection** (e.g. Tauri `invoke` returning a bare string like `cloudsync_activity_drain_timeout`), which the AI SDK can surface as `useChat().error` and previously broke `ErrorMessage` when it assumed `.message`.
> 
> **`guardChatTransport`** now rethrows through **`toChatTransportError`**, wrapping strings and other values in a real `Error` while leaving existing `Error` instances unchanged—at both lease acquisition and inner transport failure. A duplicate **`abortSignal?.aborted`** check in the same send path is removed.
> 
> As defense in depth, **`ErrorMessage`** takes **`error: unknown`** and displays text via exported **`getChatErrorText`**, so context-length help and the error bubble still work for string errors. New Vitest coverage locks in wrapping behavior and UI rendering for string rejections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98fa68c5af979c93945a4250a7caa53732b14c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->