### PR TITLE
Separate the people sharing the mic in in-person meetings

### DIFF
--- a/crates/listener2-core/src/batch/consolidate.rs
+++ b/crates/listener2-core/src/batch/consolidate.rs
@@ -18,7 +18,7 @@ use owhisper_interface::batch;
 
 use super::diarize::{
     ChannelAudio, DIARIZATION_PROGRESS_START, Heartbeat, MixedAudioSource, SAMPLE_RATE,
-    channel_audio, expected_speaker_cap, is_local_batch,
+    SHARED_MIC_CHANNEL, channel_audio, expected_speaker_cap, in_person_capture, is_local_batch,
 };
 use super::simple::resample_audio_to_channel_files_until;
 use super::{BatchParams, BatchRunOutput, KnownSpeaker};
@@ -59,32 +59,40 @@ pub(super) async fn consolidate_hosted_speakers(
     let transcript_channels = output.response.results.channels.len();
     let recording_channels = usize::from(listen_params.channels).max(1);
     let has_known = !params.known_speakers.is_empty();
+    let in_person = in_person_capture(listen_params, &output.response);
 
-    let work: Vec<ChannelWork> = output
-        .response
-        .results
-        .channels
-        .iter()
-        .enumerate()
-        .filter_map(|(index, channel)| {
-            let (audio, shift) = channel_audio(transcript_channels, recording_channels, index)?;
-            let labels = distinct_labels(channel);
-            if labels.len() < 2 && !has_known {
-                return None;
-            }
-            let cap = expected_speaker_cap(listen_params, shift);
-            let over_cap = cap.is_some_and(|cap| labels.len() > cap);
-            if !over_cap && !has_known {
-                return None;
-            }
-            Some(ChannelWork {
-                index,
-                audio,
-                cap,
-                words: word_timings(channel),
-            })
-        })
-        .collect();
+    let mut work: Vec<ChannelWork> = Vec::new();
+    let mut settled_shared_mic = false;
+    for (index, channel) in output.response.results.channels.iter().enumerate() {
+        let Some((audio, shift)) =
+            channel_audio(transcript_channels, recording_channels, index, in_person)
+        else {
+            continue;
+        };
+        let shared_mic = in_person && index == 0;
+        let labels = distinct_labels(channel);
+        if labels.len() < 2 && !has_known {
+            continue;
+        }
+        let cap = expected_speaker_cap(listen_params, shift);
+        let over_cap = cap.is_some_and(|cap| labels.len() > cap);
+        if !over_cap && !has_known {
+            // The provider already split the room mic correctly; only the
+            // channel needs to change so those people stop rendering as "You".
+            settled_shared_mic |= shared_mic && labels.len() >= 2;
+            continue;
+        }
+        work.push(ChannelWork {
+            index,
+            audio,
+            cap,
+            shared_mic,
+            words: word_timings(channel),
+        });
+    }
+    if settled_shared_mic {
+        share_mic_channel(&mut output.response);
+    }
     if work.is_empty() {
         return;
     }
@@ -130,6 +138,8 @@ struct ChannelWork {
     index: usize,
     audio: ChannelAudio,
     cap: Option<usize>,
+    /// The direct mic of an in-person meeting.
+    shared_mic: bool,
     /// `(start, end, speaker)` per word, per alternative.
     words: Vec<Vec<(f64, f64, Option<usize>)>>,
 }
@@ -139,6 +149,24 @@ struct ChannelRelabel {
     /// Old provider label → new label.
     mapping: Vec<(usize, usize)>,
     identified: usize,
+    shared_mic: bool,
+}
+
+/// Moves the direct-mic words of an in-person meeting to the shared channel so
+/// each person on it renders as their own speaker.
+fn share_mic_channel(response: &mut batch::Response) {
+    if let Some(channel) = response.results.channels.first_mut() {
+        for word in channel
+            .alternatives
+            .iter_mut()
+            .flat_map(|alternative| alternative.words.iter_mut())
+        {
+            word.channel = SHARED_MIC_CHANNEL;
+        }
+    }
+    if let Some(metadata) = response.metadata.as_object_mut() {
+        metadata.insert("shared_mic".to_string(), serde_json::json!(true));
+    }
 }
 
 fn distinct_labels(channel: &batch::Channel) -> Vec<usize> {
@@ -208,6 +236,7 @@ fn consolidate_channels(
             index: channel.index,
             mapping: plan.mapping,
             identified: plan.identified,
+            shared_mic: channel.shared_mic,
         });
     }
     Ok(relabels)
