### PR TITLE
Note the onboarding sign-in fix in the 1.4.18 changelog

### DIFF
--- a/packages/changelog/content/1.4.18.md
+++ b/packages/changelog/content/1.4.18.md
@@ -60,4 +60,6 @@ summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call u
 - Keep Settings controls visible in a narrow window, list **AI** above
   **Workspace** in the Settings sidebar, and left-align the signed-out account
   panel
+- Show a single sign-in action on the onboarding account step instead of two
+  buttons that did the same thing
 - Keep horizontal rules inside the note text column


### PR DESCRIPTION
## Summary

**Problem:** #7301 (remove the duplicate onboarding Login button) merged to `main` after the 1.4.18 changelog, so the release notes no longer cover everything shipping in 1.4.18.

**Fix:** Add one Polish bullet describing the single sign-in action on the onboarding account step.

## Verification

- `pnpm -F @anlg/changelog typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only update with no runtime or build impact.
> 
> **Overview**
> Adds a **Polish** bullet to the **1.4.18** changelog so release notes match what shipped on `main`, including the onboarding account-step fix from #7301.
> 
> The new line states that users see **one** sign-in action on the onboarding account step instead of two redundant buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7c12033aab9e6d474d93e324ac0c22f4d69cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->