### PR TITLE
Stop leftover Hugging Face tokens from blocking Soniqo model downloads

### DIFF
--- a/crates/transcribe-soniqo/build.rs
+++ b/crates/transcribe-soniqo/build.rs
@@ -203,6 +203,7 @@ fn prepare_swift_package(swift_build_dir: &Path) {
     run_command(command, "resolving Soniqo Swift dependencies");
 
     patch_speech_swift_manifest(swift_build_dir);
+    patch_huggingface_downloader_anonymous_hub_api(swift_build_dir);
     patch_parakeet_streaming_offline_mode(swift_build_dir);
 }
 
@@ -254,6 +255,60 @@ fn patch_speech_swift_manifest(swift_build_dir: &Path) {
         panic!(
             "failed to patch Soniqo speech-swift manifest {}: {error}",
             manifest.display()
+        )
+    });
+}
+
+#[cfg(target_os = "macos")]
+include!("src/hub_anonymous.rs");
+
+#[cfg(target_os = "macos")]
+fn patch_huggingface_downloader_anonymous_hub_api(swift_build_dir: &Path) {
+    let path = swift_build_dir
+        .join("checkouts")
+        .join("speech-swift")
+        .join("Sources")
+        .join("AudioCommon")
+        .join("HuggingFaceDownloader.swift");
+    let contents = fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read Soniqo HuggingFace downloader source {}: {error}",
+            path.display()
+        )
+    });
+    let patched = patch_huggingface_downloader_source(&contents).unwrap_or_else(|error| {
+        panic!(
+            "failed to patch Soniqo HuggingFace downloader anonymous Hub API in {}: {error}",
+            path.display()
+        )
+    });
+
+    if patched == contents {
+        return;
+    }
+
+    let mut permissions = fs::metadata(&path)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to read permissions for Soniqo HuggingFace downloader source {}: {error}",
+                path.display()
+            )
+        })
+        .permissions();
+    if permissions.readonly() {
+        permissions.set_readonly(false);
+        fs::set_permissions(&path, permissions).unwrap_or_else(|error| {
+            panic!(
+                "failed to make Soniqo HuggingFace downloader source writable {}: {error}",
+                path.display()
+            )
+        });
+    }
+
+    fs::write(&path, patched).unwrap_or_else(|error| {
+        panic!(
+            "failed to patch Soniqo HuggingFace downloader source {}: {error}",
+            path.display()
         )
     });
 }

--- a/crates/transcribe-soniqo/src/download_error.rs
+++ b/crates/transcribe-soniqo/src/download_error.rs
@@ -1,0 +1,40 @@
+const ANONYMOUS_DOWNLOAD_FAILED: &str =
+    "Couldn't download this on-device model. Check your internet connection and try again.";
+
+pub(crate) fn user_facing_download_error(error: &str) -> String {
+    if is_huggingface_auth_error(error) {
+        ANONYMOUS_DOWNLOAD_FAILED.to_string()
+    } else {
+        error.to_string()
+    }
+}
+
+fn is_huggingface_auth_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("authentication required")
+        || lower.contains("hugging face token")
+        || lower.contains("huggingface token")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ANONYMOUS_DOWNLOAD_FAILED, user_facing_download_error};
+
+    #[test]
+    fn rewrites_hub_auth_errors_without_asking_for_a_token() {
+        assert_eq!(
+            user_facing_download_error(
+                "Failed to download: aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s after 5 attempts (target: /Users/adam/Library/Caches/qwen3-speech-models/aufklarer/Parakeet-TDT-v3-CoreML-INT8-30s): Authentication required. Please provide a valid Hugging Face token."
+            ),
+            ANONYMOUS_DOWNLOAD_FAILED
+        );
+    }
+
+    #[test]
+    fn leaves_unrelated_download_errors_unchanged() {
+        assert_eq!(
+            user_facing_download_error("Downloaded Soniqo Parakeet Batch files are incomplete."),
+            "Downloaded Soniqo Parakeet Batch files are incomplete."
+        );
+    }
+}

