### PR TITLE
Left-align the signed-out account sign-in block

### DIFF
--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -123,28 +123,24 @@ export function SettingsAccount() {
     return (
       <div className="flex flex-col gap-8">
         <SettingsPageTitle title={<Trans>Account</Trans>} />
-        <section className="pb-4">
-          <div className="flex min-w-0 flex-col gap-6 @sm:flex-row @sm:items-center @sm:justify-between">
-            <div className="flex min-w-0 flex-1 flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <h3 className="text-sm font-medium">
-                  <Trans>Sign in to Anarlog</Trans>
-                </h3>
-                <div className="text-muted-foreground text-sm">
-                  <Trans>
-                    Sign in for cloud transcription, AI models, and sharing.
-                  </Trans>
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={handleSignIn}
-                className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 rounded-pill h-10 w-fit border-2 px-6 text-sm font-medium shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 [corner-shape:round]"
-              >
-                <Trans>Get started</Trans>
-              </button>
+        <section className="flex min-w-0 flex-col items-start gap-4 pb-4">
+          <div className="flex flex-col gap-2">
+            <h3 className="text-sm font-medium">
+              <Trans>Sign in to Anarlog</Trans>
+            </h3>
+            <div className="text-muted-foreground text-sm">
+              <Trans>
+                Sign in for cloud transcription, AI models, and sharing.
+              </Trans>
             </div>
           </div>
+          <button
+            type="button"
+            onClick={handleSignIn}
+            className="border-primary bg-primary text-primary-foreground hover:bg-primary/90 rounded-pill h-10 border-2 px-6 text-sm font-medium shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 [corner-shape:round]"
+          >
+            <Trans>Get started</Trans>
+          </button>
         </section>
 
         <GuestPlanSection />


### PR DESCRIPTION
## Summary

**Problem:** The signed-out sign-in block on the Account settings page rendered centered. Its wrapper's `@sm:flex-row` never applied because the prebuilt `@anlg/ui` stylesheet is imported after the app CSS and its base `.flex-col` wins inside the shared utilities layer, while `@sm:items-center` still did apply, so the single child ended up centered in a column.

**Fix:** Drop the variant-dependent wrapper and stack the copy and button in a plain left-aligned column, which does not depend on the container-query variant winning the cascade.

## Verification

- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/`
- `pnpm -F desktop test` — `src/settings/general` suites pass; the only failures in the full run are the pre-existing `src/devtools-bar/index.test.tsx` suite (`localStorage` undefined under Node 26 + jsdom locally; CI runs Node 22)
- `pnpm fmt:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in Account settings for unauthenticated users; no auth, billing, or data-flow changes.
> 
> **Overview**
> **Fixes signed-out Account settings layout** so the “Sign in to Anarlog” copy and **Get started** button stay left-aligned instead of appearing centered.
> 
> The change **removes** the nested responsive wrapper that used container-query classes (`@sm:flex-row`, `@sm:items-center`, `@sm:justify-between`) and **replaces** it with a single column section (`flex-col`, `items-start`, `gap-4`) that stacks the heading, description, and button. The sign-in button also **drops** `w-fit` so width follows the updated layout. Sign-in behavior (`handleSignIn`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128af3c6e247193ec8359c8993ffb97593621c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->