### PR TITLE
Update product documentation to match current behavior

### DIFF
--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -121,17 +121,17 @@ Do not use custom trace propagation headers when W3C exists.
 
 Rust shared helpers live in:
 
-- [`crates/observability/src/lib.rs`](/Users/yujonglee/dev/char/crates/observability/src/lib.rs)
+- [`crates/observability/src/lib.rs`](crates/observability/src/lib.rs)
 
 API ingress extraction and root HTTP span setup live in:
 
-- [`apps/api/src/main.rs`](/Users/yujonglee/dev/char/apps/api/src/main.rs)
+- [`apps/api/src/main.rs`](apps/api/src/main.rs)
 
 Desktop request header creation lives in:
 
-- [`apps/desktop/src/shared/utils.ts`](/Users/yujonglee/dev/char/apps/desktop/src/shared/utils.ts)
-- [`apps/desktop/src/ai/traced-fetch.ts`](/Users/yujonglee/dev/char/apps/desktop/src/ai/traced-fetch.ts)
-- [`apps/desktop/src/auth/context.tsx`](/Users/yujonglee/dev/char/apps/desktop/src/auth/context.tsx)
+- [`apps/desktop/src/shared/utils.ts`](apps/desktop/src/shared/utils.ts)
+- [`apps/desktop/src/ai/traced-fetch.ts`](apps/desktop/src/ai/traced-fetch.ts)
+- [`apps/desktop/src/auth/context.tsx`](apps/desktop/src/auth/context.tsx)
 
 ### Baggage policy
 
@@ -173,12 +173,12 @@ Never do this:
 
 API ingress uses request-id middleware and records the value on the root span:
 
-- [`apps/api/src/main.rs`](/Users/yujonglee/dev/char/apps/api/src/main.rs)
+- [`apps/api/src/main.rs`](apps/api/src/main.rs)
 
 Desktop client requests add `x-request-id` separately from `traceparent`:
 
-- [`apps/desktop/src/ai/traced-fetch.ts`](/Users/yujonglee/dev/char/apps/desktop/src/ai/traced-fetch.ts)
-- [`apps/desktop/src/auth/context.tsx`](/Users/yujonglee/dev/char/apps/desktop/src/auth/context.tsx)
+- [`apps/desktop/src/ai/traced-fetch.ts`](apps/desktop/src/ai/traced-fetch.ts)
+- [`apps/desktop/src/auth/context.tsx`](apps/desktop/src/auth/context.tsx)
 
 ## Naming Rules
 
@@ -520,19 +520,19 @@ Do not do any of the following:
 
 The current implementation that this spec describes is centered in:
 
