### PR TITLE
Confirm workspace deletion in app

### DIFF
--- a/apps/desktop/src/settings/team/index.test.tsx
+++ b/apps/desktop/src/settings/team/index.test.tsx
@@ -5,9 +5,12 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { completeDestructiveButtonHold } from "~/test-utils/destructive-button";
 
 const mocks = vi.hoisted(() => ({
   billingCheckout: {
@@ -67,6 +70,7 @@ const mocks = vi.hoisted(() => ({
       isBilled: true,
     },
     revokeInvitation: vi.fn(() => Promise.resolve()),
+    deleteWorkspace: vi.fn(() => Promise.resolve()),
     renameWorkspace: vi.fn(() => Promise.resolve()),
     setWorkspaceLogo: vi.fn(() =>
       Promise.resolve({ logoDataUrl: "data:image/jpeg;base64,/9j/4AAQ" }),
@@ -160,7 +164,7 @@ vi.mock("./mirror", () => ({
 vi.mock("./client", () => ({
   requireTeamContext: (auth: unknown) => auth,
   createWorkspace: mocks.createWorkspace,
-  deleteWorkspace: vi.fn(() => Promise.resolve()),
+  deleteWorkspace: mocks.client.deleteWorkspace,
   getSeatUsage: () =>
     Promise.resolve({ seatLimit: null, usedSeats: 1, isBilled: false }),
   leaveWorkspace: vi.fn(() => Promise.resolve()),
@@ -231,6 +235,7 @@ describe("SettingsTeam", () => {
       usedSeats: 1,
     };
     mocks.client.revokeInvitation.mockClear();
+    mocks.client.deleteWorkspace.mockClear();
     mocks.client.renameWorkspace.mockClear();
     mocks.client.setWorkspaceLogo.mockClear();
     mocks.client.getWorkspacePolicy.mockClear();
@@ -601,5 +606,41 @@ describe("SettingsTeam", () => {
     expect(
       screen.getByRole("button", { name: "Leave workspace" }),
     ).toBeTruthy();
+  });
+
+  it("confirms before deleting a workspace", async () => {
+    mocks.workspaces.data = [
+      {
+        workspaceId: "00000000-0000-4000-8000-000000000001",
+        name: "Fastrepl",
+        ownerUserId: "user-1",
+        role: "owner",
+      },
+    ];
+
+    renderTeam();
+
+    completeDestructiveButtonHold(
+      await screen.findByRole("button", { name: "Delete workspace" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("heading", {
+        name: "Delete Fastrepl for everyone?",
+      }),
+    ).toBeTruthy();
+    expect(mocks.client.deleteWorkspace).not.toHaveBeenCalled();
+
+    completeDestructiveButtonHold(
+      within(dialog).getByRole("button", { name: "Delete workspace" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.client.deleteWorkspace).toHaveBeenCalledWith(
+        expect.anything(),
+        "00000000-0000-4000-8000-000000000001",
+      ),
+    );
   });
 });

--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -65,6 +65,7 @@ import { env } from "~/env";
 import { SettingsPageTitle } from "~/settings/page-title";
 import { PlanGate } from "~/settings/plan-gate";
 import { SettingSwitchRow } from "~/settings/setting-row";
+import { DestructiveConfirmationDialog } from "~/shared/ui/destructive-confirmation-dialog";
 import { buildWebAppUrl } from "~/shared/utils";
 
 export function SettingsTeam() {
@@ -316,6 +317,8 @@ function WorkspacePanel({
   const [email, setEmail] = useState("");
   const [nameDraft, setNameDraft] = useState(workspaceName);
   const [isOpeningBilling, setIsOpeningBilling] = useState(false);
+  const [isDeleteWorkspaceDialogOpen, setIsDeleteWorkspaceDialogOpen] =
+    useState(false);
   const isManager = workspaceRole === "owner" || workspaceRole === "admin";
 
   const access = useQuery({
@@ -456,7 +459,11 @@ function WorkspacePanel({
   });
   const destroy = useMutation({
     mutationFn: () => deleteWorkspace(requireTeamContext(auth), workspaceId),
-    onSuccess: onWorkspaceLeft,
+    onSuccess: () => {
+      setIsDeleteWorkspaceDialogOpen(false);
+      onWorkspaceLeft();
+    },
+    onError: () => setIsDeleteWorkspaceDialogOpen(false),
   });
 
   const viewerId = auth.session?.user.id;
@@ -771,11 +778,7 @@ function WorkspacePanel({
             variant="destructive"
             className="shrink-0"
             disabled={destroy.isPending}
-            onClick={() => {
-              if (confirm(t`Delete ${workspaceName} for everyone?`)) {
-                destroy.mutate();
-              }
-            }}
+            onClick={() => setIsDeleteWorkspaceDialogOpen(true)}
           >
             <Trans>Delete workspace</Trans>
           </Button>
@@ -793,6 +796,20 @@ function WorkspacePanel({
           </Button>
         )}
       </div>
+      <DestructiveConfirmationDialog
+        open={isDeleteWorkspaceDialogOpen}
+        onOpenChange={setIsDeleteWorkspaceDialogOpen}
+        title={t`Delete ${workspaceName} for everyone?`}
+        description={
+          <Trans>
+            Deleting removes the workspace for everyone. Transfer ownership
+            first if you only want to leave.
+          </Trans>
+        }
+        confirmLabel={<Trans>Delete workspace</Trans>}
+        isPending={destroy.isPending}
+        onConfirm={() => destroy.mutate()}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -115,7 +115,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
           onAnimationEnd?.(event);
           event.stopPropagation();
-          if (!requiresHold || !isHolding) return;
+          if (!requiresHold || holdInputRef.current === null) return;
 
           cancelHold();
           allowClickRef.current = true;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes irreversible workspace deletion UX and tweaks shared destructive-button hold behavior used across the app.
> 
> **Overview**
> Workspace owners no longer delete a team via the browser **`confirm()`** prompt. **Delete workspace** opens **`DestructiveConfirmationDialog`** (title, warning copy, hold-to-confirm destructive button) and only then runs the existing **`deleteWorkspace`** mutation; the dialog closes on success or error and selection still clears via **`onWorkspaceLeft`**.
> 
> Team settings tests assert the two-step flow (open dialog, confirm hold) and wire **`deleteWorkspace`** through shared mocks plus **`completeDestructiveButtonHold`**.
> 
> In **`packages/ui` `Button`**, the destructive hold animation completion check uses **`holdInputRef`** instead of **`isHolding`** state so the synthetic click after a completed hold is reliable (e.g. in dialogs and tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437db803ed72d1ca8bc4578b42c8bd375243444b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->