### PR TITLE
Strengthen SEO growth foundations

### DIFF
--- a/apps/web/content/articles/ai-meeting-notes-without-bot.mdx
+++ b/apps/web/content/articles/ai-meeting-notes-without-bot.mdx
@@ -8,7 +8,7 @@ category: "Guides"
 date: "2026-07-09"
 ---
 
-AI meeting notes do not have to start with a bot joining your Zoom, Google Meet, or Teams call.
+AI meeting notes do not have to start with a bot joining your [Zoom](/blog/best-ai-notetaker-for-zoom/), [Google Meet](/blog/best-ai-notetakers-google-meet/), or [Microsoft Teams](/blog/best-ai-notetaker-for-microsoft-teams/) call.
 
 That used to be the default mental model: connect your calendar, let a meeting assistant auto-join, record everything in the cloud, then get a summary afterward. It is convenient, and for some teams it is still the right workflow.
 
@@ -162,3 +162,5 @@ Choose a bot-based notetaker when the meeting needs to become a shared cloud ass
 Choose a bot-free notetaker when the meeting is sensitive, the bot would be distracting, or you want the notes to live in your own workflow instead of a vendor database.
 
 Choose a local-first bot-free notetaker when the real requirement is not just "no bot," but ownership: your files, your AI stack, your retention policy, your decision.
+
+If your process needs formal agendas, approvals, and a durable record rather than personal working notes, compare dedicated [meeting minutes software](/blog/meeting-minutes-software/).

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -78,7 +78,7 @@ The free path is most useful when you already have an API key or are comfortable
 
 ## 2. MacWhisper: best for private audio and video files on Mac
 
-[MacWhisper](https://macwhisper.com/) is a native Mac app built around local speech-to-text models. Drop in a recording, record from the microphone, or use its basic dictation mode, and the transcription runs on your Mac by default.
+[MacWhisper](https://macwhisper.com/) is a native Mac app built around local speech-to-text models. Drop in a recording, record from the microphone, or use its basic dictation mode, and the transcription runs on your Mac by default. Our [Mac transcription software comparison](/blog/transcription-software-mac/) covers the broader choice between file, dictation, and live-meeting workflows.
 
 ![MacWhisper transcript with the AI chat panel and model selector](/images/blog/library/products/macwhisper/transcription/2026-08-30-chat.png)
 

--- a/apps/web/content/articles/google-gemini-meeting-notes.mdx
+++ b/apps/web/content/articles/google-gemini-meeting-notes.mdx
@@ -176,6 +176,8 @@ If you need a verbatim compliance record, test the exact artifact settings and r
 
 Gemini fits a team already standardized on Google Meet, Drive, Docs, Calendar, and Workspace administration. There is no guest bot to admit, the recap lands in familiar tools, and existing Workspace controls apply.
 
+If you are comparing native Meet notes with bots, browser extensions, and desktop capture, see the full [Google Meet AI notetaker comparison](/blog/best-ai-notetakers-google-meet/).
+
 The choice changes when meetings leave Google or the record needs to stay local.
 
 | Need | Gemini in Meet | Anarlog |

--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -1,6 +1,6 @@
 ---
-meta_title: "Best Meeting Minutes Software in 2026"
-meta_description: "Compare the best meeting minutes software for 2026, including AI notetakers, board portals, transcript search, privacy-first workflows, and team collaboration tools."
+meta_title: "9 Best Meeting Minutes Software Tools (2026)"
+meta_description: "Compare 9 meeting minutes tools for AI summaries, board governance, CRM follow-up, and private local notes, including pricing and recording style."
 author: "John Jeong"
 featured: false
 category: "Comparisons"

--- a/apps/web/content/articles/obsidian-meeting-notes.mdx
+++ b/apps/web/content/articles/obsidian-meeting-notes.mdx
@@ -8,8 +8,6 @@ category: "Product"
 date: "2026-04-08"
 ---
 
-# How to Use Obsidian to Take Meeting Notes?
-
 You're already in Obsidian. You have a vault with projects, people notes, maybe a daily notes practice. What you don't have is meeting notes that connect to any of it. That's the specific problem this guide solves: building a meeting notes system inside an existing Obsidian PKB, where notes actually link to projects and people.
 
 ## What we're building

--- a/apps/web/src/lib/seo.test.ts
+++ b/apps/web/src/lib/seo.test.ts
@@ -49,28 +49,6 @@ test("emits offers when pricing is supplied", () => {
   });
 });
 