-- [`apps/api/src/observability.rs`](/Users/yujonglee/dev/char/apps/api/src/observability.rs)
-- [`apps/api/src/main.rs`](/Users/yujonglee/dev/char/apps/api/src/main.rs)
-- [`apps/api/src/auth.rs`](/Users/yujonglee/dev/char/apps/api/src/auth.rs)
-- [`crates/observability/src/lib.rs`](/Users/yujonglee/dev/char/crates/observability/src/lib.rs)
-- [`crates/llm-proxy/src/handler/mod.rs`](/Users/yujonglee/dev/char/crates/llm-proxy/src/handler/mod.rs)
-- [`crates/llm-proxy/src/handler/non_streaming.rs`](/Users/yujonglee/dev/char/crates/llm-proxy/src/handler/non_streaming.rs)
-- [`crates/llm-proxy/src/handler/streaming.rs`](/Users/yujonglee/dev/char/crates/llm-proxy/src/handler/streaming.rs)
-- [`crates/transcribe-proxy/src/routes/streaming/mod.rs`](/Users/yujonglee/dev/char/crates/transcribe-proxy/src/routes/streaming/mod.rs)
-- [`crates/transcribe-proxy/src/routes/streaming/session.rs`](/Users/yujonglee/dev/char/crates/transcribe-proxy/src/routes/streaming/session.rs)
-- [`apps/desktop/src/shared/utils.ts`](/Users/yujonglee/dev/char/apps/desktop/src/shared/utils.ts)
-- [`apps/desktop/src/ai/traced-fetch.ts`](/Users/yujonglee/dev/char/apps/desktop/src/ai/traced-fetch.ts)
-- [`apps/desktop/src/auth/context.tsx`](/Users/yujonglee/dev/char/apps/desktop/src/auth/context.tsx)
-- [`apps/desktop/src-tauri/src/lib.rs`](/Users/yujonglee/dev/char/apps/desktop/src-tauri/src/lib.rs)
+- [`apps/api/src/observability.rs`](apps/api/src/observability.rs)
+- [`apps/api/src/main.rs`](apps/api/src/main.rs)
+- [`apps/api/src/auth.rs`](apps/api/src/auth.rs)
+- [`crates/observability/src/lib.rs`](crates/observability/src/lib.rs)
+- [`crates/llm-proxy/src/handler/mod.rs`](crates/llm-proxy/src/handler/mod.rs)
+- [`crates/llm-proxy/src/handler/non_streaming.rs`](crates/llm-proxy/src/handler/non_streaming.rs)
+- [`crates/llm-proxy/src/handler/streaming.rs`](crates/llm-proxy/src/handler/streaming.rs)
+- [`crates/transcribe-proxy/src/routes/streaming/mod.rs`](crates/transcribe-proxy/src/routes/streaming/mod.rs)
+- [`crates/transcribe-proxy/src/routes/streaming/session.rs`](crates/transcribe-proxy/src/routes/streaming/session.rs)
+- [`apps/desktop/src/shared/utils.ts`](apps/desktop/src/shared/utils.ts)
+- [`apps/desktop/src/ai/traced-fetch.ts`](apps/desktop/src/ai/traced-fetch.ts)
+- [`apps/desktop/src/auth/context.tsx`](apps/desktop/src/auth/context.tsx)
+- [`apps/desktop/src-tauri/src/lib.rs`](apps/desktop/src-tauri/src/lib.rs)
 
 ## Change Policy
 

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -40,7 +40,7 @@ Open the desktop app once so it can create the database. The app does not need t
 }
 ```
 
-If `anarlog` is not on the client's `PATH`, use the executable's absolute path as `command`. On Flatpak, substitute `anarlog-cli` for `anarlog`. Restart the client after changing its configuration.
+If `anarlog` is not on the client's `PATH`, use the executable's absolute path as `command`. Restart the client after changing its configuration.
 
 For a custom database path:
 

--- a/docs/chat.mdx
+++ b/docs/chat.mdx
@@ -9,8 +9,7 @@ Anarlog Chat can answer questions about the open meeting, search your other meet
 
 1. Open a meeting note.
 2. Open **Chat**.
-3. Check the context chips above the input. The open meeting is added automatically when its content is available.
-4. Ask a question or choose a suggested prompt.
+3. Ask a question or choose a suggested prompt. The open meeting is added automatically when its content is available.
 
 Useful requests include:
 
@@ -22,15 +21,11 @@ Useful requests include:
 
 Chat can search meeting titles and content, recurring meeting history, contacts, and connected calendar events when the request needs them.
 
-## Control the context
+## Guide the context
 
-Context chips show the meetings, people, and other records Chat can use for the next message.
+Chat uses the open meeting automatically and can add other meetings, people, and records when your request needs them. You can also drag another meeting into Chat to include it in your next message.
 
-- Click a meeting or contact chip to open it.
-- Hover over a removable chip and click its remove button to exclude it.
-- Start a new chat when you want a clean conversation without the earlier message history.
-
-Check these chips before asking about sensitive or similarly named meetings. A clear request such as “Use only this meeting” also helps keep the answer scoped.
+The app does not show this context as removable chips. Name the meeting or person in your request when similarly named records could be confused, or say “Use only this meeting” to keep the answer scoped. Start a new chat when you want a clean conversation without the earlier message history.
 
 ## Review proposed changes
 

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -56,7 +56,7 @@ Deleting retained audio does not remove the meeting note or transcript. If you n
 
 Open **Settings → Privacy** and disable **Share usage data (PostHog)**. This controls product analytics and desktop session replay, not the meeting content sent to a provider you selected.
 
-Disable **Sentry** on the same page to stop sending sanitized crash and error reports.
+Disable **Error** on the same page to stop sending sanitized crash and error reports.
 
 <Warning>
   Recording-consent rules depend on where you and the other participants are located. Make sure you have permission before recording.

--- a/docs/desktop-installation.mdx
+++ b/docs/desktop-installation.mdx
@@ -12,8 +12,10 @@ description: "Choose the right Anarlog build for macOS, Windows, or Linux."
 | macOS | Apple Silicon DMG | For Macs with an M-series chip. Requires macOS 15 or later. |
 | macOS | Intel DMG | For Intel-based Macs. Requires macOS 15 or later. |
 | Windows | Windows x64 EXE | For 64-bit Windows PCs. Windows support is in beta. |
+| Windows | Microsoft Store | For Windows 10 and 11. Windows support is in beta. |
 | Linux | x64 or ARM64 AppImage | Portable build. Linux support is in beta. |
 | Linux | x64 or ARM64 DEB | For Debian, Ubuntu, and compatible distributions. Linux support is in beta. |
+| Linux | Arch Linux PKGBUILD | For x64 or ARM64 Arch-based distributions. Linux support is in beta. |
 
 On a Mac, open **Apple menu → About This Mac** if you do not know whether it uses an Apple or Intel chip.
 
@@ -26,8 +28,8 @@ On a Mac, open **Apple menu → About This Mac** if you do not know whether it u
 
 ## Windows
 
-1. Download the **Windows x64** installer.
-2. Run the EXE and follow the installer.
+1. Download the **Windows x64** installer or [get Anarlog from Microsoft Store](https://apps.microsoft.com/detail/XPDLN196NKSW10).
+2. For the direct download, run the EXE and follow the installer. Microsoft Store handles installation and updates automatically.
 3. Open Anarlog and complete setup.
 4. Allow microphone and system-audio access when prompted.
 
@@ -87,6 +89,18 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 WEBKIT_DISABLE_COMPOSITING_MODE=1 ./anarlog-*.A
 ```
 
 Current builds apply the DMA-BUF workaround automatically. Set the variables yourself only if a black window remains.
