### PR TITLE
Add the 1.4.18 desktop release changelog

### DIFF
--- a/packages/changelog/content/1.4.18.md
+++ b/packages/changelog/content/1.4.18.md
@@ -1,0 +1,63 @@
+---
+date: "2026-09-04"
+summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call uses, tells apart people sharing one mic, learns your voice on its own, and adds a reasoning effort setting for your own models."
+---
+
+## Recording and audio
+
+- Capture system audio from whatever output your meeting app is playing
+  through, so a call routed to a headset or second display no longer records
+  silence; the **Speakers** setting is gone because it is no longer needed
+- Skip echo cancellation when your default output is a headphone, which keeps
+  your own speech clean and saves CPU
+- Record from a wired or built-in microphone when the default input is a
+  Bluetooth headset, avoiding the muffled, gated call-mode mic, and warn when a
+  Bluetooth mic is dropping audio (macOS and Windows)
+- Start listening immediately instead of waiting on a sync round, and open a
+  scheduled meeting link the moment the meeting is due even while listening is
+  still connecting
+- See **Share** in the note header once a meeting has ended instead of a
+  redundant **Record** button
+
+## Speakers and transcripts
+
+- Keep the speaker names you assign during a meeting in the live transcript,
+  including after listening restarts on the same note
+- Separate the people sharing one microphone in an in-person meeting instead
+  of labeling everyone as **You**
+- Name the last unidentified remote participant automatically when every other
+  speaker is already known and the count matches
+- Merge over-split speakers in Pro batch transcripts down to the number of
+  people actually in the meeting
+- Learn your own voiceprint from headphone-isolated recordings without a
+  manual speaker assignment
+- Keep live speaker separation on for ad-hoc meetings that have no calendar
+  attendees
+- Search the transcript by keyword, and use the speaker picker without it being
+  clipped
+
+## Intelligence
+
+- Pick a **Reasoning effort** (Default, Low, Medium, or High) for your own
+  language models on the Intelligence page; it resets to Default when you
+  change provider or model
+- Add Smallest AI as a transcription provider, with Pulse for live and
+  after-recording transcription and Pulse Pro for after-recording
+- Refresh every transcription provider's model list: retired AssemblyAI,
+  AquaVoice, and Soniox models move to their current replacements, deprecated
+  OpenAI transcription models are labeled, and the discontinued Fireworks
+  provider is marked as such so existing selections fall back cleanly
+- Recover Pro summaries after signing in again instead of failing on an
+  expired token, and wait for sync to settle before saving
+- Keep chat open when a request fails instead of dropping to an error screen
+
+## Polish
+
+- Use smooth-cornered controls throughout Settings and the note header,
+  including selects, search fields, and the calendar navigation
+- Align the session header controls with the sidebar toggle and compact the
+  view tabs
+- Keep Settings controls visible in a narrow window, list **AI** above
+  **Workspace** in the Settings sidebar, and left-align the signed-out account
+  panel
+- Keep horizontal rules inside the note text column


### PR DESCRIPTION
## Summary

**Problem:** `main` has 30 commits since `desktop_v1.4.17` and no changelog entry for the next stable version, which the release workflow requires.

**Fix:** Add `packages/changelog/content/1.4.18.md` covering the user-facing desktop changes since 1.4.17: system-audio capture that follows the meeting app (and the removed Speakers setting), headphone AEC skip, Bluetooth-mic fallback, instant listening start and independent scheduled join, in-person mic speaker separation, elimination naming, hosted speaker consolidation, automatic owner voiceprints, live-transcript speaker assignments, transcript keyword search, reasoning effort for BYO models, the Smallest AI provider and model-list refresh, Pro summary auth recovery, chat error handling, and the squircle/settings/header polish. Internal changes (E2EE reconciliation scans, API schema sync, denoise crate removal, CI runners, dev toolbar) are excluded.

## Verification

- `pnpm -F @anlg/changelog typecheck`
- Version check: `1.4.18` matches `^[0-9]+\.[0-9]+\.[0-9]+$` and `packages/changelog/content/1.4.18.md` exists (`doxxer --config doxxer.desktop.toml next patch` → 1.4.18)
- Reviewed every commit message in `desktop_v1.4.17..origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition to the changelog package; no runtime or API behavior changes in this diff.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.18.md`** so the desktop release workflow has a user-facing entry for the next stable build after 1.4.17.
> 
> The note documents shipped desktop changes in four areas: **recording and audio** (system audio that follows the meeting output, removed Speakers setting, headphone AEC skip, Bluetooth mic fallback, faster listen/join, Share vs Record in the header), **speakers and transcripts** (persistent speaker labels, in-person diarization, elimination naming, Pro speaker merge, automatic owner voiceprints, keyword search), **Intelligence** (reasoning effort for BYO models, Smallest AI provider, refreshed provider model lists, Pro summary auth recovery, chat error UX), and **polish** (squircle controls, settings/header layout). Internal-only work is intentionally omitted, matching prior changelog style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd35d43c421ad8ce1f2141130f59319e11e4416d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->