### PR TITLE
Skip live speaker cap when remote participants are unknown

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -688,6 +688,18 @@ mod tests {
     }
 
     #[test]
+    fn expected_speakers_is_unknown_without_remote_participants() {
+        let mut args = listener_args("https://api.assemblyai.com", "u3-rt-pro");
+        args.self_human_id = Some("self".to_string());
+
+        assert_eq!(expected_speakers(&args), None);
+
+        args.participant_human_ids = vec!["self".to_string()];
+
+        assert_eq!(expected_speakers(&args), None);
+    }
+
+    #[test]
     fn build_extra_prefers_explicit_stream_offset() {
         let mut args = listener_args("https://api.deepgram.com", "nova-3");
         args.stream_offset_secs = Some(12.5);

--- a/crates/listener-core/src/lib.rs
+++ b/crates/listener-core/src/lib.rs
@@ -34,6 +34,10 @@ pub enum TranscriptionMode {
     Batch,
 }
 
+/// Remote participants per channel, used to cap provider speaker counts and clamp live
+/// speaker indices. Returns `None` when no remote participants are known: an ad-hoc meeting
+/// without calendar attendees may still have several remote speakers, and a wrong cap merges
+/// them irreversibly while a missing cap only forgoes a hint.
 pub(crate) fn expected_speakers_per_channel(
     participant_human_ids: &[String],
     self_human_id: Option<&str>,
@@ -41,18 +45,13 @@ pub(crate) fn expected_speakers_per_channel(
     let mut remote_participants = participant_human_ids
         .iter()
         .filter(|participant| Some(participant.as_str()) != self_human_id)
-        .cloned()
         .collect::<Vec<_>>();
     remote_participants.sort();
     remote_participants.dedup();
 
-    let count = if remote_participants.is_empty() && self_human_id.is_some() {
-        1
-    } else {
-        remote_participants.len()
-    };
-
-    u32::try_from(count).ok().filter(|count| *count > 0)
+    u32::try_from(remote_participants.len())
+        .ok()
+        .filter(|count| *count > 0)
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/owhisper-client/src/adapter/assemblyai/live.rs
+++ b/crates/owhisper-client/src/adapter/assemblyai/live.rs
@@ -57,13 +57,13 @@ impl RealtimeSttAdapter for AssemblyAIAdapter {
                 query_pairs.append_pair("max_turn_silence", max_silence);
             }
 
+            // Diarization is always on, as with every other live provider and the
+            // AssemblyAI batch path; participant hints only bound the speaker count.
             if matches!(
                 resolved_model,
                 ResolvedLiveModel::Universal35Pro | ResolvedLiveModel::U3RtPro
             ) {
-                if Self::streaming_speaker_labels_enabled(params) {
-                    query_pairs.append_pair("speaker_labels", "true");
-                }
+                query_pairs.append_pair("speaker_labels", "true");
 
                 if let Some(max_speakers) = Self::streaming_max_speakers(params) {
                     query_pairs.append_pair("max_speakers", &max_speakers.to_string());
@@ -234,17 +234,6 @@ impl AssemblyAIAdapter {
         } else {
             ResolvedLiveModel::WhisperRt
         }
-    }
-
-    fn streaming_speaker_labels_enabled(params: &ListenParams) -> bool {
-        params.num_speakers.is_some()
-            || params.min_speakers.is_some()
-            || params.max_speakers.is_some()
-            || params
-                .custom_query
-                .as_ref()
-                .and_then(|custom| custom.get("speaker_labels"))
-                .is_some_and(|value| value == "true")
     }
 
     fn streaming_max_speakers(params: &ListenParams) -> Option<u32> {
@@ -488,6 +477,24 @@ mod tests {
             &owhisper_interface::ListenParams {
                 model: Some("universal-3-5-pro-realtime".to_string()),
                 min_speakers: Some(2),
+                ..Default::default()
+            },
+            1,
+        );
+
+        let query = url.query().expect("query string");
+        assert!(query.contains("speaker_labels=true"));
+        assert!(!query.contains("max_speakers"));
+    }
+
+    #[test]
+    fn test_streaming_diarization_stays_on_without_speaker_hints() {
+        // An ad-hoc meeting has no participant list; remote speakers must
+        // still be told apart, just without a cap.
+        let url = AssemblyAIAdapter.build_ws_url(
+            API_BASE,
+            &owhisper_interface::ListenParams {
+                model: Some("universal-3-5-pro-realtime".to_string()),
                 ..Default::default()
             },
             1,


### PR DESCRIPTION
## Summary
- `expected_speakers_per_channel` returned `Some(1)` whenever only the local user was known, so ad-hoc meetings without calendar attendees sent `num_speakers=1`/`max_speakers=1` to live providers and `clamp_response_speaker_indices` folded every remote speaker into index 0.
- Return `None` when no remote participants are known. A missing hint forgoes a small accuracy gain; a wrong cap merges speakers irreversibly.
- Matches the desktop-side `getMaxSpeakerNumberForParticipants`, which already returns `undefined` for the same case.

## Test plan
- [x] `cargo test -p listener-core` (new `expected_speakers_is_unknown_without_remote_participants`)
- [x] `cargo clippy --locked -p listener-core --all-targets --no-deps -- -D warnings`
- [ ] Live-record an ad-hoc meeting (no calendar participants) with 2+ remote speakers and confirm they no longer collapse into one speaker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live diarization hints and post-processing clamps for sessions without participant metadata; behavior is intentionally safer but affects how multi-speaker ad-hoc calls are labeled across providers.
> 
> **Overview**
> Fixes ad-hoc live meetings (no calendar attendees) where every remote voice was folded into a single speaker because the stack assumed **one** speaker when only the local user was known.
> 
> **`expected_speakers_per_channel`** now returns **`None`** unless there is at least one distinct remote participant, so listen params no longer send `num_speakers` / `max_speakers` of 1 and **`clamp_response_speaker_indices`** skips clamping when the cap is unknown. Documented rationale: a missing hint only drops a small accuracy gain; a wrong cap merges speakers irreversibly (aligned with desktop **`getMaxSpeakerNumberForParticipants`**).
> 
> **AssemblyAI live** always sets **`speaker_labels=true`** on Universal-3 / U3-RT-Pro streams (diarization always on, like other providers); **`max_speakers`** is still added only when hints exist. Removed the gate that turned diarization off without speaker-count params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ee37e71ffb4e3e697bb16110e2baf387569a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->