### PR TITLE
Skip AEC when the default output is a headphone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10063,6 +10063,7 @@ name = "listener-core"
 version = "0.1.0"
 dependencies = [
  "audio",
+ "audio-device",
  "audio-utils",
  "bytes",
  "data",

--- a/crates/audio-device/src/device.rs
+++ b/crates/audio-device/src/device.rs
@@ -39,6 +39,33 @@ pub enum TransportType {
     Unknown,
 }
 
+/// Bluetooth outputs default to "headphone" because most Bluetooth audio on a laptop is, and
+/// popular headphones (Sony WH-*, Bose QC*) carry no headphone keyword in their name. This
+/// denylist catches the common Bluetooth speakers so they keep echo cancellation.
+pub(crate) fn name_suggests_speaker(name: &str) -> bool {
+    const SPEAKER_MARKERS: &[&str] = &[
+        "speaker",
+        "soundbar",
+        "sound bar",
+        "soundlink",
+        "boombox",
+        "homepod",
+        "sonos",
+        "megaboom",
+        "wonderboom",
+        "jbl flip",
+        "jbl charge",
+        "jbl clip",
+        "jbl go",
+        "jbl xtreme",
+    ];
+
+    let name_lower = name.to_lowercase();
+    SPEAKER_MARKERS
+        .iter()
+        .any(|marker| name_lower.contains(marker))
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 pub struct AudioDevice {
     pub id: DeviceId,
@@ -83,5 +110,30 @@ impl AudioDevice {
     pub fn with_muted(mut self, is_muted: bool) -> Self {
         self.is_muted = Some(is_muted);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::name_suggests_speaker;
+
+    #[test]
+    fn bluetooth_speakers_are_recognized_by_name() {
+        for name in [
+            "Bose SoundLink Flex",
+            "JBL Flip 6",
+            "Sonos Roam",
+            "HomePod mini",
+            "Living Room Speaker",
+        ] {
+            assert!(name_suggests_speaker(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn bluetooth_headphones_without_keywords_are_not_speakers() {
+        for name in ["WH-1000XM5", "Bose QC45", "AirPods Pro", "Jabra Elite 85t"] {
+            assert!(!name_suggests_speaker(name), "{name}");
+        }
     }
 }

--- a/crates/audio-device/src/lib.rs
+++ b/crates/audio-device/src/lib.rs
@@ -35,6 +35,16 @@ pub fn backend() -> impl AudioDeviceBackend {
     }
 }
 
+/// Returns the default output device when it is classified as a headphone.
+pub fn default_output_headphone() -> Option<AudioDevice> {
+    let backend = backend();
+    backend
+        .get_default_output_device()
+        .ok()
+        .flatten()
+        .filter(|device| backend.is_headphone(device))
+}
+
 pub trait AudioDeviceBackend {
     fn list_devices(&self) -> Result<Vec<AudioDevice>, Error>;
 

--- a/crates/audio-device/src/linux.rs
+++ b/crates/audio-device/src/linux.rs
@@ -371,11 +371,8 @@ impl AudioDeviceBackend for LinuxBackend {
             if let pulse::callbacks::ListResult::Item(sink_info) = list_result {
                 if let Some(active_port) = &sink_info.active_port {
                     if let Some(name) = active_port.name.as_ref() {
-                        let name_lower = name.to_lowercase();
-                        let is_headphone =
-                            name_lower.contains("headphone") || name_lower.contains("headset");
                         if let Ok(mut r) = result_clone.lock() {
-                            *r = is_headphone;
+                            *r = is_headphone_port(name);
                         }
                     }
                 }
@@ -558,6 +555,12 @@ impl AudioDeviceBackend for LinuxBackend {
     }
 }
 
+/// PulseAudio names analog jack ports after what is plugged in, e.g. `analog-output-headphones`.
+pub fn is_headphone_port(port_name: &str) -> bool {
+    let name_lower = port_name.to_lowercase();
+    name_lower.contains("headphone") || name_lower.contains("headset")
+}
+
 pub fn is_headphone_from_default_output_device() -> Option<bool> {
     let mut mainloop = Mainloop::new()?;
 
@@ -594,11 +597,8 @@ pub fn is_headphone_from_default_output_device() -> Option<bool> {
             if let pulse::callbacks::ListResult::Item(sink_info) = list_result {
                 if let Some(active_port) = &sink_info.active_port {
                     if let Some(name) = active_port.name.as_ref() {
-                        let name_lower = name.to_lowercase();
-                        let is_headphone =
-                            name_lower.contains("headphone") || name_lower.contains("headset");
                         if let Ok(mut r) = result.lock() {
-                            *r = if is_headphone { Some(true) } else { None };
+                            *r = is_headphone_port(name).then_some(true);
                         }
                     }
                 }

--- a/crates/audio-device/src/macos.rs
+++ b/crates/audio-device/src/macos.rs
@@ -1,5 +1,6 @@
 use cidre::{cf, core_audio as ca, io};
 
+use crate::device::name_suggests_speaker;
 use crate::{AudioDevice, AudioDeviceBackend, AudioDirection, DeviceId, Error, TransportType};
 
 pub struct MacOSBackend;
@@ -233,7 +234,7 @@ impl AudioDeviceBackend for MacOSBackend {
         }
 
         match device.transport_type {
-            TransportType::Bluetooth => true,
+            TransportType::Bluetooth => !name_suggests_speaker(&device.name),
             TransportType::Usb => {
                 let name_lower = device.name.to_lowercase();
                 name_lower.contains("headphone")

--- a/crates/audio-device/src/windows.rs
+++ b/crates/audio-device/src/windows.rs
@@ -1,3 +1,4 @@
+use crate::device::name_suggests_speaker;
 use crate::{AudioDevice, AudioDeviceBackend, AudioDirection, DeviceId, Error, TransportType};
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
@@ -377,7 +378,9 @@ impl AudioDeviceBackend for WindowsBackend {
             return false;
         }
 
-        is_headphone_from_name(&device.name) || device.transport_type == TransportType::Bluetooth
+        is_headphone_from_name(&device.name)
+            || (device.transport_type == TransportType::Bluetooth
+                && !name_suggests_speaker(&device.name))
     }
 
     fn get_device_volume(&self, device_id: &DeviceId) -> Result<f32, Error> {

--- a/crates/device-monitor/src/linux.rs
+++ b/crates/device-monitor/src/linux.rs
@@ -1,5 +1,6 @@
 use crate::{DeviceEvent, DeviceSwitch, DeviceUpdate};
 use libpulse_binding::{
+    callbacks::ListResult,
     context::{
         Context, FlagSet as ContextFlagSet,
         subscribe::{Facility, InterestMaskSet, Operation},
@@ -24,13 +25,37 @@ struct DefaultDeviceChanges {
 struct DefaultDevices {
     source: Option<String>,
     sink: Option<String>,
+    // Plugging or unplugging an analog jack switches the default sink's active port without
+    // changing its name, so the port's headphone verdict is tracked as its own output change.
+    sink_headphone: Option<bool>,
 }
 
 impl DefaultDevices {
     fn observe(&mut self, source: Option<&str>, sink: Option<&str>) -> DefaultDeviceChanges {
-        DefaultDeviceChanges {
+        let changes = DefaultDeviceChanges {
             source_changed: Self::observe_name(&mut self.source, source),
             sink_changed: Self::observe_name(&mut self.sink, sink),
+        };
+        if changes.sink_changed {
+            self.sink_headphone = None;
+        }
+        changes
+    }
+
+    fn observe_sink_headphone(&mut self, headphone: Option<bool>) -> bool {
+        let Some(headphone) = headphone else {
+            return false;
+        };
+        match self.sink_headphone {
+            Some(previous) if previous != headphone => {
+                self.sink_headphone = Some(headphone);
+                true
+            }
+            None => {
+                self.sink_headphone = Some(headphone);
+                false
+            }
+            Some(_) => false,
         }
     }
 
@@ -155,6 +180,7 @@ fn refresh_default_devices(
     };
     let tracker = Rc::clone(tracker);
     let emit = Rc::clone(emit);
+    let context = Rc::clone(context);
     ctx.introspect().get_server_info(move |info| {
         let source = info.default_source_name.as_deref();
         let sink = info.default_sink_name.as_deref();
@@ -174,6 +200,39 @@ fn refresh_default_devices(
             emit(DeviceSwitch::DefaultOutputChanged {
                 headphone: is_headphone_from_default_output_device(),
             });
+        }
+        if let Some(sink) = sink {
+            refresh_default_sink_port(&context, &tracker, &emit, sink);
+        }
+    });
+}
+
+fn refresh_default_sink_port(
+    context: &Rc<RefCell<Context>>,
+    tracker: &Rc<RefCell<DefaultDevices>>,
+    emit: &DeviceSwitchEmit,
+    sink: &str,
+) {
+    let Ok(ctx) = context.try_borrow() else {
+        return;
+    };
+    let tracker = Rc::clone(tracker);
+    let emit = Rc::clone(emit);
+    ctx.introspect().get_sink_info_by_name(sink, move |result| {
+        let ListResult::Item(info) = result else {
+            return;
+        };
+        let headphone = info
+            .active_port
+            .as_ref()
+            .and_then(|port| port.name.as_deref())
+            .map(anlg_audio_device::linux::is_headphone_port);
+        if tracker.borrow_mut().observe_sink_headphone(headphone) {
+            tracing::info!(
+                anarlog.audio.default_sink_headphone = headphone,
+                "default_sink_port_changed"
+            );
+            emit(DeviceSwitch::DefaultOutputChanged { headphone });
         }
     });
 }
@@ -370,5 +429,31 @@ mod tests {
                 sink_changed: false,
             }
         );
+    }
+
+    #[test]
+    fn jack_port_flip_on_same_sink_counts_as_output_change() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("alsa_output.pci"));
+
+        assert!(!devices.observe_sink_headphone(Some(false)));
+        assert!(!devices.observe_sink_headphone(Some(false)));
+        assert!(devices.observe_sink_headphone(Some(true)));
+        assert!(!devices.observe_sink_headphone(None));
+        assert!(devices.observe_sink_headphone(Some(false)));
+    }
+
+    #[test]
+    fn new_default_sink_resets_port_baseline() {
+        let mut devices = DefaultDevices::default();
+        devices.observe(Some("qa_mic_bus.monitor"), Some("alsa_output.pci"));
+        devices.observe_sink_headphone(Some(false));
+
+        assert!(
+            devices
+                .observe(Some("qa_mic_bus.monitor"), Some("alsa_output.usb"))
+                .sink_changed
+        );
+        assert!(!devices.observe_sink_headphone(Some(true)));
     }
 }

--- a/crates/listener-core/Cargo.toml
+++ b/crates/listener-core/Cargo.toml
@@ -10,6 +10,7 @@ tauri-event = ["specta", "dep:tauri-specta"]
 
 [dependencies]
 anlg-audio = { workspace = true }
+anlg-audio-device = { workspace = true }
 anlg-audio-utils = { workspace = true }
 anlg-device-monitor = { workspace = true }
 anlg-host = { workspace = true }

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -112,7 +112,11 @@ impl DeviceChangeWatcher {
                     tracing::info!("default_input_changed_restarting_source");
                     actor.stop(Some("device_change".to_string()));
                 }
-                Ok(_) => {}
+                Ok(DeviceSwitch::DefaultOutputChanged { .. }) => {
+                    tracing::info!("default_output_changed_restarting_source");
+                    actor.stop(Some("device_change".to_string()));
+                }
+                Ok(DeviceSwitch::DeviceListChanged) => {}
                 Err(_) => break,
             }
         }

--- a/crates/listener-core/src/actors/source/stream.rs
+++ b/crates/listener-core/src/actors/source/stream.rs
@@ -115,7 +115,7 @@ async fn run_stream_loop(ctx: StreamContext, mode: ChannelMode) {
                 chunk_size,
                 mic_device: ctx.mic_device.clone(),
                 speaker_device: ctx.speaker_device.clone(),
-                enable_aec: std::env::var("NO_AEC").as_deref() != Ok("1"),
+                enable_aec: aec_enabled(),
             };
             ctx.audio.open_capture(config)
         }
@@ -146,6 +146,26 @@ async fn run_stream_loop(ctx: StreamContext, mode: ChannelMode) {
         if matches!(result, StreamResult::Stop) {
             return;
         }
+    }
+}
+
+// Headphones keep speaker output out of the mic, so AEC only costs CPU and can degrade near-end
+// speech. The source restarts on default output changes, so this is re-evaluated per stream.
+fn aec_enabled() -> bool {
+    if std::env::var("NO_AEC").as_deref() == Ok("1") {
+        return false;
+    }
+
+    match anlg_audio_device::default_output_headphone() {
+        Some(device) => {
+            tracing::info!(
+                device = %device.name,
+                transport = ?device.transport_type,
+                "aec_disabled_headphone_output"
+            );
+            false
+        }
+        None => true,
     }
 }
 


### PR DESCRIPTION
Headphones keep speaker output out of the mic, so AEC only burns CPU and can degrade near-end speech. Decide AEC per stream from the default output device (terminal type, Bluetooth transport, or name heuristics), and restart the source on default output changes so the decision is re-evaluated, mirroring the existing input-change restart. NO_AEC=1 still force-disables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time capture behavior and device heuristics; misclassified Bluetooth or Linux ports could leave AEC on when needed or off when echo is present.
> 
> **Overview**
> **Disables acoustic echo cancellation (AEC)** when the system default output is classified as headphones, since speaker bleed is unlikely and AEC can hurt near-end quality and CPU use. `NO_AEC=1` still forces AEC off.
> 
> Capture now uses `aec_enabled()` instead of only checking `NO_AEC`. It calls **`default_output_headphone()`** from `anlg-audio-device`, which returns the default output only if platform **`is_headphone`** logic agrees. **Bluetooth outputs** are treated as headphones by default, except names matching a **speaker denylist** (Sonos, JBL, SoundLink, etc.) so portable speakers keep AEC. Linux factors **`is_headphone_port`** for PulseAudio active ports; macOS/Windows use the same denylist for Bluetooth.
> 
> The **source actor restarts** on **`DefaultOutputChanged`** (like default input), so AEC is re-decided each stream. On **Linux**, the device monitor also emits output changes when the **default sink’s active port** flips (e.g. headphone jack) without renaming the sink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f525632355da3c1c090bddd6bc43470587a28af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->