### PR TITLE
Exclude user-caused failures from Sentry

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -71,6 +71,7 @@
     "@anlg/store": "workspace:*",
     "@anlg/supabase": "workspace:*",
     "@anlg/ui": "workspace:^",
+    "@anlg/user-error": "workspace:*",
     "@anlg/utils": "workspace:^",
     "@iconify-icon/react": "^3.0.3",
     "@lingui/core": "^6.0.1",

--- a/apps/desktop/src/error-reporting.ts
+++ b/apps/desktop/src/error-reporting.ts
@@ -2,6 +2,8 @@ import * as Sentry from "@sentry/react";
 import type { ErrorEvent, SeverityLevel } from "@sentry/react";
 import { emit, listen } from "@tauri-apps/api/event";
 
+import { isUserError, isUserErrorEvent } from "@anlg/user-error";
+
 import { env } from "./env";
 import { commands as desktopCommands } from "./types/tauri.gen";
 
@@ -10,29 +12,6 @@ const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_.:/-]{1,128}$/;
 const ERROR_REPORTING_CONSENT_EVENT = "anlg:error-reporting-consent-changed";
 let errorReportingEnabled = false;
 let errorReportingConsentRevision = 0;
-
-// Failures caused by the user's own account state (exhausted credits, expired
-// plans, bad API keys) are not actionable for engineering, so they never reach
-// Sentry. Keep in sync with `crates/user-error`.
-const USER_ERROR_MARKERS = [
-  "billing_hard_limit_reached",
-  "credit balance is too low",
-  "exceeded your current quota",
-  "incorrect api key",
-  "insufficient balance",
-  "insufficient credits",
-  "insufficient funds",
-  "insufficient_quota",
-  "invalid api key",
-  "invalid x-api-key",
-  "invalid_api_key",
-  "not enough credits",
-  "payment required",
-  "plans & billing",
-  "plans and billing",
-  "quota exceeded",
-  "upgrade or purchase credits",
-];
 
 // Archived Sentry issue types. Local error logs stay; Sentry should not reopen
 // or bill for issues that were already solved. Keep in sync with
@@ -77,10 +56,6 @@ function textMatchesMarkers(value: unknown, markers: readonly string[]) {
   return markers.some((marker) => text.includes(marker));
 }
 
