### PR TITLE
Require holds for destructive buttons

### DIFF
--- a/apps/desktop/src/folders/index.test.tsx
+++ b/apps/desktop/src/folders/index.test.tsx
@@ -8,6 +8,8 @@ import {
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { completeDestructiveButtonHold } from "~/test-utils/destructive-button";
+
 const mocks = vi.hoisted(() => ({
   createNamedFolder: vi.fn(),
   deleteLocalFolderMaterial: vi.fn(),
@@ -280,7 +282,9 @@ describe("Folders workspace", () => {
         "Notes stay in All notes. This folder, its nested folders, and all their materials will be deleted.",
       ),
     ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Delete folder" }));
+    completeDestructiveButtonHold(
+      screen.getByRole("button", { name: "Delete folder" }),
+    );
 
     await waitFor(() => {
       expect(mocks.deleteNamedFolder).toHaveBeenCalledWith("Work");

--- a/apps/desktop/src/settings/general/account.test.tsx
+++ b/apps/desktop/src/settings/general/account.test.tsx
@@ -8,6 +8,8 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { completeDestructiveButtonHold } from "~/test-utils/destructive-button";
+
 const mocks = vi.hoisted(() => ({
   analyticsEvent: vi.fn(() => Promise.resolve()),
   analyticsSetProperties: vi.fn(() => Promise.resolve()),
@@ -106,7 +108,9 @@ describe("SettingsAccount", () => {
   it("confirms sign-out before ending the session", async () => {
     renderAccount();
 
-    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    completeDestructiveButtonHold(
+      screen.getByRole("button", { name: "Sign out" }),
+    );
 
     expect(mocks.signOut).not.toHaveBeenCalled();
     expect(
@@ -119,9 +123,11 @@ describe("SettingsAccount", () => {
     expect(mocks.signOut).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    completeDestructiveButtonHold(
+      screen.getByRole("button", { name: "Sign out" }),
+    );
     const signOutButtons = screen.getAllByRole("button", { name: "Sign out" });
-    fireEvent.click(signOutButtons[signOutButtons.length - 1]!);
+    completeDestructiveButtonHold(signOutButtons[signOutButtons.length - 1]!);
 
     await waitFor(() => expect(mocks.signOut).toHaveBeenCalledOnce());
     expect(mocks.analyticsEvent).toHaveBeenCalledWith({

--- a/apps/desktop/src/settings/general/storage/legacy-cleanup.test.tsx
+++ b/apps/desktop/src/settings/general/storage/legacy-cleanup.test.tsx
@@ -11,6 +11,8 @@ import {
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { completeDestructiveButtonHold } from "~/test-utils/destructive-button";
+
 const mocks = vi.hoisted(() => ({
   cleanupLegacyFiles: vi.fn(),
   getLegacyCleanupStatus: vi.fn(),
@@ -125,7 +127,7 @@ describe("LegacyMigrationCleanupRow", () => {
       name: "Clean Up",
     });
 
-    fireEvent.click(openButton);
+    completeDestructiveButtonHold(openButton);
 
     expect(screen.getByText("Clean up legacy files?")).toBeTruthy();
     expect(
@@ -135,7 +137,7 @@ describe("LegacyMigrationCleanupRow", () => {
     ).toBeTruthy();
     expect(mocks.cleanupLegacyFiles).not.toHaveBeenCalled();
 
-    fireEvent.click(
+    completeDestructiveButtonHold(
       within(screen.getByRole("dialog")).getByRole("button", {
         name: "Clean Up",
       }),

--- a/apps/desktop/src/shared/ui/destructive-button.test.tsx
+++ b/apps/desktop/src/shared/ui/destructive-button.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Button } from "@anlg/ui/components/ui/button";
+
+import { finishDestructiveButtonHold } from "~/test-utils/destructive-button";
+
+describe("destructive Button", () => {
+  afterEach(cleanup);
+
+  it("requires a completed pointer hold", () => {
+    const onClick = vi.fn();
+    render(
+      <Button variant="destructive" onClick={onClick}>
+        Delete
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "Delete" });
+
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(button, { button: 0, isPrimary: true });
+    expect(button.dataset.holdState).toBe("holding");
+
+    finishDestructiveButtonHold(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(button.dataset.holdState).toBe("idle");
+  });
+
+  it("cancels a pointer hold when released early", () => {
+    const onClick = vi.fn();
+    render(
+      <Button variant="destructive" onClick={onClick}>
+        Delete
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "Delete" });
+
+    fireEvent.pointerDown(button, { button: 0, isPrimary: true });
+    fireEvent.pointerUp(button);
+    finishDestructiveButtonHold(button);
+    fireEvent.click(button);
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(button.dataset.holdState).toBe("idle");
+  });
+
+  it("supports holding Enter from the keyboard", () => {
+    const onClick = vi.fn();
+    render(
+      <Button variant="destructive" onClick={onClick}>
+        Delete
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "Delete" });
+
+    fireEvent.keyDown(button, { key: "Enter" });
+    expect(button.dataset.holdState).toBe("holding");
+
+    finishDestructiveButtonHold(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a keyboard hold when focus leaves", () => {
+    const onClick = vi.fn();
+    render(
+      <Button variant="destructive" onClick={onClick}>
+        Delete
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "Delete" });
+
+    fireEvent.keyDown(button, { key: "Enter" });
+    fireEvent.blur(button);
+    finishDestructiveButtonHold(button);
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(button.dataset.holdState).toBe("idle");
+  });
+
+  it("keeps non-destructive buttons clickable", () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Save</Button>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/sidebar/folder-materials.test.tsx
+++ b/apps/desktop/src/sidebar/folder-materials.test.tsx
@@ -8,6 +8,8 @@ import {
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { completeDestructiveButtonHold } from "~/test-utils/destructive-button";
+
 const mocks = vi.hoisted(() => ({
   createNamedFolder: vi.fn(),
   deleteLocalFolderMaterial: vi.fn(),
@@ -175,7 +177,9 @@ describe("FolderMaterialsPanel", () => {
     render(<FolderMaterialsPanel folderPath="CS 101" />);
 
     fireEvent.click(screen.getByLabelText("Delete folder"));
-    fireEvent.click(screen.getByRole("button", { name: "Delete folder" }));
+    completeDestructiveButtonHold(
+      screen.getByRole("button", { name: "Delete folder" }),
+    );
 
     await waitFor(() => {
       expect(mocks.deleteNamedFolder).toHaveBeenCalledWith("CS 101");

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { completeDestructiveButtonHold } from "~/test-utils/destructive-button";
+
 const mocks = vi.hoisted(() => ({
   anchorNode: null as HTMLDivElement | null,
   openNew: vi.fn(),
@@ -576,7 +578,9 @@ describe("TimelineView", () => {
       ).toBeTruthy();
       expect(screen.getByRole("dialog").className).toContain("max-w-[320px]");
 
-      fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+      completeDestructiveButtonHold(
+        screen.getByRole("button", { name: "Delete" }),
+      );
 
       expect(mocks.deleteSession).toHaveBeenCalledTimes(2);
       expect(mocks.deleteSession).toHaveBeenCalledWith("selected-note", {

--- a/apps/desktop/src/test-utils/destructive-button.ts
+++ b/apps/desktop/src/test-utils/destructive-button.ts
@@ -1,0 +1,15 @@
+import { fireEvent } from "@testing-library/react";
+
+export function completeDestructiveButtonHold(button: HTMLElement) {
+  fireEvent.pointerDown(button, { button: 0, isPrimary: true });
+
+  finishDestructiveButtonHold(button);
+}
+
+export function finishDestructiveButtonHold(button: HTMLElement) {
+  const event = new Event("animationend", { bubbles: true });
+  Object.defineProperty(event, "animationName", {
+    value: "destructive-button-hold",
+  });
+  fireEvent(button, event);
+}

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -39,6 +39,8 @@ const buttonVariants = cva(
   },
 );
 
+const DESTRUCTIVE_HOLD_ANIMATION = "destructive-button-hold";
+
 export interface ButtonProps
   extends
     React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -55,15 +57,134 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size,
       asChild = false,
       smoothCorners = true,
+      onBlur,
+      disabled,
+      onAnimationEnd,
+      onAnimationEndCapture,
+      onClick,
+      onKeyDown,
+      onKeyUp,
+      onPointerCancel,
+      onPointerDown,
+      onPointerLeave,
+      onPointerUp,
       ...props
     },
     ref,
   ) => {
+    const [isHolding, setIsHolding] = React.useState(false);
+    const allowClickRef = React.useRef(false);
+    const holdInputRef = React.useRef<"keyboard" | "pointer" | null>(null);
     const Comp = asChild ? Slot : "button";
     const squircleRef = useSquircleRef(ref);
+    const requiresHold = variant === "destructive" && !disabled;
+
+    const cancelHold = () => {
+      holdInputRef.current = null;
+      setIsHolding(false);
+    };
+
     return (
       <Comp
-        className={cn([buttonVariants({ variant, size, className })])}
+        className={cn([
+          buttonVariants({ variant, size, className }),
+          variant === "destructive" && [
+            "relative overflow-hidden",
+            "before:bg-destructive-foreground/80 before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-0.5 before:origin-left before:content-['']",
+            isHolding
+              ? "before:animate-[destructive-button-hold_1.2s_linear_forwards] before:opacity-100"
+              : "before:opacity-0",
+          ],
+        ])}
+        data-hold-state={
+          variant === "destructive"
+            ? isHolding
+              ? "holding"
+              : "idle"
+            : undefined
+        }
+        onBlur={(event) => {
+          onBlur?.(event);
+          if (holdInputRef.current === "keyboard") cancelHold();
+        }}
+        disabled={disabled}
+        onAnimationEnd={onAnimationEnd}
+        onAnimationEndCapture={(event) => {
+          onAnimationEndCapture?.(event);
+          if (event.animationName !== DESTRUCTIVE_HOLD_ANIMATION) return;
+
+          onAnimationEnd?.(event);
+          event.stopPropagation();
+          if (!requiresHold || !isHolding) return;
+
+          cancelHold();
+          allowClickRef.current = true;
+          try {
+            event.currentTarget.click();
+          } finally {
+            allowClickRef.current = false;
+          }
+        }}
+        onClick={(event) => {
+          if (!requiresHold || allowClickRef.current) {
+            onClick?.(event);
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onKeyDown={(event) => {
+          onKeyDown?.(event);
+          if (
+            event.defaultPrevented ||
+            !requiresHold ||
+            event.repeat ||
+            (event.key !== "Enter" && event.key !== " ")
+          ) {
+            return;
+          }
+
+          event.preventDefault();
+          holdInputRef.current = "keyboard";
+          setIsHolding(true);
+        }}
+        onKeyUp={(event) => {
+          onKeyUp?.(event);
+          if (
+            holdInputRef.current === "keyboard" &&
+            (event.key === "Enter" || event.key === " ")
+          ) {
+            event.preventDefault();
+            cancelHold();
+          }
+        }}
+        onPointerCancel={(event) => {
+          onPointerCancel?.(event);
+          if (holdInputRef.current === "pointer") cancelHold();
+        }}
+        onPointerDown={(event) => {
+          onPointerDown?.(event);
+          if (
+            event.defaultPrevented ||
+            !requiresHold ||
+            !event.isPrimary ||
+            event.button !== 0
+          ) {
+            return;
+          }
+
+          holdInputRef.current = "pointer";
+          setIsHolding(true);
+        }}
+        onPointerLeave={(event) => {
+          onPointerLeave?.(event);
+          if (holdInputRef.current === "pointer") cancelHold();
+        }}
+        onPointerUp={(event) => {
+          onPointerUp?.(event);
+          if (holdInputRef.current === "pointer") cancelHold();
+        }}
         {...props}
         ref={smoothCorners ? squircleRef : ref}
       />

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -133,6 +133,16 @@
     }
   }
 
+  @keyframes destructive-button-hold {
+    from {
+      transform: scaleX(1);
+    }
+
+    to {
+      transform: scaleX(0);
+    }
+  }
+
   @keyframes marquee {
     from {
       transform: translateX(0);


### PR DESCRIPTION
Require a 1.2-second press-and-hold before shared destructive buttons activate. Add the draining progress gauge, pointer and keyboard cancellation behavior, and focused desktop interaction coverage.

Testing:
- pnpm fmt:check
- pnpm -F @anlg/ui typecheck
- pnpm -F desktop typecheck
- pnpm exec oxlint --quiet --format=github apps/desktop/src/
- pnpm -F desktop exec vitest run src/shared/ui/destructive-button.test.tsx src/settings/team/index.test.tsx src/settings/general/account.test.tsx src/settings/general/storage/legacy-cleanup.test.tsx src/sidebar/timeline/index.test.tsx src/folders/index.test.tsx src/sidebar/folder-materials.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared UI button behavior changes every destructive control app-wide; mistakes could block deletes/sign-out or fire actions unintentionally, though scope is limited to the destructive variant and disabled state.
> 
> **Overview**
> Destructive actions in the shared `Button` now need a **1.2s press-and-hold** before `onClick` runs. Plain clicks are ignored; a bottom progress bar (`destructive-button-hold` animation) shows while holding. Holds work for pointer (primary button) and keyboard (Enter/Space), and cancel on early release, pointer leave/cancel, or keyboard blur/key-up.
> 
> Desktop tests use new helpers in `~/test-utils/destructive-button` to simulate a completed hold, and `destructive-button.test.tsx` covers hold completion, early cancel, and unchanged non-destructive clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c484c032a8482b1424e576842ba44f3b36a4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->