### PR TITLE
fix: show Share instead of Record after a meeting ends

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr "Settings"
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr "Share"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -4163,6 +4163,7 @@ msgid "Settings"
 msgstr ""
 
 #: src/session-sharing/draft-panel.tsx
+#: src/session-sharing/index.tsx
 #: src/session-sharing/management-panel.tsx
 msgid "Share"
 msgstr ""

--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -696,6 +696,28 @@ describe("SessionShareButton", () => {
     expect(mocks.markSessionShareActivated).not.toHaveBeenCalled();
   });
 
+  it("renders a labeled share CTA for the session header", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SessionShareButton sessionId="session-1" variant="cta" />
+      </QueryClientProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Share note" });
+    expect(trigger.textContent).toContain("Share");
+    expect(trigger.className).toContain("bg-primary");
+    expect(trigger.className).toContain("dark:bg-white");
+    expect(trigger.querySelector("svg")?.getAttribute("class")).toContain(
+      "size-3.5",
+    );
+  });
+
   it("shows existing share controls while access is still loading", async () => {
     let resolveManagement!: (
       value: ReturnType<typeof defaultManagement>,

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -73,7 +73,13 @@ import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 export { sessionShareManagementQueryKey };
 
-export function SessionShareButton({ sessionId }: { sessionId: string }) {
+export function SessionShareButton({
+  sessionId,
+  variant = "icon",
+}: {
+  sessionId: string;
+  variant?: "icon" | "cta";
+}) {
   const auth = useAuth();
   const latestAuthRef = useRef(auth);
   latestAuthRef.current = auth;
@@ -618,19 +624,33 @@ export function SessionShareButton({ sessionId }: { sessionId: string }) {
         <Button
           key={accountUserId ?? "signed-out"}
           type="button"
-          size="icon"
-          variant="ghost"
+          size={variant === "cta" ? "sm" : "icon"}
+          variant={variant === "cta" ? "default" : "ghost"}
           data-tauri-drag-region="false"
           aria-label={t`Share note`}
           aria-expanded={sharePopoverOpen}
           title={t`Share note`}
           onClick={handleShare}
           className={cn([
-            "text-muted-foreground hover:text-foreground rounded-full [&_svg]:size-4",
-            sharePopoverOpen && "bg-accent text-foreground",
+            variant === "cta"
+              ? [
+                  "max-w-56 gap-1.5 overflow-hidden border pr-2.5 pl-1.5 text-sm shadow-sm",
+                  "border-primary dark:border-white dark:bg-white dark:text-black",
+                  "dark:hover:bg-white/90",
+                ]
+              : [
+                  "text-muted-foreground hover:text-foreground rounded-full [&_svg]:size-4",
+                  sharePopoverOpen && "bg-accent text-foreground",
+                ],
           ])}
         >
-          <ShareNetwork className="size-4" aria-hidden="true" />
+          <ShareNetwork
+            className={variant === "cta" ? "size-3.5" : "size-4"}
+            aria-hidden="true"
+          />
+          {variant === "cta" ? (
+            <span className="truncate">{t`Share`}</span>
+          ) : null}
         </Button>
       </PopoverTrigger>
       {showUpgradePrompt ? (

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -57,6 +57,14 @@ vi.mock("./overflow", () => ({
   },
 }));
 
+vi.mock("~/session-sharing", () => ({
+  SessionShareButton: () => (
+    <button type="button" aria-label="Share note">
+      Share
+    </button>
+  ),
+}));
+
 vi.mock("../shared", () => ({
   RecordingIcon: () => <div data-testid="recording-icon" />,
   useHasTranscript: (sessionId: string) =>
@@ -227,6 +235,7 @@ describe("OuterHeader", () => {
 
     expect(screen.queryByRole("button", { name: "Join & record" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share note" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
     expect(spacer?.className).toContain("flex-1");
@@ -254,6 +263,7 @@ describe("OuterHeader", () => {
 
     expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share note" })).toBeNull();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
   });
 
@@ -332,6 +342,7 @@ describe("OuterHeader", () => {
     const spacer = container.firstElementChild?.firstElementChild;
 
     expect(screen.getByRole("button", { name: "Record" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Share note" })).toBeNull();
     expect(spacer?.className).toContain("flex-1");
   });
 
@@ -1211,10 +1222,11 @@ describe("OuterHeader", () => {
     fireEvent.click(recordButton);
 
     expect(mocks.startListening).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Share note" })).toBeNull();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
   });
 
-  it("hides record for an inactive ad hoc session with a transcript", () => {
+  it("shows share instead of record for an inactive ad hoc session with a transcript", () => {
     mocks.hasTranscriptBySession = { "session-1": true };
 
     render(
@@ -1225,11 +1237,12 @@ describe("OuterHeader", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Share note" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
 
-  it("hides record for an inactive ad hoc session with audio", () => {
+  it("shows share instead of record for an inactive ad hoc session with audio", () => {
     mocks.audioExists = true;
 
     render(
@@ -1240,6 +1253,7 @@ describe("OuterHeader", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Share note" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
@@ -1339,7 +1353,7 @@ describe("OuterHeader", () => {
     expect(mocks.stopListening).toHaveBeenCalledTimes(1);
   });
 
-  it("hides record and keeps overflow after the meeting is over", () => {
+  it("shows share instead of record after the meeting is over", () => {
     mocks.sessionEvents = {
       "session-1": {
         title: "Design Review",
@@ -1350,22 +1364,29 @@ describe("OuterHeader", () => {
     };
     mocks.nowMs = new Date("2026-06-05T10:31:00.000Z").getTime();
 
-    render(
+    const { container } = render(
       <OuterHeader
         sessionId="session-1"
         currentView={{ type: "raw" } as EditorView}
       />,
     );
 
-    const moreButton = screen.getByRole("button", { name: "More" });
+    const share = screen.getByRole("button", { name: "Share note" });
+    const more = screen.getByRole("button", { name: "More" });
+    const actionStrip = container.firstElementChild?.lastElementChild;
+    const actionChildren = [...(actionStrip?.children ?? [])];
 
     expect(screen.queryByRole("button", { name: "Join & record" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
-    expect(moreButton).not.toBeNull();
+    expect(share).not.toBeNull();
+    expect(more).not.toBeNull();
+    expect(
+      actionChildren.findIndex((child) => child.contains(share)),
+    ).toBeLessThan(actionChildren.findIndex((child) => child.contains(more)));
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
 
-  it("hides record instead of rejoining when a recorded event has no ended_at", () => {
+  it("shows share instead of rejoining when a recorded event has no ended_at", () => {
     mocks.sessionEvents = {
       "session-1": {
         title: "Design Review",
@@ -1385,6 +1406,7 @@ describe("OuterHeader", () => {
 
     expect(screen.queryByRole("button", { name: "Join & record" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Share note" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
@@ -1401,5 +1423,6 @@ describe("OuterHeader", () => {
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Done" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Share note" })).not.toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -22,6 +22,7 @@ import {
   buildWelcomeNoteDemoUrl,
   WELCOME_NOTE_TRACKING_ID,
 } from "~/onboarding/welcome-note.constants";
+import { SessionShareButton } from "~/session-sharing";
 import { useEventCountdown } from "~/session/hooks/useEventCountdown";
 import { useMeetingMicInUse } from "~/session/hooks/useMeetingMicInUse";
 import {
@@ -130,12 +131,20 @@ function HeaderMeetingControl({
     ? safeParseDate(sessionEvent.ended_at)
     : null;
   const ended = !!endedAt && endedAt.getTime() <= now.getTime();
-  if (
-    sessionMode === "finalizing" ||
-    sessionMode === "running_batch" ||
-    meetingOver
-  ) {
+  if (sessionMode === "finalizing" || sessionMode === "running_batch") {
     return null;
+  }
+
+  if (meetingOver) {
+    return (
+      <div className="relative mr-1 flex min-w-0 shrink-0 items-center">
+        <SessionShareButton
+          key={sessionId}
+          sessionId={sessionId}
+          variant="cta"
+        />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Put a labeled Share CTA in the header once the meeting is over, instead of leaving Record in that slot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header action swap with existing share popover logic; no auth or data-path changes beyond when the button appears.
> 
> **Overview**
> After a meeting ends (or the note already has transcript/audio), the session header **shows a labeled Share button** in the slot that used to hide Record entirely, instead of leaving that area empty.
> 
> `SessionShareButton` gains an optional **`variant="cta"`** that renders a small primary-style control with the **Share** label and tighter icon styling; the default **`icon`** ghost behavior is unchanged for other entry points.
> 
> `HeaderMeetingControl` routes **`meetingOver`** to that CTA share control while still hiding meeting actions during **finalizing** / **batch transcription**. Locale **`.po`** files pick up the new **Share** string reference from `session-sharing/index.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240af52232b83b43dacdc9a2cd176089c1ca9b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->