-export function isUserError(value: unknown): boolean {
-  return textMatchesMarkers(value, USER_ERROR_MARKERS);
-}
-
 export function isIgnoredError(value: unknown): boolean {
   const text = serializeForUserErrorMatch(value);
   return (
@@ -103,8 +78,11 @@ function isDroppedErrorEvent(event: ErrorEvent): boolean {
     return true;
   }
 
-  return [event.message, event.logentry, event.exception, event.extra].some(
-    (value) => isUserError(value) || isIgnoredError(value),
+  return (
+    isUserErrorEvent(event) ||
+    [event.message, event.logentry, event.exception, event.extra].some(
+      isIgnoredError,
+    )
   );
 }
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -23,6 +23,7 @@
     "@anlg/design-system": "workspace:^",
     "@anlg/mobile-bridge": "workspace:*",
     "@anlg/supabase": "workspace:*",
+    "@anlg/user-error": "workspace:*",
     "@expo/material-symbols": "^0.1.1",
     "@expo/metro-runtime": "^57.0.14",
     "@expo/ui": "~57.0.14",

--- a/apps/mobile/src/lib/error-reporting.ts
+++ b/apps/mobile/src/lib/error-reporting.ts
@@ -7,6 +7,8 @@ import type {
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 
+import { isUserError, isUserErrorEvent } from "@anlg/user-error";
+
 import { env } from "@/lib/env";
 import {
   normalizeOperationalError,
@@ -44,7 +46,8 @@ export function initializeErrorReporting() {
     dist: appDist(),
     sendDefaultPii: false,
     attachStacktrace: true,
-    beforeSend: sanitizeErrorEvent,
+    beforeSend: (event) =>
+      isUserErrorEvent(event) ? null : sanitizeErrorEvent(event),
     beforeBreadcrumb: (breadcrumb) =>
       sanitizeBreadcrumb(breadcrumb as Breadcrumb),
     enableAutoSessionTracking: true,
@@ -82,6 +85,8 @@ export function captureOperationalError(
     context?: Record<string, ErrorContextValue>;
   },
 ) {
+  if (isUserError(error)) return;
+
   if (error && typeof error === "object") {
     if (capturedErrors.has(error)) return;
     capturedErrors.add(error);

--- a/apps/stripe/package.json
+++ b/apps/stripe/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@anlg/supabase": "workspace:*",
+    "@anlg/user-error": "workspace:*",
     "@sentry/bun": "^10.48.0",
     "@supabase/stripe-sync-engine": "^0.45.0",
     "@supabase/supabase-js": "^2.103.0",

--- a/apps/stripe/src/error-reporting.test.ts
+++ b/apps/stripe/src/error-reporting.test.ts
@@ -38,6 +38,8 @@ describe("sanitizeErrorEvent", () => {
       ],
     });
 
+    expect(event).not.toBeNull();
+    if (!event) throw new Error("expected sanitized event");
     expect(event.message).toBeUndefined();
     expect(event.logentry).toBeUndefined();
     expect(event.extra).toBeUndefined();
@@ -66,5 +68,16 @@ describe("sanitizeErrorEvent", () => {
         },
       },
     ]);
+  });
+
+  it("drops user-caused provider failures", () => {
+    expect(
+      sanitizeErrorEvent({
+        type: undefined,
+        exception: {
+          values: [{ type: "ProviderError", value: "insufficient_quota" }],
+        },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/stripe/src/error-reporting.ts
+++ b/apps/stripe/src/error-reporting.ts
@@ -1,6 +1,8 @@
 import * as Sentry from "@sentry/bun";
 import type { SeverityLevel } from "@sentry/bun";
 
+import { isUserError, isUserErrorEvent } from "@anlg/user-error";
+
 type ErrorContextValue = null | boolean | number | string;
 
 function sanitizeUrl(value: string | undefined) {
@@ -9,7 +11,9 @@ function sanitizeUrl(value: string | undefined) {
 
 export function sanitizeErrorEvent(
   event: Sentry.ErrorEvent,
-): Sentry.ErrorEvent {
+): Sentry.ErrorEvent | null {
+  if (isUserErrorEvent(event)) return null;
+
   if (event.user) {
     event.user = event.user.id ? { id: event.user.id } : undefined;
   }
@@ -67,6 +71,8 @@ export function captureOperationalError(
     context?: Record<string, ErrorContextValue>;
   },
 ) {
+  if (isUserError(error)) return;
+
   const exception =
     error instanceof Error ? error : new Error(`${operation} failed`);
 

--- a/apps/web/instrument.server.mjs
+++ b/apps/web/instrument.server.mjs
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/tanstackstart-react";
 
+import { isUserErrorEvent } from "@anlg/user-error";
+
 function sanitizeUrl(value) {
   return value?.split(/[?#]/, 1)[0];
 }
@@ -12,6 +14,8 @@ Sentry.init({
     : undefined,
   sendDefaultPii: false,
   beforeSend(event) {
+    if (isUserErrorEvent(event)) return null;
+
     if (event.user) {
       event.user = event.user.id ? { id: event.user.id } : undefined;
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@anlg/pricing": "workspace:^",
     "@anlg/supabase": "workspace:*",
     "@anlg/ui": "workspace:*",
+    "@anlg/user-error": "workspace:*",
     "@anlg/utils": "workspace:*",
     "@chenglou/pretext": "^0.0.4",
     "@deepgram/sdk": "^4.11.3",

--- a/apps/web/src/lib/error-reporting.test.ts
+++ b/apps/web/src/lib/error-reporting.test.ts
@@ -98,6 +98,27 @@ test("reports one grouped signal for repeated stackless promise rejections", () 
   assert.equal(filter(event()), null);
 });
 
+test("drops user-caused provider failures without inspecting breadcrumbs", () => {
+  const filter = createErrorEventFilter();
+  assert.equal(
+    filter({
+      type: undefined,
+      exception: {
+        values: [{ type: "ProviderError", value: "insufficient_quota" }],
+      },
+    }),
+    null,
+  );
+  assert.notEqual(
+    filter({
+      type: undefined,
+      exception: { values: [{ type: "RouteError", value: "socket hang up" }] },
+      breadcrumbs: [{ message: "quota exceeded" }],
+    }),
+    null,
+  );
+});
+
 test("does not rate-limit promise rejections with stack traces", () => {
   const filter = createErrorEventFilter();
   const event = () => ({

--- a/apps/web/src/lib/error-reporting.ts
+++ b/apps/web/src/lib/error-reporting.ts
@@ -1,6 +1,8 @@
 import * as Sentry from "@sentry/tanstackstart-react";
 import type { ErrorEvent, SeverityLevel } from "@sentry/tanstackstart-react";
 
+import { isUserError, isUserErrorEvent } from "@anlg/user-error";
+
 type ErrorContextValue = null | boolean | number | string;
 const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_.:/-]{1,128}$/;
 
@@ -136,6 +138,8 @@ export function createErrorEventFilter() {
   let reportedStacklessUnhandledRejection = false;
 
   return (event: ErrorEvent): ErrorEvent | null => {
+    if (isUserErrorEvent(event)) return null;
+
     const sanitized = sanitizeErrorEvent(event);
     if (!isStacklessUnhandledRejection(sanitized)) return sanitized;
     if (reportedStacklessUnhandledRejection) return null;
@@ -164,6 +168,8 @@ export function captureOperationalError(
     context?: Record<string, ErrorContextValue>;
   },
 ) {
+  if (isUserError(error)) return;
+
   const metadata = operationalErrorMetadata(error);
   const exception = normalizeOperationalError(error, operation);
 

--- a/crates/user-error/src/lib.rs
+++ b/crates/user-error/src/lib.rs
@@ -6,8 +6,11 @@
 
 use sentry::protocol::{Context, Event, Value};
 
+// Keep in sync with packages/user-error/src/index.js.
 const USER_ERROR_MARKERS: &[&str] = &[
     "billing_hard_limit_reached",
+    "api key is invalid",
+    "apikey is invalid",
     "credit balance is too low",
     "exceeded your current quota",
     "incorrect api key",
@@ -16,9 +19,11 @@ const USER_ERROR_MARKERS: &[&str] = &[
     "insufficient funds",
     "insufficient_quota",
     "invalid api key",
+    "invalid apikey",
     "invalid x-api-key",
     "invalid_api_key",
     "not enough credits",
+    "no quota",
     "payment required",
     "plans & billing",
     "plans and billing",
@@ -144,6 +149,8 @@ mod tests {
         assert!(is_user_error_text(
             "{\"code\":\"insufficient_quota\",\"type\":\"invalid_request_error\"}"
         ));
+        assert!(is_user_error_text("API key is invalid"));
+        assert!(is_user_error_text("Invalid APIKEY"));
         assert!(!is_user_error_text("failed to open database"));
     }
 

--- a/packages/user-error/package.json
+++ b/packages/user-error/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@anlg/user-error",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/user-error/src/index.d.ts
+++ b/packages/user-error/src/index.d.ts
@@ -1,0 +1,2 @@
+export function isUserError(value: unknown): boolean;
+export function isUserErrorEvent(event: unknown): boolean;

--- a/packages/user-error/src/index.js
+++ b/packages/user-error/src/index.js
@@ -1,0 +1,65 @@
+// Keep in sync with USER_ERROR_MARKERS in crates/user-error/src/lib.rs.
+const USER_ERROR_MARKERS = [
+  "billing_hard_limit_reached",
+  "api key is invalid",
+  "apikey is invalid",
+  "credit balance is too low",
+  "exceeded your current quota",
+  "incorrect api key",
+  "insufficient balance",
+  "insufficient credits",
+  "insufficient funds",
+  "insufficient_quota",
+  "invalid api key",
+  "invalid apikey",
+  "invalid x-api-key",
+  "invalid_api_key",
+  "not enough credits",
+  "no quota",
+  "payment required",
+  "plans & billing",
+  "plans and billing",
+  "quota exceeded",
+  "upgrade or purchase credits",
+];
+
+/** @param {string} value */
+function textMatchesUserError(value) {
+  const text = value.toLowerCase();
+  return USER_ERROR_MARKERS.some((marker) => text.includes(marker));
+}
+
+/**
+ * @param {unknown} value
+ * @param {WeakSet<object>} seen
+ * @returns {boolean}
+ */
+function valueMatchesUserError(value, seen) {
+  if (typeof value === "string") return textMatchesUserError(value);
+  if (typeof value !== "object" || value === null) return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+
+  if (
+    value instanceof Error &&
+    textMatchesUserError(`${value.name}: ${value.message}`)
+  ) {
+    return true;
+  }
+
+  return Object.values(value).some((item) => valueMatchesUserError(item, seen));
+}
+
+/** @param {unknown} value */
+export function isUserError(value) {
+  return valueMatchesUserError(value, new WeakSet());
+}
+
+/** @param {unknown} event */
+export function isUserErrorEvent(event) {
+  if (typeof event !== "object" || event === null) return isUserError(event);
+
+  return ["message", "logentry", "exception", "extra", "tags", "contexts"].some(
+    (key) => isUserError(Reflect.get(event, key)),
+  );
+}

--- a/packages/user-error/src/index.test.js
+++ b/packages/user-error/src/index.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isUserError, isUserErrorEvent } from "./index.js";
+
+test("recognizes provider quota and API key failures", () => {
+  assert.equal(
+    isUserError({
+      error: {
+        code: "insufficient_quota",
+        message: "You exceeded your current quota",
+      },
+    }),
+    true,
+  );
+  assert.equal(isUserError(new Error("Invalid API key")), true);
+  assert.equal(isUserError(new Error("API key is invalid")), true);
+  assert.equal(isUserError(new Error("Invalid APIKEY")), true);
+  assert.equal(isUserError(new Error("socket hang up")), false);
+});
+
+test("matches the current event without inspecting breadcrumbs", () => {
+  assert.equal(
+    isUserErrorEvent({
+      exception: {
+        values: [{ type: "ProviderError", value: "quota exceeded" }],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isUserErrorEvent({
+      exception: { values: [{ type: "RouteError", value: "socket hang up" }] },
+      breadcrumbs: [{ message: "quota exceeded" }],
+    }),
+    false,
+  );
+});
+
+test("handles cyclic error metadata", () => {
+  /** @type {Record<string, unknown>} */
+  const value = { message: "connection failed" };
+  value.context = value;
+  assert.equal(isUserError(value), false);
+});

--- a/packages/user-error/tsconfig.json
+++ b/packages/user-error/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "include": ["src/index.js", "src/index.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@anlg/ui':
         specifier: workspace:^
         version: link:../../packages/ui
+      '@anlg/user-error':
+        specifier: workspace:*
+        version: link:../../packages/user-error
       '@anlg/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -447,6 +450,9 @@ importers:
       '@anlg/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
+      '@anlg/user-error':
+        specifier: workspace:*
+        version: link:../../packages/user-error
       '@expo/material-symbols':
         specifier: ^0.1.1
         version: 0.1.1
@@ -583,6 +589,9 @@ importers:
       '@anlg/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
+      '@anlg/user-error':
+        specifier: workspace:*
+        version: link:../../packages/user-error
       '@sentry/bun':
         specifier: ^10.48.0
         version: 10.48.0(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))
@@ -647,6 +656,9 @@ importers:
       '@anlg/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@anlg/user-error':
+        specifier: workspace:*
+        version: link:../../packages/user-error
       '@anlg/utils':
         specifier: workspace:*
         version: link:../../packages/utils
@@ -1419,6 +1431,8 @@ importers:
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+
+  packages/user-error: {}
 
   packages/utils:
     dependencies:


### PR DESCRIPTION
## Summary

- Share quota and API-key error classification across runtime surfaces.
- Drop user-caused failures before Sentry capture.
- Cover the shared classifier and web/Stripe filtering paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-surface Sentry filtering changes can hide real incidents or leak user-caused noise if markers drift from provider messages; impact is observability, not auth or data integrity.
> 
> **Overview**
> Introduces shared **`@anlg/user-error`** with `isUserError` and `isUserErrorEvent`, aligned with **`crates/user-error`** marker lists (including extra API-key and quota phrases). Desktop, mobile, web, and Stripe stop duplicating marker tables and use the package to **drop billing/quota/credential failures** before Sentry (`beforeSend`, event filters, and `captureOperationalError`).
> 
> **`isUserErrorEvent`** only inspects the current event payload (message, exception, extra, tags, contexts)—**not breadcrumbs**—so stale breadcrumb text does not suppress unrelated errors. Tests cover the package plus web and Stripe sanitization paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14769c8a8ccb1768abfc03977cd3a0c739babb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->