### PR TITLE
Fix Filipino transcription language code

### DIFF
--- a/apps/desktop/src/i18n/locales.test.ts
+++ b/apps/desktop/src/i18n/locales.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, test } from "vitest";
 import { resolveDisplayLocale, SUPPORTED_DISPLAY_LOCALES } from "./locales";
 
 describe("resolveDisplayLocale", () => {
-  test("uses exact supported locales", () => {
-    expect(resolveDisplayLocale("es")).toBe("es");
+  test.each(SUPPORTED_DISPLAY_LOCALES)("uses supported locale %s", (locale) => {
+    expect(resolveDisplayLocale(locale)).toBe(locale);
+  });
+
+  test("resolves the canonical Filipino locale to the Tagalog catalog", () => {
+    expect(resolveDisplayLocale("fil-PH")).toBe("tl");
   });
 
   test("includes broad settings main-language options", () => {

--- a/apps/desktop/src/i18n/locales.ts
+++ b/apps/desktop/src/i18n/locales.ts
@@ -115,6 +115,11 @@ export const SUPPORTED_DISPLAY_LOCALES = [
 export type DisplayLocale = (typeof SUPPORTED_DISPLAY_LOCALES)[number];
 
 const supportedDisplayLocales = new Set<string>(SUPPORTED_DISPLAY_LOCALES);
+const supportedDisplayLocaleByLanguage = new Map(
+  SUPPORTED_DISPLAY_LOCALES.map(
+    (locale) => [new Intl.Locale(locale).language, locale] as const,
+  ),
+);
 
 export function resolveDisplayLocale(
   language: string | null | undefined,
@@ -135,9 +140,5 @@ export function resolveDisplayLocale(
     return exactLocale as DisplayLocale;
   }
 
-  if (supportedDisplayLocales.has(locale.language)) {
-    return locale.language as DisplayLocale;
-  }
-
-  return SOURCE_LOCALE;
+  return supportedDisplayLocaleByLanguage.get(locale.language) ?? SOURCE_LOCALE;
 }

--- a/apps/desktop/src/settings/general/language.test.ts
+++ b/apps/desktop/src/settings/general/language.test.ts
@@ -31,8 +31,18 @@ describe("getAdditionalSpokenLanguages", () => {
     ]);
   });
 
-  test("preserves the ISO 639-1 code for Filipino", () => {
-    expect(getBaseLanguageCode("tl")).toBe("tl");
+  test.each([
+    ["tl", "tl"],
+    ["fil-PH", "tl"],
+    ["bh-IN", "bh"],
+    ["bho-IN", "bh"],
+    ["tw-GH", "tw"],
+    ["ak-GH", "ak"],
+  ])("normalizes transcription language alias %s to %s", (input, expected) => {
+    expect(getBaseLanguageCode(input)).toBe(expected);
+  });
+
+  test("normalizes persisted Filipino aliases", () => {
     expect(getAdditionalSpokenLanguages("en", ["fil"])).toEqual(["tl"]);
   });
 
@@ -42,6 +52,12 @@ describe("getAdditionalSpokenLanguages", () => {
 });
 
 describe("CORE_TRANSCRIPTION_LANGUAGE_CODES", () => {
+  test("preserves every supported ISO 639-1 code", () => {
+    for (const code of CORE_TRANSCRIPTION_LANGUAGE_CODES) {
+      expect(getBaseLanguageCode(code)).toBe(code);
+    }
+  });
+
   test("uses languages supported by both Deepgram and Soniox", () => {
     expect(CORE_TRANSCRIPTION_LANGUAGE_CODES).toContain("en");
     expect(CORE_TRANSCRIPTION_LANGUAGE_CODES).toContain("zh");

--- a/apps/desktop/src/settings/general/language.test.ts
+++ b/apps/desktop/src/settings/general/language.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   CORE_TRANSCRIPTION_LANGUAGE_CODES,
   getAdditionalSpokenLanguages,
+  getBaseLanguageCode,
   parseLocale,
 } from "./language";
 
@@ -28,6 +29,11 @@ describe("getAdditionalSpokenLanguages", () => {
     expect(getAdditionalSpokenLanguages("en", ["not a locale", "ko"])).toEqual([
       "ko",
     ]);
+  });
+
+  test("preserves the ISO 639-1 code for Filipino", () => {
+    expect(getBaseLanguageCode("tl")).toBe("tl");
+    expect(getAdditionalSpokenLanguages("en", ["fil"])).toEqual(["tl"]);
   });
 
   test("uses a valid fallback while the main language is loading", () => {

--- a/apps/desktop/src/settings/general/language.ts
+++ b/apps/desktop/src/settings/general/language.ts
@@ -1,6 +1,16 @@
 const MAX_DISPLAY_NAME_LOCALES = 16;
 const displayNamesByLocale = new Map<string, Intl.DisplayNames>();
 
+// Keep settings on the ISO 639-1 values used by the transcription boundary
+// when Intl.Locale prefers another alias.
+const TRANSCRIPTION_LANGUAGE_CODE_OVERRIDES: Record<string, string> = {
+  bh: "bh",
+  bho: "bh",
+  fil: "tl",
+  tl: "tl",
+  tw: "tw",
+};
+
 export const CORE_TRANSCRIPTION_LANGUAGE_CODES = [
   "ar",
   "be",
@@ -66,8 +76,12 @@ export function getBaseLanguageDisplayName(
 
 export function getBaseLanguageCode(code: string): string {
   const language = tryParseLocale(code)?.language ?? "";
+  if (!language) {
+    return "";
+  }
+  const sourceLanguage = code.split(/[-_]/)[0]?.toLowerCase() ?? "";
 
-  return language === "fil" ? "tl" : language;
+  return TRANSCRIPTION_LANGUAGE_CODE_OVERRIDES[sourceLanguage] ?? language;
 }
 
 export function getAdditionalSpokenLanguages(

--- a/apps/desktop/src/settings/general/language.ts
+++ b/apps/desktop/src/settings/general/language.ts
@@ -65,7 +65,9 @@ export function getBaseLanguageDisplayName(
 }
 
 export function getBaseLanguageCode(code: string): string {
-  return tryParseLocale(code)?.language ?? "";
+  const language = tryParseLocale(code)?.language ?? "";
+
+  return language === "fil" ? "tl" : language;
 }
 
 export function getAdditionalSpokenLanguages(

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -160,8 +160,13 @@ impl FromStr for Language {
         }
 
         let lang_part = parts[0].to_lowercase();
+        // Intl.Locale canonicalizes ISO 639-1 `tl` to the ISO 639-3 alias `fil`.
+        let lang_part = match lang_part.as_str() {
+            "fil" => "tl",
+            _ => &lang_part,
+        };
         let iso639 =
-            ISO639::from_str(&lang_part).map_err(|_| Error::InvalidLanguageCode(s.to_string()))?;
+            ISO639::from_str(lang_part).map_err(|_| Error::InvalidLanguageCode(s.to_string()))?;
 
         let mut script = None;
         let mut region = None;
@@ -249,6 +254,13 @@ mod tests {
         assert_eq!(lang.iso639(), ISO639::En);
         assert_eq!(lang.region(), None);
         assert_eq!(lang.bcp47_code(), "en");
+    }
+
+    #[test]
+    fn test_parse_filipino_alias() {
+        let lang: Language = "fil".parse().unwrap();
+        assert_eq!(lang.iso639(), ISO639::Tl);
+        assert_eq!(lang.bcp47_code(), "tl");
     }
 
     #[test]

--- a/crates/language/src/lib.rs
+++ b/crates/language/src/lib.rs
@@ -160,8 +160,9 @@ impl FromStr for Language {
         }
 
         let lang_part = parts[0].to_lowercase();
-        // Intl.Locale canonicalizes ISO 639-1 `tl` to the ISO 639-3 alias `fil`.
+        // Intl.Locale canonicalizes some ISO 639-1 codes to ISO 639-3 aliases.
         let lang_part = match lang_part.as_str() {
+            "bho" => "bh",
             "fil" => "tl",
             _ => &lang_part,
         };
@@ -257,10 +258,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_filipino_alias() {
-        let lang: Language = "fil".parse().unwrap();
-        assert_eq!(lang.iso639(), ISO639::Tl);
-        assert_eq!(lang.bcp47_code(), "tl");
+    fn test_parse_iso_639_3_aliases() {
+        for (alias, expected) in [("bho", ISO639::Bh), ("fil", ISO639::Tl)] {
+            let lang: Language = alias.parse().unwrap();
+            assert_eq!(lang.iso639(), expected);
+            assert_eq!(lang.bcp47_code(), expected.code());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Preserve tl in settings and accept persisted fil aliases at the Rust boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized alias normalization with broad test coverage; no auth or data-model changes beyond accepting legacy language codes.
> 
> **Overview**
> Aligns **Filipino/Tagalog** and other **Intl.Locale canonicalization mismatches** so persisted `fil` values and `fil-PH` UI locales map to the **`tl`** catalog and transcription codes the app already supports.
> 
> **Display locale resolution** now maps language subtags via `Intl.Locale` to the canonical entry in `SUPPORTED_DISPLAY_LOCALES` (e.g. `fil-PH` → `tl`) instead of treating the raw language subtag as a supported locale.
> 
> **Settings transcription helpers** add explicit overrides in `getBaseLanguageCode` (`fil` → `tl`, `bho` → `bh`, etc.) so spoken-language lists and labels stay on ISO 639-1 codes used at the provider boundary even when `Intl` prefers ISO 639-3 aliases.
> 
> The **Rust `Language` parser** accepts the same aliases (`fil`, `bho`) when deserializing language strings. Tests cover display resolution, settings normalization, and Rust parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b937388c2a8d9ddef06baa95d66b72eda828d4ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->