### PR TITLE
Give developer settings roomier typography

### DIFF
--- a/apps/desktop/src/settings/developers/cli.tsx
+++ b/apps/desktop/src/settings/developers/cli.tsx
@@ -124,12 +124,12 @@ function CliSection({
   const isInstalled = status?.state === "installed";
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-5">
       <h2 className="font-sans text-lg font-semibold">{t`CLI & MCP`}</h2>
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-6">
+        <div className="flex min-h-10 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0">
-            <h3 className="flex items-center gap-1.5 text-sm font-medium">
+            <h3 className="flex items-center gap-1.5 text-base font-medium">
               <Trans>Anarlog CLI</Trans>
               {isInstalled && (
                 <CheckCircle
@@ -227,9 +227,9 @@ function McpRow({ status }: { status: EmbeddedCliStatus | undefined }) {
   );
 
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex min-h-10 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
-        <h3 className="text-sm font-medium">{t`MCP server`}</h3>
+        <h3 className="text-base font-medium">{t`MCP server`}</h3>
       </div>
       <div className="flex shrink-0 gap-2">
         <Button

--- a/apps/desktop/src/settings/developers/cloud-api.tsx
+++ b/apps/desktop/src/settings/developers/cloud-api.tsx
@@ -87,7 +87,7 @@ export function CloudApiSection() {
   }
 
   const endpoints = (
-    <div className="grid gap-3 sm:grid-cols-2">
+    <div className="grid gap-x-8 gap-y-5 sm:grid-cols-2">
       <CloudEndpoint
         label={t`REST API`}
         value={CLOUD_API_BASE_URL}
@@ -104,7 +104,7 @@ export function CloudApiSection() {
   if (!billing.isPro) {
     return (
       <PlanGate plan="pro" allowed={false}>
-        <section className="flex flex-col gap-4">
+        <section className="flex flex-col gap-5">
           <div className="flex items-start justify-between gap-4">
             <CloudApiHeading />
             <Switch
@@ -119,7 +119,7 @@ export function CloudApiSection() {
   }
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-5">
       <div className="flex items-start justify-between gap-4">
         <CloudApiHeading error={settingsQuery.error?.message} />
         <Switch
@@ -150,7 +150,7 @@ function CloudApiHeading({ error }: { error?: string }) {
       <h2 className="font-sans text-lg font-semibold">
         <Trans>Cloud API & Connectors</Trans>
       </h2>
-      <p className="text-muted-foreground mt-1 text-xs">
+      <p className="text-muted-foreground mt-1 text-sm leading-5">
         <Trans>
           Uploads meeting content for remote access while Anarlog is closed.
         </Trans>
@@ -171,9 +171,9 @@ function CloudEndpoint({
 }) {
   return (
     <div className="min-w-0">
-      <p className="text-muted-foreground text-xs font-medium">{label}</p>
+      <p className="text-muted-foreground text-sm font-medium">{label}</p>
       <div className="mt-1 flex items-center gap-1">
-        <code className="bg-muted scrollbar-hide min-w-0 overflow-x-auto rounded-md px-1.5 py-0.5 text-xs">
+        <code className="bg-muted scrollbar-hide min-w-0 overflow-x-auto rounded-md px-2 py-1 text-sm">
           {value}
         </code>
         <Button
@@ -221,9 +221,9 @@ function CloudApiKeys() {
 
   return (
     <div>
-      <div className="mb-3 flex items-center gap-2">
+      <div className="mb-4 flex items-center gap-2">
         <Key className="text-muted-foreground size-4" />
-        <h4 className="text-sm font-medium">
+        <h4 className="text-base font-medium">
           <Trans>Cloud API keys</Trans>
         </h4>
       </div>
@@ -238,7 +238,7 @@ function CloudApiKeys() {
         <form.Field name="name">
           {(field) => (
             <Input
-              className="h-8 max-w-64 text-sm"
+              className="h-9 max-w-64 text-sm"
               placeholder={t`Key name (e.g. Claude Code)`}
               value={field.state.value}
               onChange={(event) => field.handleChange(event.target.value)}
@@ -256,8 +256,8 @@ function CloudApiKeys() {
       </form>
 
       {createdKey && (
-        <div className="border-border bg-muted/30 mt-3 rounded-xl border p-3">
-          <p className="text-muted-foreground text-xs">
+        <div className="border-border bg-muted/30 mt-4 rounded-xl border p-4">
+          <p className="text-muted-foreground text-sm">
             <Trans>Copy this key now — it is only shown once.</Trans>
           </p>
           <div className="mt-2 flex items-center gap-2">
@@ -283,7 +283,7 @@ function CloudApiKeys() {
       )}
 
       {keys.length > 0 && (
-        <ul className="mt-3 flex flex-col gap-1.5">
+        <ul className="mt-4 flex flex-col gap-2">
           {keys.map((key) => (
             <CloudApiKeyRow
               key={key.id}

--- a/apps/desktop/src/settings/developers/index.tsx
+++ b/apps/desktop/src/settings/developers/index.tsx
@@ -16,7 +16,7 @@ const DEVELOPERS_GUIDE_URL = "https://docs.anarlog.so/agents/overview";
 
 export function SettingsDevelopers() {
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-10">
       <div className="flex items-center justify-between gap-4">
         <SettingsPageTitle title={t`Developers`} />
         <Button

--- a/apps/desktop/src/settings/developers/skills.tsx
+++ b/apps/desktop/src/settings/developers/skills.tsx
@@ -113,12 +113,12 @@ export function SkillsRow() {
   const detected = agents.filter((agent) => agent.detected);
 
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex min-h-10 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
-        <h3 className="text-sm font-medium">
+        <h3 className="text-base font-medium">
           <Trans>Agent skills</Trans>
         </h3>
-        <p className="text-muted-foreground mt-1 text-xs">
+        <p className="text-muted-foreground mt-1 text-sm leading-5">
           <Trans>
             Teach coding agents when and how to use the Anarlog CLI and MCP
           </Trans>

--- a/apps/desktop/src/settings/developers/webhooks.tsx
+++ b/apps/desktop/src/settings/developers/webhooks.tsx
@@ -83,7 +83,7 @@ export function WebhooksSection() {
   const webhooks = webhooksQuery.data ?? [];
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className="flex flex-col gap-5">
       <h2 className="font-sans text-lg font-semibold">{t`Webhooks`}</h2>
       <div>
         <form
@@ -97,7 +97,7 @@ export function WebhooksSection() {
           <form.Field name="url">
             {(field) => (
               <Input
-                className="h-8 max-w-md text-sm"
+                className="h-9 max-w-md text-sm"
                 placeholder="https://example.com/webhooks/anarlog"
                 value={field.state.value}
                 onChange={(event) => field.handleChange(event.target.value)}
@@ -115,8 +115,8 @@ export function WebhooksSection() {
         </form>
 
         {createdWebhook && (
-          <div className="border-border bg-muted/30 mt-3 rounded-xl border p-3">
-            <p className="text-muted-foreground text-xs">
+          <div className="border-border bg-muted/30 mt-4 rounded-xl border p-4">
+            <p className="text-muted-foreground text-sm">
               <Trans>
                 Copy this signing secret now — it is only shown once.
               </Trans>
@@ -149,7 +149,7 @@ export function WebhooksSection() {
         )}
 
         {webhooks.length > 0 && (
-          <ul className="mt-3 flex flex-col gap-1.5">
+          <ul className="mt-4 flex flex-col gap-2">
             {webhooks.map((webhook) => (
               <WebhookRow
                 key={webhook.id}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tailwind class-only UI tweaks on the Developers settings screen; no logic, API, or data-handling changes.
> 
> **Overview**
> Updates **Developers** settings layout and type scale so sections read less cramped, without changing behavior.
> 
> Section spacing is increased on the page shell (`gap-10`) and within CLI & MCP, Cloud API, and Webhooks blocks (`gap-5`/`gap-6`). Row layouts for CLI, MCP, and Agent skills add `min-h-10` for steadier alignment with action buttons on wide layouts.
> 
> **Typography and controls** bump several labels and helper copy from `text-xs`/`text-sm` to `text-sm`/`text-base` (with `leading-5` on descriptions), enlarge endpoint `code` chips and one-time secret/key callouts (`p-4`, slightly taller inputs `h-9`), and widen the Cloud API endpoint grid (`gap-x-8 gap-y-5`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d2c2d9f47abcdca71209a9d6a991965b96abad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->