### PR TITLE
Refresh desktop changelog for 1.4.19

### DIFF
--- a/packages/changelog/content/1.4.19.md
+++ b/packages/changelog/content/1.4.19.md
@@ -1,12 +1,16 @@
 ---
 date: "2026-09-04"
-summary: "Anarlog 1.4.19 keeps chat replies visible as they stream and retries rate-limited batch transcription automatically."
+summary: "Anarlog 1.4.19 lets you edit dictionary entries, keeps chat replies streaming, improves pre-meeting briefs, and retries rate-limited transcriptions."
 ---
 
 ## Fixes
 
+- Edit existing dictionary entries in place, with Save and Cancel controls,
+  keyboard shortcuts, and duplicate protection
 - See your message, thinking state, tool progress, and reply as chat streams,
   instead of waiting for the full response to appear at once
+- Generate pre-meeting briefs more reliably when a model returns plain
+  Markdown, while still discarding incomplete results
 - Keep long, segmented batch transcriptions moving through temporary provider
   rate limits with automatic retries and clearer quota guidance if the limit
   persists


### PR DESCRIPTION
Include the dictionary editing and pre-meeting brief improvements that joined the next stable desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog copy only; no application or API behavior changes in this PR.
> 
> **Overview**
> Updates the **1.4.19** desktop release notes so they match what shipped in the next stable build.
> 
> The one-line **summary** now calls out dictionary editing and pre-meeting brief improvements alongside streaming chat and transcription retries. Under **Fixes**, two bullets were added: in-place dictionary entry editing (Save/Cancel, shortcuts, duplicate checks) and more reliable pre-meeting brief generation when the model returns plain Markdown without keeping broken partial output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0baaebbee2f04a17463d8a7c629a58162370f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->