-test("emits source-backed software reviews", () => {
-  const jsonLd = getSoftwareApplicationJsonLd({
-    description: "Anarlog",
-    reviews: [
-      {
-        author: "Ada Lovelace",
-        reviewBody: "A useful local app.",
-        url: "https://example.com/review",
-      },
-    ],
-  });
-
-  assert.deepEqual(jsonLd.review, [
-    {
-      "@type": "Review",
-      author: { "@type": "Person", name: "Ada Lovelace" },
-      reviewBody: "A useful local app.",
-      url: "https://example.com/review",
-    },
-  ]);
-});
-
 test("builds blog posting metadata with typed authors", () => {
   const url = getCanonicalUrl("/blog/local-ai-meeting-notes");
   const jsonLd = getBlogPostingJsonLd({

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -12,7 +12,7 @@ export function getCanonicalUrl(path = "/") {
   const withSlash = normalized.endsWith("/") ? normalized : `${normalized}/`;
   return `${ANARLOG_SITE_URL}${withSlash}`;
 }
-export const ROOT_TITLE = "AI notepad for private meetings.";
+export const ROOT_TITLE = "Private AI Meeting Notetaker | Anarlog";
 export const ROOT_DESCRIPTION =
   "Anarlog is the open-source, privacy-first, local-first alternative to Granola AI. Take notes during private meetings, turn them into editable summaries, and keep your local meeting data and AI stack under your control.";
 export const ROOT_KEYWORDS =
@@ -48,12 +48,6 @@ export function getShortLinkSharedNoteOgImageUrl(linkId: string) {
 
 type StructuredDataNode = Record<string, unknown>;
 
-type SoftwareReview = {
-  author: string;
-  reviewBody: string;
-  url: string;
-};
-
 export function getStructuredDataGraph(nodes: StructuredDataNode[]) {
   return {
     "@context": "https://schema.org",
@@ -75,7 +69,6 @@ export function getSoftwareApplicationJsonLd({
   description,
   featureList,
   aggregateOffer,
-  reviews,
 }: {
   url?: string;
   description: string;
@@ -85,7 +78,6 @@ export function getSoftwareApplicationJsonLd({
     highPrice: number;
     offerCount: number;
   };
-  reviews?: SoftwareReview[];
 }) {
   return {
     "@type": "SoftwareApplication",
@@ -97,19 +89,6 @@ export function getSoftwareApplicationJsonLd({
     downloadUrl: getCanonicalUrl("/download"),
     publisher: getOrganizationJsonLd(),
     ...(featureList ? { featureList } : {}),
-    ...(reviews
-      ? {
-          review: reviews.map(({ author, reviewBody, url: reviewUrl }) => ({
-            "@type": "Review",
-            author: {
-              "@type": "Person",
-              name: author,
-            },
-            reviewBody,
-            url: reviewUrl,
-          })),
-        }
-      : {}),
     ...(aggregateOffer
       ? {
           offers: {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -36,25 +36,6 @@ const aggregateOffer = {
   offerCount: MARKETING_PLAN_TIERS.length,
 };
 
-const softwareReviews = [
-  {
-    author: "Tobi Lutke",
-    reviewBody: "Anarlog is great and local.",
-    url: "https://x.com/tobi/status/1983892259230699921",
-  },
-  {
-    author: "James Koshigoe",
-    reviewBody: "Anarlog is one of my favorite AI secret weapons.",
-    url: "https://x.com/JamesKoshigoe/status/2024676687980671195",
-  },
-  {
-    author: "Tom Yang",
-    reviewBody:
-      "I love the flexibility that Anarlog gives me to integrate personal notes with AI summaries.",
-    url: "https://twitter.com/tomyang11_/status/1956395933538902092",
-  },
-];
-
 const authCallbackSearchSchema = z.object({
   code: z.string().optional(),
   token_hash: z.string().optional(),
@@ -135,7 +116,6 @@ export const Route = createFileRoute("/")({
               description: ROOT_DESCRIPTION,
               featureList,
               aggregateOffer,
-              reviews: softwareReviews,
             }),
           ]),
         ),


### PR DESCRIPTION
## Summary

- Improve search titles and internal link paths.
- Remove invalid review markup and a duplicate article heading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy and JSON-LD cleanup only; no auth, data, or application runtime behavior changes.
> 
> **Overview**
> **SEO and content linking:** Updates the homepage `ROOT_TITLE` to *Private AI Meeting Notetaker | Anarlog*, refreshes meeting-minutes article meta title/description, adds internal blog links (platform notetaker guides, Mac transcription comparison, meeting minutes software), and removes a duplicate H1 from the Obsidian meeting-notes article.
> 
> **Structured data:** Drops `Review` nodes from homepage `SoftwareApplication` JSON-LD—removes the `reviews` option from `getSoftwareApplicationJsonLd`, the hardcoded social-quote list on the home route, and the related unit test—while keeping organization, features, and aggregate offer markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ece9548e4ab1ae0be32604447fbc8c03e8039f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->