+
+### Arch Linux
+
+Build the maintained `anarlog-bin` package with `makepkg`:
+
+```bash
+git clone https://github.com/fastrepl/anarlog.git
+cd anarlog/packaging/aur/anarlog-bin
+makepkg -si
+```
+
+The PKGBUILD downloads the stable DEB for your architecture, verifies its checksum, and installs it through pacman.
 
 ## Platform differences
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,6 +28,7 @@
           "imports",
           "notes",
           "sharing",
+          "teams",
           "chat",
           "customize-summaries",
           "calendar",

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -19,7 +19,6 @@ Open **Settings → Developers** and select **Install** (or **Reinstall**). Dire
 | --- | --- | --- |
 | macOS | `anarlog` | `~/.local/bin/anarlog` |
 | Linux (DEB / AppImage) | `anarlog` | `~/.local/bin/anarlog` |
-| Linux (Flatpak) | `anarlog-cli` | Preinstalled host wrapper; Settings install is optional |
 | Windows | `anarlog` | `%LOCALAPPDATA%\Anarlog\bin\anarlog.exe` (added to your user PATH) |
 
 On macOS and Linux, add `~/.local/bin` to `PATH` if your shell cannot find `anarlog`:

--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -36,7 +36,7 @@ The managed Transcription route chooses a provider from the meeting's languages 
 - Soniox currently resolves it to **Soniox 5**: `stt-rt-v5` for live transcription and `stt-async-v5` after recording.
 - AssemblyAI currently resolves it to **Universal 3.5 Pro** (`universal-3-5-pro`) for live and after-recording transcription.
 - After-recording transcription prefers Soniox when it supports the selected languages.
-- The eligible fallback pool also includes configured routes for Gladia (currently **Solaria 1**), ElevenLabs, Fireworks, OpenAI, Mistral, and Alibaba Cloud Model Studio.
+- The eligible fallback pool also includes configured routes for Gladia (currently **Solaria 1**), ElevenLabs, OpenAI, Mistral, and Alibaba Cloud Model Studio.
 
 Only configured providers that support the requested mode and languages enter the route. If one returns a retryable error, Anarlog can try the next eligible provider.
 
@@ -106,8 +106,9 @@ Recent bring-your-own Transcription models in Settings include:
 
 - **Google Gemini 3.5 Transcribe** (`gemini-3.5-transcribe-live` during the meeting, `gemini-3.5-transcribe` after recording)
 - **AssemblyAI Universal 3.5 Pro** (`universal-3-5-pro-realtime` during the meeting, `universal-3-5-pro` after recording)
+- **Smallest AI Pulse** (`pulse`) and **Pulse Pro** (`pulse-pro`) for live and after-recording transcription
 