--- a/crates/transcribe-soniqo/src/hub_anonymous.rs
+++ b/crates/transcribe-soniqo/src/hub_anonymous.rs
@@ -1,0 +1,51 @@
+pub(crate) fn patch_huggingface_downloader_source(source: &str) -> Result<String, &'static str> {
+    const ORIGINAL: &str = "        return HubApi(downloadBase: downloadBase, endpoint: resolvedEndpoint(), useOfflineMode: offlineMode)";
+    const PATCHED: &str = "        return HubApi(downloadBase: downloadBase, hfToken: \"\", endpoint: resolvedEndpoint(), useOfflineMode: offlineMode)";
+
+    if source.contains(PATCHED) {
+        return Ok(source.to_string());
+    }
+
+    if !source.contains(ORIGINAL) {
+        return Err("HuggingFaceDownloader HubApi construction not found");
+    }
+
+    Ok(source.replacen(ORIGINAL, PATCHED, 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::patch_huggingface_downloader_source;
+
+    const SOURCE: &str = r#"    private static func makeHubApi(for modelId: String, repoDir: URL, offlineMode: Bool) -> HubApi {
+        return HubApi(downloadBase: downloadBase, endpoint: resolvedEndpoint(), useOfflineMode: offlineMode)
+    }
+"#;
+
+    #[test]
+    fn forces_anonymous_hub_api_for_built_in_models() {
+        let patched = patch_huggingface_downloader_source(SOURCE).unwrap();
+
+        assert!(patched.contains("hfToken: \"\""));
+        assert!(!patched.contains(
+            "return HubApi(downloadBase: downloadBase, endpoint: resolvedEndpoint(), useOfflineMode: offlineMode)"
+        ));
+    }
+
+    #[test]
+    fn anonymous_hub_api_patch_is_idempotent() {
+        let patched = patch_huggingface_downloader_source(SOURCE).unwrap();
+
+        assert_eq!(
+            patch_huggingface_downloader_source(&patched).unwrap(),
+            patched
+        );
+    }
+
+    #[test]
+    fn anonymous_hub_api_patch_rejects_unknown_source() {
+        let error = patch_huggingface_downloader_source("public enum Unrelated {}").unwrap_err();
+
+        assert_eq!(error, "HuggingFaceDownloader HubApi construction not found");
+    }
+}

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+mod download_error;
 mod error;
+#[cfg(test)]
+mod hub_anonymous;
 mod model;
 mod platform;
 mod responses;
@@ -41,7 +44,12 @@ pub fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
 
 pub fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
     ensure_supported_platform(model)?;
