### PR TITLE
Retry rate-limited batch transcription requests instead of failing mid-recording

### DIFF
--- a/crates/listener2-core/Cargo.toml
+++ b/crates/listener2-core/Cargo.toml
@@ -50,4 +50,4 @@ anlg-data = { workspace = true }
 axum = { workspace = true }
 reqwest-middleware = { workspace = true }
 rodio = { workspace = true }
-tokio = { workspace = true, features = ["net", "time"] }
+tokio = { workspace = true, features = ["net", "test-util", "time"] }

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -346,7 +346,7 @@ pub(super) fn format_user_friendly_error(error: &str) -> String {
             .to_string();
     }
     if error_lower.contains("429") || error_lower.contains("rate limit") {
-        return "Rate limit exceeded. Please wait a moment and try again.".to_string();
+        return "Rate limit exceeded. Wait a few minutes or check your provider plan's quota, then try again.".to_string();
     }
     if error_lower.contains("timeout") {
         return "Connection timed out. Please check your internet connection and try again."

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -11,8 +11,9 @@ pub(super) use local::{
 use super::upload::segment_plan;
 #[cfg(test)]
 use direct::{
-    DIRECT_BATCH_TIMEOUT_CEILING, DIRECT_BATCH_TIMEOUT_FLOOR, direct_batch_timeout_for_audio,
-    merge_segment_responses, prepare_anarlog_batch_upload, run_direct_batch,
+    DIRECT_BATCH_TIMEOUT_CEILING, DIRECT_BATCH_TIMEOUT_FLOOR, RATE_LIMIT_BASE_DELAY,
+    RATE_LIMIT_MAX_DELAY, direct_batch_timeout_for_audio, merge_segment_responses,
+    prepare_anarlog_batch_upload, rate_limit_retry_delay, run_direct_batch,
     run_direct_batch_with_timeout,
 };
 #[cfg(test)]

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -22,6 +22,11 @@ pub(super) const DIRECT_BATCH_TIMEOUT_CEILING: Duration = Duration::from_secs(6 
 const DIRECT_BATCH_TIMEOUT_BUFFER: Duration = Duration::from_secs(5 * 60);
 const DIRECT_BATCH_AUDIO_DURATION_MULTIPLIER: u32 = 2;
 const ANARLOG_PROXY_MAX_AUDIO_BYTES: u64 = 512 * 1024 * 1024;
+// Provider quotas are mostly per-minute windows. Segmented uploads fire several
+// requests back to back, so a 429 usually clears within the next minute.
+const RATE_LIMIT_MAX_RETRIES: u32 = 3;
+pub(super) const RATE_LIMIT_BASE_DELAY: Duration = Duration::from_secs(15);
+pub(super) const RATE_LIMIT_MAX_DELAY: Duration = Duration::from_secs(90);
 
 pub(super) enum PreparedBatchUpload {
     Original(PathBuf),
@@ -365,35 +370,39 @@ pub(super) async fn run_direct_batch_with_timeout<A: BatchSttAdapter>(
             .build();
 
         tracing::debug!("transcribing file: {}", params.file_path);
-        let response =
-            match tokio::time::timeout(timeout, client.transcribe_file(&params.file_path)).await {
-                Ok(Ok(response)) => response,
-                Ok(Err(err)) => {
-                    let raw_error = format!("{err:?}");
-                    let message = format_user_friendly_error(&raw_error);
-                    tracing::error!(
-                        error = %raw_error,
-                        anarlog.error.user_message = %message,
-                        "batch transcription failed"
-                    );
-                    return Err(crate::BatchFailure::DirectRequestFailed {
-                        provider: provider.to_string(),
-                        message,
-                    }
-                    .into());
+        let response = match tokio::time::timeout(
+            timeout,
+            transcribe_with_rate_limit_retry(&client, &params.file_path),
+        )
+        .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(err)) => {
+                let raw_error = format!("{err:?}");
+                let message = format_user_friendly_error(&raw_error);
+                tracing::error!(
+                    error = %raw_error,
+                    anarlog.error.user_message = %message,
+                    "batch transcription failed"
+                );
+                return Err(crate::BatchFailure::DirectRequestFailed {
+                    provider: provider.to_string(),
+                    message,
                 }
-                Err(_) => {
-                    tracing::error!(
-                        timeout_seconds = timeout.as_secs(),
-                        "batch transcription timed out"
-                    );
-                    return Err(crate::BatchFailure::DirectRequestTimedOut {
-                        provider: provider.to_string(),
-                        timeout_seconds: timeout.as_secs(),
-                    }
-                    .into());
+                .into());
+            }
+            Err(_) => {
+                tracing::error!(
+                    timeout_seconds = timeout.as_secs(),
+                    "batch transcription timed out"
+                );
+                return Err(crate::BatchFailure::DirectRequestTimedOut {
+                    provider: provider.to_string(),
+                    timeout_seconds: timeout.as_secs(),
                 }
-            };
+                .into());
+            }
+        };
         tracing::info!("batch transcription completed");
 
         Ok(BatchRunOutput {
@@ -404,6 +413,67 @@ pub(super) async fn run_direct_batch_with_timeout<A: BatchSttAdapter>(
     }
     .instrument(span)
     .await
+}
+
+async fn transcribe_with_rate_limit_retry<A: BatchSttAdapter>(
+    client: &owhisper_client::BatchClient<A>,
+    file_path: &str,
+) -> Result<Response, owhisper_client::Error> {
+    let mut attempt = 0;
+    loop {
+        let error = match client.transcribe_file(file_path).await {
+            Ok(response) => return Ok(response),
+            Err(error) => error,
+        };
+        if attempt >= RATE_LIMIT_MAX_RETRIES {
+            return Err(error);
+        }
+        let Some(delay) = rate_limit_retry_delay(&error, attempt) else {
+            return Err(error);
+        };
+        attempt += 1;
+        tracing::warn!(
+            attempt,
+            delay_seconds = delay.as_secs(),
+            "batch transcription rate limited, retrying"
+        );
+        tokio::time::sleep(delay).await;
+    }
+}
+
+pub(super) fn rate_limit_retry_delay(
+    error: &owhisper_client::Error,
+    attempt: u32,
+) -> Option<Duration> {
+    let body = match error {
+        owhisper_client::Error::UnexpectedStatus { status, body } if status.as_u16() == 429 => {
+            Some(body.as_str())
+        }
+        owhisper_client::Error::ProviderFailure {
+            status: Some(status),
+            ..
+        } if status.as_u16() == 429 => None,
+        _ => return None,
+    };
+    let backoff = RATE_LIMIT_BASE_DELAY.saturating_mul(2u32.saturating_pow(attempt));
+    let delay = body.and_then(server_retry_delay).unwrap_or(backoff);
+    Some(delay.min(RATE_LIMIT_MAX_DELAY))
+}
+
+/// Google APIs return `google.rpc.RetryInfo` in the 429 body, e.g.
+/// `{"error":{"details":[{"retryDelay":"37s"}]}}`.
+fn server_retry_delay(body: &str) -> Option<Duration> {
+    let payload: serde_json::Value = serde_json::from_str(body).ok()?;
+    payload
+        .pointer("/error/details")?
+        .as_array()?
+        .iter()
+        .find_map(|detail| detail.get("retryDelay"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|value| value.strip_suffix('s'))
+        .and_then(|value| value.trim().parse::<f64>().ok())
+        .filter(|seconds| seconds.is_finite() && *seconds > 0.0)
+        .map(Duration::from_secs_f64)
 }
 
 pub(super) fn direct_batch_timeout_for_audio(audio_duration: Option<Duration>) -> Duration {

--- a/crates/listener2-core/src/batch/simple/tests.rs
+++ b/crates/listener2-core/src/batch/simple/tests.rs
@@ -105,6 +105,60 @@ impl BatchSttAdapter for RecordingAdapter {
     }
 }
 
+static RATE_LIMITED_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+const RATE_LIMITED_FAILURES: usize = 2;
+
+#[derive(Clone, Default)]
+struct RateLimitedAdapter;
+
+impl BatchSttAdapter for RateLimitedAdapter {
+    fn provider_name(&self) -> &'static str {
+        "rate-limited"
+    }
+
+    fn is_supported_languages(
+        &self,
+        _languages: &[anlg_language::Language],
+        _model: Option<&str>,
+    ) -> bool {
+        true
+    }
+
+    fn transcribe_file<'a, P: AsRef<Path> + Send + 'a>(
+        &'a self,
+        _client: &'a reqwest_middleware::ClientWithMiddleware,
+        _api_base: &'a str,
+        _api_key: &'a str,
+        _params: &'a owhisper_interface::ListenParams,
+        _file_path: P,
+    ) -> Pin<
+        Box<dyn Future<Output = std::result::Result<Response, owhisper_client::Error>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            let call = RATE_LIMITED_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if call < RATE_LIMITED_FAILURES {
+                return Err(owhisper_client::Error::UnexpectedStatus {
+                    status: reqwest_middleware::reqwest::StatusCode::TOO_MANY_REQUESTS,
+                    body: r#"{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"7s"}]}}"#.to_string(),
+                });
+            }
+
+            Ok(Response {
+                metadata: serde_json::json!({ "provider": "rate-limited" }),
+                results: owhisper_interface::batch::Results {
+                    channels: vec![owhisper_interface::batch::Channel {
+                        alternatives: vec![owhisper_interface::batch::Alternatives {
+                            transcript: "recovered".to_string(),
+                            confidence: 1.0,
+                            words: vec![],
+                        }],
+                    }],
+                },
+            })
+        })
+    }
+}
+
 #[derive(Clone)]
 struct HangingProviderState {
     request_started: Arc<Notify>,
@@ -459,6 +513,115 @@ async fn direct_provider_timeout_cancels_non_responding_request() {
         .expect("provider request was not cancelled");
 
     server.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn rate_limited_direct_request_is_retried_until_it_succeeds() {
+    RATE_LIMITED_CALLS.store(0, std::sync::atomic::Ordering::SeqCst);
+    let audio = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+    write_test_wav(audio.path());
+    let params = BatchParams {
+        session_id: "rate-limit-test".to_string(),
+        provider: super::super::BatchProvider::GoogleGenerativeAi,
+        file_path: audio.path().to_string_lossy().into_owned(),
+        model: None,
+        base_url: "https://generativelanguage.googleapis.com/v1beta".to_string(),
+        api_key: "test".to_string(),
+        languages: vec![anlg_language::ISO639::En.into()],
+        keywords: vec![],
+        num_speakers: None,
+        min_speakers: None,
+        max_speakers: None,
+        known_speakers: vec![],
+    };
+
+    let started = tokio::time::Instant::now();
+    let output = run_direct_batch_with_timeout::<RateLimitedAdapter>(
+        "rate-limited",
+        params,
+        owhisper_interface::ListenParams::default(),
+        DIRECT_BATCH_TIMEOUT_FLOOR,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        RATE_LIMITED_CALLS.load(std::sync::atomic::Ordering::SeqCst),
+        RATE_LIMITED_FAILURES + 1
+    );
+    assert_eq!(
+        output.response.results.channels[0].alternatives[0].transcript,
+        "recovered"
+    );
+    assert_eq!(
+        started.elapsed(),
+        Duration::from_secs(7 * RATE_LIMITED_FAILURES as u64),
+        "waits the server-provided retryDelay before each retry"
+    );
+}
+
+#[test]
+fn rate_limit_retry_delay_backs_off_and_honors_server_hint() {
+    let rate_limited = |body: &str| owhisper_client::Error::UnexpectedStatus {
+        status: reqwest_middleware::reqwest::StatusCode::TOO_MANY_REQUESTS,
+        body: body.to_string(),
+    };
+
+    assert_eq!(
+        rate_limit_retry_delay(&rate_limited("slow down"), 0),
+        Some(RATE_LIMIT_BASE_DELAY)
+    );
+    assert_eq!(
+        rate_limit_retry_delay(&rate_limited("slow down"), 1),
+        Some(RATE_LIMIT_BASE_DELAY * 2)
+    );
+    assert_eq!(
+        rate_limit_retry_delay(&rate_limited("slow down"), 2),
+        Some(RATE_LIMIT_BASE_DELAY * 4)
+    );
+    assert_eq!(
+        rate_limit_retry_delay(&rate_limited("slow down"), 10),
+        Some(RATE_LIMIT_MAX_DELAY)
+    );
+    assert_eq!(
+        rate_limit_retry_delay(
+            &rate_limited(r#"{"error":{"details":[{"retryDelay":"42.5s"}]}}"#),
+            0
+        ),
+        Some(Duration::from_secs_f64(42.5))
+    );
+    assert_eq!(
+        rate_limit_retry_delay(
+            &rate_limited(r#"{"error":{"details":[{"retryDelay":"600s"}]}}"#),
+            0
+        ),
+        Some(RATE_LIMIT_MAX_DELAY)
+    );
+    assert_eq!(
+        rate_limit_retry_delay(
+            &owhisper_client::Error::provider_failure_with_status(
+                reqwest_middleware::reqwest::StatusCode::TOO_MANY_REQUESTS,
+                "quota",
+                true,
+            ),
+            0
+        ),
+        Some(RATE_LIMIT_BASE_DELAY)
+    );
+    assert_eq!(
+        rate_limit_retry_delay(
+            &owhisper_client::Error::UnexpectedStatus {
+                status: reqwest_middleware::reqwest::StatusCode::BAD_REQUEST,
+                body: "rate limit".to_string(),
+            },
+            0
+        ),
+        None
+    );
+    assert_eq!(
+        rate_limit_retry_delay(&owhisper_client::Error::AudioProcessing("429".into()), 0),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**Problem:** Long recordings sent to providers with per-request caps (Gemini 3.5 Transcribe splits at 15 minutes) are uploaded as several back-to-back requests. A 61-minute meeting becomes five sequential Interactions API calls inside about two minutes, which trips Google's per-minute quota on free/Tier-1 keys. The first HTTP 429 aborted the whole run, so users saw "rate limit exceeded" at roughly the same point every attempt (ANLG-317). The reporter's guess that the file exceeded Gemini's 1-hour cap was wrong; each segment is already well under the 30-minute diarization limit.

**Fix:** Every direct batch request (single-file and per-segment) now retries HTTP 429 up to three times with 15s/30s/60s backoff, capped at 90s, and honors Google's `RetryInfo.retryDelay` when the 429 body carries one. The retry loop runs inside the existing per-request timeout, so the overall bound is unchanged. The rate-limit error copy now points users at their provider plan's quota, since that is the usual cause when retries are exhausted.

## Verification

- `cargo test -p listener2-core --lib batch::` (87 passed, including new `rate_limited_direct_request_is_retried_until_it_succeeds` and `rate_limit_retry_delay_backs_off_and_honors_server_hint`)
- `cargo clippy -p listener2-core --all-targets --no-deps`: no warnings in changed files
- `pnpm exec dprint check` on changed files

Refs ANLG-317

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cloud batch request behavior and timing; retries extend work within the same timeout window but only affect 429 responses, with bounded attempts.
> 
> **Overview**
> **Direct batch transcription** no longer fails immediately on provider **HTTP 429** when segmented uploads hit per-minute quotas (e.g. Google Gemini). Each `transcribe_file` call inside the existing per-request timeout now retries up to **3** times, sleeping **15s → 30s → 60s** (capped at **90s**) unless the 429 body includes Google’s **`retryDelay`** hint, which is parsed and used instead.
> 
> The rate-limit user message now tells users to wait or check their **provider plan quota** when retries are exhausted. Dev tests cover end-to-end retry behavior (with `tokio` **`test-util`** / paused time) and `rate_limit_retry_delay` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95483bb52a0d9fa54e1a2ec45a371f559cda88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->