@@ -551,6 +580,7 @@ fn apply_relabels(
     relabels: &[ChannelRelabel],
 ) -> Vec<ChannelConsolidation> {
     let mut summary = Vec::new();
+    let mut shared_mic = false;
     for relabel in relabels {
         let Some(channel) = response.results.channels.get_mut(relabel.index) else {
             continue;
@@ -572,12 +602,16 @@ fn apply_relabels(
                 word.speaker = Some(*new);
             }
         }
+        shared_mic |= relabel.shared_mic && after >= 2;
         summary.push(ChannelConsolidation {
             index: relabel.index,
             before: relabel.mapping.len(),
             after,
             identified: relabel.identified,
         });
+    }
+    if shared_mic {
+        share_mic_channel(response);
     }
 
     if let Some(metadata) = response.metadata.as_object_mut() {
@@ -603,7 +637,7 @@ fn apply_relabels(
 #[cfg(test)]
 mod tests {
     use super::super::test_fixtures::{
-        NeverCancelled, Turn, english_1_coalesced_turns, params, stereo_fixture,
+        NeverCancelled, Turn, english_1_coalesced_turns, in_person_fixture, params, stereo_fixture,
     };
     use super::*;
     use crate::batch::{BatchProvider, BatchRunMode};
@@ -948,6 +982,146 @@ mod tests {
         assert_eq!(speaker0.len(), 1, "speaker0 labels: {speaker0:?}");
         assert_eq!(speaker1.len(), 1, "speaker1 labels: {speaker1:?}");
         assert_ne!(speaker0, speaker1);
+    }
+
+    /// The mic channel of an in-person meeting as a hosted provider labels
+    /// it: speaker0's turns over `speaker0_labels` alternating labels, speaker1
+    /// on the next label.
+    fn in_person_mic_channel(speaker0_labels: usize) -> batch::Channel {
+        let turns = english_1_coalesced_turns();
+        let mut speaker0_index = 0;
+        channel(words_for_turns(&turns, 0, |_, turn| {
+            if turn.speaker == "speaker0" {
+                speaker0_index += 1;
+                Some((speaker0_index - 1) % speaker0_labels)
+            } else {
+                Some(speaker0_labels)
+            }
+        }))
+    }
+
+    fn labels_by_speaker(
+        words: &[batch::Word],
+        turns: &[Turn],
+    ) -> (
+        std::collections::BTreeSet<usize>,
+        std::collections::BTreeSet<usize>,
+    ) {
+        let label_at = |time_ms: u64| {
+            let time = time_ms as f64 / 1000.0;
+            words
+                .iter()
+                .find(|word| word.start <= time && time < word.end)
+                .and_then(|word| word.speaker)
+                .unwrap_or_else(|| panic!("no word at {time_ms} ms"))
+        };
+        let collect = |speaker: &str| {
+            turns
+                .iter()
+                .filter(|turn| turn.speaker == speaker && turn.end - turn.start >= 2_000)
+                .map(|turn| label_at((turn.start + turn.end) / 2))
+                .collect()
+        };
+        (collect("speaker0"), collect("speaker1"))
+    }
+
+    #[tokio::test]
+    async fn in_person_mic_is_consolidated_to_the_room_and_shared() {
+        let file = in_person_fixture();
+        let mut params = params(
+            BatchProvider::Deepgram,
+            "https://api.deepgram.com/v1",
+            file.path().to_str().unwrap(),
+        );
+        params.num_speakers = Some(2);
+        let listen_params = owhisper_interface::ListenParams {
+            channels: 2,
+            num_speakers: Some(2),
+            ..Default::default()
+        };
+        let mut output = output(vec![in_person_mic_channel(2), channel(vec![])]);
+
+        consolidate_hosted_speakers(
+            Arc::new(NeverCancelled),
+            &params,
+            &listen_params,
+            &mut output,
+        )
+        .await;
+
+        let words = &output.response.results.channels[0].alternatives[0].words;
+        assert!(words.iter().all(|word| word.channel == SHARED_MIC_CHANNEL));
+        let (speaker0, speaker1) = labels_by_speaker(words, &english_1_coalesced_turns());
+        assert_eq!(speaker0.len(), 1, "speaker0 labels: {speaker0:?}");
+        assert_eq!(speaker1.len(), 1, "speaker1 labels: {speaker1:?}");
+        assert_ne!(speaker0, speaker1);
+        assert_eq!(output.response.metadata["shared_mic"], true);
+    }
+
+    #[tokio::test]
+    async fn in_person_mic_already_within_count_is_shared_without_decoding() {
+        // Two labels for two people: nothing to merge, so the recording is
+        // never opened, but the words still have to leave the "You" channel.
+        let params = params(
+            BatchProvider::Deepgram,
+            "https://api.deepgram.com/v1",
+            "/nonexistent/recording.wav",
+        );
+        let listen_params = owhisper_interface::ListenParams {
+            channels: 2,
+            num_speakers: Some(2),
+            ..Default::default()
+        };
+        let mut output = output(vec![in_person_mic_channel(1), channel(vec![])]);
+        let before_labels = distinct_labels(&output.response.results.channels[0]);
+
+        consolidate_hosted_speakers(
+            Arc::new(NeverCancelled),
+            &params,
+            &listen_params,
+            &mut output,
+        )
+        .await;
+
+        let mic = &output.response.results.channels[0];
+        assert_eq!(distinct_labels(mic), before_labels);
+        assert!(
+            mic.alternatives[0]
+                .words
+                .iter()
+                .all(|word| word.channel == SHARED_MIC_CHANNEL)
+        );
+    }
+
+    #[tokio::test]
+    async fn call_mic_labels_are_left_alone_even_when_over_split() {
+        // Far-end speech on the remote channel makes this a call; whatever the
+        // provider did to the mic channel, it stays the local user's.
+        let params = params(
+            BatchProvider::Deepgram,
+            "https://api.deepgram.com/v1",
+            "/nonexistent/recording.wav",
+        );
+        let listen_params = owhisper_interface::ListenParams {
+            channels: 2,
+            num_speakers: Some(2),
+            ..Default::default()
+        };
+        let mut output = output(vec![
+            in_person_mic_channel(2),
+            channel(vec![word(100.0, 110.0, 1, Some(0))]),
+        ]);
+        let before = output.response.clone();
+
+        consolidate_hosted_speakers(
+            Arc::new(NeverCancelled),
+            &params,
+            &listen_params,
+            &mut output,
+        )
+        .await;
+
+        assert_eq!(output.response, before);
     }
 
     #[tokio::test]

--- a/crates/listener2-core/src/batch/diarize.rs
+++ b/crates/listener2-core/src/batch/diarize.rs
@@ -24,6 +24,12 @@ pub(super) const LOCAL_DIARIZATION_PROVIDER: &str = "pyannote-local";
 pub(super) const DIARIZATION_PROGRESS_START: f64 = 0.95;
 /// Word timings in a batch response are seconds; recorded audio is 16 kHz.
 pub(super) const SAMPLE_RATE: usize = anlg_pyannote_local::SAMPLE_RATE as usize;
+/// A system-audio channel with no more speech than this carried no call:
+/// a stray word or two of noise, not a remote participant.
+pub(super) const REMOTE_SILENCE_MAX_SECONDS: f64 = 3.0;
+/// Word channel for a microphone shared by several people in the room. The
+/// renderer names its speakers instead of folding them into "You".
+pub(super) const SHARED_MIC_CHANNEL: i32 = 2;
 /// Progressive sessions are torn down after 60 s without a streamed event, so
 /// the diarizer emits a progress heartbeat at least this often.
 pub(super) const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -70,32 +76,75 @@ pub(super) enum ChannelAudio {
 /// (the user alone) and channel 1 carries every remote participant, so
 /// participant counts shift by one. Progressive local providers collapse a
 /// stereo recording into one transcript channel; that channel is scored on
-/// the mix with the full participant count. `None` means skip the channel.
+/// the mix with the full participant count. In an in-person meeting the mic
+/// is shared by everyone, so channel 0 takes the full count too. `None`
+/// means skip the channel.
 pub(super) fn plan_channel(
     listen_params: &owhisper_interface::ListenParams,
     transcript_channels: usize,
     recording_channels: usize,
     channel_index: usize,
+    in_person: bool,
 ) -> Option<(ChannelAudio, SpeakerBounds)> {
-    let (audio, shift) = channel_audio(transcript_channels, recording_channels, channel_index)?;
+    let (audio, shift) = channel_audio(
+        transcript_channels,
+        recording_channels,
+        channel_index,
+        in_person,
+    )?;
     channel_speaker_bounds(listen_params, shift).map(|bounds| (audio, bounds))
 }
 
 /// Which recorded audio a transcript channel was heard from, and how many of the
 /// session's participants that audio cannot contain (the direct-mic user on a
-/// stereo capture). `None` for the direct-mic channel itself and for layouts
-/// the pipeline does not produce.
+/// stereo capture). `None` for the direct-mic channel of a call and for
+/// layouts the pipeline does not produce.
 pub(super) fn channel_audio(
     transcript_channels: usize,
     recording_channels: usize,
     channel_index: usize,
+    in_person: bool,
 ) -> Option<(ChannelAudio, usize)> {
     match (transcript_channels, recording_channels, channel_index) {
         (1, 1, 0) => Some((ChannelAudio::File(0), 0)),
         (1, 2, 0) => Some((ChannelAudio::Mix, 0)),
+        (2, 2, 0) if in_person => Some((ChannelAudio::File(0), 0)),
         (2, 2, 1) => Some((ChannelAudio::File(1), 1)),
         _ => None,
     }
+}
+
+/// Whether a stereo capture was an in-person meeting: the session expected
+/// several participants, yet the system-audio channel stayed silent, so they
+/// were all in the room sharing the microphone. Headphones are not a factor;
+/// they keep the far end out of the mic, not the people beside it. Unknown
+/// participant counts stay closed: a solo memo and a two-person meeting sound
+/// the same to the recorder.
+pub(super) fn in_person_capture(
+    listen_params: &owhisper_interface::ListenParams,
+    response: &batch::Response,
+) -> bool {
+    let channels = &response.results.channels;
+    if channels.len() != 2 {
+        return false;
+    }
+    let several_participants = listen_params.num_speakers.is_some_and(|count| count >= 2)
+        || listen_params.min_speakers.is_some_and(|count| count >= 2);
+    several_participants && channel_speech_seconds(&channels[1]) <= REMOTE_SILENCE_MAX_SECONDS
+}
+
+fn channel_speech_seconds(channel: &batch::Channel) -> f64 {
+    channel
+        .alternatives
+        .first()
+        .map(|alternative| {
+            alternative
+                .words
+                .iter()
+                .map(|word| (word.end - word.start).max(0.0))
+                .sum()
+        })
+        .unwrap_or(0.0)
 }
 
 /// Upper bound on distinct speakers a channel should carry, from the session's
@@ -133,6 +182,7 @@ pub(super) fn could_plan_channel(
     listen_params: &owhisper_interface::ListenParams,
     transcript_channels: usize,
     channel_index: usize,
+    in_person: bool,
 ) -> bool {
     let declared = usize::from(listen_params.channels);
     let layouts: &[usize] = match declared {
@@ -146,6 +196,7 @@ pub(super) fn could_plan_channel(
             transcript_channels,
             *recording_channels,
             channel_index,
+            in_person,
         )
         .is_some()
     })
@@ -196,6 +247,7 @@ pub(super) async fn apply_local_diarization(
         return;
     }
     let transcript_channels = output.response.results.channels.len();
+    let in_person = in_person_capture(listen_params, &output.response);
     // Only word timings cross into the blocking task; the transcript itself
     // stays here so a panic in the diarizer cannot lose it. Channels that no
     // recording layout could plan are dropped now, before the recording is
@@ -208,7 +260,7 @@ pub(super) async fn apply_local_diarization(
         .enumerate()
         .filter(|(index, channel)| {
             channel_needs_diarization(channel)
-                && could_plan_channel(listen_params, transcript_channels, *index)
+                && could_plan_channel(listen_params, transcript_channels, *index, in_person)
         })
         .map(|(index, channel)| UnlabeledChannel {
             index,
@@ -248,11 +300,14 @@ pub(super) async fn apply_local_diarization(
             diarize_channels(
                 runtime.as_ref(),
                 &heartbeat,
-                &file_path,
-                &listen_params,
-                transcript_channels,
-                &unlabeled,
-                &known_speakers,
+                &DiarizeJob {
+                    file_path: &file_path,
+                    listen_params: &listen_params,
+                    transcript_channels,
+                    in_person,
+                    unlabeled: &unlabeled,
+                    known_speakers: &known_speakers,
+                },
             )
         }
     })
@@ -267,6 +322,7 @@ pub(super) async fn apply_local_diarization(
                 diarization.channels = summary.channel_speakers.len(),
                 diarization.speakers = ?summary.channel_speakers,
                 diarization.identified = summary.identified,
+                diarization.shared_mic = summary.shared_mic,
                 "local_diarization_completed"
             );
         }
@@ -290,18 +346,31 @@ struct UnlabeledChannel {
     alternatives: Vec<Vec<(f64, f64)>>,
 }
 
+struct DiarizeJob<'a> {
+    file_path: &'a str,
+    listen_params: &'a owhisper_interface::ListenParams,
+    transcript_channels: usize,
+    in_person: bool,
+    unlabeled: &'a [UnlabeledChannel],
+    known_speakers: &'a [anlg_pyannote_local::KnownSpeaker],
+}
+
 struct ChannelLabels {
     index: usize,
     /// Speaker per word, per alternative, aligned with `UnlabeledChannel`.
     alternatives: Vec<Vec<Option<usize>>>,
     speaker_count: usize,
     identified: usize,
+    /// The direct mic of an in-person meeting: its words move to the shared
+    /// channel when more than one person turned out to be speaking into it.
+    shared_mic: bool,
 }
 
 #[derive(Debug, Default)]
 struct DiarizationSummary {
     channel_speakers: Vec<(usize, usize)>,
     identified: usize,
+    shared_mic: bool,
 }
 
 fn apply_labels(response: &mut batch::Response, labels: &[ChannelLabels]) -> DiarizationSummary {
@@ -310,6 +379,7 @@ fn apply_labels(response: &mut batch::Response, labels: &[ChannelLabels]) -> Dia
         let Some(channel) = response.results.channels.get_mut(channel_labels.index) else {
             continue;
         };
+        let share_mic = channel_labels.shared_mic && channel_labels.speaker_count >= 2;
         for (alternative, speakers) in channel
             .alternatives
             .iter_mut()
@@ -317,12 +387,16 @@ fn apply_labels(response: &mut batch::Response, labels: &[ChannelLabels]) -> Dia
         {
             for (word, speaker) in alternative.words.iter_mut().zip(speakers) {
                 word.speaker = *speaker;
+                if share_mic {
+                    word.channel = SHARED_MIC_CHANNEL;
+                }
             }
         }
         summary
             .channel_speakers
             .push((channel_labels.index, channel_labels.speaker_count));
         summary.identified += channel_labels.identified;
+        summary.shared_mic |= share_mic;
     }
 
     if let Some(metadata) = response.metadata.as_object_mut() {
@@ -332,6 +406,7 @@ fn apply_labels(response: &mut batch::Response, labels: &[ChannelLabels]) -> Dia
                 "provider": LOCAL_DIARIZATION_PROVIDER,
                 "channel_speakers": summary.channel_speakers,
                 "identified": summary.identified,
+                "shared_mic": summary.shared_mic,
             }),
         );
     }
@@ -384,12 +459,16 @@ impl<'a> Heartbeat<'a> {
 fn diarize_channels(
     runtime: &dyn BatchRuntime,
     heartbeat: &Heartbeat<'_>,
-    file_path: &str,
-    listen_params: &owhisper_interface::ListenParams,
-    transcript_channels: usize,
-    unlabeled: &[UnlabeledChannel],
-    known_speakers: &[anlg_pyannote_local::KnownSpeaker],
+    job: &DiarizeJob<'_>,
 ) -> Result<Vec<ChannelLabels>, String> {
+    let DiarizeJob {
+        file_path,
+        listen_params,
+        transcript_channels,
+        in_person,
+        unlabeled,
+        known_speakers,
+    } = *job;
     heartbeat.emit(DIARIZATION_PROGRESS_START);
     let source = anlg_audio_utils::source_from_path(file_path).map_err(|e| e.to_string())?;
     // A stereo file whose channels were identical collapses to one file, so
@@ -406,6 +485,7 @@ fn diarize_channels(
                 transcript_channels,
                 channel_files.len(),
                 channel.index,
+                in_person,
             )
             .map(|(audio, bounds)| (channel, audio, bounds))
         })
@@ -458,6 +538,7 @@ fn diarize_channels(
                 .iter()
                 .filter(|speaker| speaker.identity.is_some())
                 .count(),
+            shared_mic: in_person && channel.index == 0 && transcript_channels == 2,
         });
     }
     Ok(labels)
