### PR TITLE
Note Claude sign-in, Soniqo download fix, and outlined header actions in the 1.4.18 changelog

### DIFF
--- a/packages/changelog/content/1.4.18.md
+++ b/packages/changelog/content/1.4.18.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-09-04"
-summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call uses, tells apart people sharing one mic, learns your voice on its own, and adds a reasoning effort setting for your own models."
+summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call uses, tells apart people sharing one mic, learns your voice on its own, connects your Claude Pro or Max plan, and adds a reasoning effort setting for your own models."
 ---
 
 ## Recording and audio
@@ -38,6 +38,9 @@ summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call u
 
 ## Intelligence
 
+- Connect your **Claude Pro or Max** plan from the Anthropic card on the
+  Intelligence page and use Sonnet, Opus, and Haiku without an Anthropic API
+  key
 - Pick a **Reasoning effort** (Default, Low, Medium, or High) for your own
   language models on the Intelligence page; it resets to Default when you
   change provider or model
@@ -47,6 +50,9 @@ summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call u
   AquaVoice, and Soniox models move to their current replacements, deprecated
   OpenAI transcription models are labeled, and the discontinued Fireworks
   provider is marked as such so existing selections fall back cleanly
+- Download the built-in Soniqo Parakeet models even when a leftover Hugging
+  Face token is set on your machine, instead of stopping on a token prompt the
+  public models never needed
 - Recover Pro summaries after signing in again instead of failing on an
   expired token, and wait for sync to settle before saving
 - Keep chat open when a request fails instead of dropping to an error screen
@@ -55,6 +61,8 @@ summary: "Anarlog 1.4.18 records meeting audio from whatever speaker your call u
 
 - Use smooth-cornered controls throughout Settings and the note header,
   including selects, search fields, and the calendar navigation
+- Show **Join & record**, **Record**, and **Share** in the note header as
+  outlined buttons that follow your theme
 - Align the session header controls with the sidebar toggle and compact the
   view tabs
 - Keep Settings controls visible in a narrow window, list **AI** above


### PR DESCRIPTION
Covers the three user-facing changes that landed on main after the 1.4.18 notes were written:

- #7305 Connect a Claude Pro or Max plan from the Anthropic card (Intelligence)
- #7304 Built-in Soniqo Parakeet downloads ignore leftover Hugging Face tokens
- #7302 Outlined Join & record / Record / Share buttons in the note header

Also mentions the Claude connection in the frontmatter summary.

Verified with `pnpm -F @anlg/changelog typecheck`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog copy only; no application or build behavior changes.
> 
> **Overview**
> Updates the **1.4.18** release notes to document three features that shipped after the first draft of the changelog.
> 
> The frontmatter **summary** now mentions connecting a **Claude Pro or Max** plan. Under **Intelligence**, new bullets describe signing in via the Anthropic card (Sonnet, Opus, Haiku without an API key) and downloading built-in Soniqo Parakeet models when a stale Hugging Face token would previously block the flow. Under **Polish**, the note header **Join & record**, **Record**, and **Share** actions are called out as theme-aware outlined buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c63068b82d37dd50b2f0d3414789439bb0cce47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->