-    platform::model_download_state(model)
+    let mut state = platform::model_download_state(model)?;
+    state.error = state
+        .error
+        .as_deref()
+        .map(download_error::user_facing_download_error);
+    Ok(state)
 }
 
 pub fn start_model_download(model: SoniqoModel) -> Result<()> {

--- a/crates/transcribe-soniqo/src/platform/macos.rs
+++ b/crates/transcribe-soniqo/src/platform/macos.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use swift_rs::{Bool, SRData, SRString, swift};
 
+use crate::download_error::user_facing_download_error;
 use crate::{
     DiarizationSegment, Error, FileTranscript, LivePartial, ModelDownloadState, Result,
     SoniqoModel, TranscriptSource,
@@ -92,7 +93,8 @@ pub(crate) fn diarization_cache_dir() -> Result<PathBuf> {
 pub(crate) fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
     let model_id = sr_string(model.as_str());
     let payload = unsafe { _soniqo_model_download_state(&model_id) };
-    let state: ModelDownloadState = serde_json::from_str(payload.as_str())?;
+    let mut state: ModelDownloadState = serde_json::from_str(payload.as_str())?;
+    state.error = state.error.as_deref().map(user_facing_download_error);
 
     Ok(state)
 }
@@ -133,7 +135,7 @@ pub(crate) fn transcribe_file(
     let result: FileTranscriptionPayload = serde_json::from_str(payload.as_str())?;
 
     if let Some(error) = result.error {
-        return Err(Error::Bridge(error));
+        return Err(Error::Bridge(user_facing_download_error(&error)));
     }
 
     Ok(FileTranscript {
@@ -156,7 +158,7 @@ pub(crate) fn diarize_samples(
     let result: DiarizationPayload = serde_json::from_str(payload.as_str())?;
 
     if let Some(error) = result.error {
-        return Err(Error::Bridge(error));
+        return Err(Error::Bridge(user_facing_download_error(&error)));
     }
     if result.num_speakers != exact_speakers {
         return Err(Error::Bridge(format!(
@@ -182,9 +184,11 @@ fn live_start_result(result: StatusPayload) -> Result<String> {
             Error::Bridge("Soniqo live session started without a session token".to_string())
         })
     } else {
-        Err(Error::Bridge(result.error.unwrap_or_else(|| {
-            "failed to start Soniqo live session".to_string()
-        })))
+        Err(Error::Bridge(user_facing_download_error(
+            &result
+                .error
+                .unwrap_or_else(|| "failed to start Soniqo live session".to_string()),
+        )))
     }
 }
 
@@ -200,7 +204,7 @@ pub(crate) fn live_append(
     let result: LiveAppendPayload = serde_json::from_str(payload.as_str())?;
 
     if let Some(error) = result.error {
-        return Err(Error::Bridge(error));
+        return Err(Error::Bridge(user_facing_download_error(&error)));
     }
 
     Ok(result.partials)
@@ -216,7 +220,7 @@ pub(crate) fn live_finalize(
     let result: LiveAppendPayload = serde_json::from_str(payload.as_str())?;
 
     if let Some(error) = result.error {
-        return Err(Error::Bridge(error));
+        return Err(Error::Bridge(user_facing_download_error(&error)));
     }
 
     Ok(result.partials)
@@ -228,7 +232,7 @@ pub(crate) fn live_stop(session_token: &str) -> Result<()> {
     let result: StatusPayload = serde_json::from_str(payload.as_str())?;
 
     if let Some(error) = result.error {
-        return Err(Error::Bridge(error));
+        return Err(Error::Bridge(user_facing_download_error(&error)));
     }
 
     Ok(())
@@ -274,6 +278,22 @@ mod tests {
         .unwrap();
 
         assert_eq!(token, "42");
+    }
+
+    #[test]
+    fn live_start_rewrites_huggingface_auth_errors() {
+        let result = live_start_result(StatusPayload {
+            running: false,
+            session_token: None,
+            error: Some(
+                "Authentication required. Please provide a valid Hugging Face token.".to_string(),
+            ),
+        });
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Soniqo bridge failed: Couldn't download this on-device model. Check your internet connection and try again."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Problem:** Built-in Soniqo Parakeet Batch downloads can fail with "Authentication required. Please provide a valid Hugging Face token" even though the model repo is public. The hub client was picking up leftover `HF_TOKEN` / CLI tokens from the machine, and the error told users they needed credentials they do not.

**Fix:** Download built-in Soniqo models anonymously (`hfToken: ""` on `HubApi`) so stale environment tokens are ignored, and rewrite Hugging Face auth errors to a connection retry message instead of asking for a token.

Fixes [ANLG-314](https://linear.app/fastrepl-inc/issue/ANLG-314/soniqo-parakeet-batch-model-download-fails-authentication-required).

## Verification

- `cargo test -p transcribe-soniqo --lib` — 30 passed
- `pnpm exec dprint fmt` / `dprint check` on the changed Rust files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build-time patching of vendored Swift Hub client behavior and alters user-visible errors across model download and transcription paths on macOS.
> 
> **Overview**
> Fixes built-in Soniqo on-device model downloads failing when stale `HF_TOKEN` / CLI credentials are present on the machine, and stops surfacing “provide a Hugging Face token” for public models.
> 
> During macOS Swift dependency resolution, the build now patches `HuggingFaceDownloader.swift` so `HubApi` is created with **`hfToken: ""`**, forcing anonymous Hub access for bundled models (same pattern as existing speech-swift manifest / offline patches).
> 
> A new **`user_facing_download_error`** helper rewrites Hugging Face authentication messages into a generic connectivity retry string; that mapping is applied on **`model_download_state`** (public API and macOS bridge) and on Swift bridge errors for transcribe, diarization, and live sessions. Unit tests cover the patch logic and error rewriting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1884ff362be24bcff7595a14fdee0be7b3b26b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->