### PR TITLE
Fix chat scroll control and hide context chips

### DIFF
--- a/apps/desktop/src/chat/components/body/index.test.tsx
+++ b/apps/desktop/src/chat/components/body/index.test.tsx
@@ -1,7 +1,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { shellState } = vi.hoisted(() => ({
+const { autoScrollState, shellState } = vi.hoisted(() => ({
+  autoScrollState: {
+    isAtBottom: true,
+    showGoToRecent: false,
+  },
   shellState: {
     mode: "FloatingOpen" as
       | "FloatingClosed"
@@ -25,10 +29,10 @@ vi.mock("./use-chat-auto-scroll", () => ({
     handlePointerDown: vi.fn(),
     handlePointerMove: vi.fn(),
     handleWheel: vi.fn(),
-    isAtBottom: true,
+    isAtBottom: autoScrollState.isAtBottom,
     scrollRef: { current: null },
     scrollToBottom: vi.fn(),
-    showGoToRecent: false,
+    showGoToRecent: autoScrollState.showGoToRecent,
     updateAutoScrollState: vi.fn(),
   }),
 }));
@@ -43,9 +47,13 @@ vi.mock("~/contexts/shell", () => ({
 
 import { ChatBody } from "./index";
 
+import type { AnlgUIMessage } from "~/chat/types";
+
 describe("ChatBody", () => {
   beforeEach(() => {
     cleanup();
+    autoScrollState.isAtBottom = true;
+    autoScrollState.showGoToRecent = false;
     shellState.mode = "FloatingOpen";
   });
 
@@ -82,5 +90,31 @@ describe("ChatBody", () => {
     expect(root?.className).toContain("flex-1");
     expect(content?.className).not.toContain("px-5");
     expect(content?.className).not.toContain("px-2");
+  });
+
+  it("positions the go-to-recent control without offsetting its visual effects", () => {
+    autoScrollState.isAtBottom = false;
+    autoScrollState.showGoToRecent = true;
+
+    render(
+      <ChatBody
+        messages={[
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "Recent response" }],
+          } as AnlgUIMessage,
+        ]}
+        status="ready"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Go to recent" });
+    const anchor = button.parentElement;
+
+    expect(anchor?.hasAttribute("data-chat-go-to-recent-anchor")).toBe(true);
+    expect(anchor?.className).toContain("-translate-x-1/2");
+    expect(button.className).not.toContain("-translate-x-1/2");
+    expect(button.className).not.toContain("transform");
   });
 });

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -96,20 +96,25 @@ export function ChatBody({
         </div>
       </div>
       {messages.length > 0 && showGoToRecent && !isAtBottom && (
-        <Button
-          onClick={scrollToBottom}
-          size="sm"
-          className={cn([
-            "absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 transform items-center gap-1 rounded-full border shadow-xs",
-            chatFloatingControlClassNames(),
-          ])}
-          variant="outline"
+        <div
+          data-chat-go-to-recent-anchor
+          className="absolute bottom-3 left-1/2 z-20 -translate-x-1/2"
         >
-          <CaretDown size={12} />
-          <span className="text-xs">
-            <Trans>Go to recent</Trans>
-          </span>
-        </Button>
+          <Button
+            onClick={scrollToBottom}
+            size="sm"
+            className={cn([
+              "flex items-center gap-1 rounded-full border shadow-xs",
+              chatFloatingControlClassNames(),
+            ])}
+            variant="outline"
+          >
+            <CaretDown size={12} />
+            <span className="text-xs">
+              <Trans>Go to recent</Trans>
+            </span>
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/apps/desktop/src/chat/components/content.test.tsx
+++ b/apps/desktop/src/chat/components/content.test.tsx
@@ -115,6 +115,50 @@ describe("ChatContent", () => {
     expect(content?.className).not.toContain("shrink-0");
   });
 
+  it("hides context chips without removing context from new messages", () => {
+    const handleSendMessage = vi.fn();
+    const sendMessage = vi.fn();
+    const contextRef = {
+      kind: "human" as const,
+      key: "human:manual:artem",
+      humanId: "artem",
+    };
+
+    render(
+      <ChatContent
+        sessionId="active-session"
+        messages={[]}
+        sendMessage={sendMessage}
+        regenerate={vi.fn()}
+        stop={vi.fn()}
+        status="ready"
+        model={{} as never}
+        handleSendMessage={handleSendMessage}
+        contextEntities={[
+          {
+            ...contextRef,
+            source: "manual",
+            name: "Artem",
+            pending: true,
+          },
+        ]}
+        pendingRefs={[contextRef]}
+        isSystemPromptReady
+      />,
+    );
+
+    expect(screen.queryByTestId("context-bar")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("chat-input"));
+
+    expect(handleSendMessage).toHaveBeenCalledWith(
+      "Queued follow-up",
+      [{ type: "text", text: "Queued follow-up" }],
+      sendMessage,
+      [contextRef],
+    );
+  });
+
   it("adds dropped session refs to chat context", () => {
     const onAddContextEntity = vi.fn();
     const container = renderContent(onAddContextEntity);

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -3,7 +3,6 @@ import type { ChatStatus } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { ChatBody } from "./body";
-import { ContextBar } from "./context-bar";
 import { ChatMessageInput } from "./input";
 
 import type { useLanguageModel } from "~/ai/hooks";
@@ -36,9 +35,7 @@ export function ChatContent({
   error,
   model,
   handleSendMessage,
-  contextEntities,
   pendingRefs,
-  onRemoveContextEntity,
   onAddContextEntity,
   onDraftContentChange,
   onDraftContextRefsChange,
@@ -227,10 +224,6 @@ export function ChatContent({
       )}
       {isModelConfigured && (
         <>
-          <ContextBar
-            entities={contextEntities}
-            onRemoveEntity={onRemoveContextEntity}
-          />
           <ChatQueue
             messages={queuedMessages}
             onRemoveMessage={removeQueuedMessage}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only chat layout changes with behavior preserved for message context; no auth, data, or security impact.
> 
> **Overview**
> **Go to recent** is wrapped in a positioned anchor (`data-chat-go-to-recent-anchor`) so horizontal centering (`-translate-x-1/2`) applies to the wrapper instead of the button, avoiding transform-related glitches on the control’s border/shadow styling.
> 
> **Context chips** are no longer rendered above the composer: `ContextBar` is removed from `ChatContent`, while `pendingRefs` / merged context refs are still attached when sending or queueing messages. Tests cover anchor vs. button classes and that sends still include context without showing the bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f63ec104ad86db2347e233754005c8c5d594aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->