@@ -623,30 +704,53 @@ mod tests {
 
     #[test]
     fn mono_recording_uses_participant_counts_directly() {
-        let (audio, bounds) = plan_channel(&listen_params(Some(3), None, None), 1, 1, 0).unwrap();
+        let (audio, bounds) =
+            plan_channel(&listen_params(Some(3), None, None), 1, 1, 0, false).unwrap();
         assert_eq!(audio, ChannelAudio::File(0));
         assert_eq!(bounds, SpeakerBounds::exact(3));
 
-        let (_, free) = plan_channel(&listen_params(None, None, None), 1, 1, 0).unwrap();
+        let (_, free) = plan_channel(&listen_params(None, None, None), 1, 1, 0, false).unwrap();
         assert_eq!(free, SpeakerBounds::default());
     }
 
     #[test]
     fn stereo_remote_channel_drops_the_direct_mic_speaker() {
         let params = listen_params(Some(3), None, None);
-        assert!(plan_channel(&params, 2, 2, 0).is_none());
+        assert!(plan_channel(&params, 2, 2, 0, false).is_none());
         assert_eq!(
-            plan_channel(&params, 2, 2, 1).unwrap(),
+            plan_channel(&params, 2, 2, 1, false).unwrap(),
             (ChannelAudio::File(1), SpeakerBounds::exact(2))
         );
 
         // A 1:1 call has a single remote voice: nothing to separate.
-        assert!(plan_channel(&listen_params(Some(2), None, None), 2, 2, 1).is_none());
-        assert!(plan_channel(&listen_params(None, None, Some(2)), 2, 2, 1).is_none());
+        assert!(plan_channel(&listen_params(Some(2), None, None), 2, 2, 1, false).is_none());
+        assert!(plan_channel(&listen_params(None, None, Some(2)), 2, 2, 1, false).is_none());
 
-        let (_, range) = plan_channel(&listen_params(None, Some(2), Some(5)), 2, 2, 1).unwrap();
+        let (_, range) =
+            plan_channel(&listen_params(None, Some(2), Some(5)), 2, 2, 1, false).unwrap();
         assert_eq!(range.min_speakers, None);
         assert_eq!(range.max_speakers, Some(4));
+    }
+
+    #[test]
+    fn in_person_meeting_opens_the_direct_mic_with_the_full_count() {
+        // Everyone was in the room, so the mic carried all three people and
+        // the system-audio channel has nothing to plan.
+        let params = listen_params(Some(3), None, None);
+        assert_eq!(
+            plan_channel(&params, 2, 2, 0, true).unwrap(),
+            (ChannelAudio::File(0), SpeakerBounds::exact(3))
+        );
+        // An in-person 1:1 still has two voices on the mic.
+        assert_eq!(
+            plan_channel(&listen_params(Some(2), None, None), 2, 2, 0, true).unwrap(),
+            (ChannelAudio::File(0), SpeakerBounds::exact(2))
+        );
+        // The remote channel keeps its call-shaped budget either way.
+        assert_eq!(
+            plan_channel(&params, 2, 2, 1, true).unwrap(),
+            (ChannelAudio::File(1), SpeakerBounds::exact(2))
+        );
     }
 
     #[test]
@@ -654,23 +758,25 @@ mod tests {
         // Whisper/Argmax collapse a stereo capture into one transcript
         // channel; its words come from mic and system audio together, so the
         // direct mic file alone would miss every remote turn.
-        let (audio, bounds) = plan_channel(&listen_params(Some(3), None, None), 1, 2, 0).unwrap();
+        let (audio, bounds) =
+            plan_channel(&listen_params(Some(3), None, None), 1, 2, 0, false).unwrap();
         assert_eq!(audio, ChannelAudio::Mix);
         assert_eq!(bounds, SpeakerBounds::exact(3));
 
         // A 1:1 call still has two voices in the mix.
-        let (audio, bounds) = plan_channel(&listen_params(Some(2), None, None), 1, 2, 0).unwrap();
+        let (audio, bounds) =
+            plan_channel(&listen_params(Some(2), None, None), 1, 2, 0, false).unwrap();
         assert_eq!(audio, ChannelAudio::Mix);
         assert_eq!(bounds, SpeakerBounds::exact(2));
     }
 
     #[test]
     fn single_speaker_and_unexpected_layouts_are_skipped() {
-        assert!(plan_channel(&listen_params(Some(1), None, None), 1, 1, 0).is_none());
-        assert!(plan_channel(&listen_params(None, None, None), 3, 3, 2).is_none());
+        assert!(plan_channel(&listen_params(Some(1), None, None), 1, 1, 0, false).is_none());
+        assert!(plan_channel(&listen_params(None, None, None), 3, 3, 2, false).is_none());
         // Identical stereo channels collapse to one file; the transcript's
         // remote channel then has no audio of its own.
-        assert!(plan_channel(&listen_params(None, None, None), 2, 1, 1).is_none());
+        assert!(plan_channel(&listen_params(None, None, None), 2, 1, 1, false).is_none());
     }
 
     #[test]
@@ -679,29 +785,103 @@ mod tests {
             channels: 2,
             ..listen_params(None, None, None)
         };
-        // The direct-mic channel of a stereo capture is never diarized, so a
+        // The direct-mic channel of a call is never diarized, so a
         // Soniqo/Apple Speech batch whose remote channel is already labeled
         // must not pay for a second resample.
-        assert!(!could_plan_channel(&stereo, 2, 0));
-        assert!(could_plan_channel(&stereo, 2, 1));
+        assert!(!could_plan_channel(&stereo, 2, 0, false));
+        assert!(could_plan_channel(&stereo, 2, 1, false));
         // A 1:1 call: one remote voice, nothing to separate.
         let one_on_one = owhisper_interface::ListenParams {
             channels: 2,
             ..listen_params(Some(2), None, None)
         };
-        assert!(!could_plan_channel(&one_on_one, 2, 1));
+        assert!(!could_plan_channel(&one_on_one, 2, 1, false));
+        // In person, the same 1:1 puts both voices on the mic.
+        assert!(could_plan_channel(&one_on_one, 2, 0, true));
 
         // Downmixed transcripts stay eligible whether the stereo file keeps
         // both channels or collapses to one.
-        assert!(could_plan_channel(&stereo, 1, 0));
+        assert!(could_plan_channel(&stereo, 1, 0, false));
         let mono = owhisper_interface::ListenParams {
             channels: 1,
             ..listen_params(None, None, None)
         };
-        assert!(could_plan_channel(&mono, 1, 0));
-        assert!(!could_plan_channel(&mono, 2, 1));
+        assert!(could_plan_channel(&mono, 1, 0, false));
+        assert!(!could_plan_channel(&mono, 2, 1, false));
         // Unknown channel count stays permissive.
-        assert!(could_plan_channel(&listen_params(None, None, None), 1, 0));
+        assert!(could_plan_channel(
+            &listen_params(None, None, None),
+            1,
+            0,
+            false
+        ));
+    }
+
+    fn two_channel_response(remote_words: Vec<batch::Word>) -> batch::Response {
+        batch::Response {
+            metadata: serde_json::json!({}),
+            results: batch::Results {
+                channels: vec![channel(vec![word(None)]), channel(remote_words)],
+            },
+        }
+    }
+
+    #[test]
+    fn in_person_needs_several_participants_and_a_silent_remote_channel() {
+        let silent = two_channel_response(vec![]);
+        assert!(in_person_capture(
+            &listen_params(Some(2), None, None),
+            &silent
+        ));
+        assert!(in_person_capture(
+            &listen_params(None, Some(2), None),
+            &silent
+        ));
+        // A solo memo and a two-person meeting sound the same to the recorder.
+        assert!(!in_person_capture(
+            &listen_params(None, None, None),
+            &silent
+        ));
+        assert!(!in_person_capture(
+            &listen_params(Some(1), None, None),
+            &silent
+        ));
+
+        // A stray word of noise on system audio is still silence.
+        let noise = two_channel_response(vec![batch::Word {
+            start: 10.0,
+            end: 11.5,
+            channel: 1,
+            ..word(None)
+        }]);
+        assert!(in_person_capture(
+            &listen_params(Some(2), None, None),
+            &noise
+        ));
+
+        // Real far-end speech means a call, however many people were invited.
+        let call = two_channel_response(vec![batch::Word {
+            start: 10.0,
+            end: 20.0,
+            channel: 1,
+            ..word(Some(0))
+        }]);
+        assert!(!in_person_capture(
+            &listen_params(Some(3), None, None),
+            &call
+        ));
+
+        // Downmixed transcripts have no remote channel to judge by.
+        let downmixed = batch::Response {
+            metadata: serde_json::json!({}),
+            results: batch::Results {
+                channels: vec![channel(vec![word(None)])],
+            },
+        };
+        assert!(!in_person_capture(
+            &listen_params(Some(3), None, None),
+            &downmixed
+        ));
     }
 
     #[test]
