### PR TITLE
Add wired input lookup for Bluetooth default mics

### DIFF
--- a/crates/audio-device/src/device.rs
+++ b/crates/audio-device/src/device.rs
@@ -66,6 +66,33 @@ pub(crate) fn name_suggests_speaker(name: &str) -> bool {
         .any(|marker| name_lower.contains(marker))
 }
 
+/// Capture endpoints that are not microphones: loopbacks of the output mix and analog or digital
+/// jacks. Opening one instead of a mic records the far end or nothing at all. Generic USB mics
+/// enumerate as "USB Digital Audio" and the like, so a name that says "mic" always wins.
+pub(crate) fn name_suggests_non_microphone(name: &str) -> bool {
+    const NON_MIC_MARKERS: &[&str] = &[
+        "line in",
+        "line-in",
+        "stereo mix",
+        "wave out mix",
+        "what u hear",
+        "loopback",
+        "monitor of",
+        "s/pdif",
+        "spdif",
+    ];
+
+    let name_lower = name.to_lowercase();
+    !name_lower.contains("mic")
+        && NON_MIC_MARKERS
+            .iter()
+            .any(|marker| name_lower.contains(marker))
+}
+
+pub(crate) fn name_suggests_microphone(name: &str) -> bool {
+    name.to_lowercase().contains("mic")
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 pub struct AudioDevice {
     pub id: DeviceId,
@@ -115,7 +142,38 @@ impl AudioDevice {
 
 #[cfg(test)]
 mod tests {
-    use super::name_suggests_speaker;
+    use super::{name_suggests_microphone, name_suggests_non_microphone, name_suggests_speaker};
+
+    #[test]
+    fn loopbacks_and_jacks_are_not_microphones() {
+        for name in [
+            "Stereo Mix (Realtek(R) Audio)",
+            "Line In (Realtek(R) Audio)",
+            "What U Hear (Sound Blaster)",
+            "Monitor of Built-in Audio Analog Stereo",
+            "Digital Audio (S/PDIF) (Realtek(R) Audio)",
+        ] {
+            assert!(name_suggests_non_microphone(name), "{name}");
+        }
+        for name in [
+            "Microphone Array (Realtek(R) Audio)",
+            "MacBook Pro Microphone",
+            "External Microphone",
+            "Microphone (USB Digital Audio)",
+            "Microphone (USB PnP Audio Device)",
+            "Blue Yeti",
+        ] {
+            assert!(!name_suggests_non_microphone(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn microphone_names_are_recognized() {
+        assert!(name_suggests_microphone("MacBook Pro Microphone"));
+        assert!(name_suggests_microphone("Mic Array (Intel SST)"));
+        assert!(!name_suggests_microphone("Built-in Input"));
+        assert!(!name_suggests_microphone("Blue Yeti"));
+    }
 
     #[test]
     fn bluetooth_speakers_are_recognized_by_name() {

--- a/crates/audio-device/src/lib.rs
+++ b/crates/audio-device/src/lib.rs
@@ -71,6 +71,45 @@ fn resolve_headphone_only_output(
     }
 }
 
+/// When the default input is a Bluetooth device, returns a wired input to use instead.
+///
+/// Opening a Bluetooth headset's mic forces it into the HFP call profile: the headset gates the
+/// mic to silence between words and the wearer's audio drops to 8–16 kHz. Any wired input avoids
+/// both, so built-in mics are preferred, then USB. Linux reports onboard mics as PCI rather than
+/// built-in, so PCI ranks with built-in.
+pub fn wired_input_replacing_bluetooth_default() -> Option<AudioDevice> {
+    let backend = backend();
+    let default = backend.get_default_input_device().ok().flatten()?;
+    let inputs = backend.list_input_devices().unwrap_or_default();
+    resolve_wired_input_replacement(&default, inputs)
+}
+
+fn resolve_wired_input_replacement(
+    default: &AudioDevice,
+    inputs: Vec<AudioDevice>,
+) -> Option<AudioDevice> {
+    if default.transport_type != TransportType::Bluetooth {
+        return None;
+    }
+
+    inputs
+        .into_iter()
+        .filter(|device| device.direction == AudioDirection::Input && device.id != default.id)
+        .filter_map(|device| wired_input_rank(device.transport_type).map(|rank| (rank, device)))
+        .min_by_key(|(rank, _)| *rank)
+        .map(|(_, device)| device)
+}
+
+fn wired_input_rank(transport: TransportType) -> Option<u8> {
+    match transport {
+        TransportType::BuiltIn | TransportType::Pci => Some(0),
+        TransportType::Usb => Some(1),
+        TransportType::Hdmi => Some(2),
+        TransportType::Unknown => Some(3),
+        TransportType::Bluetooth | TransportType::Virtual => None,
+    }
+}
+
 pub trait AudioDeviceBackend {
     fn list_devices(&self) -> Result<Vec<AudioDevice>, Error>;
 
@@ -166,6 +205,72 @@ mod tests {
             is_headphone,
         );
         assert_eq!(result.map(|d| d.id.0), Some("hp-default".to_string()));
+    }
+
+    fn input(id: &str, transport: TransportType) -> AudioDevice {
+        AudioDevice::new(id, id, AudioDirection::Input, transport)
+    }
+
+    #[test]
+    fn wired_default_input_needs_no_replacement() {
+        let result = resolve_wired_input_replacement(
+            &input("builtin", TransportType::BuiltIn),
+            vec![
+                input("builtin", TransportType::BuiltIn),
+                input("usb", TransportType::Usb),
+            ],
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn bluetooth_default_input_prefers_built_in_then_usb() {
+        let inputs = vec![
+            input("headset", TransportType::Bluetooth),
+            input("usb", TransportType::Usb),
+            input("builtin", TransportType::BuiltIn),
+        ];
+        let result =
+            resolve_wired_input_replacement(&input("headset", TransportType::Bluetooth), inputs);
+        assert_eq!(result.map(|d| d.id.0), Some("builtin".to_string()));
+
+        let inputs = vec![
+            input("headset", TransportType::Bluetooth),
+            input("usb", TransportType::Usb),
+        ];
+        let result =
+            resolve_wired_input_replacement(&input("headset", TransportType::Bluetooth), inputs);
+        assert_eq!(result.map(|d| d.id.0), Some("usb".to_string()));
+    }
+
+    #[test]
+    fn pci_onboard_input_ranks_with_built_in_over_usb() {
+        let inputs = vec![
+            input("headset", TransportType::Bluetooth),
+            input("usb", TransportType::Usb),
+            input("onboard", TransportType::Pci),
+        ];
+        let result =
+            resolve_wired_input_replacement(&input("headset", TransportType::Bluetooth), inputs);
+        assert_eq!(result.map(|d| d.id.0), Some("onboard".to_string()));
+    }
+
+    #[test]
+    fn bluetooth_default_input_never_falls_back_to_bluetooth_or_virtual() {
+        let inputs = vec![
+            input("headset", TransportType::Bluetooth),
+            input("earbuds", TransportType::Bluetooth),
+            input("aggregate", TransportType::Virtual),
+            AudioDevice::new(
+                "speakers",
+                "speakers",
+                AudioDirection::Output,
+                TransportType::BuiltIn,
+            ),
+        ];
+        let result =
+            resolve_wired_input_replacement(&input("headset", TransportType::Bluetooth), inputs);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/audio-device/src/lib.rs
+++ b/crates/audio-device/src/lib.rs
@@ -71,12 +71,13 @@ fn resolve_headphone_only_output(
     }
 }
 
-/// When the default input is a Bluetooth device, returns a wired input to use instead.
+/// When the default input is a Bluetooth device, returns a wired microphone to use instead.
 ///
 /// Opening a Bluetooth headset's mic forces it into the HFP call profile: the headset gates the
 /// mic to silence between words and the wearer's audio drops to 8–16 kHz. Any wired input avoids
 /// both, so built-in mics are preferred, then USB. Linux reports onboard mics as PCI rather than
-/// built-in, so PCI ranks with built-in.
+/// built-in, so PCI ranks with built-in. Line-in jacks and output loopbacks are capture endpoints
+/// too but never microphones, so they are skipped.
 pub fn wired_input_replacing_bluetooth_default() -> Option<AudioDevice> {
     let backend = backend();
     let default = backend.get_default_input_device().ok().flatten()?;
@@ -95,8 +96,11 @@ fn resolve_wired_input_replacement(
     inputs
         .into_iter()
         .filter(|device| device.direction == AudioDirection::Input && device.id != default.id)
+        .filter(|device| !name_suggests_non_microphone(&device.name))
         .filter_map(|device| wired_input_rank(device.transport_type).map(|rank| (rank, device)))
-        .min_by_key(|(rank, _)| *rank)
+        // Within a transport, a device that calls itself a microphone beats one that does not;
+        // `min_by_key` keeps list order for full ties.
+        .min_by_key(|(rank, device)| (*rank, !name_suggests_microphone(&device.name)))
         .map(|(_, device)| device)
 }
 
@@ -253,6 +257,62 @@ mod tests {
         let result =
             resolve_wired_input_replacement(&input("headset", TransportType::Bluetooth), inputs);
         assert_eq!(result.map(|d| d.id.0), Some("onboard".to_string()));
+    }
+
+    fn named_input(id: &str, name: &str, transport: TransportType) -> AudioDevice {
+        AudioDevice::new(id, name, AudioDirection::Input, transport)
+    }
+
+    #[test]
+    fn line_in_and_loopback_inputs_never_replace_bluetooth() {
+        let headset = input("headset", TransportType::Bluetooth);
+        let inputs = vec![
+            headset.clone(),
+            named_input(
+                "mix",
+                "Stereo Mix (Realtek(R) Audio)",
+                TransportType::BuiltIn,
+            ),
+            named_input("line", "Line In (Realtek(R) Audio)", TransportType::BuiltIn),
+            named_input(
+                "array",
+                "Microphone Array (Realtek(R) Audio)",
+                TransportType::BuiltIn,
+            ),
+        ];
+        let result = resolve_wired_input_replacement(&headset, inputs);
+        assert_eq!(result.map(|d| d.id.0), Some("array".to_string()));
+
+        let inputs = vec![
+            headset.clone(),
+            named_input(
+                "mix",
+                "Stereo Mix (Realtek(R) Audio)",
+                TransportType::BuiltIn,
+            ),
+            named_input("line", "Line In (Realtek(R) Audio)", TransportType::BuiltIn),
+        ];
+        assert!(resolve_wired_input_replacement(&headset, inputs).is_none());
+    }
+
+    #[test]
+    fn microphone_wins_ties_within_a_transport_but_not_across() {
+        let headset = input("headset", TransportType::Bluetooth);
+        let inputs = vec![
+            headset.clone(),
+            named_input("jack", "Built-in Input", TransportType::BuiltIn),
+            named_input("mic", "Built-in Microphone", TransportType::BuiltIn),
+        ];
+        let result = resolve_wired_input_replacement(&headset, inputs);
+        assert_eq!(result.map(|d| d.id.0), Some("mic".to_string()));
+
+        let inputs = vec![
+            headset.clone(),
+            named_input("yeti", "Yeti Stereo Microphone", TransportType::Usb),
+            named_input("jack", "Built-in Input", TransportType::BuiltIn),
+        ];
+        let result = resolve_wired_input_replacement(&headset, inputs);
+        assert_eq!(result.map(|d| d.id.0), Some("jack".to_string()));
     }
 
     #[test]

--- a/crates/audio-device/src/windows.rs
+++ b/crates/audio-device/src/windows.rs
@@ -5,8 +5,8 @@ use std::os::windows::ffi::OsStringExt;
 use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
 use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
 use windows::Win32::Media::Audio::{
-    DEVICE_STATE_ACTIVE, IMMDevice, IMMDeviceEnumerator, MMDeviceEnumerator, eAll, eCapture,
-    eConsole, eRender,
+    DEVICE_STATE_ACTIVE, IDeviceTopology, IMMDevice, IMMDeviceEnumerator, MMDeviceEnumerator, eAll,
+    eCapture, eConsole, eRender,
 };
 use windows::Win32::System::Com::{
     CLSCTX_ALL, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, CoUninitialize, STGM_READ,
@@ -98,22 +98,62 @@ impl Drop for ComGuard {
     }
 }
 
-fn get_device_id(device: &IMMDevice) -> Result<String, Error> {
-    unsafe {
-        let id: PWSTR = device
-            .GetId()
-            .map_err(|e| Error::EnumerationFailed(format!("Failed to get device ID: {}", e)))?;
-
-        let len = (0..).take_while(|&i| *id.0.add(i) != 0).count();
-        let slice = std::slice::from_raw_parts(id.0, len);
-        let os_string = OsString::from_wide(slice);
-
-        windows::Win32::System::Com::CoTaskMemFree(Some(id.0 as *const _));
-
-        os_string
-            .into_string()
-            .map_err(|_| Error::EnumerationFailed("Invalid device ID encoding".into()))
+fn take_co_task_string(value: PWSTR) -> Option<String> {
+    if value.is_null() {
+        return None;
     }
+    unsafe {
+        let string = value.to_string().ok();
+        windows::Win32::System::Com::CoTaskMemFree(Some(value.0 as *const _));
+        string
+    }
+}
+
+fn get_device_id(device: &IMMDevice) -> Result<String, Error> {
+    let id: PWSTR = unsafe { device.GetId() }
+        .map_err(|e| Error::EnumerationFailed(format!("Failed to get device ID: {}", e)))?;
+
+    take_co_task_string(id)
+        .ok_or_else(|| Error::EnumerationFailed("Invalid device ID encoding".into()))
+}
+
+// The endpoint's first connector leads to the adapter device, whose ID is a device path such as
+// `{2}.\\?\bthhfenum#bthhfpaudio#...`. Fails for endpoints with a software connection.
+fn get_adapter_device_id(device: &IMMDevice) -> Option<String> {
+    unsafe {
+        let topology: IDeviceTopology = device.Activate(CLSCTX_ALL, None).ok()?;
+        let connector = topology.GetConnector(0).ok()?;
+        take_co_task_string(connector.GetDeviceIdConnectedTo().ok()?)
+    }
+}
+
+fn adapter_enumerator(device_id: &str) -> Option<&str> {
+    let path = &device_id[device_id.find("\\\\?\\")? + 4..];
+    path.split('#')
+        .next()
+        .filter(|enumerator| !enumerator.is_empty())
+}
+
+// Windows' in-box Bluetooth driver labels its endpoints "Headset (X Hands-Free AG Audio)" and
+// never says "Bluetooth", so the bus enumerator in the adapter path is the reliable signal. Both
+// HFP (BTHHFENUM) and A2DP/LE (BTHENUM, BTHLEENUM) enumerators start with "bth".
+fn transport_type_from_enumerator(enumerator: &str) -> Option<TransportType> {
+    match enumerator.to_ascii_lowercase().as_str() {
+        bus if bus.starts_with("bth") => Some(TransportType::Bluetooth),
+        "usb" => Some(TransportType::Usb),
+        "hdaudio" | "intelaudio" => Some(TransportType::BuiltIn),
+        "pci" => Some(TransportType::Pci),
+        "swd" | "root" => Some(TransportType::Virtual),
+        _ => None,
+    }
+}
+
+fn get_transport_type(device: &IMMDevice, name: &str) -> TransportType {
+    get_adapter_device_id(device)
+        .as_deref()
+        .and_then(adapter_enumerator)
+        .and_then(transport_type_from_enumerator)
+        .unwrap_or_else(|| get_transport_type_from_name(name))
 }
 
 fn get_device_name(device: &IMMDevice) -> Result<String, Error> {
@@ -143,7 +183,7 @@ fn get_device_name(device: &IMMDevice) -> Result<String, Error> {
 
 fn get_transport_type_from_name(name: &str) -> TransportType {
     let name_lower = name.to_lowercase();
-    if name_lower.contains("bluetooth") {
+    if name_lower.contains("bluetooth") || name_lower.contains("hands-free") {
         TransportType::Bluetooth
     } else if name_lower.contains("usb") {
         TransportType::Usb
@@ -228,7 +268,7 @@ impl AudioDeviceBackend for WindowsBackend {
                     _ => continue,
                 };
 
-                let transport_type = get_transport_type_from_name(&name);
+                let transport_type = get_transport_type(&device, &name);
 
                 let is_default = match direction {
                     AudioDirection::Input => {
@@ -286,7 +326,7 @@ impl AudioDeviceBackend for WindowsBackend {
 
             let id = get_device_id(&device)?;
             let name = get_device_name(&device)?;
-            let transport_type = get_transport_type_from_name(&name);
+            let transport_type = get_transport_type(&device, &name);
 
             Ok(Some(AudioDevice {
                 id: DeviceId::new(id),
@@ -316,7 +356,7 @@ impl AudioDeviceBackend for WindowsBackend {
 
             let id = get_device_id(&device)?;
             let name = get_device_name(&device)?;
-            let transport_type = get_transport_type_from_name(&name);
+            let transport_type = get_transport_type(&device, &name);
 
             let mut audio_device = AudioDevice {
                 id: DeviceId::new(id),
@@ -516,6 +556,65 @@ impl AudioDeviceBackend for WindowsBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn adapter_path_classifies_bluetooth_usb_and_onboard() {
+        let cases = [
+            (
+                "{2}.\\\\?\\bthhfenum#bthhfpaudio#8&2f0a1b2c&0&97#{6994ad04-93ef-11d0-a3cc-00a0c9223196}\\hfpaudio",
+                TransportType::Bluetooth,
+            ),
+            (
+                "{2}.\\\\?\\bthenum#{0000110b-0000-1000-8000-00805f9b34fb}_vid&0001004c#{6994ad04-93ef-11d0-a3cc-00a0c9223196}\\a2dp",
+                TransportType::Bluetooth,
+            ),
+            (
+                "{2}.\\\\?\\usb#vid_046d&pid_0825&mi_02#7&1f2e3d4c&0&0002#{6994ad04-93ef-11d0-a3cc-00a0c9223196}\\global",
+                TransportType::Usb,
+            ),
+            (
+                "{2}.\\\\?\\hdaudio#func_01&ven_10ec&dev_0295#4&7f7f8f0&0&0001#{6994ad04-93ef-11d0-a3cc-00a0c9223196}\\topo",
+                TransportType::BuiltIn,
+            ),
+            (
+                "{2}.\\\\?\\root#vbaudiovirtualcable#0000#{6994ad04-93ef-11d0-a3cc-00a0c9223196}\\wave",
+                TransportType::Virtual,
+            ),
+        ];
+        for (path, expected) in cases {
+            let transport = adapter_enumerator(path).and_then(transport_type_from_enumerator);
+            assert_eq!(transport, Some(expected), "{path}");
+        }
+    }
+
+    #[test]
+    fn unrecognized_adapter_path_defers_to_the_name() {
+        assert_eq!(
+            adapter_enumerator("{2}.\\\\?\\acpaudio#func_01#4&1#{guid}\\topo")
+                .and_then(transport_type_from_enumerator),
+            None
+        );
+        assert_eq!(adapter_enumerator("{0.0.1.00000000}.{guid}"), None);
+    }
+
+    #[test]
+    fn in_box_bluetooth_endpoint_names_are_bluetooth() {
+        for name in [
+            "Headset (WH-1000XM5 Hands-Free AG Audio)",
+            "Headset Microphone (Jabra Elite 85t Hands-Free)",
+            "Bluetooth Hands-free Audio",
+        ] {
+            assert_eq!(
+                get_transport_type_from_name(name),
+                TransportType::Bluetooth,
+                "{name}"
+            );
+        }
+        assert_eq!(
+            get_transport_type_from_name("Microphone Array (Realtek(R) Audio)"),
+            TransportType::BuiltIn
+        );
+    }
 
     #[test]
     fn test_list_devices() {

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -358,7 +358,7 @@ impl Actor for SourceActor {
                     st.runtime.emit_error(SessionErrorEvent::AudioError {
                         session_id: st.session_id.clone(),
                         error: reason.clone(),
-                        device: st.mic_device.clone(),
+                        device: st.active_mic_device.clone(),
                         is_fatal: true,
                     });
                     myself.stop(Some(reason));
@@ -393,7 +393,7 @@ fn recorder_failure(state: &SourceState, reason: String) -> Result<(), ActorProc
     state.runtime.emit_error(SessionErrorEvent::AudioError {
         session_id: state.session_id.clone(),
         error: reason.clone(),
-        device: state.mic_device.clone(),
+        device: state.active_mic_device.clone(),
         is_fatal: true,
     });
     Err(std::io::Error::other(reason).into())

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -66,7 +66,11 @@ pub struct SourceState {
     pub(super) runtime: Arc<dyn ListenerRuntime>,
     pub(super) audio: Arc<dyn AudioProvider>,
     pub(super) session_id: String,
+    /// The user's explicit choice; `None` defers to the system default.
     pub(super) mic_device: Option<String>,
+    /// The device the current stream actually opened. Differs from `mic_device` when a Bluetooth
+    /// default input was swapped for a wired one.
+    pub(super) active_mic_device: Option<String>,
     pub(super) onboarding: bool,
     pub(super) mic_muted: Arc<AtomicBool>,
     pub(super) run_task: Option<tokio::task::JoinHandle<()>>,
@@ -221,6 +225,7 @@ impl Actor for SourceActor {
                 audio: args.audio,
                 session_id: args.session_id,
                 mic_device,
+                active_mic_device: None,
                 onboarding: args.onboarding,
                 mic_muted: Arc::new(AtomicBool::new(false)),
                 run_task: None,
@@ -267,7 +272,7 @@ impl Actor for SourceActor {
                 }
                 SourceMsg::GetMicDevice(reply) => {
                     if !reply.is_closed() {
-                        let _ = reply.send(st.mic_device.clone());
+                        let _ = reply.send(st.active_mic_device.clone());
                     }
                 }
                 SourceMsg::PrepareListenerRefresh(reply) => {

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -245,7 +245,7 @@ impl Actor for SourceActor {
             let capture = start_source_loop(&myself, &mut st).await?;
             st._device_watcher = Some(DeviceChangeWatcher::spawn(
                 myself.clone(),
-                capture.mic_isolated,
+                capture.headphone_output,
             ));
             Ok(st)
         }

--- a/crates/listener-core/src/actors/source/pipeline.rs
+++ b/crates/listener-core/src/actors/source/pipeline.rs
@@ -561,9 +561,14 @@ impl ReplayHistory {
 // Real microphones never produce exact zeros; a run of them means the device or its driver stopped
 // delivering audio. Bluetooth headsets in call mode do this between words. Reported once per
 // stream so the UI can warn without being spammed.
+//
+// Dual capture pads the mic with zeros while the speaker stream leads it, which is routine until
+// the mic delivers its first samples. Counting starts at the first non-zero sample so a slow mic
+// start is not mistaken for gating; padding after that means the mic stalled, which is a dropout.
 struct DropoutMonitor {
     runtime: Arc<dyn ListenerRuntime>,
     session_id: String,
+    mic_started: bool,
     zero_samples: usize,
     total_samples: usize,
     reported: bool,
@@ -574,6 +579,7 @@ impl DropoutMonitor {
         Self {
             runtime,
             session_id,
+            mic_started: false,
             zero_samples: 0,
             total_samples: 0,
             reported: false,
@@ -581,6 +587,7 @@ impl DropoutMonitor {
     }
 
     fn reset(&mut self) {
+        self.mic_started = false;
         self.zero_samples = 0;
         self.total_samples = 0;
         self.reported = false;
@@ -591,7 +598,15 @@ impl DropoutMonitor {
             return;
         }
 
-        self.zero_samples += raw_mic.iter().filter(|sample| **sample == 0.0).count();
+        let zero_samples = raw_mic.iter().filter(|sample| **sample == 0.0).count();
+        if !self.mic_started {
+            if zero_samples == raw_mic.len() {
+                return;
+            }
+            self.mic_started = true;
+        }
+
+        self.zero_samples += zero_samples;
         self.total_samples += raw_mic.len();
         if self.total_samples < DROPOUT_WINDOW_SAMPLES {
             return;
@@ -1586,6 +1601,19 @@ mod tests {
         let mut monitor = DropoutMonitor::new(runtime.clone(), "session".to_string());
 
         feed_window(&mut monitor, 0.1);
+        feed_window(&mut monitor, 0.0);
+
+        assert!(runtime.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn dropout_monitor_ignores_silence_before_the_mic_starts() {
+        let runtime = Arc::new(DropoutRuntime::default());
+        let mut monitor = DropoutMonitor::new(runtime.clone(), "session".to_string());
+
+        for _ in 0..20 {
+            monitor.observe(&[0.0; 1_600]);
+        }
         feed_window(&mut monitor, 0.0);
 
         assert!(runtime.0.lock().unwrap().is_empty());

--- a/crates/listener-core/src/actors/source/pipeline.rs
+++ b/crates/listener-core/src/actors/source/pipeline.rs
@@ -30,6 +30,8 @@ const LISTENER_BACKPRESSURE_RETRY_DELAY: Duration = Duration::from_millis(10);
 const MAX_BACKLOG_DISPATCH_PER_FRAME: usize = 2;
 const RECORDER_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(2);
 const RECORDER_RPC_TIMEOUT: Duration = Duration::from_millis(100);
+const DROPOUT_WINDOW_SAMPLES: usize = SAMPLE_RATE as usize * 5;
+const DROPOUT_RATIO_THRESHOLD: f32 = 0.15;
 
 #[derive(Clone)]
 struct BufferedAudio {
@@ -57,6 +59,7 @@ pub(super) enum DispatchFrameResult {
 pub(in crate::actors) struct Pipeline {
     vad_mask: VadMask,
     amplitude: AmplitudeEmitter,
+    dropouts: DropoutMonitor,
     audio_buffer: AudioBuffer,
     replay_history: ReplayHistory,
     listener_dispatcher: ListenerDispatcher,
@@ -67,7 +70,8 @@ pub(in crate::actors) struct Pipeline {
 impl Pipeline {
     pub(super) fn new(runtime: Arc<dyn ListenerRuntime>, session_id: String) -> Self {
         Self {
-            amplitude: AmplitudeEmitter::new(runtime, session_id),
+            amplitude: AmplitudeEmitter::new(runtime.clone(), session_id.clone()),
+            dropouts: DropoutMonitor::new(runtime, session_id),
             audio_buffer: AudioBuffer::new(MAX_BUFFER_CHUNKS),
             replay_history: ReplayHistory::new(SAMPLE_RATE as usize * REPLAY_HISTORY_SECS),
             listener_dispatcher: ListenerDispatcher::new(),
@@ -79,6 +83,7 @@ impl Pipeline {
 
     pub(super) fn reset(&mut self) {
         self.amplitude.reset();
+        self.dropouts.reset();
         self.audio_buffer.clear();
         self.replay_history.clear();
         self.listener_dispatcher.reset();
@@ -168,6 +173,10 @@ impl Pipeline {
     ) -> Result<DispatchFrameResult, String> {
         if self.pending_recorder_item.is_some() {
             return Err("recorder audio must be retried before dispatching another frame".into());
+        }
+
+        if mode != ChannelMode::SpeakerOnly {
+            self.dropouts.observe(&frame.capture.raw_mic);
         }
 
         let (mut processed_mic, processed_spk) = Self::select_tracks(frame, mode);
@@ -549,6 +558,61 @@ impl ReplayHistory {
     }
 }
 
+// Real microphones never produce exact zeros; a run of them means the device or its driver stopped
+// delivering audio. Bluetooth headsets in call mode do this between words. Reported once per
+// stream so the UI can warn without being spammed.
+struct DropoutMonitor {
+    runtime: Arc<dyn ListenerRuntime>,
+    session_id: String,
+    zero_samples: usize,
+    total_samples: usize,
+    reported: bool,
+}
+
+impl DropoutMonitor {
+    fn new(runtime: Arc<dyn ListenerRuntime>, session_id: String) -> Self {
+        Self {
+            runtime,
+            session_id,
+            zero_samples: 0,
+            total_samples: 0,
+            reported: false,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.zero_samples = 0;
+        self.total_samples = 0;
+        self.reported = false;
+    }
+
+    fn observe(&mut self, raw_mic: &[f32]) {
+        if self.reported {
+            return;
+        }
+
+        self.zero_samples += raw_mic.iter().filter(|sample| **sample == 0.0).count();
+        self.total_samples += raw_mic.len();
+        if self.total_samples < DROPOUT_WINDOW_SAMPLES {
+            return;
+        }
+
+        let ratio = self.zero_samples as f32 / self.total_samples as f32;
+        self.zero_samples = 0;
+        self.total_samples = 0;
+        if ratio < DROPOUT_RATIO_THRESHOLD {
+            return;
+        }
+
+        tracing::warn!(ratio, "mic_dropouts_detected");
+        self.runtime.emit_data(SessionDataEvent::MicDropouts {
+            session_id: self.session_id.clone(),
+            ratio,
+        });
+        self.reported = true;
+    }
+}
+
 struct AmplitudeEmitter {
     runtime: Arc<dyn ListenerRuntime>,
     session_id: String,
@@ -666,6 +730,33 @@ mod tests {
         fn emit_error(&self, _event: SessionErrorEvent) {}
 
         fn emit_data(&self, _event: SessionDataEvent) {}
+    }
+
+    #[derive(Default)]
+    struct DropoutRuntime(std::sync::Mutex<Vec<f32>>);
+
+    impl anlg_storage::StorageRuntime for DropoutRuntime {
+        fn global_base(&self) -> Result<PathBuf, anlg_storage::Error> {
+            Ok(std::env::temp_dir())
+        }
+
+        fn vault_base(&self) -> Result<PathBuf, anlg_storage::Error> {
+            Ok(std::env::temp_dir())
+        }
+    }
+
+    impl ListenerRuntime for DropoutRuntime {
+        fn emit_lifecycle(&self, _event: SessionLifecycleEvent) {}
+
+        fn emit_progress(&self, _event: SessionProgressEvent) {}
+
+        fn emit_error(&self, _event: SessionErrorEvent) {}
+
+        fn emit_data(&self, event: SessionDataEvent) {
+            if let SessionDataEvent::MicDropouts { ratio, .. } = event {
+                self.0.lock().unwrap().push(ratio);
+            }
+        }
     }
 
     enum ProbeEvent {
@@ -1464,5 +1555,51 @@ mod tests {
         let (mic, speaker) = Pipeline::select_tracks(source_frame(false), ChannelMode::SpeakerOnly);
         assert_eq!(mic, vec![0.0, 0.0, 0.0, 0.0]);
         assert_eq!(&*speaker, &[0.75, -0.75, 1.0, -1.0]);
+    }
+
+    fn feed_window(monitor: &mut DropoutMonitor, zero_ratio: f32) {
+        let chunk = 1_600;
+        let zeros = (chunk as f32 * zero_ratio) as usize;
+        let mut frame = vec![0.01_f32; chunk];
+        frame[..zeros].fill(0.0);
+        for _ in 0..DROPOUT_WINDOW_SAMPLES.div_ceil(chunk) {
+            monitor.observe(&frame);
+        }
+    }
+
+    #[test]
+    fn dropout_monitor_reports_gated_mic_once_per_stream() {
+        let runtime = Arc::new(DropoutRuntime::default());
+        let mut monitor = DropoutMonitor::new(runtime.clone(), "session".to_string());
+
+        feed_window(&mut monitor, 0.3);
+        feed_window(&mut monitor, 0.3);
+
+        let reported = runtime.0.lock().unwrap().clone();
+        assert_eq!(reported.len(), 1);
+        assert!((reported[0] - 0.3).abs() < 0.01, "ratio {}", reported[0]);
+    }
+
+    #[test]
+    fn dropout_monitor_ignores_healthy_mic() {
+        let runtime = Arc::new(DropoutRuntime::default());
+        let mut monitor = DropoutMonitor::new(runtime.clone(), "session".to_string());
+
+        feed_window(&mut monitor, 0.1);
+        feed_window(&mut monitor, 0.0);
+
+        assert!(runtime.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn dropout_monitor_reports_again_after_reset() {
+        let runtime = Arc::new(DropoutRuntime::default());
+        let mut monitor = DropoutMonitor::new(runtime.clone(), "session".to_string());
+
+        feed_window(&mut monitor, 0.5);
+        monitor.reset();
+        feed_window(&mut monitor, 0.5);
+
+        assert_eq!(runtime.0.lock().unwrap().len(), 2);
     }
 }

--- a/crates/listener-core/src/actors/source/stream.rs
+++ b/crates/listener-core/src/actors/source/stream.rs
@@ -27,7 +27,8 @@ pub(super) async fn start_source_loop(
     st.pipeline.reset();
 
     st.active_mic_device = active_mic_device(st.mic_device.clone(), st.audio.as_ref());
-    let capture = capture_settings();
+    let mic_swapped = st.mic_device.is_none() && st.active_mic_device.is_some();
+    let capture = capture_settings(mic_swapped);
     let result = start_streams(myself, st, capture).await;
 
     if result.is_ok() {
@@ -49,14 +50,18 @@ pub(super) async fn start_source_loop(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct CaptureSettings {
     enable_aec: bool,
+    /// Every playing output is a headphone. Re-evaluated per stream because the source restarts
+    /// on default output changes; the routing watcher starts from this verdict.
+    pub(super) headphone_output: bool,
     /// Headphones keep speaker output out of the mic, so whatever the mic hears is the local
-    /// user. Re-evaluated per stream because the source restarts on default output changes.
+    /// user. Not claimed when the mic was swapped away from the user's Bluetooth headset: the
+    /// headset mic sat on their head, the replacement is a room mic as far as we know.
     pub(super) mic_isolated: bool,
 }
 
 // Headphones make AEC pure cost: it burns CPU and can degrade near-end speech. The check covers
 // every output that is playing, not just the default, because meeting apps pick their own speaker.
-fn capture_settings() -> CaptureSettings {
+fn capture_settings(mic_swapped: bool) -> CaptureSettings {
     let headphone_output = anlg_audio_device::headphone_only_output();
     if let Some(device) = &headphone_output {
         tracing::info!(
@@ -68,13 +73,19 @@ fn capture_settings() -> CaptureSettings {
     resolve_capture_settings(
         std::env::var("NO_AEC").as_deref() == Ok("1"),
         headphone_output.is_some(),
+        mic_swapped,
     )
 }
 
-fn resolve_capture_settings(no_aec_override: bool, headphone_output: bool) -> CaptureSettings {
+fn resolve_capture_settings(
+    no_aec_override: bool,
+    headphone_output: bool,
+    mic_swapped: bool,
+) -> CaptureSettings {
     CaptureSettings {
         enable_aec: !no_aec_override && !headphone_output,
-        mic_isolated: headphone_output,
+        headphone_output,
+        mic_isolated: headphone_output && !mic_swapped,
     }
 }
 
@@ -267,9 +278,10 @@ mod tests {
     #[test]
     fn headphones_disable_aec_and_isolate_the_mic() {
         assert_eq!(
-            resolve_capture_settings(false, true),
+            resolve_capture_settings(false, true, false),
             CaptureSettings {
                 enable_aec: false,
+                headphone_output: true,
                 mic_isolated: true,
             }
         );
@@ -278,9 +290,10 @@ mod tests {
     #[test]
     fn speakers_keep_aec_and_leave_the_mic_shared() {
         assert_eq!(
-            resolve_capture_settings(false, false),
+            resolve_capture_settings(false, false, false),
             CaptureSettings {
                 enable_aec: true,
+                headphone_output: false,
                 mic_isolated: false,
             }
         );
@@ -289,9 +302,22 @@ mod tests {
     #[test]
     fn no_aec_override_does_not_imply_isolation() {
         assert_eq!(
-            resolve_capture_settings(true, false),
+            resolve_capture_settings(true, false, false),
             CaptureSettings {
                 enable_aec: false,
+                headphone_output: false,
+                mic_isolated: false,
+            }
+        );
+    }
+
+    #[test]
+    fn swapped_mic_is_not_isolated_but_headphones_still_skip_aec() {
+        assert_eq!(
+            resolve_capture_settings(false, true, true),
+            CaptureSettings {
+                enable_aec: false,
+                headphone_output: true,
                 mic_isolated: false,
             }
         );

--- a/crates/listener-core/src/actors/source/stream.rs
+++ b/crates/listener-core/src/actors/source/stream.rs
@@ -26,13 +26,14 @@ pub(super) async fn start_source_loop(
 
     st.pipeline.reset();
 
+    st.active_mic_device = active_mic_device(st.mic_device.clone(), st.audio.as_ref());
     let capture = capture_settings();
     let result = start_streams(myself, st, capture).await;
 
     if result.is_ok() {
         st.runtime.emit_progress(SessionProgressEvent::AudioReady {
             session_id: st.session_id.clone(),
-            device: st.mic_device.clone(),
+            device: st.active_mic_device.clone(),
         });
         if new_mode == ChannelMode::MicAndSpeaker {
             st.runtime.emit_data(SessionDataEvent::MicIsolated {
@@ -77,6 +78,30 @@ fn resolve_capture_settings(no_aec_override: bool, headphone_output: bool) -> Ca
     }
 }
 
+// Opening a Bluetooth headset's mic forces it into HFP: the headset gates the mic to silence
+// between words and the wearer's audio drops to 16 kHz. Only the system default is swapped; an
+// explicit selection is respected.
+fn active_mic_device(explicit: Option<String>, audio: &dyn AudioProvider) -> Option<String> {
+    if explicit.is_some() {
+        return explicit;
+    }
+
+    let replacement = anlg_audio_device::wired_input_replacing_bluetooth_default()?;
+    // The provider enumerates by name, and only macOS/Windows share names with the device layer.
+    let active = audio
+        .list_mic_devices()
+        .into_iter()
+        .find(|name| *name == replacement.name);
+    match &active {
+        Some(device) => tracing::info!(device = %device, "bluetooth_default_mic_replaced"),
+        None => tracing::warn!(
+            device = %replacement.name,
+            "bluetooth_default_mic_replacement_unavailable"
+        ),
+    }
+    active
+}
+
 async fn start_streams(
     myself: &ActorRef<SourceMsg>,
     st: &mut SourceState,
@@ -85,7 +110,7 @@ async fn start_streams(
     let mode = st.current_mode;
     let myself2 = myself.clone();
     let mic_muted = st.mic_muted.clone();
-    let mic_device = st.mic_device.clone();
+    let mic_device = st.active_mic_device.clone();
     let audio = st.audio.clone();
     let (frame_tx, frame_rx) = tokio::sync::mpsc::channel(CAPTURE_FRAME_QUEUE_CAPACITY);
     let wake_pending = st.capture_wake_pending.clone();

--- a/crates/listener-core/src/actors/source/stream.rs
+++ b/crates/listener-core/src/actors/source/stream.rs
@@ -78,16 +78,21 @@ fn resolve_capture_settings(no_aec_override: bool, headphone_output: bool) -> Ca
     }
 }
 
+// The mic opens by the provider's device name, which only matches the device layer's name on
+// macOS and Windows. On Linux the mic goes through cpal/ALSA, whose names are ALSA PCM hints and
+// never match PulseAudio source names, so a replacement could not be opened; avoiding HFP there
+// needs a PulseAudio/PipeWire mic capture path.
+const SWAPS_BLUETOOTH_DEFAULT_MIC: bool = cfg!(any(target_os = "macos", target_os = "windows"));
+
 // Opening a Bluetooth headset's mic forces it into HFP: the headset gates the mic to silence
 // between words and the wearer's audio drops to 16 kHz. Only the system default is swapped; an
 // explicit selection is respected.
 fn active_mic_device(explicit: Option<String>, audio: &dyn AudioProvider) -> Option<String> {
-    if explicit.is_some() {
+    if explicit.is_some() || !SWAPS_BLUETOOTH_DEFAULT_MIC {
         return explicit;
     }
 
     let replacement = anlg_audio_device::wired_input_replacing_bluetooth_default()?;
-    // The provider enumerates by name, and only macOS/Windows share names with the device layer.
     let active = audio
         .list_mic_devices()
         .into_iter()

--- a/crates/listener-core/src/events.rs
+++ b/crates/listener-core/src/events.rs
@@ -75,6 +75,11 @@ pub enum SessionDataEvent {
     /// headphone, so no far-end audio reaches the mic. Emitted each time capture (re)starts.
     #[serde(rename = "mic_isolated")]
     MicIsolated { session_id: String, value: bool },
+    /// The mic delivered exact digital silence for `ratio` of the last few seconds. Bluetooth
+    /// headsets in call mode gate their mic between words, and those words never reach the
+    /// transcript. Emitted at most once per capture stream.
+    #[serde(rename = "mic_dropouts")]
+    MicDropouts { session_id: String, ratio: f32 },
     #[serde(rename = "transcript_delta")]
     TranscriptDelta {
         session_id: String,

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -113,6 +113,8 @@ pub enum CaptureDataEvent {
     MicMuted { session_id: String, value: bool },
     #[serde(rename = "mic_isolated")]
     MicIsolated { session_id: String, value: bool },
+    #[serde(rename = "mic_dropouts")]
+    MicDropouts { session_id: String, ratio: f32 },
     #[serde(rename = "transcript_delta")]
     TranscriptDelta {
         session_id: String,
@@ -308,6 +310,9 @@ impl From<listener::SessionDataEvent> for CaptureDataEvent {
             }
             listener::SessionDataEvent::MicIsolated { session_id, value } => {
                 Self::MicIsolated { session_id, value }
+            }
+            listener::SessionDataEvent::MicDropouts { session_id, ratio } => {
+                Self::MicDropouts { session_id, ratio }
             }
             listener::SessionDataEvent::TranscriptDelta { session_id, delta } => {
                 Self::TranscriptDelta { session_id, delta }


### PR DESCRIPTION
Opening a Bluetooth headset mic forces HFP: the headset gates the mic to silence between words (26-52% zeros measured on Shokz and Jabra) and drops the wearer to 16 kHz. Expose a helper that picks a wired input (built-in, then USB) when the default input is Bluetooth so the capture path can avoid the headset mic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default capture device selection and Windows device typing, which can alter which mic opens and AEC/isolation behavior; dropout detection is additive but affects live session UX.
> 
> **Overview**
> When the system default input is a **Bluetooth** headset and the user did not pick a mic, capture on **macOS/Windows** now opens a **wired** input instead (built-in/PCI, then USB), skipping loopback/line-in endpoints, so opening the headset mic does not force **HFP** gating and narrowband audio. The source tracks **`active_mic_device`** separately from the user choice; progress/errors and **`GetMicDevice`** report what is actually open.
> 
> **Windows** transport classification now uses the adapter device path (e.g. `bthhfenum`) so in-box “Hands-Free” endpoints count as Bluetooth, not only names containing “bluetooth”.
> 
> After a swap, **`mic_isolated`** is no longer asserted even with headphone-only output (replacement is treated as a room mic). A **`DropoutMonitor`** watches raw mic for high exact-zero ratios and emits **`mic_dropouts`** once per stream (surfaced through listener and transcription events) when gating still happens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa366e807204bed04310b89dde444995b69740f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->