### PR TITLE
Recover automatically from dead webviews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -990,7 +990,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2722,7 +2722,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3548,7 +3548,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4104,13 +4104,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctutils"
@@ -4475,6 +4481,17 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4885,7 +4902,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5092,6 +5109,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -5427,7 +5459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9404,7 +9436,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9871,6 +9903,15 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -10833,9 +10874,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -10846,7 +10887,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -11126,7 +11167,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11290,7 +11331,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -12104,7 +12145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13492,7 +13533,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14439,7 +14480,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14452,7 +14493,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14531,7 +14572,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15426,7 +15467,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -15675,7 +15716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16045,6 +16086,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -16956,15 +16998,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -16975,13 +17018,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -17028,9 +17072,9 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -17082,9 +17126,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -17098,15 +17142,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -17131,9 +17174,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -18497,9 +18540,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -18522,9 +18565,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http 1.4.0",
@@ -18576,14 +18619,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -18593,7 +18637,8 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -18605,7 +18650,7 @@ dependencies = [
  "serde_with",
  "swift-rs 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -18640,7 +18685,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -19624,9 +19669,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -19638,7 +19683,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -20129,7 +20174,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -21547,7 +21592,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -22262,9 +22307,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "3013fd6116aac351dd2e18f349b28b2cfef3a5ff3253a9d0ce2d7193bb1b4429"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,8 +164,8 @@ owhisper-client = { path = "crates/owhisper-client", package = "owhisper-client"
 owhisper-interface = { path = "crates/owhisper-interface", package = "owhisper-interface" }
 soniox = { path = "crates/soniox", package = "soniox" }
 
-tauri = "2.10"
-tauri-build = "2.5"
+tauri = "2.11.5"
+tauri-build = "2.6.3"
 tauri-plugin = "2.5"
 tauri-plugin-autostart = "2.5"
 tauri-plugin-clipboard-manager = "2.3"

--- a/plugins/tray/Cargo.toml
+++ b/plugins/tray/Cargo.toml
@@ -44,4 +44,4 @@ libloading = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { workspace = true, features = ["NSStatusItem"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSUserDefaults"] }
-tray-icon = { version = "0.21.3", default-features = false }
+tray-icon = { version = "0.24.2", default-features = false }

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -8,8 +8,6 @@ const WEBVIEW_HEALTH_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::f
 #[cfg(target_os = "macos")]
 const WEBVIEW_HEALTH_CHECK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 #[cfg(target_os = "macos")]
-const WEBVIEW_HEALTH_MONITOR_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
-#[cfg(target_os = "macos")]
 const WEBVIEW_HEALTH_CHECK_ATTEMPTS: u8 = 2;
 
 #[cfg(target_os = "macos")]
@@ -66,25 +64,6 @@ fn webview_is_visible(app: &AppHandle<tauri::Wry>, label: &str) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-pub(crate) fn start_webview_health_monitor(app: AppHandle<tauri::Wry>) {
-    tauri::async_runtime::spawn(async move {
-        let mut interval = tokio::time::interval(WEBVIEW_HEALTH_MONITOR_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        interval.tick().await;
-
-        loop {
-            interval.tick().await;
-            let Some(window) = AppWindow::Main.get(&app) else {
-                continue;
-            };
-            if window.is_visible().unwrap_or(false) {
-                AppWindow::Main.request_webview_health_check(&app, &window);
-            }
-        }
-    });
-}
-
-#[cfg(target_os = "macos")]
 pub(crate) fn run_on_main_thread<R: Send + 'static>(
     app: &AppHandle<tauri::Wry>,
     f: impl FnOnce() -> R + Send + 'static,
@@ -100,16 +79,12 @@ pub(crate) fn run_on_main_thread<R: Send + 'static>(
 
 impl AppWindow {
     #[cfg(target_os = "macos")]
-    fn restart_unresponsive_app(app: &AppHandle<tauri::Wry>, label: &str, request_id: &str) {
-        if !webview_is_visible(app, label) {
-            return;
-        }
-
+    fn prepare_clean_restart(app: &AppHandle<tauri::Wry>, label: &str) -> bool {
         let Some(state) = app.try_state::<WebviewHealthState>() else {
-            return;
+            return false;
         };
         if !state.begin_recovery(label) {
-            return;
+            return false;
         }
 
         use tauri_plugin_window_state::AppHandleExt;
@@ -117,12 +92,17 @@ impl AppWindow {
             tracing::warn!(%error, "failed to save window state before webview recovery");
         }
 
-        tracing::error!(
-            %request_id,
-            attempts = WEBVIEW_HEALTH_CHECK_ATTEMPTS,
-            "restarting app after repeated main webview health check failures"
-        );
-        app.request_restart();
+        true
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn recover_terminated_webview(webview: &tauri::Webview<tauri::Wry>) {
+        let app = webview.app_handle();
+        let label = webview.label();
+        if Self::prepare_clean_restart(app, label) {
+            tracing::error!(webview = %label, "restarting app after web content process termination");
+            app.request_restart();
+        }
     }
 
     pub fn request_webview_health_check(
@@ -165,7 +145,17 @@ impl AppWindow {
                 }
 
                 if let Some(request_id) = last_request_id {
-                    Self::restart_unresponsive_app(&app, &label, &request_id);
+                    if !webview_is_visible(&app, &label) {
+                        return;
+                    }
+                    if Self::prepare_clean_restart(&app, &label) {
+                        tracing::error!(
+                            %request_id,
+                            attempts = WEBVIEW_HEALTH_CHECK_ATTEMPTS,
+                            "restarting app after repeated main webview health check failures"
+                        );
+                        app.request_restart();
+                    }
                 }
             });
         }

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -64,6 +64,11 @@ fn webview_is_visible(app: &AppHandle<tauri::Wry>, label: &str) -> bool {
 }
 
 #[cfg(target_os = "macos")]
+pub(crate) fn should_restart_terminated_webview(label: &str, is_visible: bool) -> bool {
+    is_visible && matches!(label.parse::<AppWindow>(), Ok(AppWindow::Main))
+}
+
+#[cfg(target_os = "macos")]
 pub(crate) fn run_on_main_thread<R: Send + 'static>(
     app: &AppHandle<tauri::Wry>,
     f: impl FnOnce() -> R + Send + 'static,
@@ -99,6 +104,16 @@ impl AppWindow {
     pub(crate) fn recover_terminated_webview(webview: &tauri::Webview<tauri::Wry>) {
         let app = webview.app_handle();
         let label = webview.label();
+        let is_visible = webview_is_visible(app, label);
+        if !should_restart_terminated_webview(label, is_visible) {
+            tracing::warn!(
+                webview = %label,
+                is_visible,
+                "web content process terminated without requiring immediate app recovery"
+            );
+            return;
+        }
+
         if Self::prepare_clean_restart(app, label) {
             tracing::error!(webview = %label, "restarting app after web content process termination");
             app.request_restart();

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -4,7 +4,85 @@ use tauri_specta::Event;
 use crate::{AppWindow, SavedFrame, WebviewHealthState, WindowImpl, WindowReadyState, events};
 
 #[cfg(target_os = "macos")]
-const WEBVIEW_HEALTH_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const WEBVIEW_HEALTH_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+#[cfg(target_os = "macos")]
+const WEBVIEW_HEALTH_CHECK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+#[cfg(target_os = "macos")]
+const WEBVIEW_HEALTH_MONITOR_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(target_os = "macos")]
+const WEBVIEW_HEALTH_CHECK_ATTEMPTS: u8 = 2;
+
+#[cfg(target_os = "macos")]
+enum WebviewHealthCheckResult {
+    Healthy,
+    Unhealthy { request_id: String },
+    Skipped,
+}
+
+#[cfg(target_os = "macos")]
+async fn check_webview_health(
+    app: &AppHandle<tauri::Wry>,
+    label: &str,
+) -> WebviewHealthCheckResult {
+    let Some(state) = app.try_state::<WebviewHealthState>() else {
+        return WebviewHealthCheckResult::Skipped;
+    };
+    let Some((registration_id, request_id, rx)) = state.register(label.to_string()) else {
+        return WebviewHealthCheckResult::Skipped;
+    };
+
+    let health_check = events::WebviewHealthCheck {
+        request_id: request_id.clone(),
+    };
+    if let Err(error) = health_check.emit_to(app, label) {
+        let is_current = state.unregister(label, registration_id);
+        tracing::warn!(%error, %request_id, "failed to request main webview health check");
+        return if is_current {
+            WebviewHealthCheckResult::Unhealthy { request_id }
+        } else {
+            WebviewHealthCheckResult::Skipped
+        };
+    }
+
+    match tokio::time::timeout(WEBVIEW_HEALTH_CHECK_TIMEOUT, rx).await {
+        Ok(Ok(())) => WebviewHealthCheckResult::Healthy,
+        Ok(Err(_)) => WebviewHealthCheckResult::Skipped,
+        Err(_) => {
+            let is_current = state.unregister(label, registration_id);
+            if is_current {
+                WebviewHealthCheckResult::Unhealthy { request_id }
+            } else {
+                WebviewHealthCheckResult::Skipped
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn webview_is_visible(app: &AppHandle<tauri::Wry>, label: &str) -> bool {
+    app.get_webview_window(label)
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn start_webview_health_monitor(app: AppHandle<tauri::Wry>) {
+    tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(WEBVIEW_HEALTH_MONITOR_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+            let Some(window) = AppWindow::Main.get(&app) else {
+                continue;
+            };
+            if window.is_visible().unwrap_or(false) {
+                AppWindow::Main.request_webview_health_check(&app, &window);
+            }
+        }
+    });
+}
 
 #[cfg(target_os = "macos")]
 pub(crate) fn run_on_main_thread<R: Send + 'static>(
@@ -22,33 +100,29 @@ pub(crate) fn run_on_main_thread<R: Send + 'static>(
 
 impl AppWindow {
     #[cfg(target_os = "macos")]
-    fn reload_unresponsive_webview(app: &AppHandle<tauri::Wry>, label: &str, request_id: &str) {
-        let Some(window) = app.get_webview_window(label) else {
-            return;
-        };
-        if !window.is_visible().unwrap_or(false) {
+    fn restart_unresponsive_app(app: &AppHandle<tauri::Wry>, label: &str, request_id: &str) {
+        if !webview_is_visible(app, label) {
             return;
         }
 
         let Some(state) = app.try_state::<WebviewHealthState>() else {
             return;
         };
-        state.begin_recovery(label);
-
-        match window.reload() {
-            Ok(()) => tracing::warn!(
-                request_id,
-                "reloaded unresponsive main webview after reopen"
-            ),
-            Err(error) => {
-                state.ready(label);
-                tracing::error!(
-                    %error,
-                    request_id,
-                    "failed to reload unresponsive main webview after reopen"
-                );
-            }
+        if !state.begin_recovery(label) {
+            return;
         }
+
+        use tauri_plugin_window_state::AppHandleExt;
+        if let Err(error) = app.save_window_state(crate::persisted_window_state_flags()) {
+            tracing::warn!(%error, "failed to save window state before webview recovery");
+        }
+
+        tracing::error!(
+            %request_id,
+            attempts = WEBVIEW_HEALTH_CHECK_ATTEMPTS,
+            "restarting app after repeated main webview health check failures"
+        );
+        app.request_restart();
     }
 
     pub fn request_webview_health_check(
@@ -62,41 +136,37 @@ impl AppWindow {
                 return;
             }
 
-            let Some(state) = app.try_state::<WebviewHealthState>() else {
-                return;
-            };
             let label = window.label().to_string();
-            let Some((registration_id, request_id, rx)) = state.register(label.clone()) else {
-                return;
-            };
-
-            let health_check = events::WebviewHealthCheck {
-                request_id: request_id.clone(),
-            };
-            if let Err(error) = health_check.emit_to(app, &label) {
-                let should_reload = state.unregister(&label, registration_id);
-                tracing::warn!(%error, "failed to request main webview health check");
-                if should_reload {
-                    Self::reload_unresponsive_webview(app, &label, &request_id);
-                }
-                return;
-            }
-
             let app = app.clone();
             tauri::async_runtime::spawn(async move {
-                match tokio::time::timeout(WEBVIEW_HEALTH_CHECK_TIMEOUT, rx).await {
-                    Ok(Ok(())) | Ok(Err(_)) => return,
-                    Err(_) => {}
+                let mut last_request_id = None;
+                for attempt in 1..=WEBVIEW_HEALTH_CHECK_ATTEMPTS {
+                    if !webview_is_visible(&app, &label) {
+                        return;
+                    }
+
+                    match check_webview_health(&app, &label).await {
+                        WebviewHealthCheckResult::Healthy | WebviewHealthCheckResult::Skipped => {
+                            return;
+                        }
+                        WebviewHealthCheckResult::Unhealthy { request_id } => {
+                            tracing::warn!(
+                                %request_id,
+                                attempt,
+                                "main webview health check failed"
+                            );
+                            last_request_id = Some(request_id);
+                        }
+                    }
+
+                    if attempt < WEBVIEW_HEALTH_CHECK_ATTEMPTS {
+                        tokio::time::sleep(WEBVIEW_HEALTH_CHECK_RETRY_DELAY).await;
+                    }
                 }
 
-                let Some(state) = app.try_state::<WebviewHealthState>() else {
-                    return;
-                };
-                if !state.unregister(&label, registration_id) {
-                    return;
+                if let Some(request_id) = last_request_id {
+                    Self::restart_unresponsive_app(&app, &label, &request_id);
                 }
-
-                Self::reload_unresponsive_webview(&app, &label, &request_id);
             });
         }
 

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -11,12 +11,11 @@ pub use ext::{Windows, WindowsPluginExt};
 pub use tab::*;
 pub use window::*;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{
     Mutex,
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
-use std::time::{Duration, Instant};
 
 const PLUGIN_NAME: &str = "windows";
 
@@ -24,8 +23,6 @@ pub fn persisted_window_state_flags() -> tauri_plugin_window_state::StateFlags {
     use tauri_plugin_window_state::StateFlags;
     StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED
 }
-
-const WEBVIEW_RECOVERY_GRACE_PERIOD: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy)]
 pub struct SavedFrame {
@@ -103,28 +100,26 @@ pub struct WindowReadyState {
 struct WebviewHealthState {
     next_registration_id: AtomicU64,
     pending: Mutex<HashMap<String, (u64, String, oneshot::Sender<()>)>>,
-    recovering_since: Mutex<HashMap<String, Instant>>,
+    recovering: Mutex<HashSet<String>>,
 }
 
 impl WebviewHealthState {
     fn register(&self, label: String) -> Option<(u64, String, oneshot::Receiver<()>)> {
-        let mut recovering_since = self.recovering_since.lock().unwrap();
-        if recovering_since
-            .get(&label)
-            .is_some_and(|started_at| started_at.elapsed() < WEBVIEW_RECOVERY_GRACE_PERIOD)
-        {
+        let recovering = self.recovering.lock().unwrap();
+        if recovering.contains(&label) {
             return None;
         }
-        recovering_since.remove(&label);
+
+        let mut pending = self.pending.lock().unwrap();
+        if pending.contains_key(&label) {
+            return None;
+        }
 
         let (tx, rx) = oneshot::channel();
         let registration_id = self.next_registration_id.fetch_add(1, Ordering::Relaxed);
         let request_id = uuid::Uuid::new_v4().to_string();
-        self.pending
-            .lock()
-            .unwrap()
-            .insert(label, (registration_id, request_id.clone(), tx));
-        drop(recovering_since);
+        pending.insert(label, (registration_id, request_id.clone(), tx));
+        drop(recovering);
 
         Some((registration_id, request_id, rx))
     }
@@ -157,19 +152,21 @@ impl WebviewHealthState {
         is_match
     }
 
-    fn begin_recovery(&self, label: &str) {
-        let mut recovering_since = self.recovering_since.lock().unwrap();
-        recovering_since.insert(label.to_string(), Instant::now());
+    fn begin_recovery(&self, label: &str) -> bool {
+        let mut recovering = self.recovering.lock().unwrap();
+        if !recovering.insert(label.to_string()) {
+            return false;
+        }
         self.pending.lock().unwrap().remove(label);
+        true
     }
 
     fn ready(&self, label: &str) {
-        self.recovering_since.lock().unwrap().remove(label);
+        self.recovering.lock().unwrap().remove(label);
     }
 
     fn remove(&self, label: &str) {
-        let mut recovering_since = self.recovering_since.lock().unwrap();
-        recovering_since.remove(label);
+        self.recovering.lock().unwrap().remove(label);
         self.pending.lock().unwrap().remove(label);
     }
 }
@@ -287,6 +284,9 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
                 app.manage(health_state);
             }
 
+            #[cfg(target_os = "macos")]
+            crate::ext::start_webview_health_monitor(app.clone());
+
             {
                 let dock_visibility_state = DockVisibilityState::default();
                 app.manage(dock_visibility_state);
@@ -356,34 +356,32 @@ mod test {
     async fn webview_health_acknowledges_only_the_current_request() {
         let state = WebviewHealthState::default();
         let (first_id, first_request_id, first_rx) = state.register("main".into()).unwrap();
-        let (second_id, second_request_id, second_rx) = state.register("main".into()).unwrap();
 
-        assert!(first_rx.await.is_err());
-        assert!(!state.acknowledge("main", &first_request_id));
+        assert!(!state.acknowledge("main", "stale-request"));
+        assert!(!state.unregister("main", first_id + 1));
+        assert!(state.acknowledge("main", &first_request_id));
+        assert!(first_rx.await.is_ok());
         assert!(!state.unregister("main", first_id));
-        assert!(state.acknowledge("main", &second_request_id));
-        assert!(second_rx.await.is_ok());
-        assert!(!state.unregister("main", second_id));
         assert!(state.pending.lock().unwrap().is_empty());
     }
 
     #[test]
-    fn webview_health_timeout_unregisters_only_the_current_request() {
+    fn webview_health_allows_only_one_probe_per_window() {
         let state = WebviewHealthState::default();
         let (first_id, _, _) = state.register("main".into()).unwrap();
-        let (second_id, _, _) = state.register("main".into()).unwrap();
 
-        assert!(!state.unregister("main", first_id));
-        assert!(state.unregister("main", second_id));
-        assert!(state.pending.lock().unwrap().is_empty());
+        assert!(state.register("main".into()).is_none());
+        assert!(state.unregister("main", first_id));
+        assert!(state.register("main".into()).is_some());
     }
 
     #[test]
-    fn webview_health_waits_for_reloaded_frontend() {
+    fn webview_health_recovery_starts_once_and_blocks_probes() {
         let state = WebviewHealthState::default();
-        state.begin_recovery("main");
+        assert!(state.begin_recovery("main"));
 
         assert!(state.register("main".into()).is_none());
+        assert!(!state.begin_recovery("main"));
         state.ready("main");
         assert!(state.register("main".into()).is_some());
     }

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -284,9 +284,6 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
                 app.manage(health_state);
             }
 
-            #[cfg(target_os = "macos")]
-            crate::ext::start_webview_health_monitor(app.clone());
-
             {
                 let dock_visibility_state = DockVisibilityState::default();
                 app.manage(dock_visibility_state);
@@ -319,6 +316,9 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
 }
 
 pub fn extend_builder(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wry> {
+    #[cfg(target_os = "macos")]
+    let builder = builder.on_web_content_process_terminate(AppWindow::recover_terminated_webview);
+
     #[cfg(all(target_os = "macos", feature = "macos-private-api"))]
     {
         builder.plugin(tauri_nspanel::init())

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -386,6 +386,21 @@ mod test {
         assert!(state.register("main".into()).is_some());
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminated_webview_restarts_only_for_visible_main_window() {
+        assert!(crate::ext::should_restart_terminated_webview("main", true));
+        assert!(!crate::ext::should_restart_terminated_webview(
+            "main", false
+        ));
+        assert!(!crate::ext::should_restart_terminated_webview(
+            "composer", true
+        ));
+        assert!(!crate::ext::should_restart_terminated_webview(
+            "note-1", true
+        ));
+    }
+
     #[test]
     fn expansion_pop_removes_empty_window_entry() {
         let expansions = WindowExpansions::default();


### PR DESCRIPTION
## Why

The stable app entered a white-screen state after an in-place webview reload. Stable logs showed a sustained stream of missing Tauri callback IDs while the WebContent process consumed high CPU and memory.

A renderer reload resets the JavaScript callback table, but native listeners, IPC channels, and live-query subscriptions can remain alive. Those stale native producers then continue targeting callbacks that no longer exist. Recovery therefore needs to replace the process boundary, not reload the renderer in place.

## Approach

- never use `window.reload()` to recover a failed renderer
- save native window geometry before recovery
- cleanly restart the whole app so stale listeners, channels, and WebKit state are destroyed
- use the native macOS WebContent termination callback exposed by Tauri 2.11
- restart immediately only when the visible main WebContent process terminates
- defer hidden-main recovery until explicit reopen and ignore background note/composer termination
- keep the two-attempt health probe only for an explicit reopen of an unresponsive main window
- remove periodic background polling, avoiding false positives and surprise restarts during normal use
- prevent overlapping probes and duplicate recovery for the same webview
- pin Wry 0.55.0 and Tao 0.35.2 to avoid the reported macOS 26 startup regression in the next patch pair

## UX impact

Normal use has no new timer, UI, or interaction cost. If the visible main WebKit content process terminates, Anarlog briefly relaunches and restores its saved window geometry. If the hidden main renderer hangs or terminates, reopening Anarlog triggers two health checks before the same clean recovery. A background note or composer WebView cannot unexpectedly relaunch the tray-resident app.

An active recording can still be interrupted if the visible main WebContent process fails and forces an app relaunch. This change prevents the corrupted renderer/native callback state from surviving recovery; it does not claim uninterrupted recording across a process crash.

## Validation

- `pnpm fmt:check`
- `cargo test -p tauri-plugin-windows` — 28 passed
- `cargo check -p tauri-plugin-windows`
- `cargo check -p desktop --features direct-distribution`
- `cargo check -p desktop --features app-store`
- `cargo test -p desktop` — 49 passed
- scoped dprint checks for all changed files
- macOS 26 dev startup with the pinned runtime
- fault injection by terminating only the dev WebContent process: the native callback fired, the old app exited, and the replacement process reached frontend startup again in about 1.6 seconds
