### PR TITLE
Restore desktop storage location setting

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr "Capture meeting chat in Memos"
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr "Change"
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr "Choose how much detail generated meeting summaries include."
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr "Choose storage location"
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr "When this happens"
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr "Where your notes and recordings are stored"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -828,6 +828,7 @@ msgid "Capture meeting chat in Memos"
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Change"
 msgstr ""
 
@@ -1011,6 +1012,7 @@ msgid "Choose how much detail generated meeting summaries include."
 msgstr ""
 
 #: src/onboarding/folder-location.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Choose storage location"
 msgstr ""
 
@@ -5540,6 +5542,7 @@ msgid "When this happens"
 msgstr ""
 
 #: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 

--- a/apps/desktop/src/settings/general/storage/index.test.tsx
+++ b/apps/desktop/src/settings/general/storage/index.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  copyVault: vi.fn(),
+  homeDir: vi.fn(),
+  openPath: vi.fn(),
+  scheduleAutomaticRelaunch: vi.fn(),
+  selectFolder: vi.fn(),
+  setVaultBase: vi.fn(),
+  vaultBase: vi.fn(),
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  useLingui: () => ({
+    t: (strings: TemplateStringsArray, ...values: unknown[]) =>
+      strings.reduce(
+        (message, part, index) =>
+          `${message}${part}${index < values.length ? String(values[index]) : ""}`,
+        "",
+      ),
+  }),
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({ homeDir: mocks.homeDir }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: mocks.selectFolder,
+}));
+vi.mock("@anlg/plugin-opener2", () => ({
+  commands: { openPath: mocks.openPath },
+}));
+vi.mock("@anlg/plugin-settings", () => ({
+  commands: {
+    copyVault: mocks.copyVault,
+    setVaultBase: mocks.setVaultBase,
+    vaultBase: mocks.vaultBase,
+  },
+}));
+vi.mock("~/shared/relaunch", () => ({
+  scheduleAutomaticRelaunch: mocks.scheduleAutomaticRelaunch,
+}));
+vi.mock("./legacy-cleanup", () => ({
+  LegacyMigrationCleanupRow: () => <div>Legacy cleanup</div>,
+  useLegacyMigrationCleanup: () => ({ visible: false }),
+}));
+
+import { StorageSettingsView } from "./index";
+
+function renderView() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <StorageSettingsView />
+    </QueryClientProvider>,
+  );
+}
+
+describe("StorageSettingsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.homeDir.mockResolvedValue("/Users/test");
+    mocks.vaultBase.mockResolvedValue({
+      status: "ok",
+      data: "/Users/test/Google Drive/Anarlog",
+    });
+    mocks.copyVault.mockResolvedValue({ status: "ok", data: null });
+    mocks.setVaultBase.mockResolvedValue({ status: "ok", data: null });
+    mocks.scheduleAutomaticRelaunch.mockResolvedValue("scheduled");
+    mocks.selectFolder.mockResolvedValue(null);
+  });
+
+  afterEach(cleanup);
+
+  it("shows the current storage location even without legacy cleanup", async () => {
+    renderView();
+
+    expect(screen.getByText("Storage")).toBeTruthy();
+    expect(
+      screen.getByText("Where your notes and recordings are stored"),
+    ).toBeTruthy();
+    expect(await screen.findByText("~/Google Drive/Anarlog")).toBeTruthy();
+    expect(screen.queryByText("Legacy cleanup")).toBeNull();
+  });
+
+  it("copies the vault, updates the location, and relaunches", async () => {
+    mocks.selectFolder.mockResolvedValue("/Users/test/Anarlog");
+    renderView();
+
+    await screen.findByText("~/Google Drive/Anarlog");
+    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+
+    await waitFor(() => {
+      expect(mocks.copyVault).toHaveBeenCalledWith("/Users/test/Anarlog");
+      expect(mocks.setVaultBase).toHaveBeenCalledWith("/Users/test/Anarlog");
+      expect(mocks.scheduleAutomaticRelaunch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not update the location when copying fails", async () => {
+    mocks.selectFolder.mockResolvedValue("/Users/test/Anarlog");
+    mocks.copyVault.mockResolvedValue({
+      status: "error",
+      error: "Could not copy storage",
+    });
+    renderView();
+
+    await screen.findByText("~/Google Drive/Anarlog");
+    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+
+    expect(await screen.findByText("Could not copy storage")).toBeTruthy();
+    expect(mocks.setVaultBase).not.toHaveBeenCalled();
+    expect(mocks.scheduleAutomaticRelaunch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/settings/general/storage/index.test.tsx
+++ b/apps/desktop/src/settings/general/storage/index.test.tsx
@@ -10,12 +10,12 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  copyVault: vi.fn(),
+  flushApplicationState: vi.fn(),
   homeDir: vi.fn(),
+  moveVault: vi.fn(),
   openPath: vi.fn(),
   scheduleAutomaticRelaunch: vi.fn(),
   selectFolder: vi.fn(),
-  setVaultBase: vi.fn(),
   vaultBase: vi.fn(),
 }));
 
@@ -40,12 +40,12 @@ vi.mock("@anlg/plugin-opener2", () => ({
 }));
 vi.mock("@anlg/plugin-settings", () => ({
   commands: {
-    copyVault: mocks.copyVault,
-    setVaultBase: mocks.setVaultBase,
+    moveVault: mocks.moveVault,
     vaultBase: mocks.vaultBase,
   },
 }));
 vi.mock("~/shared/relaunch", () => ({
+  flushApplicationState: mocks.flushApplicationState,
   scheduleAutomaticRelaunch: mocks.scheduleAutomaticRelaunch,
 }));
 vi.mock("./legacy-cleanup", () => ({
@@ -75,8 +75,8 @@ describe("StorageSettingsView", () => {
       status: "ok",
       data: "/Users/test/Google Drive/Anarlog",
     });
-    mocks.copyVault.mockResolvedValue({ status: "ok", data: null });
-    mocks.setVaultBase.mockResolvedValue({ status: "ok", data: null });
+    mocks.flushApplicationState.mockResolvedValue(undefined);
+    mocks.moveVault.mockResolvedValue({ status: "ok", data: null });
     mocks.scheduleAutomaticRelaunch.mockResolvedValue("scheduled");
     mocks.selectFolder.mockResolvedValue(null);
   });
@@ -94,7 +94,7 @@ describe("StorageSettingsView", () => {
     expect(screen.queryByText("Legacy cleanup")).toBeNull();
   });
 
-  it("copies the vault, updates the location, and relaunches", async () => {
+  it("flushes pending writes, moves the vault, and relaunches", async () => {
     mocks.selectFolder.mockResolvedValue("/Users/test/Anarlog");
     renderView();
 
@@ -102,25 +102,45 @@ describe("StorageSettingsView", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Change" }));
 
     await waitFor(() => {
-      expect(mocks.copyVault).toHaveBeenCalledWith("/Users/test/Anarlog");
-      expect(mocks.setVaultBase).toHaveBeenCalledWith("/Users/test/Anarlog");
+      expect(mocks.flushApplicationState).toHaveBeenCalledTimes(1);
+      expect(mocks.moveVault).toHaveBeenCalledWith("/Users/test/Anarlog");
       expect(mocks.scheduleAutomaticRelaunch).toHaveBeenCalledTimes(1);
     });
+
+    expect(
+      mocks.flushApplicationState.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.moveVault.mock.invocationCallOrder[0]);
   });
 
-  it("does not update the location when copying fails", async () => {
+  it("does not relaunch when moving the vault fails", async () => {
     mocks.selectFolder.mockResolvedValue("/Users/test/Anarlog");
-    mocks.copyVault.mockResolvedValue({
+    mocks.moveVault.mockResolvedValue({
       status: "error",
-      error: "Could not copy storage",
+      error: "Could not move storage",
     });
     renderView();
 
     await screen.findByText("~/Google Drive/Anarlog");
     fireEvent.click(await screen.findByRole("button", { name: "Change" }));
 
-    expect(await screen.findByText("Could not copy storage")).toBeTruthy();
-    expect(mocks.setVaultBase).not.toHaveBeenCalled();
+    expect(await screen.findByText("Could not move storage")).toBeTruthy();
+    expect(mocks.scheduleAutomaticRelaunch).not.toHaveBeenCalled();
+  });
+
+  it("does not move the vault when pending writes fail to flush", async () => {
+    mocks.selectFolder.mockResolvedValue("/Users/test/Anarlog");
+    mocks.flushApplicationState.mockRejectedValue(
+      new Error("Could not save pending changes"),
+    );
+    renderView();
+
+    await screen.findByText("~/Google Drive/Anarlog");
+    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+
+    expect(
+      await screen.findByText("Could not save pending changes"),
+    ).toBeTruthy();
+    expect(mocks.moveVault).not.toHaveBeenCalled();
     expect(mocks.scheduleAutomaticRelaunch).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -1,13 +1,109 @@
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { CircleNotch, FolderSimple } from "@phosphor-icons/react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { homeDir } from "@tauri-apps/api/path";
+import { open as selectFolder } from "@tauri-apps/plugin-dialog";
+
+import { commands as openerCommands } from "@anlg/plugin-opener2";
+import { commands as settingsCommands } from "@anlg/plugin-settings";
+import { Button } from "@anlg/ui/components/ui/button";
 
 import {
   LegacyMigrationCleanupRow,
   useLegacyMigrationCleanup,
 } from "./legacy-cleanup";
+import { displayPath } from "./path-utils";
+
+import { scheduleAutomaticRelaunch } from "~/shared/relaunch";
+
+function StorageLocationRow() {
+  const { t } = useLingui();
+  const { data: home } = useQuery({ queryKey: ["home-dir"], queryFn: homeDir });
+  const vaultBaseQuery = useQuery({
+    queryKey: ["vault-base-path"],
+    queryFn: async () => {
+      const result = await settingsCommands.vaultBase();
+      if (result.status === "error") {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
+  });
+  const changeMutation = useMutation({
+    mutationFn: async (newPath: string) => {
+      const copyResult = await settingsCommands.copyVault(newPath);
+      if (copyResult.status === "error") {
+        throw new Error(copyResult.error);
+      }
+
+      const setResult = await settingsCommands.setVaultBase(newPath);
+      if (setResult.status === "error") {
+        throw new Error(setResult.error);
+      }
+
+      await scheduleAutomaticRelaunch();
+    },
+  });
+
+  const handleChange = async () => {
+    const selected = await selectFolder({
+      title: t`Choose storage location`,
+      directory: true,
+      multiple: false,
+      defaultPath: vaultBaseQuery.data,
+    });
+
+    if (selected && selected !== vaultBaseQuery.data) {
+      changeMutation.mutate(selected);
+    }
+  };
+
+  return (
+    <div>
+      <div className="grid grid-cols-[minmax(0,1fr)_9rem] items-center gap-3">
+        <button
+          type="button"
+          className="hover:bg-muted/40 flex min-w-0 items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors"
+          disabled={!vaultBaseQuery.data}
+          onClick={() => {
+            if (vaultBaseQuery.data) {
+              void openerCommands.openPath(vaultBaseQuery.data, null);
+            }
+          }}
+        >
+          <FolderSimple className="text-muted-foreground size-4 shrink-0" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium">
+              <Trans>Where your notes and recordings are stored</Trans>
+            </p>
+            <p className="text-muted-foreground truncate text-xs">
+              {displayPath(vaultBaseQuery.data, home)}
+            </p>
+          </div>
+        </button>
+        <Button
+          variant="outline"
+          className="h-9 w-full justify-center"
+          disabled={vaultBaseQuery.isPending || changeMutation.isPending}
+          onClick={() => void handleChange()}
+        >
+          {changeMutation.isPending && (
+            <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
+          )}
+          <Trans>Change</Trans>
+        </Button>
+      </div>
+      {(vaultBaseQuery.error || changeMutation.error) && (
+        <p className="mt-1 text-xs text-red-500">
+          {(vaultBaseQuery.error ?? changeMutation.error)?.message}
+        </p>
+      )}
+    </div>
+  );
+}
 
 export function StorageSettingsView() {
   const { visible } = useLegacyMigrationCleanup();
-  if (!visible) return null;
 
   return (
     <div>
@@ -15,7 +111,8 @@ export function StorageSettingsView() {
         <Trans>Storage</Trans>
       </h2>
       <div className="flex flex-col gap-3">
-        <LegacyMigrationCleanupRow />
+        <StorageLocationRow />
+        {visible && <LegacyMigrationCleanupRow />}
       </div>
     </div>
   );

--- a/apps/desktop/src/settings/general/storage/index.tsx
+++ b/apps/desktop/src/settings/general/storage/index.tsx
@@ -14,7 +14,10 @@ import {
 } from "./legacy-cleanup";
 import { displayPath } from "./path-utils";
 
-import { scheduleAutomaticRelaunch } from "~/shared/relaunch";
+import {
+  flushApplicationState,
+  scheduleAutomaticRelaunch,
+} from "~/shared/relaunch";
 
 function StorageLocationRow() {
   const { t } = useLingui();
@@ -31,14 +34,11 @@ function StorageLocationRow() {
   });
   const changeMutation = useMutation({
     mutationFn: async (newPath: string) => {
-      const copyResult = await settingsCommands.copyVault(newPath);
-      if (copyResult.status === "error") {
-        throw new Error(copyResult.error);
-      }
+      await flushApplicationState();
 
-      const setResult = await settingsCommands.setVaultBase(newPath);
-      if (setResult.status === "error") {
-        throw new Error(setResult.error);
+      const moveResult = await settingsCommands.moveVault(newPath);
+      if (moveResult.status === "error") {
+        throw new Error(moveResult.error);
       }
 
       await scheduleAutomaticRelaunch();

--- a/apps/desktop/src/shared/relaunch.ts
+++ b/apps/desktop/src/shared/relaunch.ts
@@ -9,7 +9,7 @@ let pendingAutomaticRelaunch = false;
 let automaticRelaunchTimeout: ReturnType<typeof setTimeout> | null = null;
 const APPLICATION_STATE_FLUSH_TIMEOUT_MS = 5000;
 
-async function saveApplicationState(): Promise<void> {
+export async function flushApplicationState(): Promise<void> {
   const results = await Promise.allSettled([
     flushDatabaseWritesWithin(APPLICATION_STATE_FLUSH_TIMEOUT_MS),
     store2Commands.save(),
@@ -20,7 +20,7 @@ async function saveApplicationState(): Promise<void> {
 
 async function relaunch(): Promise<void> {
   try {
-    await saveApplicationState();
+    await flushApplicationState();
   } catch (error) {
     console.error("Failed to flush application data before relaunch", error);
   }


### PR DESCRIPTION
## Summary

- restore the storage location control under Settings → General → Storage
- copy existing recordings and attachments before switching the vault path and relaunching
- keep legacy migration cleanup conditional while always showing the active storage path
- add coverage for visibility, successful migration, and copy failures

## Verification

- pnpm exec dprint fmt
- pnpm fmt:check
- pnpm -F desktop typecheck
- NODE_OPTIONS=--no-experimental-webstorage pnpm -F desktop test (3,947 tests)
- pnpm exec oxlint --quiet --format=github apps/desktop/src/
- pnpm -F desktop i18n:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the vault path moves user data on disk and forces a relaunch; incorrect ordering or partial failure could affect local notes and recordings.
> 
> **Overview**
> **Restores changing where the desktop app stores notes and recordings** from **Settings → General → Storage**, not only during onboarding.
> 
> The screen always shows the active vault path (with a home-directory shortcut), lets users open that folder, and offers **Change** to pick a new directory. A successful change **flushes pending app state**, calls **`moveVault`** on the new path, then **schedules an automatic relaunch**; failures surface inline and skip relaunch when the move does not complete.
> 
> **Legacy migration cleanup** stays optional and only renders when the legacy hook says it is needed. Lingui catalogs now attribute shared strings (`Change`, `Choose storage location`, storage description) to `storage/index.tsx` as well as onboarding. **New unit tests** cover default visibility, the flush → move → relaunch order, and error paths when flush or move fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41de96121f1425442c08e47e72379eb786be536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->