-Settings may still show older model IDs for compatibility. Prefer the current Gemini 3.5, Universal 3.5, Soniox 5, and GPT Transcribe models when you configure a provider yourself.
+Settings may still show older model IDs for compatibility. Prefer the current Gemini 3.5, Universal 3.5, Soniox 5, Smallest AI Pulse, and GPT Transcribe models when you configure a provider yourself.
 
 ## Choose a setup
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -25,7 +25,7 @@ description: "Set up Anarlog and try a private demo before your next call."
 
 - The sidebar keeps upcoming meetings and recent notes within reach.
 - The center of the app shows the open memo, summary, or transcript.
-- **Chat** works with the open meeting and any context shown above its input.
+- **Chat** works with the open meeting and any additional context you add.
 - **Settings** controls audio, AI providers, storage, sync, imports, integrations, and developer tools.
 
 You can rename a note from its title and keep several notes open in tabs. A meeting note stays useful before, during, and after the call.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -17,7 +17,7 @@ anarlog [--base DIR] [--db-path FILE] [--json] <command>
 
 `--db-path` takes precedence over `--base`. Without either option, the CLI uses Anarlog's platform application-data directory and recognized legacy locations.
 
-On Flatpak, the host command is `anarlog-cli`. On DEB, AppImage, macOS, Windows, and Settings-installed builds, the command is `anarlog`. Substitute `anarlog-cli` only when that is the command on your PATH.
+The installed command is `anarlog` on DEB, AppImage, macOS, Windows, and Settings-installed builds.
 
 ## Account commands
 

--- a/docs/sharing.mdx
+++ b/docs/sharing.mdx
@@ -41,6 +41,8 @@ There is no global switch for sharing emails because Anarlog does not send them 
 
 Invited people can have **Can view** or **Can comment** access. The note owner keeps full access and can change or revoke each person's access.
 
+See [Teams and shared libraries](/teams) to create a workspace, manage members, or share reusable folders, templates, and automations.
+
 <Warning>
   Treat an **Anyone with the link** URL like sensitive data. Replace the link if it was sent to the wrong place, or switch General access back to invited-only.
 </Warning>

--- a/docs/sync.mdx
+++ b/docs/sync.mdx
@@ -78,13 +78,15 @@ This includes Obsidian vaults stored in iCloud Drive.
 
 Anarlog shows a warning in **Settings → Sync** when your storage location is inside a known cloud-storage folder. Backup tools that snapshot files without continuously syncing them back are fine.
 
-Anarlog does not currently expose a control for changing a storage location selected in an older version. If you see this warning:
+If you see this warning:
 
-1. Turn off Cloud sync so changes remain on this device.
-2. Leave the existing folder in place. Do not move or delete it manually.
-3. Email [founders@anarlog.so](mailto:founders@anarlog.so) with your operating system and the cloud-storage service named in the warning.
+1. Pause Cloud sync so changes remain on this device while the files move.
+2. Open **Settings → General** and find **Storage**.
+3. Click **Change** and choose a local folder that is not managed by a file-syncing service.
+4. Wait for Anarlog to move the data and relaunch automatically.
+5. Return to **Settings → Sync**, confirm that the warning is gone, and resume sync.
 
