### PR TITLE
Center session header controls on the sidebar toggle row

### DIFF
--- a/apps/desktop/src/session/components/note-input/header-shared.tsx
+++ b/apps/desktop/src/session/components/note-input/header-shared.tsx
@@ -95,7 +95,7 @@ export function iconHeaderViewClassName(
   size: "tray" | "standalone" = "tray",
   className?: string,
 ) {
-  const heightClassName = size === "tray" ? "h-[26px]" : "h-7";
+  const heightClassName = size === "tray" ? "h-6" : "h-7";
 
   return cn([
     "group/header-view rounded-pill flex shrink-0 items-center justify-center transition-colors select-none [corner-shape:round] [&>svg]:shrink-0",

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -391,7 +391,7 @@ describe("Header", () => {
 
     expect(summaryTab.getAttribute("data-state")).toBeNull();
     expect(viewSwitcher.getAttribute("data-tauri-drag-region")).toBe("false");
-    expect(viewSwitcher.className).toContain("h-[30px]");
+    expect(viewSwitcher.className).toContain("h-7");
     expect(viewSwitcher.className).toContain("p-[2px]");
     expect(viewSwitcher.className).toContain("gap-[2px]");
     expect(viewSwitcher.className).toContain("rounded-pill");
@@ -403,7 +403,7 @@ describe("Header", () => {
     expect(summaryTab.getAttribute("aria-current")).toBeNull();
     expect(memoTab.getAttribute("aria-current")).toBe("page");
     expect(memoTab.textContent).toBe("Memos");
-    expect(memoTab.className).toContain("h-[26px]");
+    expect(memoTab.className).toContain("h-6");
     expect(memoTab.className).not.toContain("-my-px");
     expect(memoTab.className).toContain("bg-white");
     expect(memoTab.className).toContain("text-foreground");
@@ -415,7 +415,7 @@ describe("Header", () => {
     expect(memoTab.querySelector("span")?.className).toContain(
       "@max-[480px]:sr-only",
     );
-    expect(summaryTab.className).toContain("h-[26px]");
+    expect(summaryTab.className).toContain("h-6");
     expect(summaryTab.className).toContain("px-2");
     expect(summaryTab.className).not.toContain("min-w-10");
     expect(summaryTab.className).toContain("dark:hover:bg-accent/80");

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -51,7 +51,7 @@ export function SessionViewSwitcher({
       data-tauri-drag-region="false"
       className={cn([
         "pointer-events-auto relative z-10 w-fit max-w-full shrink-0 overflow-visible",
-        "bg-foreground/10 dark:bg-accent/55 rounded-pill flex h-[30px] items-center gap-[2px] p-[2px] [corner-shape:round]",
+        "bg-foreground/10 dark:bg-accent/55 rounded-pill flex h-7 items-center gap-[2px] p-[2px] [corner-shape:round]",
       ])}
     >
       {editorTabs.map((view, index) => {

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -364,7 +364,7 @@ describe("OuterHeader", () => {
     expect(container.firstElementChild?.className).not.toContain("pl-[108px]");
   });
 
-  it("keeps the session header at 48px tall", () => {
+  it("keeps the session header at 48px tall and centers controls on the sidebar toggle row", () => {
     const { container } = render(
       <OuterHeader
         sessionId="session-1"
@@ -373,6 +373,7 @@ describe("OuterHeader", () => {
     );
 
     expect(container.firstElementChild?.className).toContain("h-12");
+    expect(container.firstElementChild?.className).toContain("pb-0.5");
   });
 
   it("marks the spacer and action strip as draggable", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -78,7 +78,9 @@ export function OuterHeader({
       data-tauri-drag-region
       className={cn([
         "relative flex w-full items-center gap-[2px]",
-        "h-12",
+        // 46px content box centers the 28px controls at 23px, matching the
+        // sidebar toggle row (pt-[9px] + size-7).
+        "h-12 pb-0.5",
         standaloneWindow && (showWindowControlsGutter ? "pl-[76px]" : "pl-2"),
         !standaloneWindow && leftsidebar.expanded && "pl-2",
         showSidebarTimelineHeaderGutter &&


### PR DESCRIPTION
## Summary

**Problem:** The `h-12` session header centered its content at 24px, but the sidebar toggle overlay (`pt-[9px]` + `size-7`) sits at 23px, so the view tabs, title, Record/Join button, and overflow menu all rendered 1px low relative to the toggle. The view-switcher pill was also taller (30px) than the header buttons it sits beside.

**Fix:** Add `pb-0.5` to the header so its 46px content box centers at 23px, in line with the toggle. Shrink the view-switcher pill to `h-7` (matching the header buttons) and its tabs to `h-6`.

## Verification

- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop test` — `note-input/header.test.tsx` and `outer-header/index.test.tsx` updated and passing; the only failures in the full run are the pre-existing `src/devtools-bar/index.test.tsx` suite (`localStorage` undefined under Node 26 + jsdom locally; CI runs Node 22)
- `pnpm fmt:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks in session header components with no logic or data-path changes; tests updated for class expectations.
> 
> **Overview**
> Fixes a **1px vertical misalignment** between the session outer header and the sidebar toggle row by adding **`pb-0.5`** on the `h-12` header so flex centering lands at 23px (matching `pt-[9px]` + `size-7`).
> 
> The **session note view switcher** is tightened to match adjacent header buttons: pill **`h-7`** (was 30px) and tray tab buttons **`h-6`** (was 26px) via `SessionViewSwitcher` and `iconHeaderViewClassName`. Unit tests in `header.test.tsx` and `outer-header/index.test.tsx` assert the new Tailwind classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feddd89367d59edf39956e3be7d7750bdff2b553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->