### PR TITLE
Prevent stale witness reconciliation loops

### DIFF
--- a/crates/db-app/src/e2ee/tests/revision_conflicts.rs
+++ b/crates/db-app/src/e2ee/tests/revision_conflicts.rs
@@ -105,6 +105,126 @@ async fn rejects_and_repairs_replayed_older_field_revisions() {
 }
 
 #[tokio::test]
+async fn stale_witness_repair_keeps_newer_local_replica_pending_for_upload() {
+    let db = test_db().await;
+    let workspace_keys = keys("workspace-a");
+    let key = &workspace_keys["workspace-a"];
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session-1', 'workspace-a', 'user-a', 'First')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    encrypt_e2ee_replica_changes(db.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    let initial = pending_e2ee_witness_uploads(db.pool(), "workspace-a", key, 128, usize::MAX)
+        .await
+        .unwrap();
+    let title_record_id = key.blind_field_id("sessions", "session-1", "title");
+    let stale_title = initial
+        .iter()
+        .find(|upload| upload.record_id == title_record_id)
+        .unwrap()
+        .clone();
+    let initial_events = initial
+        .iter()
+        .enumerate()
+        .map(|(index, upload)| E2eeWitnessEvent {
+            sequence: u64::try_from(index + 1).unwrap(),
+            record_id: upload.record_id.clone(),
+            workspace_id: upload.workspace_id.clone(),
+            payload_hash: upload.payload_hash.clone(),
+            payload: upload.payload.clone(),
+        })
+        .collect::<Vec<_>>();
+    merge_e2ee_witness_events(db.pool(), key, "workspace-a", &initial_events)
+        .await
+        .unwrap();
+    let initial_stats =
+        apply_received_e2ee_replica_changes_with_witness(db.pool(), &workspace_keys, true)
+            .await
+            .unwrap();
+    assert!(!initial_stats.remaining_replica_changes);
+
+    sqlx::query("UPDATE sessions SET title = 'Second' WHERE id = 'session-1'")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    encrypt_e2ee_replica_changes(db.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    let current_payload: String =
+        sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+            .bind(&title_record_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+    merge_e2ee_witness_events(
+        db.pool(),
+        key,
+        "workspace-a",
+        &[E2eeWitnessEvent {
+            sequence: u64::try_from(initial.len() + 1).unwrap(),
+            record_id: stale_title.record_id,
+            workspace_id: stale_title.workspace_id,
+            payload_hash: stale_title.payload_hash,
+            payload: stale_title.payload,
+        }],
+    )
+    .await
+    .unwrap();
+
+    let stats = apply_received_e2ee_replica_changes_with_witness(db.pool(), &workspace_keys, true)
+        .await
+        .unwrap();
+    let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    let replica_payload: String =
+        sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+            .bind(&title_record_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    let replica_pending: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_replica_pending WHERE record_id = ?")
+            .bind(&title_record_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    let repair_pending: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_witness_repair_pending WHERE record_id = ?")
+            .bind(&title_record_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    let witness_pending: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_witness_pending WHERE record_id = ?")
+            .bind(&title_record_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+    assert!(!stats.remaining_replica_changes);
+    assert_eq!(title, "Second");
+    assert_eq!(replica_payload, current_payload);
+    assert_eq!(replica_pending, 0);
+    assert_eq!(repair_pending, 0);
+    assert_eq!(witness_pending, 1);
+
+    let repeated =
+        apply_received_e2ee_replica_changes_with_witness(db.pool(), &workspace_keys, true)
+            .await
+            .unwrap();
+    assert!(!repeated.remaining_replica_changes);
+}
+
+#[tokio::test]
 async fn equal_revision_payloads_converge_and_repair_the_replica() {
     let db = test_db().await;
     let workspace_keys = keys("workspace-a");

--- a/crates/db-app/src/e2ee/witness.rs
+++ b/crates/db-app/src/e2ee/witness.rs
@@ -662,8 +662,31 @@ async fn load_bounded_e2ee_witness_repairs(
                  replica.id IS NOT NULL
                  AND (
                    replica.workspace_id != witness.workspace_id
-                   OR replica_hash.record_id IS NULL
-                   OR replica_hash.payload_hash != witness.payload_hash
+                   OR (
+                     (
+                       replica_hash.record_id IS NULL
+                       OR replica_hash.payload_hash != witness.payload_hash
+                     )
+                     AND NOT EXISTS (
+                       SELECT 1
+                       FROM e2ee_local_state AS local
+                       WHERE local.record_id = replica.id
+                         AND local.workspace_id = replica.workspace_id
+                         AND local.payload_hash = replica_hash.payload_hash
+                         AND (
+                           local.revision > witness.revision
+                           OR (
+                             local.revision = witness.revision
+                             AND local.writer_id > witness.writer_id
+                           )
+                           OR (
+                             local.revision = witness.revision
+                             AND local.writer_id = witness.writer_id
+                             AND local.payload_hash > witness.payload_hash
+                           )
+                         )
+                     )
+                   )
                  )
                )
              ) AS needs_repair


### PR DESCRIPTION
Keep locally newer ciphertext authoritative during witness repair and cover the reconciliation drain path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes E2EE witness–replica reconciliation SQL and authority rules; incorrect logic could leave replicas unsynced or skip needed repairs, though behavior is locked down by a targeted test.
> 
> **Overview**
> **Witness repair no longer overwrites locally newer ciphertext** when the replica disagrees with a stale witness entry. The bounded witness-repair scan’s `needs_repair` predicate in `witness.rs` now treats hash/replica mismatches as reconciled if `e2ee_local_state` already holds the replica’s payload hash and wins on revision, `writer_id`, or payload-hash tie-break—so repair pending can drain without rolling the replica back to the witness.
> 
> A new integration test in `revision_conflicts.rs` replays a stale witness event after a local title update: plaintext and replica ciphertext stay on the newer value, replica/repair pending clear, and **`e2ee_witness_pending` stays set** so the newer local state is uploaded instead of looping reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa90645acc50b22efa5811bb2d05e90988700bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->