@@ -717,7 +897,7 @@ mod tests {
         assert!(!channel_needs_diarization(&channel(vec![])));
     }
 
-    use super::super::test_fixtures::{NeverCancelled, params, stereo_fixture};
+    use super::super::test_fixtures::{NeverCancelled, in_person_fixture, params, stereo_fixture};
 
     #[test]
     fn local_providers_are_detected() {
@@ -918,6 +1098,88 @@ mod tests {
             speakers.len() >= 2,
             "expected both channels' speakers, got {speakers:?}"
         );
+    }
+
+    /// A stereo transcript whose remote channel is empty: every word came
+    /// from the mic.
+    fn in_person_output(word_count: usize, duration: f64) -> BatchRunOutput {
+        let mut output = unlabeled_output(word_count, duration);
+        output.response.results.channels.push(channel(vec![]));
+        output
+    }
+
+    #[tokio::test]
+    async fn in_person_meeting_separates_the_people_sharing_the_mic() {
+        let file = in_person_fixture();
+        let mut params = params(
+            BatchProvider::WhisperLocal,
+            "http://localhost:1234",
+            file.path().to_str().unwrap(),
+        );
+        params.num_speakers = Some(2);
+        let listen_params = owhisper_interface::ListenParams {
+            channels: 2,
+            num_speakers: Some(2),
+            ..Default::default()
+        };
+        let mut output = in_person_output(300, 153.0);
+
+        apply_local_diarization(
+            Arc::new(NeverCancelled),
+            &params,
+            &listen_params,
+            &mut output,
+        )
+        .await;
+
+        let words = &output.response.results.channels[0].alternatives[0].words;
+        assert!(words.iter().all(|word| word.speaker.is_some()));
+        assert!(
+            words.iter().all(|word| word.channel == SHARED_MIC_CHANNEL),
+            "mic words should move to the shared channel"
+        );
+        let speakers = words
+            .iter()
+            .filter_map(|word| word.speaker)
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(speakers.len(), 2, "expected both people, got {speakers:?}");
+        assert_eq!(output.response.metadata["diarization"]["shared_mic"], true);
+    }
+
+    #[tokio::test]
+    async fn call_with_far_end_speech_keeps_the_mic_as_the_user() {
+        // Same recording layout, but the remote channel carried a voice, so
+        // this was a call and the mic stays the local user's alone.
+        let file = in_person_fixture();
+        let mut params = params(
+            BatchProvider::WhisperLocal,
+            "http://localhost:1234",
+            file.path().to_str().unwrap(),
+        );
+        params.num_speakers = Some(2);
+        let listen_params = owhisper_interface::ListenParams {
+            channels: 2,
+            num_speakers: Some(2),
+            ..Default::default()
+        };
+        let mut output = in_person_output(300, 153.0);
+        output.response.results.channels[1] = channel(vec![batch::Word {
+            start: 100.0,
+            end: 110.0,
+            channel: 1,
+            ..word(Some(0))
+        }]);
+        let before = output.response.clone();
+
+        apply_local_diarization(
+            Arc::new(NeverCancelled),
+            &params,
+            &listen_params,
+            &mut output,
+        )
+        .await;
+
+        assert_eq!(output.response, before);
     }
 
     #[tokio::test]