-Notes and transcripts migrated to the local app data store, but saved recordings and attachments may still depend on the existing folder.
+Use **Change** instead of moving or deleting the storage folder manually. If the move fails, leave the existing folder in place and email [founders@anarlog.so](mailto:founders@anarlog.so) with your operating system and the error shown in Settings.
 
 ## Fix a blocked sync
 

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -1,0 +1,55 @@
+---
+title: "Teams and shared libraries"
+description: "Create a shared workspace, manage members, and share reusable folders, templates, and automations."
+---
+
+Teams give a group shared membership for meeting-note access and reusable resources. Your personal notes remain private unless you share them.
+
+## Create a workspace
+
+1. Sign in to Anarlog.
+2. Open **Settings → Teams**.
+3. Enter a workspace name and click **Create**. If workspace creation is locked, upgrade to Pro first.
+4. If the workspace needs shared billing and Pro for every member, use **Start Team** to continue to Team checkout.
+
+Use the workspace tabs at the top of Teams settings to switch between workspaces or create another one.
+
+## Invite and manage members
+
+Workspace owners and admins can open **Members** to:
+
+- Invite a teammate by email
+- Resend or cancel a pending invitation
+- Change a member between the Admin and Member roles
+- Remove a member
+
+Only the owner can transfer ownership. Transfer ownership before leaving when someone else should keep the workspace. Deleting a workspace removes it for everyone.
+
+## Share a meeting with the workspace
+
+Open a meeting's **Share** panel and set **General access** to the workspace. Everyone in that workspace can then open the shared note. The meeting's private memo is not included.
+
+See [Share meetings](/sharing) for invitations, links, comments, and shared audio.
+
+## Share a reusable resource
+
+You can share a folder, template, or automation:
+
+1. Open the folder, template, or automation and click **Share**.
+2. Under **Team library**, choose a workspace.
+3. Click **Add**.
+
+You can also invite one guest by email without adding them to the Team. A guest can access one shared item for free; add them as a Team member when they need more.
+
+Shared resources appear under **Shared with me** in the corresponding Folders, Templates, or Automations view. Click one and choose **Add a copy**. The copy is yours to edit and does not change the shared original.
+
+To change access, open **Share** on the original item. You can move it to another Team library, remove a guest, or choose **Stop sharing**.
+
+## Plans
+
+- **Free** keeps notes and local features on your computer.
+- **Pro** adds personal cloud features and lets you share reusable resources with guests.
+- **Team** adds shared workspaces, roles, Pro for every member, and centralized billing.
+- **Enterprise** can add organization controls such as sharing policies, usage visibility, a custom workspace subdomain, SSO, SCIM, retention, and managed capture.
+
+See [Anarlog pricing](https://anarlog.so/pricing) for current prices and plan availability.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -52,9 +52,9 @@ If you already removed the source app, reinstall it long enough to complete the 
 
 ## Chat has no meeting context
 
-Open the meeting before opening Chat and wait for its transcript or summary to finish. Check the context chips above the input. If no Intelligence model is configured, open **Settings → Intelligence**.
+Open the meeting before opening Chat and wait for its transcript or summary to finish. The open meeting is added automatically when its content is available. If Chat still answers without it, start a new chat from that meeting and name the meeting in your request. If no Intelligence model is configured, open **Settings → Intelligence**.
 
-See [Chat with your meetings](/chat) for context controls and example requests.
+See [Chat with your meetings](/chat) for context guidance and example requests.
 
 ## Sharing does not work
 


### PR DESCRIPTION
Refresh storage, chat, provider, installation, team, privacy, and observability guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and navigation changes only; no application code or runtime behavior is modified.
> 
> **Overview**
> **Documentation-only refresh** so user-facing guides match current product behavior, distribution channels, and settings labels.
> 
> **New and expanded topics:** Adds [`docs/teams.mdx`](docs/teams.mdx) (workspaces, members, team libraries for folders/templates/automations, plans) and wires it into [`docs/docs.json`](docs/docs.json) and [`docs/sharing.mdx`](docs/sharing.mdx). **Chat** docs ([`docs/chat.mdx`](docs/chat.mdx), [`docs/quickstart.mdx`](docs/quickstart.mdx), [`docs/troubleshooting.mdx`](docs/troubleshooting.mdx)) drop removable **context chips** in favor of automatic open-meeting context, drag-to-add meetings, and prompt-based scoping.
> 
> **Install and CLI:** [`docs/desktop-installation.mdx`](docs/desktop-installation.mdx) documents **Microsoft Store** and **Arch** (`makepkg`) installs; MCP/CLI pages remove **Flatpak** / `anarlog-cli` guidance ([`docs/agents/mcp.mdx`](docs/agents/mcp.mdx), [`docs/installation.mdx`](docs/installation.mdx), [`docs/reference/cli.mdx`](docs/reference/cli.mdx)).
> 
> **Other accuracy updates:** [`docs/sync.mdx`](docs/sync.mdx) documents self-service **Settings → General → Storage → Change** when data lives in a cloud-sync folder (replacing “contact support” steps). [`docs/models-and-providers.mdx`](docs/models-and-providers.mdx) adds **Smallest AI Pulse** BYO models and drops **Fireworks** from the cloud fallback list. Privacy copy uses **Error** instead of **Sentry** ([`docs/data-and-privacy.mdx`](docs/data-and-privacy.mdx)). [`OBSERVABILITY.md`](OBSERVABILITY.md) link targets use repo-relative paths only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809b51162868eab95d02ed49f4ee9bf52cb48d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->