### PR TITLE
Use squircle CTAs for note header record and share

### DIFF
--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -711,6 +711,7 @@ describe("SessionShareButton", () => {
 
     const trigger = screen.getByRole("button", { name: "Share note" });
     expect(trigger.textContent).toContain("Share");
+    expect(trigger.className).toContain("rounded-full");
     expect(trigger.className).toContain("bg-primary");
     expect(trigger.className).toContain("dark:bg-white");
     expect(trigger.querySelector("svg")?.getAttribute("class")).toContain(

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -1211,6 +1211,7 @@ describe("OuterHeader", () => {
 
     const recordButton = screen.getByRole("button", { name: "Record" });
 
+    expect(recordButton.className).toContain("rounded-full");
     expect(recordButton.className).toContain("bg-primary");
     expect(recordButton.className).toContain("dark:bg-white");
     expect(recordButton.className).toContain("dark:text-black");

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 
 import { commands as deeplinkCommands } from "@anlg/plugin-deeplink2";
 import { commands as openerCommands } from "@anlg/plugin-opener2";
+import { Button } from "@anlg/ui/components/ui/button";
 import {
   Popover,
   PopoverAnchor,
@@ -148,7 +149,7 @@ function HeaderMeetingControl({
   }
 
   return (
-    <HeaderMeetingActionPill
+    <HeaderMeetingAction
       sessionId={sessionId}
       event={sessionEvent}
       eventEnded={ended}
@@ -164,7 +165,7 @@ function meetingHasStarted(startedAt: string | undefined, now: Date) {
   return start != null && now.getTime() >= start.getTime();
 }
 
-function HeaderMeetingActionPill({
+function HeaderMeetingAction({
   sessionId,
   event,
   eventEnded,
@@ -317,30 +318,26 @@ function HeaderMeetingActionPill({
     <Popover open={showWelcomeDemoPrompt}>
       <div className="relative mr-1 flex min-w-0 shrink-0 items-center">
         <PopoverAnchor asChild>
-          <button
+          <Button
             type="button"
+            size="sm"
+            variant={isPrimaryCta ? "default" : "outline"}
             data-tauri-drag-region="false"
             aria-label={action.label}
             title={action.title}
             disabled={disabled}
             onClick={action.onClick}
             className={cn([
-              "flex h-7 max-w-56 shrink-0 items-center gap-1.5 overflow-hidden rounded-full border pr-2.5 pl-1.5",
-              "text-sm font-medium",
-              "transition-colors",
+              "max-w-56 shrink-0 gap-1.5 overflow-hidden border pr-2.5 pl-1.5 text-sm",
               isPrimaryCta
-                ? "border-primary bg-primary text-primary-foreground shadow-sm dark:border-white dark:bg-white dark:text-black"
+                ? "border-primary shadow-sm dark:border-white dark:bg-white dark:text-black dark:hover:bg-white/90"
                 : "border-border bg-card text-foreground",
-              !disabled &&
-                (isPrimaryCta
-                  ? "hover:bg-primary/90 dark:hover:bg-white/90"
-                  : "hover:bg-accent"),
               disabled && "cursor-default opacity-60",
             ])}
           >
             {action.icon}
             <span className="truncate">{action.label}</span>
-          </button>
+          </Button>
         </PopoverAnchor>
         {showWelcomeDemoPrompt ? (
           <PopoverContent


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only refactor of header controls with no behavior changes; risk is limited to visual regression on meeting CTAs.
> 
> **Overview**
> Note header **Record**, **Join & record**, and **Stop** actions now render through the shared `@anlg/ui` **Button** (`size="sm"`, `default`/`outline` by state) instead of a bespoke pill `<button>`, matching how the header **Share** CTA is built.
> 
> The meeting-action helper is renamed from `HeaderMeetingActionPill` to `HeaderMeetingAction`, with primary styling delegated to the button variant plus a smaller set of dark-mode border/background overrides. Tests now assert header Record and Share CTAs include **`rounded-full`** (and existing primary color classes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee5efd77ef2f8323eb78e4fb60ff18c561da977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->