### PR TITLE
Keep chat responses streaming into the UI after send

### DIFF
--- a/apps/desktop/src/ai/hooks/useLLMConnection.ts
+++ b/apps/desktop/src/ai/hooks/useLLMConnection.ts
@@ -102,6 +102,9 @@ export const useLanguageModel = (task?: CharTask): LanguageModelV3 | null => {
 
 export const useLLMConnection = (): LLMConnectionResult => {
   const auth = useAuth();
+  // Only the session feeds the connection; the auth object itself changes
+  // identity on refresh-mutation state and would churn the model chain.
+  const session = auth?.session;
   const billing = useBillingAccess();
 
   const {
@@ -124,11 +127,11 @@ export const useLLMConnection = (): LLMConnectionResult => {
         modelId: current_llm_model,
         reasoningEffort: normalizeReasoningEffort(current_llm_reasoning_effort),
         providerConfig,
-        session: auth?.session,
+        session,
         isPaid: billing.isPaid,
       }),
     [
-      auth,
+      session,
       billing.isPaid,
       current_llm_model,
       current_llm_provider,

--- a/apps/desktop/src/chat/components/session-provider.real-sdk.test.tsx
+++ b/apps/desktop/src/chat/components/session-provider.real-sdk.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
+import type { UIMessageChunk } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { beginCloudsyncActivity, endCloudsyncActivity } from "@anlg/plugin-db";
@@ -27,6 +28,7 @@ const mocks = vi.hoisted(() => ({
     sendMessages: ReturnType<typeof vi.fn>;
     reconnectToStream: ReturnType<typeof vi.fn>;
   },
+  transportIdentityChangesEveryRender: false,
   upsertChatMessage: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -58,7 +60,9 @@ vi.mock("~/chat/store/queries", () => ({
 
 vi.mock("~/chat/transport/use-transport", () => ({
   useTransport: () => ({
-    transport: mocks.transport,
+    transport: mocks.transportIdentityChangesEveryRender
+      ? { ...mocks.transport }
+      : mocks.transport,
     isSystemPromptReady: true,
   }),
 }));
@@ -198,12 +202,63 @@ describe("ChatSession real SDK CloudSync activity", () => {
       sendMessages: mocks.sendMessages,
       reconnectToStream: vi.fn().mockResolvedValue(null),
     };
+    mocks.transportIdentityChangesEveryRender = false;
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it("keeps the in-flight response visible when upstream hooks hand over a new transport object", async () => {
+    // Model/provider hooks can return fresh objects on every render; the chat
+    // instance must survive that or the UI silently detaches from the stream.
+    mocks.transportIdentityChangesEveryRender = true;
+    let controller!: ReadableStreamDefaultController<UIMessageChunk>;
+    mocks.sendMessages.mockResolvedValue(
+      new ReadableStream<UIMessageChunk>({
+        start: (streamController) => {
+          controller = streamController;
+        },
+      }),
+    );
+    const harness = renderHarness();
+
+    harness.props.sendMessage(userMessage, {
+      chatGroupId: "group-1",
+      beforeSend: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await waitFor(() => expect(harness.props.status).toBe("submitted"));
+    expect(harness.props.messages.map((message) => message.id)).toEqual([
+      userMessage.id,
+    ]);
+
+    await waitFor(() => expect(mocks.sendMessages).toHaveBeenCalledOnce());
+    controller.enqueue({ type: "start", messageId: "assistant-1" });
+    controller.enqueue({ type: "text-start", id: "text-1" });
+    controller.enqueue({ type: "text-delta", id: "text-1", delta: "Hello" });
+
+    await waitFor(() => {
+      expect(harness.props.status).toBe("streaming");
+      const { messages } = harness.props;
+      expect(messages[messages.length - 1]).toMatchObject({
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Hello" }],
+      });
+    });
+
+    controller.enqueue({ type: "text-end", id: "text-1" });
+    controller.enqueue({ type: "finish" });
+    controller.close();
+
+    await waitFor(() => expect(harness.props.status).toBe("ready"));
+    expect(harness.props.messages.map((message) => message.id)).toEqual([
+      userMessage.id,
+      "assistant-1",
+    ]);
   });
 
   it("persists after unmount when deferred acquisition later succeeds", async () => {

--- a/apps/desktop/src/chat/components/session-provider.test.tsx
+++ b/apps/desktop/src/chat/components/session-provider.test.tsx
@@ -1183,13 +1183,17 @@ describe("ChatSession", () => {
     expect(mocks.beginCloudsyncActivity).toHaveBeenCalledOnce();
   });
 
-  it("recreates the SDK chat when transport becomes ready", () => {
+  it("keeps one SDK chat and sends through the latest transport", async () => {
     const initialTransport = {
       sendMessages: vi.fn(),
       reconnectToStream: vi.fn(),
     };
     const readyTransport = {
-      sendMessages: vi.fn(),
+      sendMessages: vi
+        .fn()
+        .mockResolvedValue(
+          new ReadableStream({ start: (controller) => controller.close() }),
+        ),
       reconnectToStream: vi.fn(),
     };
     mocks.transport = initialTransport;
@@ -1207,16 +1211,30 @@ describe("ChatSession", () => {
       </ChatSession>,
     );
 
-    expect(mocks.chatInits).toHaveLength(2);
-    expect((mocks.chatInits[0] as { transport: unknown }).transport).not.toBe(
-      initialTransport,
-    );
-    expect((mocks.chatInits[1] as { transport: unknown }).transport).not.toBe(
-      readyTransport,
-    );
-    expect((mocks.chatInits[0] as { transport: unknown }).transport).not.toBe(
-      (mocks.chatInits[1] as { transport: unknown }).transport,
-    );
+    expect(mocks.chatInits).toHaveLength(1);
+    const init = mocks.chatInits[0] as {
+      transport: {
+        sendMessages: (options: {
+          trigger: "submit-message";
+          chatId: string;
+          messageId: undefined;
+          messages: AnlgUIMessage[];
+          abortSignal: AbortSignal;
+        }) => Promise<ReadableStream>;
+      };
+    };
+    await init.transport.sendMessages({
+      trigger: "submit-message",
+      chatId: "session-1",
+      messageId: undefined,
+      messages: [
+        { id: "user-1", role: "user", parts: [{ type: "text", text: "Q" }] },
+      ],
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(readyTransport.sendMessages).toHaveBeenCalledOnce();
+    expect(initialTransport.sendMessages).not.toHaveBeenCalled();
   });
 
   it("syncs SDK messages when SQLite rows load later", async () => {

--- a/apps/desktop/src/chat/components/session-provider.tsx
+++ b/apps/desktop/src/chat/components/session-provider.tsx
@@ -210,14 +210,29 @@ function ChatSessionLifecycle({
     [persistedMessages],
   );
   initialMessagesRef.current = persistedVisibleMessages;
+  const latestTransportRef = useRef(transport);
+  latestTransportRef.current = transport;
 
+  // The Chat instance must live for the whole session. useChat swaps to any
+  // new instance it is handed, which resets status to "ready" and detaches
+  // the UI from an in-flight stream, so the transport is resolved per request
+  // instead of being baked into the memo.
   const chat = useMemo(
     () =>
       new Chat<AnlgUIMessage>({
         id: sessionId,
         messages: initialMessagesRef.current,
         transport: guardChatTransport(
-          transport ?? unavailableChatTransport,
+          {
+            sendMessages: (options) =>
+              (
+                latestTransportRef.current ?? unavailableChatTransport
+              ).sendMessages(options),
+            reconnectToStream: (options) =>
+              (
+                latestTransportRef.current ?? unavailableChatTransport
+              ).reconnectToStream(options),
+          },
           chatCloudsyncActivity,
           { beforeSend: takeTransportPreflight },
         ),
@@ -385,7 +400,7 @@ function ChatSessionLifecycle({
           }
         },
       }),
-    [chatCloudsyncActivity, sessionId, takeTransportPreflight, transport],
+    [chatCloudsyncActivity, sessionId, takeTransportPreflight],
   );
 
   const {

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -113,6 +113,37 @@ describe("SQLite AI providers", () => {
     );
   });
 
+  it("keeps provider objects referentially stable across renders", async () => {
+    const rows = [
+      {
+        id: "ai_provider:llm:openai",
+        value_json: JSON.stringify({
+          type: "llm",
+          base_url: "https://api.openai.com/v1",
+          api_key: "",
+        }),
+      },
+    ];
+    mocks.useLiveQuery.mockReturnValue({ data: rows, isLoading: false });
+    mocks.getSecret.mockResolvedValue({ status: "ok", data: "openai-key" });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result, rerender } = renderHook(() => useAiProvidersState("llm"), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    const before = result.current.providers;
+
+    rerender();
+
+    expect(result.current.providers).toBe(before);
+    expect(result.current.providers["llm:openai"]?.api_key).toBe("openai-key");
+  });
+
   it("uses direct provider rows over imported legacy configuration", () => {
     const providers = parseAiProviders(
       [

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 
 import { commands as store2Commands } from "@anlg/plugin-store2";
 
@@ -40,7 +41,7 @@ export function useAiProvidersState(type: AiProviderType): {
     sql: `SELECT id, value_json FROM app_settings ORDER BY id`,
     mapRows: (rows) => rows,
   });
-  const providers = parseAiProviders(rows, type);
+  const providers = useMemo(() => parseAiProviders(rows, type), [rows, type]);
   const providerIds = Object.keys(providers).sort();
   const secureApiKeysQuery = useQuery({
     queryKey: ["ai-provider-api-keys", type, providerIds],
@@ -49,17 +50,24 @@ export function useAiProvidersState(type: AiProviderType): {
     staleTime: Infinity,
   });
   const secureApiKeys = secureApiKeysQuery.data ?? EMPTY_PROVIDER_API_KEYS;
+  // Consumers memoize model/transport chains on these objects, so they must
+  // keep their identity across renders when nothing changed.
+  const resolvedProviders = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(providers).map(([rowId, provider]) => [
+          rowId,
+          {
+            ...provider,
+            api_key: secureApiKeys[rowId] ?? provider.api_key,
+          },
+        ]),
+      ),
+    [providers, secureApiKeys],
+  );
 
   return {
-    providers: Object.fromEntries(
-      Object.entries(providers).map(([rowId, provider]) => [
-        rowId,
-        {
-          ...provider,
-          api_key: secureApiKeys[rowId] ?? provider.api_key,
-        },
-      ]),
-    ),
+    providers: resolvedProviders,
     isLoading: rowsLoading || secureApiKeysQuery.isPending,
     isReady: !rowsLoading && secureApiKeysQuery.data !== undefined,
   };


### PR DESCRIPTION
## Summary

**Problem:** After sending a chat message, users saw nothing: no user bubble, no `Thinking...` row, no tool progress, no streamed text. The whole reply appeared at once when it was written to SQLite. The `Chat` instance in `ChatSession` was memoized on the transport, and the transport changed identity on every render for BYO providers because `useAiProvidersState` rebuilt provider objects with `Object.fromEntries` each render (`providerConfig` → `conn` → model → transport). `useChat` swaps to any new instance it is handed, so the first `submitted` re-render replaced the streaming `Chat` with a fresh one that reported `ready` and the old persisted messages, while the orphaned instance streamed invisibly. Hosted users hit it intermittently through `useLLMConnection` depending on the whole `auth` object, which changes identity during token refresh.

**Fix:** One `Chat` now lives for the whole session and resolves the transport through a ref at request time, so upstream identity churn can no longer detach the UI mid-stream. `useAiProvidersState` memoizes parsed and key-resolved provider objects, and `useLLMConnection` keys on `auth.session` instead of `auth`, so the model chain stops rebuilding on unrelated renders. The existing progress UI (`Thinking...`, tool disclosures, streamed text with caret) renders again without changes.

## Verification

- New real-SDK regression test in `session-provider.real-sdk.test.tsx`: with the transport identity changing every render, the user message appears immediately, status goes `submitted` → `streaming` with partial assistant text → `ready`. This test fails on `main` (`status` is `ready` right after `sendMessage`).
- New referential-stability test for `useAiProvidersState` in `providers.test.ts`.
- Rewrote the test that asserted the old behavior ("recreates the SDK chat when transport becomes ready") to assert a single `Chat` forwards sends to the latest transport.
- `pnpm -F desktop typecheck`
- `pnpm exec oxlint --quiet --format=github apps/desktop/src/` (0 errors)
- `pnpm exec dprint fmt` + `dprint check` on changed files
- `pnpm -F desktop exec vitest run src/chat src/settings/providers.test.ts src/ai/hooks src/stt/useSTTConnection.test.ts src/settings/ai` (500 tests pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat session lifecycle and LLM/provider memoization; wrong ref or dependency handling could break sends, reconnect, or provider updates, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes chat sends where **streaming progress disappeared** until the reply landed in SQLite. The SDK `Chat` was recreated whenever the memoized **transport** got a new object reference; `useChat` then swapped instances, reset status to `ready`, and left the real stream orphaned.
> 
> **`ChatSession`** now keeps **one `Chat` per session** and forwards `sendMessages` / `reconnectToStream` through a ref so each request uses the **latest** transport without rebuilding the instance. **`useAiProvidersState`** memoizes parsed and key-resolved provider maps, and **`useLLMConnection`** depends on **`auth.session`** instead of the whole **`auth`** object so token-refresh renders do not rebuild the model/transport chain.
> 
> Tests add a real-SDK case with transport identity changing every render, assert a single `Chat` delegates to the updated transport, and lock in stable provider object identity across rerenders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ddfddbfff27f1c0b581978f5457bb23383e355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->