### PR TITLE
Fix pre-meeting brief generation

### DIFF
--- a/apps/desktop/src/session/insights/pre-meeting.test.ts
+++ b/apps/desktop/src/session/insights/pre-meeting.test.ts
@@ -1,3 +1,4 @@
+import { NoObjectGeneratedError } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PastSessionNote } from "./past-notes";
@@ -354,10 +355,67 @@ describe("streamPreMeetingBrief", () => {
     expect(hoisted.streamText).toHaveBeenCalledWith(
       expect.objectContaining({
         model: { id: "model-1" },
-        maxOutputTokens: 200,
+        maxOutputTokens: 512,
         output: expect.objectContaining({}),
       }),
     );
     expect(hoisted.renderCustom).toHaveBeenCalled();
+  });
+
+  it("accepts a complete Markdown brief when the model ignores the object schema", async () => {
+    const markdown = `**Follow up with Ada on launch timing.**
+
+- Ada still owns the prototype.
+- John will confirm the launch date.
+- Listen for a decision on CI cost gating.`;
+    const error = new NoObjectGeneratedError({
+      text: markdown,
+      response: {},
+      usage: {},
+      finishReason: "stop",
+    } as never);
+    hoisted.streamText.mockReturnValue({
+      partialOutputStream: (async function* () {})(),
+      get output() {
+        return Promise.reject(error);
+      },
+    });
+
+    await expect(
+      streamPreMeetingBrief({
+        model: { id: "model-1" } as never,
+        language: "en",
+        event: { title: "Weekly Product Sync" },
+        notes: [makeNote({ sessionId: "previous" })],
+      }),
+    ).resolves.toBe(markdown);
+  });
+
+  it("rejects truncated Markdown instead of saving an incomplete brief", async () => {
+    const error = new NoObjectGeneratedError({
+      text: `**Follow up with Ada on launch timing.**
+
+- Ada still owns the prototype.
+- John will confirm the launch date.
+- Listen for a decision on`,
+      response: {},
+      usage: {},
+      finishReason: "length",
+    } as never);
+    hoisted.streamText.mockReturnValue({
+      partialOutputStream: (async function* () {})(),
+      get output() {
+        return Promise.reject(error);
+      },
+    });
+
+    await expect(
+      streamPreMeetingBrief({
+        model: { id: "model-1" } as never,
+        language: "en",
+        event: { title: "Weekly Product Sync" },
+        notes: [makeNote({ sessionId: "previous" })],
+      }),
+    ).rejects.toBe(error);
   });
 });

--- a/apps/desktop/src/session/insights/pre-meeting.ts
+++ b/apps/desktop/src/session/insights/pre-meeting.ts
@@ -1,4 +1,9 @@
-import { Output, streamText, type LanguageModel } from "ai";
+import {
+  NoObjectGeneratedError,
+  Output,
+  streamText,
+  type LanguageModel,
+} from "ai";
 import { z } from "zod";
 
 import {
@@ -21,7 +26,7 @@ const MAX_PROMPT_FACTS = 4;
 const MAX_BRIEF_BULLETS = 3;
 const MAX_SUMMARY_LENGTH = 320;
 const BRIEF_GENERATION_TIMEOUT_MS = 45_000;
-const BRIEF_MAX_OUTPUT_TOKENS = 200;
+const BRIEF_MAX_OUTPUT_TOKENS = 512;
 const briefSchema = z.object({
   opener: z.string(),
   bullets: z.array(z.string()).min(1).max(MAX_BRIEF_BULLETS),
@@ -325,7 +330,23 @@ export async function streamPreMeetingBrief({
     }
   }
 
-  return formatPreMeetingBrief((await result.output) ?? {});
+  try {
+    return formatPreMeetingBrief((await result.output) ?? {});
+  } catch (error) {
+    if (
+      !NoObjectGeneratedError.isInstance(error) ||
+      error.finishReason === "length"
+    ) {
+      throw error;
+    }
+
+    const brief = trimPreMeetingBrief(error.text ?? "");
+    const bulletCount = brief.match(/^- /gm)?.length ?? 0;
+    if (bulletCount !== MAX_BRIEF_BULLETS) {
+      throw error;
+    }
+    return brief;
+  }
 }
 
 type TemplateContext = Partial<{ [key: string]: JsonValue }>;


### PR DESCRIPTION
Accept complete Markdown when a model ignores structured output, reject truncated responses, and raise the generation budget.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM output handling and what gets persisted as a brief; validation limits bad fallbacks but wrong acceptance could still show incorrect content.
> 
> **Overview**
> Pre-meeting brief generation now has more headroom (**`maxOutputTokens` 200 → 512**) and a fallback when the model returns plain Markdown instead of the expected JSON object.
> 
> **`streamPreMeetingBrief`** still prefers structured output and streaming partials, but on **`NoObjectGeneratedError`** it can accept the raw **`error.text`** after **`trimPreMeetingBrief`**, only if **`finishReason`** is not **`length`** and the trimmed text has exactly three bullets. Truncated or incomplete Markdown is still rejected so incomplete briefs are not saved.
> 
> Tests cover the happy-path fallback and length-truncation rejection, and assert the new token limit on **`streamText`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f18e214e1cb570debbc8a41e849430a27ec0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->