### PR TITLE
Use Javanese provider language codes

### DIFF
--- a/crates/owhisper-client/src/adapter/cartesia/batch.rs
+++ b/crates/owhisper-client/src/adapter/cartesia/batch.rs
@@ -10,7 +10,7 @@ use crate::adapter::http::{ensure_success, streaming_file_part};
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL};
 use crate::error::Error;
 
-use super::{API_VERSION, CartesiaAdapter, DEFAULT_MODEL};
+use super::{API_VERSION, CartesiaAdapter, DEFAULT_MODEL, batch_language_code};
 
 impl BatchSttAdapter for CartesiaAdapter {
     fn provider_name(&self) -> &'static str {
@@ -82,7 +82,7 @@ async fn transcribe_file(
         .text("timestamp_granularities[]", "word");
 
     if let Some(language) = params.languages.first() {
-        form = form.text("language", language.iso639().code().to_string());
+        form = form.text("language", batch_language_code(language).to_string());
     }
 
     let mut request = client.post(transcription_url(api_base)?.to_string());

--- a/crates/owhisper-client/src/adapter/cartesia/mod.rs
+++ b/crates/owhisper-client/src/adapter/cartesia/mod.rs
@@ -24,7 +24,7 @@ impl CartesiaAdapter {
 
     pub fn language_support_batch(languages: &[anlg_language::Language]) -> LanguageSupport {
         LanguageSupport::min(languages.iter().map(|language| {
-            if BATCH_LANGUAGE_CODES.contains(&language.iso639().code()) {
+            if BATCH_LANGUAGE_CODES.contains(&batch_language_code(language)) {
                 LanguageSupport::Supported {
                     quality: LanguageQuality::NoData,
                 }
@@ -68,6 +68,13 @@ const BATCH_LANGUAGE_CODES: &[&str] = &[
     "vi", "yi", "yo", "zh",
 ];
 
+fn batch_language_code(language: &anlg_language::Language) -> &str {
+    match language.iso639() {
+        anlg_language::ISO639::Jv => "jw",
+        _ => language.iso639().code(),
+    }
+}
+
 pub(super) fn documented_language_codes_live() -> impl Iterator<Item = &'static str> {
     ["en"].into_iter()
 }
@@ -93,5 +100,13 @@ mod tests {
 
         assert!(codes.contains(&"ko"));
         assert!(codes.contains(&"zh"));
+    }
+
+    #[test]
+    fn batch_supports_the_javanese_provider_code() {
+        let javanese = anlg_language::Language::new(anlg_language::ISO639::Jv);
+
+        assert_eq!(batch_language_code(&javanese), "jw");
+        assert!(CartesiaAdapter::is_supported_languages_batch(&[javanese]));
     }
 }

--- a/crates/owhisper-client/src/adapter/gladia/batch.rs
+++ b/crates/owhisper-client/src/adapter/gladia/batch.rs
@@ -212,7 +212,7 @@ impl GladiaAdapter {
         let languages: Vec<String> = params
             .languages
             .iter()
-            .map(|l| l.iso639().code().to_string())
+            .map(|language| super::language::provider_code(language).to_string())
             .collect();
 
         let language_config = (!languages.is_empty()).then(|| LanguageConfig {

--- a/crates/owhisper-client/src/adapter/gladia/language.rs
+++ b/crates/owhisper-client/src/adapter/gladia/language.rs
@@ -1,4 +1,5 @@
 use crate::adapter::{LanguageQuality, LanguageSupport};
+use anlg_language::ISO639;
 
 // https://docs.gladia.io/chapters/language/supported-languages
 pub(super) const SUPPORTED_LANGUAGES: &[&str] = &[
@@ -13,8 +14,15 @@ pub(super) const SUPPORTED_LANGUAGES: &[&str] = &[
 
 pub(super) const SOLARIA_3_LANGUAGES: &[&str] = &["de", "en", "es", "fr", "it"];
 
+pub(super) fn provider_code(language: &anlg_language::Language) -> &str {
+    match language.iso639() {
+        ISO639::Jv => "jw",
+        _ => language.iso639().code(),
+    }
+}
+
 pub(super) fn single_language_support(language: &anlg_language::Language) -> LanguageSupport {
-    let code = language.iso639().code();
+    let code = provider_code(language);
     if SUPPORTED_LANGUAGES.contains(&code) {
         LanguageSupport::Supported {
             quality: LanguageQuality::NoData,

--- a/crates/owhisper-client/src/adapter/gladia/live.rs
+++ b/crates/owhisper-client/src/adapter/gladia/live.rs
@@ -145,7 +145,7 @@ impl RealtimeSttAdapter for GladiaAdapter {
             let languages: Vec<String> = params
                 .languages
                 .iter()
-                .map(|l| l.iso639().code().to_string())
+                .map(|language| super::language::provider_code(language).to_string())
                 .collect();
 
             let language_config = if languages.is_empty() {
@@ -364,7 +364,7 @@ impl GladiaAdapter {
         let languages: Vec<String> = params
             .languages
             .iter()
-            .map(|l| l.iso639().code().to_string())
+            .map(|language| super::language::provider_code(language).to_string())
             .collect();
 
         if languages.is_empty() {

--- a/crates/owhisper-client/src/adapter/gladia/mod.rs
+++ b/crates/owhisper-client/src/adapter/gladia/mod.rs
@@ -157,6 +157,21 @@ mod tests {
     }
 
     #[test]
+    fn javanese_uses_the_provider_language_code() {
+        let javanese = anlg_language::Language::new(ISO639::Jv);
+
+        assert_eq!(language::provider_code(&javanese), "jw");
+        assert!(GladiaAdapter::is_supported_languages_live(
+            std::slice::from_ref(&javanese),
+            None,
+        ));
+        assert!(GladiaAdapter::is_supported_languages_batch(
+            &[javanese],
+            None,
+        ));
+    }
+
+    #[test]
     fn test_batch_api_url_empty_uses_default() {
         let url = GladiaAdapter::batch_api_url("");
         assert_eq!(url.as_str(), "https://api.gladia.io/v2");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, provider-specific language-code mapping with tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **Javanese** language handling for Cartesia and Gladia so requests and support checks use each provider’s **`jw`** code instead of the raw ISO 639 value from `anlg_language`.
> 
> **Cartesia** adds `batch_language_code` and uses it when setting the batch `language` form field and when matching `BATCH_LANGUAGE_CODES`. **Gladia** adds `provider_code` in `language.rs` and routes batch, live, and language-support paths through it.
> 
> Unit tests assert `ISO639::Jv` maps to `jw` and is treated as supported for batch (and live on Gladia).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb2b7b1ede4ae38755f914278af5216bd083b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->