### PR TITLE
Retry hosted summary auth and wait out CloudSync drain

### DIFF
--- a/apps/desktop/src/ai/auth-fetch.test.ts
+++ b/apps/desktop/src/ai/auth-fetch.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAuthFetch } from "./auth-fetch";
+
+function jsonResponse(status: number, body: string) {
+  return new Response(body, { status });
+}
+
+function authorizationHeader(
+  fetchMock: ReturnType<typeof vi.fn>,
+  callIndex: number,
+) {
+  const init = fetchMock.mock.calls[callIndex]?.[1] as RequestInit | undefined;
+  return new Headers(init?.headers).get("Authorization");
+}
+
+describe("createAuthFetch", () => {
+  it("attaches the current access token before calling the base fetch", async () => {
+    const baseFetch = vi.fn(async () => jsonResponse(200, "ok"));
+    const fetchWithAuth = createAuthFetch(baseFetch, () => "fresh-token");
+
+    const response = await fetchWithAuth("https://api.anarlog.so/llm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+    expect(baseFetch).toHaveBeenCalledOnce();
+    expect(authorizationHeader(baseFetch, 0)).toBe("Bearer fresh-token");
+  });
+
+  it("refreshes once and retries when the hosted API rejects an expired token", async () => {
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, "invalid_token"))
+      .mockResolvedValueOnce(jsonResponse(200, "ok"));
+    const refreshAccessToken = vi.fn(async () => "rotated-token");
+    const fetchWithAuth = createAuthFetch(
+      baseFetch,
+      () => "stale-token",
+      refreshAccessToken,
+    );
+
+    const response = await fetchWithAuth("https://api.anarlog.so/llm", {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    expect(refreshAccessToken).toHaveBeenCalledOnce();
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+    expect(authorizationHeader(baseFetch, 0)).toBe("Bearer stale-token");
+    expect(authorizationHeader(baseFetch, 1)).toBe("Bearer rotated-token");
+  });
+
+  it("does not retry when refresh cannot produce a different token", async () => {
+    const unauthorized = jsonResponse(401, "invalid_token");
+    const baseFetch = vi.fn(async () => unauthorized);
+    const refreshAccessToken = vi.fn(async () => "stale-token");
+    const fetchWithAuth = createAuthFetch(
+      baseFetch,
+      () => "stale-token",
+      refreshAccessToken,
+    );
+
+    const response = await fetchWithAuth("https://api.anarlog.so/llm");
+
+    expect(response).toBe(unauthorized);
+    expect(refreshAccessToken).toHaveBeenCalledOnce();
+    expect(baseFetch).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/ai/auth-fetch.ts
+++ b/apps/desktop/src/ai/auth-fetch.ts
@@ -1,13 +1,26 @@
 export function createAuthFetch(
   baseFetch: typeof fetch,
-  getAccessToken: () => string | undefined,
+  getAccessToken: () => string | undefined | Promise<string | undefined>,
+  refreshAccessToken?: () => Promise<string | undefined>,
 ): typeof fetch {
   return async (input, init) => {
     const headers = new Headers(init?.headers);
-    const token = getAccessToken();
+    const token = await getAccessToken();
     if (token) {
       headers.set("Authorization", `Bearer ${token}`);
     }
-    return baseFetch(input, { ...init, headers });
+    const response = await baseFetch(input, { ...init, headers });
+    if (response.status !== 401 || !refreshAccessToken) {
+      return response;
+    }
+
+    const refreshed = await refreshAccessToken();
+    if (!refreshed || refreshed === token) {
+      return response;
+    }
+
+    const retryHeaders = new Headers(headers);
+    retryHeaders.set("Authorization", `Bearer ${refreshed}`);
+    return baseFetch(input, { ...init, headers: retryHeaders });
   };
 }

--- a/apps/desktop/src/ai/hooks/useLLMConnection.ts
+++ b/apps/desktop/src/ai/hooks/useLLMConnection.ts
@@ -65,12 +65,14 @@ export const normalizeLLMProviderId = (providerId: string): string =>
 
 export const useLanguageModel = (task?: CharTask): LanguageModelV3 | null => {
   const { conn } = useLLMConnection();
-  const { session } = useAuth();
+  const auth = useAuth();
 
   // Auth is resolved at fetch time (not model construction) so token
   // refreshes take effect without recreating the chat transport chain.
-  const accessTokenRef = useRef(session?.access_token);
-  accessTokenRef.current = session?.access_token;
+  const getSessionForRequestRef = useRef(auth.getSessionForRequest);
+  getSessionForRequestRef.current = auth.getSessionForRequest;
+  const refreshSessionRef = useRef(auth.refreshSession);
+  refreshSessionRef.current = auth.refreshSession;
 
   return useMemo(() => {
     if (!conn) return null;
@@ -79,7 +81,8 @@ export const useLanguageModel = (task?: CharTask): LanguageModelV3 | null => {
       conn.providerId === "anarlog"
         ? createAuthFetch(
             task ? createTracedFetch(task) : tracedFetch,
-            () => accessTokenRef.current,
+            async () => (await getSessionForRequestRef.current())?.access_token,
+            async () => (await refreshSessionRef.current())?.access_token,
           )
         : undefined;
 

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -292,7 +292,9 @@ describe("CloudSync auth lifecycle", () => {
   });
 
   test("binds the local account without a token exchange", async () => {
-    await expect(bindCloudsyncAccountForAuth("user-id")).resolves.toBe(true);
+    await expect(bindCloudsyncAccountForAuth("user-id")).resolves.toBe(
+      "claimed",
+    );
 
     expect(bindCloudsyncAccount).toHaveBeenCalledWith("user-id");
     expect(configureCloudsyncToken).not.toHaveBeenCalled();
@@ -1659,7 +1661,7 @@ describe("CloudSync auth lifecycle", () => {
     const binding = bindCloudsyncAccountForAuth("user-id");
     await vi.advanceTimersByTimeAsync(0);
 
-    await expect(binding).resolves.toBe(true);
+    await expect(binding).resolves.toBe("claimed");
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
     expect(bindCloudsyncAccount).toHaveBeenCalledTimes(1);
     expect(
@@ -1743,7 +1745,7 @@ describe("CloudSync auth lifecycle", () => {
     status.resolve(cloudsyncStatus());
     await status.promise;
     await activation;
-    await expect(binding).resolves.toBe(true);
+    await expect(binding).resolves.toBe("claimed");
 
     expect(bindCloudsyncAccount).toHaveBeenCalledTimes(1);
   });
@@ -1764,9 +1766,21 @@ describe("CloudSync auth lifecycle", () => {
     status.resolve(cloudsyncStatus());
     await status.promise;
     await activation;
-    await expect(binding).resolves.toBe(true);
+    await expect(binding).resolves.toBe("superseded");
 
     expect(bindCloudsyncAccount).not.toHaveBeenCalled();
+  });
+
+  test("reports a mismatch even when CloudSync moved on after the bind ran", async () => {
+    vi.mocked(bindCloudsyncAccount).mockImplementationOnce(async () => {
+      await handleCloudsyncAuthChange("SIGNED_OUT", null);
+      return false;
+    });
+
+    await expect(bindCloudsyncAccountForAuth("user-id")).resolves.toBe(
+      "mismatch",
+    );
+    expect(bindCloudsyncAccount).toHaveBeenCalledTimes(1);
   });
 
   test("suspends a configuration superseded while it is in flight", async () => {
@@ -1913,7 +1927,9 @@ describe("CloudSync auth lifecycle", () => {
     expect(getE2eeIdentityStatus).toHaveBeenCalledTimes(1);
 
     await handleCloudsyncAuthChange("SIGNED_OUT", null);
-    await expect(bindCloudsyncAccountForAuth("user-id")).resolves.toBe(true);
+    await expect(bindCloudsyncAccountForAuth("user-id")).resolves.toBe(
+      "claimed",
+    );
     expect(bindCloudsyncAccount).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(25 * 1000);

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -223,9 +223,15 @@ function scheduleCloudsyncSessionEvictionRetry(activeGeneration: number) {
   }, EVICTION_RETRY_DELAY_MS);
 }
 
+/**
+ * `superseded` means a newer CloudSync transition started before the local
+ * bind ran, so nothing was verified; callers must not treat it as admission.
+ */
+export type CloudsyncAccountAdmission = "claimed" | "mismatch" | "superseded";
+
 export async function bindCloudsyncAccountForAuth(
   accountUserId: string,
-): Promise<boolean> {
+): Promise<CloudsyncAccountAdmission> {
   const activeGeneration = beginTransition();
   signedOutGeneration = null;
   currentCloudsyncReactivation = null;
@@ -247,7 +253,7 @@ export async function bindCloudsyncAccountForAuth(
       clearTimeout(timeout);
     }
     if (activeGeneration !== generation) {
-      return true;
+      return "superseded";
     }
     if (result === "timed_out") {
       teardownTimedOut = true;
@@ -264,7 +270,7 @@ export async function bindCloudsyncAccountForAuth(
       suspendCloudsyncPreemptivelyForGeneration(activeGeneration),
     );
     if (activeGeneration !== generation) {
-      return true;
+      return "superseded";
     }
     if (cleanup.status === "timed_out" || !cleanup.value) {
       throw new Error("cloudsync cleanup unavailable");
@@ -287,15 +293,18 @@ export async function bindCloudsyncAccountForAuth(
         claimed: await bindCloudsyncAccount(accountUserId),
       };
     });
-    if (activeGeneration !== generation || queuedBinding.status === "stale") {
-      return true;
+    if (queuedBinding.status === "stale") {
+      return "superseded";
     }
     if (queuedBinding.status === "cleanup_required") {
+      if (activeGeneration !== generation) {
+        return "superseded";
+      }
       const cleanup = await settleCloudsyncOperationWithin(
         suspendCloudsyncPreemptivelyForGeneration(activeGeneration),
       );
       if (activeGeneration !== generation) {
-        return true;
+        return "superseded";
       }
       if (cleanup.status === "timed_out" || !cleanup.value) {
         throw new Error("cloudsync cleanup unavailable");
@@ -305,8 +314,11 @@ export async function bindCloudsyncAccountForAuth(
       claimed = queuedBinding.claimed;
     }
   }
+  // The local bind ran, so its answer stands even if CloudSync moved on; only
+  // the generation-bound cleanup below is skipped.
+  const admission: CloudsyncAccountAdmission = claimed ? "claimed" : "mismatch";
   if (activeGeneration !== generation) {
-    return true;
+    return admission;
   }
 
   if (isCleanupSuspendRequired()) {
@@ -314,14 +326,14 @@ export async function bindCloudsyncAccountForAuth(
       suspendCloudsyncPreemptivelyForGeneration(activeGeneration),
     );
     if (activeGeneration !== generation) {
-      return true;
+      return admission;
     }
     if (cleanup.status === "timed_out" || !cleanup.value) {
       throw new Error("cloudsync cleanup unavailable");
     }
   }
 
-  return claimed;
+  return admission;
 }
 
 async function suspendCloudsyncNow() {

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAuth } from "./auth-context";
+import type { CloudsyncAccountAdmission } from "./cloudsync";
 import * as authProviderModule from "./context";
 
 const { AuthProvider } = authProviderModule;
@@ -273,7 +274,7 @@ describe("AuthProvider", () => {
     mocks.stopAutoRefresh.mockReset();
     mocks.toastDismiss.mockReset();
     mocks.toastError.mockReset();
-    mocks.bindCloudsyncAccountForAuth.mockResolvedValue(true);
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("claimed");
     mocks.clearAuthStorage.mockResolvedValue(undefined);
     mocks.emit.mockResolvedValue(undefined);
     mocks.emitTo.mockResolvedValue(undefined);
@@ -647,7 +648,7 @@ describe("AuthProvider", () => {
   it("routes secondary-window account rejection through the main window", async () => {
     const foreignSession = makeSession("foreign-account");
     mocks.currentWebviewWindowLabel = "note-session-id";
-    mocks.bindCloudsyncAccountForAuth.mockResolvedValue(false);
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("mismatch");
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     renderAuthProvider();
@@ -688,7 +689,7 @@ describe("AuthProvider", () => {
   it("preserves shared auth when main rejects secondary cleanup", async () => {
     const foreignSession = makeSession("foreign-account");
     mocks.currentWebviewWindowLabel = "note-session-id";
-    mocks.bindCloudsyncAccountForAuth.mockResolvedValue(false);
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("mismatch");
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     renderAuthProvider();
@@ -1332,7 +1333,7 @@ describe("AuthProvider", () => {
 
   it("keeps a session hidden until its local account claim succeeds", async () => {
     const nextSession = makeSession("bound-account");
-    const claim = deferred<boolean>();
+    const claim = deferred<CloudsyncAccountAdmission>();
     mocks.bindCloudsyncAccountForAuth.mockReturnValue(claim.promise);
 
     renderAuthProvider();
@@ -1359,7 +1360,7 @@ describe("AuthProvider", () => {
     );
 
     await act(async () => {
-      claim.resolve(true);
+      claim.resolve("claimed");
       await claim.promise;
     });
 
@@ -1372,7 +1373,7 @@ describe("AuthProvider", () => {
 
   it("keeps a rapid sign-out then sign-in hidden until the new account is claimed", async () => {
     const nextSession = makeSession("new-account");
-    const claim = deferred<boolean>();
+    const claim = deferred<CloudsyncAccountAdmission>();
     mocks.bindCloudsyncAccountForAuth.mockReturnValue(claim.promise);
 
     renderAuthProvider();
@@ -1403,7 +1404,7 @@ describe("AuthProvider", () => {
     );
 
     await act(async () => {
-      claim.resolve(true);
+      claim.resolve("claimed");
       await claim.promise;
     });
 
@@ -1442,7 +1443,7 @@ describe("AuthProvider", () => {
     });
 
     mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(
-      new Promise<boolean>(() => {}),
+      new Promise<CloudsyncAccountAdmission>(() => {}),
     );
 
     act(() => {
@@ -1537,7 +1538,7 @@ describe("AuthProvider", () => {
       );
     });
 
-    const claim = deferred<boolean>();
+    const claim = deferred<CloudsyncAccountAdmission>();
     mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(claim.promise);
 
     act(() => {
@@ -1552,7 +1553,7 @@ describe("AuthProvider", () => {
     );
 
     await act(async () => {
-      claim.resolve(true);
+      claim.resolve("claimed");
       await claim.promise;
     });
     await waitFor(() => {
@@ -1562,9 +1563,109 @@ describe("AuthProvider", () => {
     });
   });
 
+  it("re-runs admission when a CloudSync refresh supersedes the local bind", async () => {
+    const nextSession = makeSession("bound-account");
+    mocks.bindCloudsyncAccountForAuth
+      .mockResolvedValueOnce("superseded")
+      .mockResolvedValueOnce("claimed");
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", nextSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        nextSession.user.id,
+      );
+    });
+    expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(2);
+    expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
+      "SIGNED_IN",
+      nextSession,
+      expect.any(Function),
+    );
+  });
+
+  it("does not admit an account whose bind keeps being superseded", async () => {
+    const nextSession = makeSession("bound-account");
+    const refreshedSession = {
+      ...nextSession,
+      access_token: "refreshed-access-token",
+    };
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("superseded");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", nextSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        nextSession.user.id,
+      );
+    });
+    expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(3);
+    expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalled();
+
+    // Still unadmitted: the next refresh must go back through admission.
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("mismatch");
+    act(() => {
+      mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe("none");
+    });
+    expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not admit late when the stalled bind resolves as superseded", async () => {
+    const nextSession = makeSession("bound-account");
+    const claim = deferred<CloudsyncAccountAdmission>();
+    mocks.bindCloudsyncAccountForAuth
+      .mockReturnValueOnce(claim.promise)
+      .mockResolvedValue("superseded");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", nextSession);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(screen.getByTestId("session").textContent).toBe(nextSession.user.id);
+
+    await act(async () => {
+      claim.resolve("superseded");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(3);
+    expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("session").textContent).toBe(nextSession.user.id);
+  });
+
   it("preserves the local session when account admission stalls and finishes it late", async () => {
     const nextSession = makeSession("bound-account");
-    const claim = deferred<boolean>();
+    const claim = deferred<CloudsyncAccountAdmission>();
     mocks.bindCloudsyncAccountForAuth.mockReturnValue(claim.promise);
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -1597,7 +1698,7 @@ describe("AuthProvider", () => {
     const refreshStartsBeforeAdmission =
       mocks.startAutoRefresh.mock.calls.length;
     await act(async () => {
-      claim.resolve(true);
+      claim.resolve("claimed");
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(mocks.startAutoRefresh.mock.calls.length).toBeGreaterThan(
@@ -1640,7 +1741,7 @@ describe("AuthProvider", () => {
       expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
     });
 
-    const claim = deferred<boolean>();
+    const claim = deferred<CloudsyncAccountAdmission>();
     mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(claim.promise);
     vi.useFakeTimers();
     act(() => {
@@ -1661,7 +1762,7 @@ describe("AuthProvider", () => {
     expect(mocks.persistAuthSession).not.toHaveBeenCalled();
 
     await act(async () => {
-      claim.resolve(true);
+      claim.resolve("claimed");
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(mocks.persistAuthSession).toHaveBeenCalledWith(refreshedSession);
@@ -1699,7 +1800,7 @@ describe("AuthProvider", () => {
       boundSession.access_token,
     );
 
-    mocks.bindCloudsyncAccountForAuth.mockResolvedValue(false);
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("mismatch");
     act(() => {
       mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
     });
@@ -1727,7 +1828,7 @@ describe("AuthProvider", () => {
 
   it("rejects a stalled admission that later reports another account", async () => {
     const foreignSession = makeSession("foreign-account");
-    const claim = deferred<boolean>();
+    const claim = deferred<CloudsyncAccountAdmission>();
     mocks.bindCloudsyncAccountForAuth.mockReturnValue(claim.promise);
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -1749,7 +1850,7 @@ describe("AuthProvider", () => {
     );
 
     await act(async () => {
-      claim.resolve(false);
+      claim.resolve("mismatch");
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
@@ -1762,7 +1863,7 @@ describe("AuthProvider", () => {
 
   it("rejects a different local database account before admission", async () => {
     const foreignSession = makeSession("foreign-account");
-    mocks.bindCloudsyncAccountForAuth.mockResolvedValue(false);
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue("mismatch");
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     renderAuthProvider();

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -293,6 +293,7 @@ describe("AuthProvider", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
@@ -1418,7 +1419,7 @@ describe("AuthProvider", () => {
     );
   });
 
-  it("keeps a refreshed session hidden until admission succeeds", async () => {
+  it("applies a refreshed token for the admitted account without re-admission", async () => {
     const currentSession = makeSession("bound-account");
     const refreshedSession = {
       ...currentSession,
@@ -1440,14 +1441,108 @@ describe("AuthProvider", () => {
       );
     });
 
-    const claim = deferred<boolean>();
-    mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(claim.promise);
-    mocks.refreshSession.mockImplementationOnce(async () => {
+    mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(
+      new Promise<boolean>(() => {}),
+    );
+
+    act(() => {
       mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
-      return { data: { session: refreshedSession }, error: null };
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token").textContent).toBe(
+        refreshedSession.access_token,
+      );
+    });
+    expect(screen.getByTestId("authorization").textContent).toBe(
+      `bearer ${refreshedSession.access_token}`,
+    );
+    expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
+      "TOKEN_REFRESHED",
+      refreshedSession,
+      expect.any(Function),
+    );
+  });
+
+  it("applies a refreshed token while an earlier auth transition is still blocked", async () => {
+    const currentSession = makeSession("bound-account");
+    const refreshedSession = {
+      ...currentSession,
+      access_token: "refreshed-access-token",
+    };
+    // The SIGNED_IN transition never finishes its CloudSync handshake, which
+    // would previously have held every later auth event in the queue.
+    mocks.handleCloudsyncAuthChange.mockImplementation(
+      (event: AuthChangeEvent) =>
+        event === "SIGNED_IN" ? new Promise(() => {}) : Promise.resolve("ok"),
+    );
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+    await waitFor(() => {
+      expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
+        "SIGNED_IN",
+        currentSession,
+        expect.any(Function),
+      );
+    });
+
+    act(() => {
+      mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token").textContent).toBe(
+        refreshedSession.access_token,
+      );
+    });
+    expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
+      "TOKEN_REFRESHED",
+      refreshedSession,
+      expect.any(Function),
+    );
+  });
+
+  it("keeps re-admitting refreshes for a session preserved without verification", async () => {
+    const currentSession = makeSession("unverified-account");
+    const refreshedSession = {
+      ...currentSession,
+      access_token: "refreshed-access-token",
+    };
+    mocks.bindCloudsyncAccountForAuth.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token").textContent).toBe(
+        currentSession.access_token,
+      );
+    });
+
+    const claim = deferred<boolean>();
+    mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(claim.promise);
+
+    act(() => {
+      mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
+    });
 
     await waitFor(() => {
       expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(2);
@@ -1465,6 +1560,79 @@ describe("AuthProvider", () => {
         refreshedSession.access_token,
       );
     });
+  });
+
+  it("preserves the local session when account admission stalls and finishes it late", async () => {
+    const nextSession = makeSession("bound-account");
+    const claim = deferred<boolean>();
+    mocks.bindCloudsyncAccountForAuth.mockReturnValue(claim.promise);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", nextSession);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(14_000);
+    });
+    expect(screen.getByTestId("session").textContent).toBe("none");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(screen.getByTestId("session").textContent).toBe(nextSession.user.id);
+    expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      claim.resolve(true);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
+      "SIGNED_IN",
+      nextSession,
+      expect.any(Function),
+    );
+  });
+
+  it("rejects a stalled admission that later reports another account", async () => {
+    const foreignSession = makeSession("foreign-account");
+    const claim = deferred<boolean>();
+    mocks.bindCloudsyncAccountForAuth.mockReturnValue(claim.promise);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", foreignSession);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(screen.getByTestId("session").textContent).toBe(
+      foreignSession.user.id,
+    );
+
+    await act(async () => {
+      claim.resolve(false);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("session").textContent).toBe("none");
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "The notes on this device are linked to another Anarlog account. Sign in with the account previously used here.",
+      { id: "auth-account-mismatch" },
+    );
   });
 
   it("rejects a different local database account before admission", async () => {

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -1583,21 +1583,146 @@ describe("AuthProvider", () => {
     });
     expect(screen.getByTestId("session").textContent).toBe("none");
 
+    const refreshStartsBeforePreserve =
+      mocks.startAutoRefresh.mock.calls.length;
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_000);
     });
     expect(screen.getByTestId("session").textContent).toBe(nextSession.user.id);
+    expect(mocks.startAutoRefresh.mock.calls.length).toBeGreaterThan(
+      refreshStartsBeforePreserve,
+    );
     expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalled();
 
+    const refreshStartsBeforeAdmission =
+      mocks.startAutoRefresh.mock.calls.length;
     await act(async () => {
       claim.resolve(true);
       await vi.advanceTimersByTimeAsync(0);
     });
+    expect(mocks.startAutoRefresh.mock.calls.length).toBeGreaterThan(
+      refreshStartsBeforeAdmission,
+    );
     expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
       "SIGNED_IN",
       nextSession,
       expect.any(Function),
     );
+  });
+
+  it("writes a late-admitted session back after sign-out cleanup cleared storage", async () => {
+    const oldSession = makeSession("bound-account");
+    const refreshedSession = {
+      ...oldSession,
+      access_token: "refreshed-access-token",
+    };
+    const clear = deferred();
+    mocks.clearAuthStorage.mockReturnValue(clear.promise);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", oldSession);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        oldSession.user.id,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    await waitFor(() => {
+      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    });
+
+    const claim = deferred<boolean>();
+    mocks.bindCloudsyncAccountForAuth.mockReturnValueOnce(claim.promise);
+    vi.useFakeTimers();
+    act(() => {
+      mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
+    });
+    await act(async () => {
+      clear.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(screen.getByTestId("access-token").textContent).toBe(
+      refreshedSession.access_token,
+    );
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      claim.resolve(true);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mocks.persistAuthSession).toHaveBeenCalledWith(refreshedSession);
+    expect(mocks.handleCloudsyncAuthChange).toHaveBeenCalledWith(
+      "TOKEN_REFRESHED",
+      refreshedSession,
+      expect.any(Function),
+    );
+  });
+
+  it("re-admits a refresh that arrives during account-mismatch cleanup", async () => {
+    const boundSession = makeSession("bound-account");
+    const refreshedSession = {
+      ...boundSession,
+      access_token: "refreshed-access-token",
+    };
+    const clear = deferred();
+    mocks.clearAuthStorage.mockReturnValueOnce(clear.promise);
+    mocks.handleCloudsyncAuthChange.mockResolvedValueOnce("account_mismatch");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", boundSession);
+    });
+    await waitFor(() => {
+      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("access-token").textContent).toBe(
+      boundSession.access_token,
+    );
+
+    mocks.bindCloudsyncAccountForAuth.mockResolvedValue(false);
+    act(() => {
+      mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("access-token").textContent).toBe(
+      boundSession.access_token,
+    );
+
+    await act(async () => {
+      clear.resolve();
+      await clear.promise;
+    });
+
+    await waitFor(() => {
+      expect(mocks.bindCloudsyncAccountForAuth).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe("none");
+    });
+    expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(2);
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
   });
 
   it("rejects a stalled admission that later reports another account", async () => {

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -193,6 +193,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      // Cleanup is about to clear storage and sign the account out. Any token
+      // that arrives meanwhile must re-run admission instead of fast-pathing
+      // past this rejection.
+      admittedUserIdRef.current = null;
+
       if (
         invalidateClientSession &&
         !managesCloudsync &&
@@ -312,35 +317,88 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [managesCloudsync, rejectAccountMismatch],
   );
 
+  // Runs once an account is admitted: write the session back if storage was
+  // cleared since the event was enqueued, and make sure the SDK refresh ticker
+  // is running (a preceding sign-out or rejection may have stopped it).
+  const restoreAdmittedSession = useCallback(
+    async (
+      nextSession: Session,
+      transition: number,
+      storageRevision: number,
+    ) => {
+      if (storageRevision !== authStorageRevisionRef.current) {
+        try {
+          await persistAuthSession(nextSession);
+        } catch {
+          console.warn("[auth] accepted session could not be restored");
+        }
+
+        if (transition !== authTransitionRef.current) {
+          return false;
+        }
+      }
+
+      if (supabase) {
+        try {
+          await supabase.auth.startAutoRefresh();
+        } catch {
+          console.warn("[auth] session refresh could not be started");
+        }
+
+        if (transition !== authTransitionRef.current) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+    [],
+  );
+
   const finishLateAdmission = useCallback(
     (
       event: AuthChangeEvent,
       nextSession: Session,
       transition: number,
+      storageRevision: number,
       admission: Promise<boolean>,
     ) => {
-      void admission.then(
-        (claimed) => {
-          if (transition !== authTransitionRef.current) {
-            return;
-          }
-          if (!claimed) {
-            console.warn("[auth] local database belongs to another account");
-            void rejectAccountMismatch(transition);
-            return;
-          }
-          sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
-          commitSession(nextSession, true);
-          void applyCloudsyncAuthChange(event, nextSession, transition).catch(
-            () => {
-              console.warn("[cloudsync] late admission could not start sync");
-            },
-          );
-        },
-        () => {},
-      );
+      void admission
+        .then(
+          async (claimed) => {
+            if (transition !== authTransitionRef.current) {
+              return;
+            }
+            if (!claimed) {
+              console.warn("[auth] local database belongs to another account");
+              await rejectAccountMismatch(transition);
+              return;
+            }
+            sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
+            if (
+              !(await restoreAdmittedSession(
+                nextSession,
+                transition,
+                storageRevision,
+              ))
+            ) {
+              return;
+            }
+            commitSession(nextSession, true);
+            await applyCloudsyncAuthChange(event, nextSession, transition);
+          },
+          () => {},
+        )
+        .catch(() => {
+          console.warn("[cloudsync] late admission could not start sync");
+        });
     },
-    [applyCloudsyncAuthChange, commitSession, rejectAccountMismatch],
+    [
+      applyCloudsyncAuthChange,
+      commitSession,
+      rejectAccountMismatch,
+      restoreAdmittedSession,
+    ],
   );
 
   const applyAuthChange = useCallback(
@@ -400,7 +458,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             );
             commitSession(nextSession);
             void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
-            finishLateAdmission(event, nextSession, transition, admission);
+            void supabase?.auth.startAutoRefresh().catch(() => {
+              console.warn("[auth] session refresh could not be started");
+            });
+            finishLateAdmission(
+              event,
+              nextSession,
+              transition,
+              storageRevision,
+              admission,
+            );
             return;
           }
           claimed = settled.value;
@@ -421,28 +488,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           return;
         }
         sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
-      }
-
-      if (nextSession && storageRevision !== authStorageRevisionRef.current) {
-        try {
-          await persistAuthSession(nextSession);
-        } catch {
-          console.warn("[auth] accepted session could not be restored");
-        }
-
-        if (transition !== authTransitionRef.current) {
-          return;
-        }
-      }
-
-      if (nextSession && supabase) {
-        try {
-          await supabase.auth.startAutoRefresh();
-        } catch {
-          console.warn("[auth] session refresh could not be started");
-        }
-
-        if (transition !== authTransitionRef.current) {
+        if (
+          !(await restoreAdmittedSession(
+            nextSession,
+            transition,
+            storageRevision,
+          ))
+        ) {
           return;
         }
       }
@@ -460,6 +512,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       managesCloudsync,
       rejectAccountMismatch,
       rejectAuthChange,
+      restoreAdmittedSession,
     ],
   );
 

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -26,6 +26,7 @@ import { AuthContext } from "./auth-context";
 import { persistAuthSession, supabase } from "./client";
 import {
   bindCloudsyncAccountForAuth,
+  type CloudsyncAccountAdmission,
   handleCloudsyncAuthChange,
   prepareCloudsyncSignOut,
   refreshCloudsyncForSession,
@@ -59,6 +60,9 @@ const ACCOUNT_MISMATCH_TOAST_ID = "auth-account-mismatch";
 // Account admission runs behind the CloudSync plugin queue. If that queue is
 // jammed, auth must not stay hidden forever; admission finishes late instead.
 const ACCOUNT_ADMISSION_TIMEOUT_MS = 15_000;
+// A CloudSync refresh (e.g. on window focus) can preempt the bind before it
+// runs. Retry a few times; each attempt itself supersedes that refresh.
+const ACCOUNT_ADMISSION_MAX_ATTEMPTS = 3;
 
 async function settleWithin<T>(
   operation: Promise<T>,
@@ -355,23 +359,51 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [],
   );
 
+  const admitAccount = useCallback(
+    async (
+      accountUserId: string,
+      transition: number,
+    ): Promise<CloudsyncAccountAdmission> => {
+      let admission: CloudsyncAccountAdmission = "superseded";
+      for (
+        let attempt = 0;
+        attempt < ACCOUNT_ADMISSION_MAX_ATTEMPTS &&
+        transition === authTransitionRef.current;
+        attempt += 1
+      ) {
+        admission = await bindCloudsyncAccountForAuth(accountUserId);
+        if (admission !== "superseded") {
+          break;
+        }
+      }
+      return admission;
+    },
+    [],
+  );
+
   const finishLateAdmission = useCallback(
     (
       event: AuthChangeEvent,
       nextSession: Session,
       transition: number,
       storageRevision: number,
-      admission: Promise<boolean>,
+      admission: Promise<CloudsyncAccountAdmission>,
     ) => {
       void admission
         .then(
-          async (claimed) => {
+          async (outcome) => {
             if (transition !== authTransitionRef.current) {
               return;
             }
-            if (!claimed) {
+            if (outcome === "mismatch") {
               console.warn("[auth] local database belongs to another account");
               await rejectAccountMismatch(transition);
+              return;
+            }
+            if (outcome === "superseded") {
+              console.warn(
+                "[auth] local database account verification was superseded; keeping the local session unadmitted",
+              );
               return;
             }
             sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
@@ -442,8 +474,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       if (nextSession) {
-        const admission = bindCloudsyncAccountForAuth(nextSession.user.id);
-        let claimed: boolean;
+        const admission = admitAccount(nextSession.user.id, transition);
+        let outcome: CloudsyncAccountAdmission;
         try {
           const settled = await settleWithin(
             admission,
@@ -470,7 +502,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             );
             return;
           }
-          claimed = settled.value;
+          outcome = settled.value;
         } catch {
           if (transition !== authTransitionRef.current) {
             return;
@@ -482,9 +514,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
           return;
         }
-        if (!claimed) {
+        if (outcome === "mismatch") {
           console.warn("[auth] local database belongs to another account");
           await rejectAccountMismatch(transition);
+          return;
+        }
+        if (outcome === "superseded") {
+          console.warn(
+            "[auth] local database account verification was superseded; preserving the local session",
+          );
+          commitSession(nextSession);
+          void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
           return;
         }
         sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
@@ -504,6 +544,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await applyCloudsyncAuthChange(event, nextSession, transition);
     },
     [
+      admitAccount,
       applyCloudsyncAuthChange,
       commitSession,
       coordinateMainSignOut,

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -56,6 +56,28 @@ import {
 } from "~/shared/utils";
 
 const ACCOUNT_MISMATCH_TOAST_ID = "auth-account-mismatch";
+// Account admission runs behind the CloudSync plugin queue. If that queue is
+// jammed, auth must not stay hidden forever; admission finishes late instead.
+const ACCOUNT_ADMISSION_TIMEOUT_MS = 15_000;
+
+async function settleWithin<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<{ status: "settled"; value: T } | { status: "timed_out" }> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      operation.then((value) => ({ status: "settled" as const, value })),
+      new Promise<{ status: "timed_out" }>((resolve) => {
+        timeout = setTimeout(() => resolve({ status: "timed_out" }), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
@@ -70,6 +92,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const authAnalyticsQueueRef = useRef(Promise.resolve());
   const authStorageRevisionRef = useRef(0);
   const coordinatedMainSignOutRef = useRef<Promise<boolean> | null>(null);
+  // The committed session, readable synchronously so request headers never
+  // lag behind React state. Admission is the account id whose local database
+  // binding was verified; only admitted accounts get fast-path token refreshes.
+  const sessionRef = useRef<Session | null>(null);
+  const admittedUserIdRef = useRef<string | null>(null);
+
+  const commitSession = useCallback(
+    (nextSession: Session | null, admitted = false) => {
+      sessionRef.current = nextSession;
+      admittedUserIdRef.current =
+        nextSession &&
+        (admitted || admittedUserIdRef.current === nextSession.user.id)
+          ? nextSession.user.id
+          : null;
+      setSession(nextSession);
+    },
+    [],
+  );
 
   const enqueueAuthAnalytics = useCallback((task: () => Promise<void>) => {
     const queued = authAnalyticsQueueRef.current.then(task, task);
@@ -205,12 +245,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       resetTrackedAuthIdentity();
       await enqueueAuthAnalytics(clearAuthAnalyticsGroups);
-      setSession(null);
+      commitSession(null);
       if (managesCloudsync) {
         await handleCloudsyncAuthChange("SIGNED_OUT", null);
       }
     },
-    [coordinateMainSignOut, enqueueAuthAnalytics, managesCloudsync],
+    [
+      commitSession,
+      coordinateMainSignOut,
+      enqueueAuthAnalytics,
+      managesCloudsync,
+    ],
   );
 
   const rejectAccountMismatch = useCallback(
@@ -238,6 +283,66 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [currentWindowLabel, managesCloudsync, rejectAuthChange],
   );
 
+  const applyCloudsyncAuthChange = useCallback(
+    async (
+      event: AuthChangeEvent,
+      nextSession: Session | null,
+      transition: number,
+    ) => {
+      if (!managesCloudsync) {
+        return;
+      }
+
+      const rejectCurrentAccountMismatch = () =>
+        rejectAccountMismatch(transition);
+      const result = await handleCloudsyncAuthChange(
+        event,
+        nextSession,
+        rejectCurrentAccountMismatch,
+      );
+      if (
+        result !== "account_mismatch" ||
+        transition !== authTransitionRef.current
+      ) {
+        return;
+      }
+
+      await rejectCurrentAccountMismatch();
+    },
+    [managesCloudsync, rejectAccountMismatch],
+  );
+
+  const finishLateAdmission = useCallback(
+    (
+      event: AuthChangeEvent,
+      nextSession: Session,
+      transition: number,
+      admission: Promise<boolean>,
+    ) => {
+      void admission.then(
+        (claimed) => {
+          if (transition !== authTransitionRef.current) {
+            return;
+          }
+          if (!claimed) {
+            console.warn("[auth] local database belongs to another account");
+            void rejectAccountMismatch(transition);
+            return;
+          }
+          sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
+          commitSession(nextSession, true);
+          void applyCloudsyncAuthChange(event, nextSession, transition).catch(
+            () => {
+              console.warn("[cloudsync] late admission could not start sync");
+            },
+          );
+        },
+        () => {},
+      );
+    },
+    [applyCloudsyncAuthChange, commitSession, rejectAccountMismatch],
+  );
+
   const applyAuthChange = useCallback(
     async (
       event: AuthChangeEvent,
@@ -253,7 +358,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         let mainSignOutCompleted = false;
         if (event === "SIGNED_OUT" && !managesCloudsync) {
           resetTrackedAuthIdentity();
-          setSession(null);
+          commitSession(null);
 
           try {
             mainSignOutCompleted = await coordinateMainSignOut();
@@ -279,19 +384,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       if (nextSession) {
+        const admission = bindCloudsyncAccountForAuth(nextSession.user.id);
+        let claimed: boolean;
         try {
-          const claimed = await bindCloudsyncAccountForAuth(
-            nextSession.user.id,
+          const settled = await settleWithin(
+            admission,
+            ACCOUNT_ADMISSION_TIMEOUT_MS,
           );
           if (transition !== authTransitionRef.current) {
             return;
           }
-          if (!claimed) {
-            console.warn("[auth] local database belongs to another account");
-            await rejectAccountMismatch(transition);
+          if (settled.status === "timed_out") {
+            console.warn(
+              "[auth] local database account verification is stalled; preserving the local session",
+            );
+            commitSession(nextSession);
+            void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
+            finishLateAdmission(event, nextSession, transition, admission);
             return;
           }
-          sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
+          claimed = settled.value;
         } catch {
           if (transition !== authTransitionRef.current) {
             return;
@@ -299,10 +411,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           console.warn(
             "[auth] local database account verification failed; preserving the local session",
           );
-          setSession(nextSession);
+          commitSession(nextSession);
           void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
           return;
         }
+        if (!claimed) {
+          console.warn("[auth] local database belongs to another account");
+          await rejectAccountMismatch(transition);
+          return;
+        }
+        sonnerToast.dismiss(ACCOUNT_MISMATCH_TOAST_ID);
       }
 
       if (nextSession && storageRevision !== authStorageRevisionRef.current) {
@@ -329,45 +447,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       }
 
-      setSession(nextSession);
+      commitSession(nextSession, true);
       void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
-
-      if (!managesCloudsync) {
-        return;
-      }
-
-      const rejectCurrentAccountMismatch = () =>
-        rejectAccountMismatch(transition);
-      const result = await handleCloudsyncAuthChange(
-        event,
-        nextSession,
-        rejectCurrentAccountMismatch,
-      );
-      if (
-        result !== "account_mismatch" ||
-        transition !== authTransitionRef.current
-      ) {
-        return;
-      }
-
-      await rejectCurrentAccountMismatch();
+      await applyCloudsyncAuthChange(event, nextSession, transition);
     },
     [
+      applyCloudsyncAuthChange,
+      commitSession,
       coordinateMainSignOut,
       enqueueAuthAnalytics,
+      finishLateAdmission,
       managesCloudsync,
       rejectAccountMismatch,
       rejectAuthChange,
     ],
   );
 
+  const beginAuthTransition = useCallback((event: AuthChangeEvent) => {
+    if (event !== "SIGNED_OUT") {
+      coordinatedMainSignOutRef.current = null;
+    }
+    authTransitionEventRef.current = event;
+    return ++authTransitionRef.current;
+  }, []);
+
   const enqueueAuthChange = useCallback(
     (event: AuthChangeEvent, nextSession: Session | null) => {
-      if (event !== "SIGNED_OUT") {
-        coordinatedMainSignOutRef.current = null;
-      }
-      authTransitionEventRef.current = event;
-      const transition = ++authTransitionRef.current;
+      const transition = beginAuthTransition(event);
       const storageRevision = authStorageRevisionRef.current;
       const apply = () =>
         applyAuthChange(event, nextSession, transition, storageRevision);
@@ -378,7 +484,43 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       authTransitionQueueRef.current = queued.catch(() => {});
       return queued;
     },
-    [applyAuthChange],
+    [applyAuthChange, beginAuthTransition],
+  );
+
+  // A new token for the already-admitted account is a credential update, not
+  // an identity change. It must never wait on the transition queue, account
+  // admission, or CloudSync: a stalled handshake would otherwise leave every
+  // hosted request signing with an expired token until the user re-logs in.
+  const applyAdmittedSessionRefresh = useCallback(
+    (event: AuthChangeEvent, nextSession: Session) => {
+      const transition = beginAuthTransition(event);
+      commitSession(nextSession, true);
+      void enqueueAuthAnalytics(() => trackAuthEvent(event, nextSession));
+      void applyCloudsyncAuthChange(event, nextSession, transition).catch(
+        (error) => {
+          console.warn(
+            "[cloudsync] refreshed credentials could not be applied",
+            error,
+          );
+        },
+      );
+    },
+    [
+      applyCloudsyncAuthChange,
+      beginAuthTransition,
+      commitSession,
+      enqueueAuthAnalytics,
+    ],
+  );
+
+  // While an explicit sign-out is clearing storage, a refresh must queue behind
+  // it so the accepted session is written back after the clear completes.
+  const isAdmittedSessionRefresh = useCallback(
+    (nextSession: Session | null): nextSession is Session =>
+      nextSession !== null &&
+      admittedUserIdRef.current === nextSession.user.id &&
+      authTransitionEventRef.current !== "SIGNED_OUT",
+    [],
   );
 
   useEffect(() => {
@@ -411,13 +553,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         `[auth] onAuthStateChange: ${event}`,
         session ? `expires_at=${session.expires_at}` : "no session",
       );
+      if (isAdmittedSessionRefresh(session)) {
+        applyAdmittedSessionRefresh(event, session);
+        return;
+      }
       void enqueueAuthChange(event, session);
     });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [enqueueAuthChange]);
+  }, [
+    applyAdmittedSessionRefresh,
+    enqueueAuthChange,
+    isAdmittedSessionRefresh,
+  ]);
 
   // Tauri's visibilitychange event is broken (always reports "visible" on Windows,
   // only fires on minimize/maximize on macOS — not when hidden behind other windows).
@@ -764,7 +914,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return null;
       }
 
-      let requestSession = session ?? null;
+      let requestSession = sessionRef.current;
       try {
         const { data, error } = await supabase.auth.getSession();
         if (!error && data.session) {
@@ -796,15 +946,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       return expiresAt > Date.now() ? requestSession : null;
-    }, [refreshSession, session]);
+    }, [refreshSession]);
 
   const getHeaders = useCallback(() => {
     if (!session) {
       return null;
     }
 
+    // Callers may hold this closure across renders; sign with the committed
+    // session so a refreshed token is used even before React re-renders.
+    const committed = sessionRef.current;
+    const current =
+      committed && committed.user.id === session.user.id ? committed : session;
     const headers: Record<string, string> = {
-      Authorization: `${session.token_type} ${session.access_token}`,
+      Authorization: `${current.token_type} ${current.access_token}`,
       [REQUEST_ID_HEADER]: id(),
     };
 

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -42,6 +42,7 @@ const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
 const CLOUDSYNC_STATUS_POOL_RETURN_GRACE: std::time::Duration =
     std::time::Duration::from_millis(10);
 const CLOUDSYNC_ACTIVITY_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const CLOUDSYNC_LOCAL_WRITE_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const CLOUDSYNC_AUTH_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const E2EE_CLOUDSYNC_DIRTY_ROW_LIMIT: i64 = 64;
 const CLOUDSYNC_WRITE_FILTER: &str =
@@ -378,7 +379,8 @@ impl PluginDbRuntime {
     }
 
     pub async fn begin_cloudsync_activity(&self, activity: String, key: String) -> Result<()> {
-        self.begin_cloudsync_activity_with_timeout(activity, key, CLOUDSYNC_ACTIVITY_DRAIN_TIMEOUT)
+        let drain_timeout = cloudsync_activity_drain_timeout(&activity);
+        self.begin_cloudsync_activity_with_timeout(activity, key, drain_timeout)
             .await
     }
 
@@ -1708,6 +1710,17 @@ async fn wait_until_cloudsync_auth_generation_changes(
             return;
         }
         generation_changed.await;
+    }
+}
+
+fn cloudsync_activity_drain_timeout(activity: &str) -> std::time::Duration {
+    // Capture start retries drain in the background and must not block recording.
+    // Summary/chat persistence waits for the current app-pool recovery query,
+    // which sqlite3_interrupt cannot abort and often exceeds two seconds.
+    if activity.trim() == CLOUDSYNC_CAPTURE_ACTIVITY {
+        CLOUDSYNC_ACTIVITY_DRAIN_TIMEOUT
+    } else {
+        CLOUDSYNC_LOCAL_WRITE_DRAIN_TIMEOUT
     }
 }
 

--- a/plugins/db/src/runtime/tests/activity.rs
+++ b/plugins/db/src/runtime/tests/activity.rs
@@ -1,5 +1,22 @@
 use super::*;
 
+#[test]
+fn local_write_activities_wait_longer_than_capture_to_drain() {
+    assert_eq!(
+        cloudsync_activity_drain_timeout("capture"),
+        CLOUDSYNC_ACTIVITY_DRAIN_TIMEOUT
+    );
+    assert_eq!(
+        cloudsync_activity_drain_timeout("enhance"),
+        CLOUDSYNC_LOCAL_WRITE_DRAIN_TIMEOUT
+    );
+    assert_eq!(
+        cloudsync_activity_drain_timeout("chat"),
+        CLOUDSYNC_LOCAL_WRITE_DRAIN_TIMEOUT
+    );
+    assert!(CLOUDSYNC_LOCAL_WRITE_DRAIN_TIMEOUT > CLOUDSYNC_ACTIVITY_DRAIN_TIMEOUT);
+}
+
 #[tokio::test]
 async fn cloudsync_activity_leases_are_idempotent_and_preserved_by_identity_clear() {
     let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());


### PR DESCRIPTION
Stable logs showed Pro summary hitting 401 invalid_token, then failing persist with cloudsync_activity_drain_timeout after re-login. Hosted LLM fetch now refreshes on 401, and enhance/chat drain waits 15s for in-flight witness repair instead of 2s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication admission semantics, session commit timing, and CloudSync queue interaction—areas that affect sign-in, multi-window auth, and hosted API access.
> 
> **Overview**
> Addresses production issues where hosted summary calls failed with **401 invalid_token** and summary/chat persistence hit **cloudsync_activity_drain_timeout** after re-login.
> 
> **Hosted LLM auth:** `createAuthFetch` now resolves tokens asynchronously, retries once on **401** after `refreshAccessToken`, and Anarlog-hosted models use `getSessionForRequest` / `refreshSession` so requests pick up rotated credentials without rebuilding the transport.
> 
> **Desktop auth / CloudSync admission:** Local account binding returns **`claimed` | `mismatch` | `superseded`** instead of a boolean, so a superseded bind is not treated as admission and a completed bind still reports mismatch if the DB belongs to another account. The auth provider keeps a **committed session ref** for headers, admits accounts with a **15s timeout** and **retries**, finishes admission in the background when stalled, and **fast-paths `TOKEN_REFRESHED`** for already-admitted users so token updates do not sit behind a jammed CloudSync handshake queue.
> 
> **Native CloudSync:** Non-capture local writes (**enhance**, **chat**, etc.) wait up to **15s** for activity drain (capture stays at **2s**), reducing premature drain timeouts during long witness/repair work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b223474fd9c4b776eb0456d6515a84d229781fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->