### PR TITLE
Render select triggers, search fields, and calendar nav as squircles

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-view.tsx
+++ b/apps/desktop/src/calendar/components/calendar-view.tsx
@@ -26,6 +26,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@anlg/ui/components/ui/tooltip";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { cn } from "@anlg/utils";
 
 import { useSync } from "./context";
@@ -98,6 +99,7 @@ export function CalendarView() {
     startOfDay(now),
   );
   const containerRef = useRef<HTMLDivElement>(null);
+  const navGroupRef = useSquircleRef<HTMLDivElement>();
   const compactScrollRef = useRef<HTMLDivElement>(null);
   const compactBaseRef = useRef(startOfDay(now));
   const cols = useVisibleCols(containerRef);
@@ -244,15 +246,18 @@ export function CalendarView() {
           <CalendarSyncHeaderControls />
         </div>
         <ButtonGroup
+          ref={navGroupRef}
           data-tauri-drag-region="false"
           className={cn([
             "border-border h-7 overflow-hidden rounded-full border",
             "bg-card",
           ])}
         >
+          {/* The group carries the squircle; segments must not clip themselves. */}
           <Button
             variant="ghost"
             size="icon"
+            smoothCorners={false}
             className="hover:bg-accent h-full w-7 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToPrev}
           >
@@ -262,6 +267,7 @@ export function CalendarView() {
           <Button
             variant="ghost"
             size="sm"
+            smoothCorners={false}
             className={cn([
               "h-full rounded-none border-0",
               "hover:bg-accent bg-transparent px-2 text-xs shadow-none",
@@ -274,6 +280,7 @@ export function CalendarView() {
           <Button
             variant="ghost"
             size="icon"
+            smoothCorners={false}
             className="hover:bg-accent h-full w-7 rounded-none border-0 bg-transparent shadow-none"
             onClick={goToNext}
           >

--- a/apps/desktop/src/contacts/related-notes.tsx
+++ b/apps/desktop/src/contacts/related-notes.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@anlg/ui/components/ui/dropdown-menu";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 
 import type { HumanSessionRecord } from "./queries";
 
@@ -24,6 +25,7 @@ export function RelatedNotesSection({
 }) {
   const { t } = useLingui();
   const [search, setSearch] = useState("");
+  const searchRef = useSquircleRef<HTMLDivElement>();
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
   const visibleSessions = sortAndFilterRelatedNotes(
     sessions,
@@ -69,7 +71,10 @@ export function RelatedNotesSection({
           </DropdownMenu>
         )}
 
-        <div className="border-border bg-muted/50 focus-within:bg-accent ml-auto flex h-8 w-52 max-w-[48%] items-center gap-2 rounded-lg border px-2.5 transition-colors">
+        <div
+          ref={searchRef}
+          className="border-border bg-muted/50 focus-within:bg-accent ml-auto flex h-8 w-52 max-w-[48%] items-center gap-2 rounded-lg border px-2.5 transition-colors"
+        >
           <MagnifyingGlass className="text-muted-foreground size-3.5 shrink-0" />
           <input
             type="text"

--- a/apps/desktop/src/contacts/shared.tsx
+++ b/apps/desktop/src/contacts/shared.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@anlg/ui/components/ui/dropdown-menu";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 
 import { CustomSidebarHeader } from "~/sidebar/custom-sidebar-header";
 
@@ -107,6 +108,7 @@ export function ColumnHeader({
   searchInputRef?: RefObject<HTMLInputElement | null>;
 }) {
   const { t } = useLingui();
+  const searchRef = useSquircleRef<HTMLDivElement>();
   const handleSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Escape") {
       onSearchChange?.("");
@@ -138,7 +140,10 @@ export function ColumnHeader({
       </CustomSidebarHeader>
       {onSearchChange && (
         <div className="pb-2">
-          <div className="border-border bg-muted focus-within:bg-accent flex h-8 w-full items-center gap-2 rounded-lg border px-3 transition-colors">
+          <div
+            ref={searchRef}
+            className="border-border bg-muted focus-within:bg-accent flex h-8 w-full items-center gap-2 rounded-lg border px-3 transition-colors"
+          >
             <MagnifyingGlass className="text-muted-foreground h-4 w-4 shrink-0" />
             <input
               ref={searchInputRef}

--- a/apps/desktop/src/folders/sidebar.tsx
+++ b/apps/desktop/src/folders/sidebar.tsx
@@ -3,6 +3,7 @@ import { FolderSimple, MagnifyingGlass, Plus, X } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@anlg/ui/components/ui/button";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { cn } from "@anlg/utils";
 
 import { useActiveFolderPath, useFolderSelection } from "./selection";
@@ -23,6 +24,7 @@ export function FoldersSidebar() {
   const activeFolder = useActiveFolderPath(folders);
   const [creating, setCreating] = useState(false);
   const [search, setSearch] = useState("");
+  const searchRef = useSquircleRef<HTMLDivElement>();
 
   const filteredFolders = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -52,6 +54,7 @@ export function FoldersSidebar() {
 
         <div className="pb-2">
           <div
+            ref={searchRef}
             className={cn([
               "border-border bg-accent/50 flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border px-3",
               "focus-within:bg-accent transition-colors",

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -370,7 +370,7 @@ export function SelectProviderAndModel() {
             value={effectiveSelection.provider}
             onValueChange={handleProviderChange}
           >
-            <SelectTrigger className="bg-card shadow-none focus:ring-0">
+            <SelectTrigger className="bg-card shadow-none">
               <SelectValue placeholder={t`Select a provider`} />
             </SelectTrigger>
             <SelectContent>

--- a/apps/desktop/src/settings/ai/shared/model-combobox.tsx
+++ b/apps/desktop/src/settings/ai/shared/model-combobox.tsx
@@ -29,6 +29,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@anlg/ui/components/ui/tooltip";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
+import { chipSquircle } from "@anlg/ui/lib/squircle";
 import { cn } from "@anlg/utils";
 
 import type { ListModelsResult, ModelIgnoreReason } from "./list-common";
@@ -359,8 +361,10 @@ export function ModelCombobox({
 }
 
 function DeprecatedBadge() {
+  const ref = useSquircleRef<HTMLSpanElement>(undefined, chipSquircle);
   return (
     <span
+      ref={ref}
       className={cn([
         "shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium",
         "bg-amber-50 text-amber-800",

--- a/apps/desktop/src/settings/ai/shared/provider-search.tsx
+++ b/apps/desktop/src/settings/ai/shared/provider-search.tsx
@@ -1,6 +1,8 @@
 import { useLingui } from "@lingui/react/macro";
 import { MagnifyingGlass, X } from "@phosphor-icons/react";
 
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
+
 export function filterProviders<
   T extends { id: string; displayName: string; description?: string },
 >(providers: readonly T[], query: string): T[] {
@@ -24,9 +26,13 @@ export function ProviderSearch({
   onChange: (value: string) => void;
 }) {
   const { t } = useLingui();
+  const ref = useSquircleRef<HTMLDivElement>();
 
   return (
-    <div className="border-border bg-muted/50 focus-within:bg-accent ml-auto flex h-8 w-56 max-w-[55%] items-center gap-2 rounded-lg border px-2.5 transition-colors">
+    <div
+      ref={ref}
+      className="border-border bg-muted/50 focus-within:bg-accent ml-auto flex h-8 w-56 max-w-[55%] items-center gap-2 rounded-lg border px-2.5 transition-colors"
+    >
       <MagnifyingGlass className="text-muted-foreground size-3.5 shrink-0" />
       <input
         type="search"

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -35,6 +35,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@anlg/ui/components/ui/tooltip";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
+import { chipSquircle } from "@anlg/ui/lib/squircle";
 import { cn } from "@anlg/utils";
 
 import { useSttSettings } from "./context";
@@ -248,7 +250,7 @@ export function SelectProviderAndModel() {
       <div className="flex flex-row items-center gap-4">
         <div className="min-w-0 flex-2" data-stt-provider-selector>
           <Select value={visibleProvider} onValueChange={handleProviderChange}>
-            <SelectTrigger className="bg-card shadow-none focus:ring-0">
+            <SelectTrigger className="bg-card shadow-none">
               <SelectValue placeholder={t`Select a provider`} />
             </SelectTrigger>
             <SelectContent>
@@ -321,7 +323,7 @@ export function SelectProviderAndModel() {
             >
               <SelectTrigger
                 className={cn([
-                  "bg-card text-left shadow-none focus:ring-0",
+                  "bg-card text-left shadow-none",
                   "[&>span]:!flex [&>span]:w-full [&>span]:min-w-0 [&>span]:items-center [&>span]:justify-start [&>span]:gap-2 [&>span]:overflow-visible [&>span]:[-webkit-line-clamp:unset]",
                   isConfigured && "[&>svg:last-child]:hidden",
                 ])}
@@ -965,8 +967,10 @@ function ModelSelectedValue({ model }: { model: ModelEntry }) {
 }
 
 function DeprecatedBadge() {
+  const ref = useSquircleRef<HTMLSpanElement>(undefined, chipSquircle);
   return (
     <span
+      ref={ref}
       className={cn([
         "shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium",
         "bg-amber-50 text-amber-800",
@@ -978,6 +982,7 @@ function DeprecatedBadge() {
 }
 
 function ModelModeBadge({ mode }: { mode?: ModelEntry["mode"] }) {
+  const ref = useSquircleRef<HTMLSpanElement>(undefined, chipSquircle);
   if (!mode) {
     return null;
   }
@@ -988,6 +993,7 @@ function ModelModeBadge({ mode }: { mode?: ModelEntry["mode"] }) {
     <Tooltip delayDuration={100}>
       <TooltipTrigger asChild>
         <span
+          ref={ref}
           className={cn([
             "shrink-0 cursor-help rounded-md px-1.5 py-0.5 text-[11px] font-medium",
             isRealtime

--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -88,8 +88,7 @@ export function SearchableSelect({
           aria-labelledby={ariaLabelledBy}
           aria-describedby={ariaDescribedBy}
           className={cn([
-            "bg-card justify-between font-normal shadow-none focus-visible:ring-0",
-            "rounded-pill px-3 [corner-shape:round]",
+            "bg-card justify-between px-3 font-normal shadow-none focus-visible:ring-0",
             className,
           ])}
         >

--- a/apps/desktop/src/settings/setting-row.tsx
+++ b/apps/desktop/src/settings/setting-row.tsx
@@ -3,8 +3,7 @@ import { type ReactNode, useId } from "react";
 import { Switch } from "@anlg/ui/components/ui/switch";
 import { cn } from "@anlg/utils";
 
-export const SETTING_CONTROL_CLASS =
-  "bg-card h-9 w-full rounded-pill shadow-none [corner-shape:round] focus:ring-0";
+export const SETTING_CONTROL_CLASS = "bg-card h-9 w-full shadow-none";
 
 export function SettingRow({
   title,

--- a/apps/desktop/src/sidebar/automations.tsx
+++ b/apps/desktop/src/sidebar/automations.tsx
@@ -3,6 +3,7 @@ import { Lightning, MagnifyingGlass, Plus, X } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@anlg/ui/components/ui/button";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { cn, formatDistanceToNow } from "@anlg/utils";
 
 import { CustomSidebarHeader } from "./custom-sidebar-header";
@@ -32,6 +33,7 @@ import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 export function AutomationsNav() {
   const { t } = useLingui();
   const [search, setSearch] = useState("");
+  const searchRef = useSquircleRef<HTMLDivElement>();
   const starters = useStarterAutomations();
   const chatAutomations = useChatGroups("automations");
   const workflows = useAutomationWorkflows();
@@ -114,6 +116,7 @@ export function AutomationsNav() {
 
       <div className="pb-2">
         <div
+          ref={searchRef}
           className={cn([
             "border-border bg-accent/50 flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border px-3",
             "focus-within:bg-accent transition-colors",

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -25,6 +25,7 @@ import {
 } from "@phosphor-icons/react";
 import { useCallback, useState } from "react";
 
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { cn } from "@anlg/utils";
 
 import { CustomSidebarHeader } from "./custom-sidebar-header";
@@ -57,6 +58,7 @@ export function SettingsNav() {
   const workspaces = useMyWorkspacesWithMirror();
   const hasExistingWorkspace = (workspaces.data?.length ?? 0) > 0;
   const [search, setSearch] = useState("");
+  const searchRef = useSquircleRef<HTMLDivElement>();
   const currentTab = useTabs((state) => state.currentTab);
   const updateSettingsTabState = useTabs(
     (state) => state.updateSettingsTabState,
@@ -189,6 +191,7 @@ export function SettingsNav() {
       <CustomSidebarHeader />
       <div className="pb-2">
         <div
+          ref={searchRef}
           className={cn([
             "border-border bg-accent/50 flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border px-3",
             "focus-within:bg-accent transition-colors",

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@anlg/ui/components/ui/dropdown-menu";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { cn } from "@anlg/utils";
 
 import { type WebTemplate } from "./codec";
@@ -39,6 +40,7 @@ export function TemplatesSidebarContent({
 }) {
   const { t } = useLingui();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useSquircleRef<HTMLDivElement>();
   const [search, setSearch] = useState("");
   const [sortOption, setSortOption] = useState<SortOption>("alphabetical");
   const autoPrompt = useConfigValue("auto_summary_prompt");
@@ -379,6 +381,7 @@ export function TemplatesSidebarContent({
 
         <div className="pb-2">
           <div
+            ref={searchRef}
             className={cn([
               "border-border bg-accent/50 flex h-8 w-full shrink-0 items-center gap-2 rounded-lg border px-3",
               "focus-within:bg-accent transition-colors",

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -2,6 +2,8 @@ import { CaretDown, CaretUp, Check } from "@phosphor-icons/react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import * as React from "react";
 
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
+import { squircleFocusVisibleClassName } from "@anlg/ui/lib/squircle";
 import { cn } from "@anlg/utils";
 
 import { appFloatingItemClassName } from "./floating-content";
@@ -13,21 +15,25 @@ const SelectValue = SelectPrimitive.Value;
 const SelectTrigger = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn([
-      "border-input ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring rounded-pill flex h-9 w-full items-center justify-between border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs [corner-shape:round] focus:ring-1 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className,
-    ])}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon asChild>
-      <CaretDown className="-mr-1 h-4 w-4 shrink-0 opacity-50" />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-));
+>(({ className, children, ...props }, ref) => {
+  const squircleRef = useSquircleRef(ref);
+  return (
+    <SelectPrimitive.Trigger
+      ref={squircleRef}
+      className={cn([
+        squircleFocusVisibleClassName,
+        "border-input data-placeholder:text-muted-foreground flex h-9 w-full items-center justify-between rounded-full border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+        className,
+      ])}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <CaretDown className="-mr-1 h-4 w-4 shrink-0 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+});
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<

--- a/packages/ui/src/lib/squircle.ts
+++ b/packages/ui/src/lib/squircle.ts
@@ -7,6 +7,11 @@ export const controlSquircle = {
   smoothing: APPLE_SMOOTHING,
 } satisfies SmoothCornerOptions;
 
+export const chipSquircle = {
+  radius: DesignRadius.md,
+  smoothing: APPLE_SMOOTHING,
+} satisfies SmoothCornerOptions;
+
 export const panelSquircle = {
   radius: DesignRadius.panel,
   smoothing: APPLE_SMOOTHING,

--- a/packages/utils/src/cn.ts
+++ b/packages/utils/src/cn.ts
@@ -1,5 +1,11 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// `rounded-pill` is a custom radius token (`--radius-pill`); register it so it
+// conflicts with the built-in `rounded-*` classes instead of stacking with them.
+const twMerge = extendTailwindMerge({
+  extend: { theme: { borderRadius: ["pill"] } },
+});
 
 /**
  * Combines multiple class names using clsx and merges Tailwind CSS classes intelligently.


### PR DESCRIPTION
## Summary

**Problem:** Select triggers still rendered as capsules while `Button` and `Badge` had moved to squircles, so settings pages mixed the two shapes. Worse, Language/Timezone showed a squircle *border* floating around a pill *fill*: `SearchableSelect` uses `Button`, whose Lisse smoothing redraws the border as an 8px squircle while `rounded-pill` kept the fill a capsule. Sidebar and provider search fields were plain rounded rectangles, and the calendar `‹ Today ›` segments each carried their own Lisse clip-path, so a hovered segment showed a standalone rounded shape with gaps at the separators. Callsite overrides could not fix any of this because `tailwind-merge` did not know `rounded-pill` is a radius class, so both it and `rounded-full` survived merging and the unlayered `.rounded-pill` rule won.

**Fix:** `SelectTrigger` now mirrors `Button` (`rounded-full` + `useSquircleRef`), and the `rounded-pill` opt-ins in `SETTING_CONTROL_CLASS` and `SearchableSelect` are dropped so every select shares the shape. The `Live`/`Deprecated` badges beside the selected model get a 6px squircle (`chipSquircle`) so they stay rounded-rect proportioned. The seven search-field wrappers (settings, automations, folders, templates, contacts sidebars, provider search, related-notes search) get `useSquircleRef`. The calendar `ButtonGroup` carries the squircle and its segments opt out with `smoothCorners={false}`, matching the imports button group. `cn` registers `pill` under `borderRadius` in `tailwind-merge` so `rounded-pill` conflicts with other `rounded-*` classes instead of stacking.

Known, pre-existing: `squircleFocusVisibleClassName` uses an outset outline, which `clip-path` clips away on smoothed controls (verified in Chromium); `SelectTrigger` now shares that with `Button`. Switching to a negative `outline-offset` is a small follow-up.

## Verification

- `pnpm -F @anlg/utils typecheck`, `pnpm -F @anlg/ui typecheck`, `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop test` — 3765 pass; the only failures are the pre-existing `src/devtools-bar/index.test.tsx` suite (`localStorage` undefined under Node 26 + jsdom locally; CI runs Node 22)
- `pnpm -F desktop i18n:check`
- `pnpm exec dprint fmt` on changed files, `pnpm fmt:check`
- Verified the merged trigger class list through the real `cn` (no `rounded-pill`/`corner-shape:round`, `rounded-full` present) and that existing pill opt-ins (session view tabs, `Switch`) still resolve to `rounded-pill`
- Not run: the Tauri desktop app (no cached debug binary); shapes rely on the same `rounded-full` + Lisse mechanism `Button` already renders with

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and class-merge changes only; no auth, data, or business-logic paths. Minor focus-outline clipping on squircled controls is a known pre-existing issue now shared by selects.
> 
> **Overview**
> Aligns **select triggers**, **sidebar search boxes**, and the **calendar ‹ Today › control** with the squircle styling already used on buttons and badges.
> 
> **Shared UI:** `SelectTrigger` now applies Lisse smoothing via `useSquircleRef` (`rounded-full` + focus outline helper) instead of `rounded-pill` / ring focus. Settings drop explicit `rounded-pill` / `[corner-shape:round]` from `SETTING_CONTROL_CLASS` and `SearchableSelect` so controls inherit the shared shape. `chipSquircle` is added for small badges (Deprecated, Live / After recording). `cn` registers the custom `rounded-pill` token in tailwind-merge so it conflicts with other radius classes instead of stacking.
> 
> **Desktop call sites:** Search wrapper divs across settings, automations, folders, templates, contacts, and provider search get `useSquircleRef`. Calendar nav puts the squircle on the `ButtonGroup` and sets `smoothCorners={false}` on segment buttons so hover states don’t clip per-button. Redundant `focus:ring-0` overrides on AI provider/model selects are removed where the shared trigger handles focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e04426ee0182a9273da73bcf57c1d574e76410d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->