--- a/crates/listener2-core/src/batch/test_fixtures.rs
+++ b/crates/listener2-core/src/batch/test_fixtures.rs
@@ -56,13 +56,17 @@ pub(super) fn english_1_coalesced_turns() -> Vec<Turn> {
     turns
 }
 
+fn english_1_mono() -> Vec<f32> {
+    anlg_data::english_1::AUDIO
+        .chunks_exact(2)
+        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / 32768.0)
+        .collect()
+}
+
 /// Splits the two-speaker `english_1` fixture into a stereo file with one
 /// speaker per channel, the shape of a mic + system-audio capture.
 pub(super) fn stereo_fixture() -> tempfile::NamedTempFile {
-    let mono: Vec<f32> = anlg_data::english_1::AUDIO
-        .chunks_exact(2)
-        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / 32768.0)
-        .collect();
+    let mono = english_1_mono();
     let rate = TARGET_SAMPLE_RATE as usize;
     let mut left = vec![0.0f32; mono.len()];
     let mut right = vec![0.0f32; mono.len()];
@@ -76,7 +80,18 @@ pub(super) fn stereo_fixture() -> tempfile::NamedTempFile {
         };
         target[start..end].copy_from_slice(&mono[start..end]);
     }
+    write_stereo_wav(&left, &right)
+}
 
