### PR TITLE
Prevent workspace subscriptions from receiving Pro welcome emails

### DIFF
--- a/apps/stripe/src/subscription-welcome-email.test.ts
+++ b/apps/stripe/src/subscription-welcome-email.test.ts
@@ -126,6 +126,50 @@ describe("sendSubscriptionWelcomeEmail", () => {
     expect(result).toBeNull();
   });
 
+  it("does not send the Pro welcome email for a Team subscription", async () => {
+    const result = await sendSubscriptionWelcomeEmail(
+      invoiceEvent(),
+      dependencies({
+        getCustomer: async () =>
+          ({
+            id: "cus_team_subscriber",
+            email: "owner@example.com",
+            name: "Workspace Team",
+            metadata: {
+              workspaceId: "workspace-team",
+            } as Stripe.Metadata,
+          }) as Stripe.Customer,
+        sendTransactional: async () => {
+          throw new Error("should not send");
+        },
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("does not send the Pro welcome email for an Enterprise subscription", async () => {
+    const result = await sendSubscriptionWelcomeEmail(
+      invoiceEvent(),
+      dependencies({
+        getCustomer: async () =>
+          ({
+            id: "cus_enterprise_subscriber",
+            email: "owner@example.com",
+            name: "Enterprise Workspace",
+            metadata: {
+              workspace_id: "workspace-enterprise",
+            } as Stripe.Metadata,
+          }) as Stripe.Customer,
+        sendTransactional: async () => {
+          throw new Error("should not send");
+        },
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("ignores zero-value trial invoices", async () => {
     const result = await sendSubscriptionWelcomeEmail(
       invoiceEvent({ amount_paid: 0 }),

--- a/apps/stripe/src/subscription-welcome-email.ts
+++ b/apps/stripe/src/subscription-welcome-email.ts
@@ -1,5 +1,7 @@
 import type Stripe from "stripe";
 
+import { getCustomerOwner } from "./customer-metadata";
+
 const SUBSCRIPTION_WELCOME_TRANSACTIONAL_ID = "cmsq3t8ns0ffi0jydc6uzj1rt";
 
 type SendTransactional = (args: {
@@ -54,7 +56,10 @@ export async function sendSubscriptionWelcomeEmail(
   }
 
   const customer = await activeDependencies.getCustomer(customerId);
-  if (!customer?.email) {
+  if (
+    !customer?.email ||
+    getCustomerOwner(customer.metadata)?.kind === "workspace"
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- suppress the Pro subscription welcome for workspace-owned Team and Enterprise customers
- cover both current and legacy workspace metadata keys

## Tests
- pnpm -F @anlg/stripe test
- pnpm -F @anlg/stripe typecheck
- pnpm fmt:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows transactional email eligibility only; no billing, auth, or data-path changes.
> 
> **Overview**
> **Pro subscription welcome emails** are no longer sent when the Stripe customer is owned by a workspace (Team/Enterprise), instead of an individual user.
> 
> `sendSubscriptionWelcomeEmail` now bails out early if `getCustomerOwner(customer.metadata)` resolves to `kind === "workspace"`, reusing existing metadata parsing so both `workspaceId` and legacy `workspace_id` are covered. Individual Pro subscribers are unchanged.
> 
> Tests assert that first paid subscription invoices for workspace customers do not trigger `sendTransactional`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2dafa3b0a25ac08403ddd175f0d9cceba56b758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->