### PR TITLE
Use outlined meeting header actions

### DIFF
--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -712,8 +712,10 @@ describe("SessionShareButton", () => {
     const trigger = screen.getByRole("button", { name: "Share note" });
     expect(trigger.textContent).toContain("Share");
     expect(trigger.className).toContain("rounded-full");
-    expect(trigger.className).toContain("bg-primary");
-    expect(trigger.className).toContain("dark:bg-white");
+    expect(trigger.className).toContain("border-border");
+    expect(trigger.className).toContain("bg-transparent");
+    expect(trigger.className).toContain("text-foreground");
+    expect(trigger.className).toContain("shadow-none");
     expect(trigger.querySelector("svg")?.getAttribute("class")).toContain(
       "size-3.5",
     );

--- a/apps/desktop/src/session-sharing/index.tsx
+++ b/apps/desktop/src/session-sharing/index.tsx
@@ -625,7 +625,7 @@ export function SessionShareButton({
           key={accountUserId ?? "signed-out"}
           type="button"
           size={variant === "cta" ? "sm" : "icon"}
-          variant={variant === "cta" ? "default" : "ghost"}
+          variant={variant === "cta" ? "outline" : "ghost"}
           data-tauri-drag-region="false"
           aria-label={t`Share note`}
           aria-expanded={sharePopoverOpen}
@@ -634,9 +634,8 @@ export function SessionShareButton({
           className={cn([
             variant === "cta"
               ? [
-                  "max-w-56 gap-1.5 overflow-hidden border pr-2.5 pl-1.5 text-sm shadow-sm",
-                  "border-primary dark:border-white dark:bg-white dark:text-black",
-                  "dark:hover:bg-white/90",
+                  "max-w-56 gap-1.5 overflow-hidden border pr-2.5 pl-1.5 text-sm shadow-none",
+                  "border-border text-foreground bg-transparent",
                 ]
               : [
                   "text-muted-foreground hover:text-foreground rounded-full [&_svg]:size-4",

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -756,11 +756,10 @@ describe("OuterHeader", () => {
     const joinButton = screen.getByRole("button", { name: "Join & record" });
     const moreButton = screen.getByRole("button", { name: "More" });
 
-    expect(joinButton.className).toContain("bg-primary");
-    expect(joinButton.className).toContain("dark:bg-white");
-    expect(joinButton.className).toContain("dark:text-black");
-    expect(joinButton.className).toContain("hover:bg-primary/90");
-    expect(joinButton.className).toContain("dark:hover:bg-white/90");
+    expect(joinButton.className).toContain("border-border");
+    expect(joinButton.className).toContain("bg-transparent");
+    expect(joinButton.className).toContain("text-foreground");
+    expect(joinButton.className).toContain("shadow-none");
     expect(joinButton.querySelector("img")?.className).toContain("size-3.5");
     expect(joinButton.getAttribute("aria-label")).toBe("Join & record");
     expect(joinButton.textContent).toContain("Join & record");
@@ -1213,11 +1212,10 @@ describe("OuterHeader", () => {
     const recordButton = screen.getByRole("button", { name: "Record" });
 
     expect(recordButton.className).toContain("rounded-full");
-    expect(recordButton.className).toContain("bg-primary");
-    expect(recordButton.className).toContain("dark:bg-white");
-    expect(recordButton.className).toContain("dark:text-black");
-    expect(recordButton.className).toContain("hover:bg-primary/90");
-    expect(recordButton.className).toContain("dark:hover:bg-white/90");
+    expect(recordButton.className).toContain("border-border");
+    expect(recordButton.className).toContain("bg-transparent");
+    expect(recordButton.className).toContain("text-foreground");
+    expect(recordButton.className).toContain("shadow-none");
     expect(recordButton.querySelector("span")?.className).not.toContain(
       "@max-[480px]:sr-only",
     );

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -323,7 +323,7 @@ function HeaderMeetingAction({
           <Button
             type="button"
             size="sm"
-            variant={isPrimaryCta ? "default" : "outline"}
+            variant="outline"
             data-tauri-drag-region="false"
             aria-label={action.label}
             title={action.title}
@@ -332,7 +332,7 @@ function HeaderMeetingAction({
             className={cn([
               "max-w-56 shrink-0 gap-1.5 overflow-hidden border pr-2.5 pl-1.5 text-sm",
               isPrimaryCta
-                ? "border-primary shadow-sm dark:border-white dark:bg-white dark:text-black dark:hover:bg-white/90"
+                ? "border-border text-foreground bg-transparent shadow-none"
                 : "border-border bg-card text-foreground",
               disabled && "cursor-default opacity-60",
             ])}


### PR DESCRIPTION
Make Join & record, Record, and Share transparent bordered buttons that follow the active theme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only desktop header and share button styling; no behavior, auth, or data-path changes.
> 
> **Overview**
> Session header **Join & record**, **Record**, and **Share** CTAs no longer use filled primary / dark-mode white pills. They now use the **`outline`** button variant with **transparent** backgrounds, **`border-border`**, **`text-foreground`**, and **no shadow**, so they follow the active theme.
> 
> **`SessionShareButton`** (`variant="cta"`) switches from `default` to `outline` with the same bordered styling. **`OuterHeader`** meeting actions always use `outline`; inactive-session primary CTAs get the transparent border treatment instead of `border-primary` / `dark:bg-white` overrides.
> 
> Unit tests were updated to assert the new class names instead of `bg-primary` and dark hover styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea386ff98fb90c57720d914b29fd10bf6162d62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->