+/// Both `english_1` speakers on the mic channel and silence on system audio:
+/// the shape of an in-person meeting recorded from one laptop.
+pub(super) fn in_person_fixture() -> tempfile::NamedTempFile {
+    let left = english_1_mono();
+    let right = vec![0.0f32; left.len()];
+    write_stereo_wav(&left, &right)
+}
+
+fn write_stereo_wav(left: &[f32], right: &[f32]) -> tempfile::NamedTempFile {
     let file = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
     let mut writer = hound::WavWriter::create(
         file.path(),
@@ -88,7 +103,7 @@ pub(super) fn stereo_fixture() -> tempfile::NamedTempFile {
         },
     )
     .unwrap();
-    for (l, r) in left.iter().zip(&right) {
+    for (l, r) in left.iter().zip(right) {
         writer.write_sample(*l).unwrap();
         writer.write_sample(*r).unwrap();
     }


### PR DESCRIPTION
Stacked on #7280 → #7277.

## Summary
- The direct-mic channel of a stereo capture has always been treated as the local user alone (`plan_channel` skipped `(2,2,0)`, the renderer hard-wires `DirectMic` to "You"). That only holds for calls; an in-person meeting recorded from one laptop rendered everyone as "You".
- New `in_person_capture`: a capture is in person when the session expected ≥2 participants (`num_speakers`/`min_speakers`) yet the system-audio channel carried ≤3 s of speech — nobody was on the call, so everyone was in the room. Headphone state is deliberately not a gate: it keeps the far end out of the mic, not the people beside it. Unknown participant counts stay closed, since a solo memo and a two-person meeting sound the same to the recorder.
- When in person, ch0 takes the full participant count: `apply_local_diarization` separates it with `SpeakerBounds::exact(total)`, and `consolidate_hosted_speakers` caps a hosted provider's mic labels to it. `channel_audio`/`plan_channel`/`could_plan_channel` gain an `in_person` flag; the remote channel keeps its call-shaped budget.
- Surfacing: only when ≥2 speakers actually come out of ch0 are its words moved to channel 2 (`MixedCapture`). The renderer then shows "Speaker N" (capped by participant count), speaker naming and voiceprint matching work in the `mixed_capture` domain, and the isolated-mic self-exemplar path no longer sees those words. A mic that still sounds like one voice is left exactly as before. Hosted transcripts whose provider already split the mic correctly are relabeled without decoding audio.
- `diarize_channels` takes a `DiarizeJob` struct (clippy `too_many_arguments`).

## Not in this PR
- Live transcripts still show "You" during an in-person meeting; the separation lands with the post-meeting refine.
- The desktop only triggers refine for >1 remote participants, so an in-person 1:1 is not yet separated. That gate could use "remote channel was silent" as an additional trigger.

## Test plan
- [x] `cargo test -p listener2-core` (93). New real-audio tests on an in-person fixture (both `english_1` speakers on the mic, silence on system audio): local diarization finds two people and moves them to the shared channel; hosted consolidation merges speaker0's two labels while keeping speaker1 apart, then shares the channel; the same layout with far-end speech present is left untouched on both paths.
- [x] `cargo clippy --locked -p listener2-core --lib --no-deps -- -D warnings`
- [ ] Record an in-person meeting with 2+ calendar attendees from one laptop, refine, and confirm distinct speakers that can be named
- [ ] Record a normal call and confirm the mic channel still renders as "You"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transcript channel/speaker assignment heuristics for stereo captures; misclassification could affect who renders as "You" vs separate speakers, though calls are explicitly guarded by remote-channel speech.
> 
> **Overview**
> Stereo batch post-processing no longer treats channel 0 as **only the local user** when the capture looks like an **in-person meeting**: `in_person_capture` requires a 2-channel transcript, participant hints of ≥2, and ≤3s of speech on the system-audio channel (real far-end speech keeps the existing call behavior).
> 
> When that heuristic fires, **channel planning** opens the direct mic with the **full participant budget** for local pyannote diarization and hosted speaker consolidation. After **≥2 distinct speakers** are resolved on that mic, words are reassigned to **`SHARED_MIC_CHANNEL` (2)** via `share_mic_channel`, with `shared_mic` metadata on the response so the UI can show named speakers instead of folding everyone into "You". Hosted consolidation can **relabel the channel without decoding audio** when the provider already split the room correctly; calls with remote speech are left unchanged.
> 
> `diarize_channels` now takes a **`DiarizeJob`** struct; tests add an **`in_person_fixture`** (both speakers on mic, silent system audio) covering local and hosted paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3bfabf8c8dc14f9b34f7a70369459be72628d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->