### PR TITLE
Sync generated API client schema

### DIFF
--- a/crates/api-client/openapi.gen.json
+++ b/crates/api-client/openapi.gen.json
@@ -3341,6 +3341,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "424": {
+            "description": "Calendar connection requires reconnect"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -3381,6 +3384,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "424": {
+            "description": "Calendar connection requires reconnect"
           },
           "500": {
             "description": "Internal server error"
@@ -3423,6 +3429,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "424": {
+            "description": "Calendar connection requires reconnect"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -3463,6 +3472,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "424": {
+            "description": "Calendar connection requires reconnect"
           },
           "500": {
             "description": "Internal server error"
@@ -4433,6 +4445,9 @@
           },
           "403": {
             "description": ""
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded"
           }
         },
         "security": [
@@ -4469,8 +4484,17 @@
             },
             "description": ""
           },
+          "401": {
+            "description": ""
+          },
+          "403": {
+            "description": ""
+          },
           "404": {
             "description": ""
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded"
           }
         },
         "security": [
@@ -4512,8 +4536,17 @@
           "400": {
             "description": ""
           },
+          "401": {
+            "description": ""
+          },
+          "403": {
+            "description": ""
+          },
           "404": {
             "description": ""
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded"
           }
         },
         "security": [
@@ -4570,8 +4603,17 @@
             },
             "description": ""
           },
+          "401": {
+            "description": ""
+          },
+          "403": {
+            "description": ""
+          },
           "404": {
             "description": ""
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded"
           }
         },
         "security": [
@@ -4628,8 +4670,17 @@
             },
             "description": ""
           },
+          "401": {
+            "description": ""
+          },
+          "403": {
+            "description": ""
+          },
           "404": {
             "description": ""
+          },
+          "429": {
+            "description": "Cloud API rate limit exceeded"
           }
         },
         "security": [


### PR DESCRIPTION
Regenerate filtered response metadata from the current API OpenAPI specification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated schema sync only; behavior depends on the API already returning these statuses, with minimal risk unless client code assumes a narrower error set.
> 
> **Overview**
> Regenerates `crates/api-client/openapi.gen.json` so the Rust API client matches the current server OpenAPI spec—**response metadata only**, no handler changes in this PR.
> 
> **Calendar (Google & Outlook):** `list-calendars` and `list-events` now document **`424`** with description *Calendar connection requires reconnect*, alongside existing `401`/`500`.
> 
> **Cloud API (`/v1/meetings`…):** Meeting list, get, export, history, and transcript operations now document **`401`**, **`403`**, and **`429`** (*Cloud API rate limit exceeded*) where they were missing before; list meetings also gains **`429`** next to existing auth responses.
> 
> Downstream generated client types can now represent these status codes for typed error handling and reconnect/rate-limit UX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e22f2fa8b04200c1b2092ad0d3951200bdafc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->