### PR TITLE
Show workspace logos in Team tabs

### DIFF
--- a/apps/desktop/src/settings/team/index.test.tsx
+++ b/apps/desktop/src/settings/team/index.test.tsx
@@ -348,6 +348,24 @@ describe("SettingsTeam", () => {
     );
   });
 
+  it("shows the workspace logo in its tab", () => {
+    const logoDataUrl = "data:image/jpeg;base64,/9j/4AAQ";
+    mocks.workspaces.data = [
+      {
+        workspaceId: "00000000-0000-4000-8000-000000000001",
+        name: "Fastrepl",
+        ownerUserId: "user-1",
+        logoDataUrl,
+        role: "owner",
+      },
+    ];
+
+    renderTeam();
+
+    const tab = screen.getByRole("button", { name: "Fastrepl" });
+    expect(tab.querySelector("img")?.getAttribute("src")).toBe(logoDataUrl);
+  });
+
   it("uploads a workspace logo from the identity tile", async () => {
     mocks.workspaces.data = [
       {

--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -52,7 +52,7 @@ import {
   getTeamSenderName,
   reportWorkspaceInvitation,
 } from "./invitation";
-import { WorkspaceLogoButton } from "./logo-button";
+import { WorkspaceLogoButton, WorkspaceLogoMark } from "./logo-button";
 import { MY_WORKSPACES_QUERY_KEY, useMyWorkspacesWithMirror } from "./mirror";
 
 import { useAuth } from "~/auth";
@@ -179,7 +179,11 @@ function WorkspaceTabs({
   onSelect,
   onCreate,
 }: {
-  workspaces: { workspaceId: string; name: string }[];
+  workspaces: {
+    workspaceId: string;
+    name: string;
+    logoDataUrl?: string | null;
+  }[];
   selectedId: string | null;
   isCreating: boolean;
   canCreate: boolean;
@@ -200,13 +204,17 @@ function WorkspaceTabs({
             aria-pressed={selected}
             onClick={() => onSelect(workspace.workspaceId)}
             className={cn([
-              "rounded-full px-3 py-1.5 text-sm transition-colors",
+              "flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition-colors",
               selected
                 ? "bg-muted text-foreground font-medium"
                 : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
             ])}
           >
-            {workspace.name}
+            <WorkspaceLogoMark
+              logoDataUrl={workspace.logoDataUrl ?? null}
+              className="size-5 rounded-md"
+            />
+            <span>{workspace.name}</span>
           </button>
         );
       })}

--- a/apps/desktop/src/settings/team/logo-button.tsx
+++ b/apps/desktop/src/settings/team/logo-button.tsx
@@ -7,23 +7,32 @@ import { compressWorkspaceLogo } from "./logo";
 
 export function WorkspaceLogoMark({
   logoDataUrl,
+  className,
 }: {
   logoDataUrl: string | null;
+  className?: string;
 }) {
+  const markClassName = cn(["size-10 rounded-xl", className]);
+
   if (logoDataUrl) {
     return (
       <img
         src={logoDataUrl}
         alt=""
         draggable={false}
-        className="size-10 rounded-xl object-cover"
+        className={cn([markClassName, "object-cover"])}
       />
     );
   }
 
   return (
-    <div className="bg-primary/10 text-primary flex size-10 items-center justify-center rounded-xl">
-      <Buildings className="size-5" />
+    <div
+      className={cn([
+        "bg-primary/10 text-primary flex items-center justify-center",
+        markClassName,
+      ])}
+    >
+      <Buildings className="size-1/2" />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only Team settings change with a focused test; no auth, billing, or API behavior changes.
> 
> **Overview**
> Team workspace switcher tabs now show each workspace’s logo (or the existing **Buildings** placeholder) beside the name, using the same `WorkspaceLogoMark` component as the identity tile.
> 
> `WorkspaceLogoMark` accepts an optional `className` so tabs can render a smaller mark (`size-5`) while the upload control keeps the default larger size; the fallback icon scales with `size-1/2` instead of a fixed pixel size.
> 
> A unit test asserts that when `logoDataUrl` is present on workspace data, the tab’s `img` uses that data URL as `src`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55fd3dbad4ca65d5f795939ac601c433f9c6f5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->