### PR TITLE
Polish workspace subdomain input

### DIFF
--- a/apps/desktop/src/settings/team/index.test.tsx
+++ b/apps/desktop/src/settings/team/index.test.tsx
@@ -474,6 +474,9 @@ describe("SettingsTeam", () => {
       name: "Workspace subdomain",
     });
     expect((input as HTMLInputElement).value).toBe("fastrepl");
+    expect(input.parentElement?.contains(screen.getByText(".anarlog.so"))).toBe(
+      true,
+    );
     fireEvent.change(input, { target: { value: "Fastrepl-HQ" } });
     fireEvent.click(screen.getByRole("button", { name: "Save subdomain" }));
 

--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -21,12 +21,18 @@ import {
 } from "@anlg/ui/components/ui/dialog";
 import { Input } from "@anlg/ui/components/ui/input";
 import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@anlg/ui/components/ui/input-group";
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@anlg/ui/components/ui/select";
+import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
 import { cn } from "@anlg/utils";
 
 import {
@@ -1187,6 +1193,7 @@ function WorkspaceShareDomainForm({
   const auth = useAuth();
   const inputId = `workspace-share-slug-${workspaceId}`;
   const [shareSlug, setShareSlug] = useState(workspaceShareSlug ?? "");
+  const inputGroupRef = useSquircleRef<HTMLDivElement>();
   const save = useMutation({
     mutationFn: (value: string) =>
       setWorkspaceShareSlug(requireTeamContext(auth), workspaceId, value),
@@ -1210,26 +1217,34 @@ function WorkspaceShareDomainForm({
       <p className="text-muted-foreground text-xs">
         <Trans>Use this domain for links shared from this workspace.</Trans>
       </p>
-      <label htmlFor={inputId} className="text-xs font-medium">
+      <label htmlFor={inputId} className="sr-only">
         <Trans>Workspace subdomain</Trans>
       </label>
-      <div className="flex min-w-0 items-center">
-        <Input
-          id={inputId}
-          value={shareSlug}
-          onChange={(event) => setShareSlug(event.target.value.toLowerCase())}
-          placeholder="company"
-          minLength={3}
-          maxLength={63}
-          pattern="[a-z0-9][a-z0-9-]{1,61}[a-z0-9]"
-          autoCapitalize="none"
-          autoCorrect="off"
-          spellCheck={false}
-          className="bg-card h-9 min-w-0 rounded-r-none shadow-none"
-        />
-        <span className="border-input bg-muted text-muted-foreground flex h-9 shrink-0 items-center rounded-r-md border border-l-0 px-3 text-xs">
-          .anarlog.so
-        </span>
+      <div className="has-[input:focus-visible]:ring-ring rounded-xl has-[input:focus-visible]:ring-1">
+        <InputGroup
+          ref={inputGroupRef}
+          className="bg-card overflow-hidden shadow-none has-[[data-slot=input-group-control]:focus-visible]:ring-0"
+        >
+          <InputGroupInput
+            id={inputId}
+            value={shareSlug}
+            onChange={(event) => setShareSlug(event.target.value.toLowerCase())}
+            placeholder="company"
+            minLength={3}
+            maxLength={63}
+            pattern="[a-z0-9][a-z0-9-]{1,61}[a-z0-9]"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            className="h-full min-w-0"
+          />
+          <InputGroupAddon
+            align="inline-end"
+            className="border-input bg-muted h-full shrink-0 border-l px-3 py-0 text-xs font-normal"
+          >
+            .anarlog.so
+          </InputGroupAddon>
+        </InputGroup>
       </div>
       <Button
         type="submit"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only change in team settings; subdomain save API and validation logic are untouched.
> 
> **Overview**
> **Sharing domain** on team settings now uses the shared `InputGroup` / `InputGroupAddon` pattern instead of a plain `Input` plus a separate `.anarlog.so` span, with `useSquircleRef` on the group and an outer wrapper for rounded focus ring styling.
> 
> The visible **Workspace subdomain** label is moved to `sr-only` so the field stays labeled for assistive tech without duplicating the section heading. Save behavior, validation, and lowercase normalization are unchanged.
> 
> The subdomain test now asserts that `.anarlog.so` still appears in the same control as the textbox after the markup change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4b31d5922f9385c0455b63c8d4ef51e6bceac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->