### PR TITLE
fix: keep note dividers in the text column

### DIFF
--- a/packages/editor/src/styles/prosemirror/note-typography.css
+++ b/packages/editor/src/styles/prosemirror/note-typography.css
@@ -349,7 +349,7 @@
 
 /* In the editor, the hover-row rule (higher specificity than the element
  * rules above) would drag these blocks into the -0.75rem row inset. Their
- * visible left edge — quote border, code background — belongs at the text
+ * visible left edge — quote border, code background, hr — belongs at the text
  * column, aligned with plain text. That rule's radius also rounds off the ends
  * of the quote border, so it is reset here too. */
 .note-typography.prosemirror-editor blockquote {
@@ -361,6 +361,11 @@
 .note-typography.prosemirror-editor pre {
   margin-inline: 0;
   padding-inline: 0.75em;
+}
+
+.note-typography.prosemirror-editor hr {
+  margin-inline: 0;
+  border-radius: 0;
 }
 
 .note-typography a {


### PR DESCRIPTION
The editor hover-row inset bled --- rules to the pane edges. Reset hr the same way quotes and code already are.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only CSS scoped to `.prosemirror-editor`; no auth, data, or API impact.
> 
> **Overview**
> **Horizontal rules (`---`) in the ProseMirror note editor** were stretching to the pane edges because they inherited the same **-0.75rem** hover-row `margin-inline` as other block rows.
> 
> This change **extends the existing blockquote/`pre` editor overrides** to `hr`: `margin-inline: 0` and `border-radius: 0` under `.note-typography.prosemirror-editor`, so divider lines stay aligned with the text column like quotes and code blocks. The nearby comment now calls out `hr` alongside those blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa29b9e328f6adc3faddfda6a27282ed9c40e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->