### PR TITLE
Add desktop 1.4.20 changelog

### DIFF
--- a/packages/changelog/content/1.4.20.md
+++ b/packages/changelog/content/1.4.20.md
@@ -1,0 +1,31 @@
+---
+date: "2026-09-05"
+summary: "Anarlog 1.4.20 adds shared resource libraries, granular notification controls and completion sounds, safer workspace actions, and more resilient desktop recovery."
+---
+
+## Sharing and workspaces
+
+- Share a folder with one guest on Pro, or publish folders, templates, and
+  automations to a Team library where collaborators can browse and import them
+- Invite workspace members from a focused dialog, see workspace logos while
+  switching Teams, and get clearer invitation emails and recovery messages
+- Check Enterprise sharing-subdomain availability as you type, with clear
+  feedback when a name is available, invalid, or already taken
+- Confirm workspace deletion inside Anarlog, and press and hold destructive
+  actions throughout the app to prevent accidental clicks
+
+## Notifications and polish
+
+- Turn all notifications off at once or choose separately when to hear about
+  transcripts, summaries, cloud sync, recording status, and upcoming events
+- Play and preview one of five optional completion sounds when background work
+  finishes
+- Keep the chat **Go to recent** control centered and send selected context
+  without showing extra chips above the composer
+
+## Reliability and transcription
+
+- Relaunch cleanly and restore the saved window position when the visible app
+  renderer fails, instead of leaving Anarlog on a blank screen
+- Use Filipino, Tagalog, and Javanese transcription without language-code
+  mismatches that could hide provider support or send the wrong code


### PR DESCRIPTION
Summarizes the user-facing sharing, notification, workspace, transcription, chat, and reliability changes in the next stable desktop release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of a changelog markdown file with no runtime or build behavior changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.20.md`** for the 2026-09-05 desktop release, using the same frontmatter (`date`, `summary`) and sectioned bullet format as prior entries.
> 
> The new copy documents user-facing changes for **sharing and workspaces** (Pro guest folder share, Team library publishing, member invites, Enterprise subdomain checks, deletion confirmation, press-and-hold destructive actions), **notifications and polish** (granular toggles, completion sounds, chat UI tweaks), and **reliability and transcription** (renderer crash recovery with window position restore, Filipino/Tagalog/Javanese language-code fixes). No application or API code is modified—only release documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27e676d7b7accd9a83850decdd8d1099a02ef37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->