### PR TITLE
Prevent duplicate Pro renewals after Team checkout

### DIFF
--- a/apps/desktop/src/settings/general/account.test.tsx
+++ b/apps/desktop/src/settings/general/account.test.tsx
@@ -28,9 +28,14 @@ const mocks = vi.hoisted(() => ({
     plan: "free",
     trialDaysRemaining: null as number | null,
   },
-  session: { user: { email: "john@example.com" } } as {
-    user: { email: string };
+  session: { user: { id: "user-1", email: "john@example.com" } } as {
+    user: { id: string; email: string };
   } | null,
+  workspaces: {
+    data: [] as Array<{ workspaceId: string }>,
+    isPending: false,
+  },
+  getWorkspaceAccess: vi.fn(),
 }));
 
 vi.mock("@anlg/plugin-analytics", () => ({
@@ -53,9 +58,19 @@ vi.mock("~/auth", () => ({
     isRefreshingSession: false,
     refreshSession: vi.fn(),
     session: mocks.session,
+    supabase: {},
     signIn: mocks.signIn,
     signOut: mocks.signOut,
   }),
+}));
+
+vi.mock("~/settings/team/client", () => ({
+  getWorkspaceAccess: mocks.getWorkspaceAccess,
+  requireTeamContext: (auth: unknown) => auth,
+}));
+
+vi.mock("~/settings/team/mirror", () => ({
+  useMyWorkspacesWithMirror: () => mocks.workspaces,
 }));
 
 vi.mock("~/auth/billing-context", () => ({
@@ -86,7 +101,13 @@ const renderAccount = () => {
 describe("SettingsAccount", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.session = { user: { email: "john@example.com" } };
+    mocks.session = { user: { id: "user-1", email: "john@example.com" } };
+    mocks.workspaces.data = [];
+    mocks.workspaces.isPending = false;
+    mocks.getWorkspaceAccess.mockResolvedValue({
+      tier: "free",
+      capabilities: [],
+    });
     mocks.billing = {
       canStartTrial: { data: false, isPending: false },
       hasPaymentMethod: false,
@@ -148,6 +169,43 @@ describe("SettingsAccount", () => {
       null,
     );
   });
+
+  it.each([
+    { personalState: "trialing", isTrialing: true, isPaused: false },
+    { personalState: "paused", isTrialing: false, isPaused: true },
+  ])(
+    "shows Team as current without the $personalState Pro status",
+    async ({ isTrialing, isPaused }) => {
+      mocks.billing = {
+        canStartTrial: { data: false, isPending: false },
+        hasPaymentMethod: true,
+        isPaid: true,
+        isTrialing,
+        isPaused,
+        plan: "pro",
+        trialDaysRemaining: null,
+      };
+      mocks.workspaces.data = [
+        { workspaceId: "00000000-0000-4000-8000-000000000001" },
+      ];
+      mocks.getWorkspaceAccess.mockResolvedValue({
+        tier: "team",
+        capabilities: ["team.shared_notes"],
+      });
+
+      renderAccount();
+
+      expect(
+        await screen.findByText(/You're on the .*Team.* plan/),
+      ).toBeTruthy();
+      expect(screen.queryByText("Your Pro trial has ended")).toBeNull();
+      expect(screen.queryByText("Trial")).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Manage billing" }),
+      ).toBeNull();
+      expect(screen.getAllByText("Current")).toHaveLength(1);
+    },
+  );
 
   it("offers to add a payment method during a cardless trial", async () => {
     mocks.billing = {

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -1,6 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ArrowsClockwise, PencilSimple } from "@phosphor-icons/react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueries } from "@tanstack/react-query";
 import { type ReactNode, useCallback, useRef, useState } from "react";
 
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
@@ -11,7 +11,6 @@ import {
   type MarketingPlanTier,
   PlanFeatureList,
   PLAN_TIERS,
-  type PlanTier,
   type TierAction,
 } from "@anlg/pricing";
 import { Button } from "@anlg/ui/components/ui/button";
@@ -21,6 +20,8 @@ import { cn } from "@anlg/utils";
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing-context";
 import { SettingsPageTitle } from "~/settings/page-title";
+import { getWorkspaceAccess, requireTeamContext } from "~/settings/team/client";
+import { useMyWorkspacesWithMirror } from "~/settings/team/mirror";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { DestructiveConfirmationDialog } from "~/shared/ui/destructive-confirmation-dialog";
 import { buildWebAppUrl } from "~/shared/utils";
@@ -44,6 +45,15 @@ export function SettingsAccount() {
     useBillingAccess();
 
   const isAuthenticated = !!auth?.session;
+  const workspaces = useMyWorkspacesWithMirror();
+  const workspaceAccess = useQueries({
+    queries: (workspaces.data ?? []).map((workspace) => ({
+      queryKey: ["team-access", workspace.workspaceId],
+      queryFn: () =>
+        getWorkspaceAccess(requireTeamContext(auth), workspace.workspaceId),
+      retry: false,
+    })),
+  });
   const [isPending, setIsPending] = useState(false);
   const [isSignOutDialogOpen, setIsSignOutDialogOpen] = useState(false);
 
@@ -140,7 +150,17 @@ export function SettingsAccount() {
     );
   }
 
-  const currentTier = plan === "free" ? "free" : "pro";
+  const workspaceTier = workspaceAccess.some(
+    (query) => query.data?.tier === "enterprise",
+  )
+    ? "enterprise"
+    : workspaceAccess.some((query) => query.data?.tier === "team")
+      ? "team"
+      : null;
+  const currentTier: MarketingPlanTier =
+    workspaceTier ?? (plan === "free" ? "free" : "pro");
+  const isCurrentTierPending =
+    workspaces.isPending || workspaceAccess.some((query) => query.isPending);
 
   return (
     <div className="flex flex-col gap-8">
@@ -190,6 +210,7 @@ export function SettingsAccount() {
         isPaused={isPaused}
         trialDaysRemaining={trialDaysRemaining}
         isPaid={isPaid}
+        isCurrentTierPending={isCurrentTierPending}
       />
     </div>
   );
@@ -201,12 +222,14 @@ function PlanBillingSection({
   isPaused,
   trialDaysRemaining,
   isPaid,
+  isCurrentTierPending,
 }: {
-  currentTier: PlanTier;
+  currentTier: MarketingPlanTier;
   isTrialing: boolean;
   isPaused: boolean;
   trialDaysRemaining: number | null;
   isPaid: boolean;
+  isCurrentTierPending: boolean;
 }) {
   const { t } = useLingui();
   const { canStartTrial: canStartTrialQuery, hasPaymentMethod } =
@@ -217,7 +240,8 @@ function PlanBillingSection({
 
   // A cardless trial pauses at the end unless a card is added, so replace the
   // static current-plan status with an explicit payment-method action.
-  const needsPaymentMethod = isTrialing && !hasPaymentMethod;
+  const needsPaymentMethod =
+    currentTier === "pro" && isTrialing && !hasPaymentMethod;
 
   const openBillingUrl = useCallback(
     async (buildUrl: () => Promise<string>) => {
@@ -234,19 +258,27 @@ function PlanBillingSection({
     [],
   );
 
-  const planLabel = currentTier === "free" ? t`Free` : "Pro";
+  const planLabel =
+    currentTier === "free"
+      ? t`Free`
+      : (PLAN_TIERS.find((tier) => tier.id === currentTier)?.name ?? "Pro");
   const trialDaysText =
     trialDaysRemaining == null
       ? null
       : trialDaysRemaining === 1
         ? t`${trialDaysRemaining} day left`
         : t`${trialDaysRemaining} days left`;
-  const statusText = isTrialing ? (
+  const statusText = isCurrentTierPending ? (
+    <span
+      className="bg-muted block h-5 w-40 animate-pulse rounded"
+      aria-hidden="true"
+    />
+  ) : currentTier === "pro" && isTrialing ? (
     <>
       <Trans>Pro trial</Trans>
       {trialDaysText != null && ` - ${trialDaysText}`}
     </>
-  ) : isPaused ? (
+  ) : currentTier !== "team" && currentTier !== "enterprise" && isPaused ? (
     <Trans>Your Pro trial has ended</Trans>
   ) : (
     <Trans>
@@ -387,7 +419,7 @@ function PlanBillingSection({
         <h2 className="font-sans text-lg font-semibold">
           <Trans>Plan & Billing</Trans>
         </h2>
-        {isPaid && (
+        {!isCurrentTierPending && isPaid && currentTier === "pro" && (
           <button
             type="button"
             onClick={handleOpenBillingPortal}
@@ -405,7 +437,7 @@ function PlanBillingSection({
       </div>
 
       <PlanTierList
-        currentTier={currentTier}
+        currentTier={isCurrentTierPending ? null : currentTier}
         isTrialing={isTrialing}
         canStartTrial={canStartTrialQuery.data}
         renderAction={renderAction}
@@ -462,7 +494,7 @@ function PlanTierList({
   canStartTrial,
   renderAction,
 }: {
-  currentTier: PlanTier;
+  currentTier: MarketingPlanTier | null;
   isTrialing: boolean;
   canStartTrial: boolean;
   renderAction?: (tierId: MarketingPlanTier, action: TierAction) => ReactNode;
@@ -493,7 +525,8 @@ function PlanTierList({
           const isCurrent = tier.id === currentTier;
           const isPro = tier.id === "pro";
           const action =
-            tier.id === "free" || tier.id === "pro"
+            (tier.id === "free" || tier.id === "pro") &&
+            (currentTier === "free" || currentTier === "pro")
               ? getActionForTier(tier.id, currentTier, canStartTrial)
               : null;
           const chips = (
@@ -503,7 +536,7 @@ function PlanTierList({
                   <Trans>Current</Trans>
                 </PlanStatusChip>
               )}
-              {isCurrent && isTrialing && (
+              {isCurrent && isPro && isTrialing && (
                 <PlanStatusChip emphasis>
                   <Trans>Trial</Trans>
                 </PlanStatusChip>

--- a/apps/desktop/src/settings/team/index.test.tsx
+++ b/apps/desktop/src/settings/team/index.test.tsx
@@ -91,6 +91,7 @@ const mocks = vi.hoisted(() => ({
     checkWorkspaceShareSlugAvailability: vi.fn(() =>
       Promise.resolve("available" as "available" | "taken" | "invalid"),
     ),
+    getWorkspaceAccess: vi.fn(),
   },
   invitation: {
     deliverWorkspaceInvitation: vi.fn(() =>
@@ -177,7 +178,7 @@ vi.mock("./client", () => ({
   setMemberRole: vi.fn(() => Promise.resolve()),
   transferOwnership: vi.fn(() => Promise.resolve()),
   getWorkspaceUsageOverview: () => Promise.resolve(mocks.client.usage),
-  getWorkspaceAccess: () => Promise.resolve(mocks.client.access),
+  getWorkspaceAccess: mocks.client.getWorkspaceAccess,
   getWorkspacePolicy: mocks.client.getWorkspacePolicy,
   setWorkspacePolicy: vi.fn(() => Promise.resolve()),
   setWorkspaceShareSlug: mocks.client.setWorkspaceShareSlug,
@@ -237,6 +238,10 @@ describe("SettingsTeam", () => {
       seatLimit: 1,
       usedSeats: 1,
     };
+    mocks.client.getWorkspaceAccess.mockReset();
+    mocks.client.getWorkspaceAccess.mockImplementation(() =>
+      Promise.resolve(mocks.client.access),
+    );
     mocks.client.revokeInvitation.mockClear();
     mocks.client.deleteWorkspace.mockClear();
     mocks.client.renameWorkspace.mockClear();
@@ -327,6 +332,24 @@ describe("SettingsTeam", () => {
         },
       ),
     );
+  });
+
+  it("does not present a paid workspace as unbilled while access loads", () => {
+    mocks.client.getWorkspaceAccess.mockReturnValue(new Promise(() => {}));
+    mocks.workspaces.data = [
+      {
+        workspaceId: "00000000-0000-4000-8000-000000000001",
+        name: "Fastrepl",
+        ownerUserId: "user-1",
+        role: "owner",
+      },
+    ];
+
+    renderTeam();
+
+    expect(screen.queryByText("Start Team")).toBeNull();
+    const button = screen.getByRole("button", { name: "Team plan" });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("renames the workspace through the name field", async () => {

--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -577,7 +577,12 @@ function WorkspacePanel({
         <section className="flex max-w-xl flex-col gap-3 rounded-lg border p-4">
           <div>
             <h2 className="text-sm font-medium">
-              {hasPaidWorkspacePlan ? (
+              {access.isPending ? (
+                <span
+                  className="bg-muted block h-5 w-20 animate-pulse rounded"
+                  aria-hidden="true"
+                />
+              ) : hasPaidWorkspacePlan ? (
                 <Trans>Team plan</Trans>
               ) : (
                 <Trans>Start Team</Trans>
@@ -597,10 +602,14 @@ function WorkspacePanel({
             disabled={access.isPending || isOpeningBilling}
             onClick={() => void openTeamBilling()}
           >
-            {isOpeningBilling ? (
+            {access.isPending || isOpeningBilling ? (
               <CircleNotch className="size-4 animate-spin" />
             ) : null}
-            {hasPaidWorkspacePlan ? (
+            {access.isPending ? (
+              <span className="sr-only">
+                <Trans>Team plan</Trans>
+              </span>
+            ) : hasPaidWorkspacePlan ? (
               <Trans>Manage Team billing</Trans>
             ) : (
               <Trans>Continue to Team checkout</Trans>

--- a/apps/stripe/src/personal-plan-transition.test.ts
+++ b/apps/stripe/src/personal-plan-transition.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "bun:test";
+import type Stripe from "stripe";
+
+import { scheduleReplacedPersonalPlanCancellation } from "./personal-plan-transition";
+
+const workspaceId = "workspace-123";
+const personalUserId = "user-123";
+
+const subscription = ({
+  id = "sub_team123",
+  customer = "cus_team123",
+  status = "active",
+  cancelAtPeriodEnd = false,
+  metadata = {
+    checkout_type: "team",
+    workspace_id: workspaceId,
+    replaces_personal_subscription_id: "sub_personal123",
+    replaces_personal_user_id: personalUserId,
+  },
+}: {
+  id?: string;
+  customer?: string;
+  status?: Stripe.Subscription.Status;
+  cancelAtPeriodEnd?: boolean;
+  metadata?: Record<string, string>;
+} = {}) =>
+  ({
+    id,
+    customer,
+    status,
+    cancel_at_period_end: cancelAtPeriodEnd,
+    metadata,
+  }) as Stripe.Subscription;
+
+const event = (
+  value: Stripe.Subscription,
+  type: Stripe.Event.Type = "customer.subscription.created",
+) =>
+  ({
+    id: "evt_team123",
+    type,
+    data: { object: value },
+  }) as Stripe.Event;
+
+function dependencies(
+  personal: Stripe.Subscription = subscription({
+    id: "sub_personal123",
+    customer: "cus_personal123",
+  }),
+) {
+  const scheduled: string[] = [];
+  return {
+    scheduled,
+    value: {
+      getCustomer: async (customerId: string) =>
+        ({
+          id: customerId,
+          metadata:
+            customerId === "cus_team123"
+              ? { workspaceId }
+              : { userId: personalUserId },
+        }) as unknown as Stripe.Customer,
+      getSubscription: async () => personal,
+      scheduleCancellation: async (subscriptionId: string) => {
+        scheduled.push(subscriptionId);
+      },
+    },
+  };
+}
+
+describe("scheduleReplacedPersonalPlanCancellation", () => {
+  it("schedules the replaced personal plan to end after Team activates", async () => {
+    const deps = dependencies();
+
+    await scheduleReplacedPersonalPlanCancellation(
+      event(subscription()),
+      deps.value,
+    );
+
+    expect(deps.scheduled).toEqual(["sub_personal123"]);
+  });
+
+  for (const status of [
+    "past_due",
+    "unpaid",
+  ] satisfies Stripe.Subscription.Status[]) {
+    it(`schedules a ${status} personal plan that Stripe may still retry`, async () => {
+      const deps = dependencies(
+        subscription({
+          id: "sub_personal123",
+          customer: "cus_personal123",
+          status,
+        }),
+      );
+
+      await scheduleReplacedPersonalPlanCancellation(
+        event(subscription()),
+        deps.value,
+      );
+
+      expect(deps.scheduled).toEqual(["sub_personal123"]);
+    });
+  }
+
+  it("waits for the Team subscription to become active", async () => {
+    const deps = dependencies();
+
+    await scheduleReplacedPersonalPlanCancellation(
+      event(subscription({ status: "incomplete" })),
+      deps.value,
+    );
+
+    expect(deps.scheduled).toEqual([]);
+  });
+
+  it("ignores Team subscriptions created before replacement metadata existed", async () => {
+    const deps = dependencies();
+
+    await scheduleReplacedPersonalPlanCancellation(
+      event(
+        subscription({
+          metadata: {
+            checkout_type: "team",
+            workspace_id: workspaceId,
+          },
+        }),
+      ),
+      deps.value,
+    );
+
+    expect(deps.scheduled).toEqual([]);
+  });
+
+  it("is idempotent when the personal plan already ends after its period", async () => {
+    const deps = dependencies(
+      subscription({
+        id: "sub_personal123",
+        customer: "cus_personal123",
+        cancelAtPeriodEnd: true,
+      }),
+    );
+
+    await scheduleReplacedPersonalPlanCancellation(
+      event(subscription()),
+      deps.value,
+    );
+
+    expect(deps.scheduled).toEqual([]);
+  });
+
+  it("does not cancel a paused personal plan", async () => {
+    const deps = dependencies(
+      subscription({
+        id: "sub_personal123",
+        customer: "cus_personal123",
+        status: "paused",
+      }),
+    );
+
+    await scheduleReplacedPersonalPlanCancellation(
+      event(subscription()),
+      deps.value,
+    );
+
+    expect(deps.scheduled).toEqual([]);
+  });
+
+  it("fails closed when the Team customer does not own the workspace", async () => {
+    const deps = dependencies();
+    deps.value.getCustomer = async (customerId) =>
+      ({
+        id: customerId,
+        metadata:
+          customerId === "cus_team123"
+            ? { workspaceId: "another-workspace" }
+            : { userId: personalUserId },
+      }) as unknown as Stripe.Customer;
+
+    await expect(
+      scheduleReplacedPersonalPlanCancellation(
+        event(subscription()),
+        deps.value,
+      ),
+    ).rejects.toThrow("Team subscription customer ownership is invalid");
+    expect(deps.scheduled).toEqual([]);
+  });
+
+  it("fails closed when the personal plan belongs to another user", async () => {
+    const deps = dependencies();
+    deps.value.getCustomer = async (customerId) =>
+      ({
+        id: customerId,
+        metadata:
+          customerId === "cus_team123"
+            ? { workspaceId }
+            : { userId: "another-user" },
+      }) as unknown as Stripe.Customer;
+
+    await expect(
+      scheduleReplacedPersonalPlanCancellation(
+        event(subscription()),
+        deps.value,
+      ),
+    ).rejects.toThrow("Personal subscription customer ownership is invalid");
+    expect(deps.scheduled).toEqual([]);
+  });
+});

--- a/apps/stripe/src/personal-plan-transition.ts
+++ b/apps/stripe/src/personal-plan-transition.ts
@@ -1,0 +1,119 @@
+import type Stripe from "stripe";
+
+import { getCustomerOwner } from "./customer-metadata";
+
+const TEAM_SUBSCRIPTION_EVENTS: Stripe.Event.Type[] = [
+  "customer.subscription.created",
+  "customer.subscription.updated",
+];
+
+type PersonalPlanTransitionDependencies = {
+  getCustomer: (customerId: string) => Promise<Stripe.Customer | null>;
+  getSubscription: (subscriptionId: string) => Promise<Stripe.Subscription>;
+  scheduleCancellation: (subscriptionId: string) => Promise<void>;
+};
+
+export async function scheduleReplacedPersonalPlanCancellation(
+  event: Stripe.Event,
+  dependencies?: PersonalPlanTransitionDependencies,
+) {
+  if (!TEAM_SUBSCRIPTION_EVENTS.includes(event.type)) {
+    return;
+  }
+
+  const teamSubscription = event.data.object as Stripe.Subscription;
+  const metadata = teamSubscription.metadata;
+  const personalSubscriptionId = metadata.replaces_personal_subscription_id;
+  const personalUserId = metadata.replaces_personal_user_id;
+  const workspaceId = metadata.workspace_id;
+  const hasTransitionMetadata = Boolean(
+    personalSubscriptionId || personalUserId,
+  );
+
+  if (!hasTransitionMetadata) {
+    return;
+  }
+
+  if (
+    metadata.checkout_type !== "team" ||
+    !workspaceId ||
+    !personalSubscriptionId ||
+    !personalUserId
+  ) {
+    throw new Error("Team personal plan transition metadata is invalid");
+  }
+
+  if (!isActiveTeamSubscription(teamSubscription)) {
+    return;
+  }
+
+  const teamCustomerId = getCustomerId(teamSubscription.customer);
+  if (!teamCustomerId) {
+    throw new Error("Team subscription customer is unavailable");
+  }
+
+  const activeDependencies =
+    dependencies ?? (await createDefaultDependencies());
+  const teamCustomer = await activeDependencies.getCustomer(teamCustomerId);
+  const teamOwner = teamCustomer
+    ? getCustomerOwner(teamCustomer.metadata)
+    : null;
+  if (teamOwner?.kind !== "workspace" || teamOwner.id !== workspaceId) {
+    throw new Error("Team subscription customer ownership is invalid");
+  }
+
+  const personalSubscription = await activeDependencies.getSubscription(
+    personalSubscriptionId,
+  );
+  const personalCustomerId = getCustomerId(personalSubscription.customer);
+  if (!personalCustomerId || personalCustomerId === teamCustomerId) {
+    throw new Error("Personal subscription customer is invalid");
+  }
+
+  const personalCustomer =
+    await activeDependencies.getCustomer(personalCustomerId);
+  const personalOwner = personalCustomer
+    ? getCustomerOwner(personalCustomer.metadata)
+    : null;
+  if (personalOwner?.kind !== "user" || personalOwner.id !== personalUserId) {
+    throw new Error("Personal subscription customer ownership is invalid");
+  }
+
+  if (
+    !shouldCancelPersonalSubscription(personalSubscription) ||
+    personalSubscription.cancel_at_period_end
+  ) {
+    return;
+  }
+
+  await activeDependencies.scheduleCancellation(personalSubscriptionId);
+}
+
+const isActiveTeamSubscription = (subscription: Stripe.Subscription) =>
+  subscription.status === "active" || subscription.status === "trialing";
+
+const shouldCancelPersonalSubscription = (subscription: Stripe.Subscription) =>
+  ["active", "trialing", "past_due", "unpaid"].includes(subscription.status);
+
+const getCustomerId = (
+  customer: string | Stripe.Customer | Stripe.DeletedCustomer,
+) => (typeof customer === "string" ? customer : customer.id);
+
+async function createDefaultDependencies(): Promise<PersonalPlanTransitionDependencies> {
+  const { stripe } = await import("./integration/stripe");
+
+  return {
+    async getCustomer(customerId) {
+      const customer = await stripe.customers.retrieve(customerId);
+      return "deleted" in customer && customer.deleted ? null : customer;
+    },
+    async getSubscription(subscriptionId) {
+      return stripe.subscriptions.retrieve(subscriptionId);
+    },
+    async scheduleCancellation(subscriptionId) {
+      await stripe.subscriptions.update(subscriptionId, {
+        cancel_at_period_end: true,
+      });
+    },
+  };
+}

--- a/apps/stripe/src/routes/webhook.ts
+++ b/apps/stripe/src/routes/webhook.ts
@@ -6,6 +6,7 @@ import { env } from "../env";
 import { captureOperationalError } from "../error-reporting";
 import type { AppBindings } from "../hono-bindings";
 import { stripeSync } from "../integration/stripe-sync";
+import { scheduleReplacedPersonalPlanCancellation } from "../personal-plan-transition";
 import { issueReferralReward } from "../referral-rewards";
 import { sendSubscriptionWelcomeEmail } from "../subscription-welcome-email";
 import { sendTrialEndingEmail } from "../trial-emails";
@@ -59,6 +60,16 @@ webhook.post("/stripe", async (c) => {
       tags: { event_type: stripeEvent.type },
     });
     return c.json({ error: "billing_bridge_sync_failed" }, 500);
+  }
+
+  try {
+    await scheduleReplacedPersonalPlanCancellation(stripeEvent);
+  } catch (error) {
+    captureOperationalError(error, {
+      operation: "personal_plan_transition",
+      tags: { event_type: stripeEvent.type },
+    });
+    return c.json({ error: "personal_plan_transition_failed" }, 500);
   }
 
   try {

--- a/apps/web/src/functions/billing.ts
+++ b/apps/web/src/functions/billing.ts
@@ -35,10 +35,12 @@ import { captureServerAnalytics } from "@/lib/server-analytics";
 import {
   getStripeCustomerIdentityMetadata,
   getStripeCustomerOwnership,
+  isUnavailableStripeCustomerError,
 } from "@/lib/stripe-customer";
 import {
   getPlanSwitchRoute,
   selectCurrentSubscription,
+  selectPersonalPlanReplacement,
 } from "@/lib/subscription-selection";
 import { WEB_TRIAL_CHECKOUT_FIELDS } from "@/lib/trial-policy";
 import {
@@ -196,6 +198,19 @@ async function getCurrentSubscription(
   });
 
   return selectCurrentSubscription(subscriptions.data);
+}
+
+async function getPersonalPlanReplacementSubscription(
+  stripe: Stripe,
+  stripeCustomerId: string,
+): Promise<Stripe.Subscription | null> {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: stripeCustomerId,
+    status: "all",
+    limit: 10,
+  });
+
+  return selectPersonalPlanReplacement(subscriptions.data);
 }
 
 async function ensureStripeCustomerId(
@@ -634,6 +649,23 @@ export const createTeamCheckoutSession = createServerFn({ method: "POST" })
     const cancelUrl = data.scheme
       ? `${getBillingReturnUrl(data.scheme)}&checkout=canceled&checkout_type=paid`
       : toAbsoluteInternalReturnUrl(appOrigin, cancelReturnPath);
+    const personalCustomerId = await getStripeCustomerIdForUser(
+      supabase,
+      stripe,
+      user,
+    ).catch((error) => {
+      if (!isUnavailableStripeCustomerError(error)) throw error;
+      return null;
+    });
+    const personalSubscription = personalCustomerId
+      ? await getPersonalPlanReplacementSubscription(stripe, personalCustomerId)
+      : null;
+    const personalPlanReplacement = personalSubscription
+      ? {
+          subscriptionId: personalSubscription.id,
+          userId: user.id,
+        }
+      : undefined;
 
     return startWorkspaceCheckout(
       {
@@ -643,6 +675,7 @@ export const createTeamCheckoutSession = createServerFn({ method: "POST" })
         successUrl,
         cancelUrl,
         returnUrl,
+        personalPlanReplacement,
       },
       {
         async getContext(workspaceId) {
@@ -705,6 +738,16 @@ export const createTeamCheckoutSession = createServerFn({ method: "POST" })
           return subscriptions.data;
         },
         async createCheckoutSession(input) {
+          const metadata: Record<string, string> = {
+            checkout_type: "team",
+            workspace_id: input.workspaceId,
+          };
+          if (input.personalPlanReplacement) {
+            metadata.replaces_personal_subscription_id =
+              input.personalPlanReplacement.subscriptionId;
+            metadata.replaces_personal_user_id =
+              input.personalPlanReplacement.userId;
+          }
           return stripe.checkout.sessions.create({
             customer: input.customerId,
             success_url: input.successUrl,
@@ -722,15 +765,9 @@ export const createTeamCheckoutSession = createServerFn({ method: "POST" })
               },
             ],
             mode: "subscription",
-            metadata: {
-              checkout_type: "team",
-              workspace_id: input.workspaceId,
-            },
+            metadata,
             subscription_data: {
-              metadata: {
-                checkout_type: "team",
-                workspace_id: input.workspaceId,
-              },
+              metadata,
             },
           });
         },

--- a/apps/web/src/lib/stripe-customer.test.ts
+++ b/apps/web/src/lib/stripe-customer.test.ts
@@ -4,7 +4,29 @@ import test from "node:test";
 import {
   getStripeCustomerIdentityMetadata,
   getStripeCustomerOwnership,
+  isUnavailableStripeCustomerError,
 } from "./stripe-customer.ts";
+
+test("recognizes stale personal Stripe customer references", () => {
+  assert.equal(
+    isUnavailableStripeCustomerError({ code: "resource_missing" }),
+    true,
+  );
+  assert.equal(
+    isUnavailableStripeCustomerError({ raw: { code: "resource_missing" } }),
+    true,
+  );
+  assert.equal(
+    isUnavailableStripeCustomerError(
+      new Error("Stripe customer does not belong to authenticated user"),
+    ),
+    true,
+  );
+  assert.equal(
+    isUnavailableStripeCustomerError(new Error("Stripe is unavailable")),
+    false,
+  );
+});
 
 test("Stripe metadata must belong to the authenticated user", () => {
   assert.equal(

--- a/apps/web/src/lib/stripe-customer.ts
+++ b/apps/web/src/lib/stripe-customer.ts
@@ -1,5 +1,26 @@
 export type StripeCustomerOwnership = "owned" | "claimable" | "unowned";
 
+const UNAVAILABLE_CUSTOMER_MESSAGES = new Set([
+  "Stripe customer is unavailable",
+  "Stripe customer does not belong to authenticated user",
+]);
+
+export function isUnavailableStripeCustomerError(error: unknown) {
+  if (typeof error !== "object" || error === null) return false;
+
+  const raw = Reflect.get(error, "raw");
+  const rawCode =
+    typeof raw === "object" && raw !== null
+      ? Reflect.get(raw, "code")
+      : undefined;
+
+  return (
+    Reflect.get(error, "code") === "resource_missing" ||
+    rawCode === "resource_missing" ||
+    UNAVAILABLE_CUSTOMER_MESSAGES.has(Reflect.get(error, "message"))
+  );
+}
+
 export function getStripeCustomerOwnership(
   customer: {
     email?: string | null;

--- a/apps/web/src/lib/subscription-selection.test.ts
+++ b/apps/web/src/lib/subscription-selection.test.ts
@@ -5,6 +5,7 @@ import type Stripe from "stripe";
 import {
   getPlanSwitchRoute,
   selectCurrentSubscription,
+  selectPersonalPlanReplacement,
 } from "./subscription-selection.ts";
 
 const subscription = (id: string, status: Stripe.Subscription.Status) => ({
@@ -83,6 +84,35 @@ test("ignores subscriptions that cannot be reused", () => {
     selectCurrentSubscription([
       subscription("sub_canceled", "canceled"),
       subscription("sub_expired", "incomplete_expired"),
+    ]),
+    null,
+  );
+});
+
+test("selects personal plans that Stripe may still renew", () => {
+  const subscriptions = [
+    { ...subscription("sub_unpaid", "unpaid"), cancel_at_period_end: false },
+    {
+      ...subscription("sub_past_due", "past_due"),
+      cancel_at_period_end: false,
+    },
+  ];
+
+  assert.equal(
+    selectPersonalPlanReplacement(subscriptions)?.id,
+    "sub_past_due",
+  );
+});
+
+test("ignores paused and already-ending personal plans", () => {
+  assert.equal(
+    selectPersonalPlanReplacement([
+      { ...subscription("sub_paused", "paused"), cancel_at_period_end: false },
+      { ...subscription("sub_ending", "active"), cancel_at_period_end: true },
+      {
+        ...subscription("sub_canceled", "canceled"),
+        cancel_at_period_end: false,
+      },
     ]),
     null,
   );

--- a/apps/web/src/lib/subscription-selection.ts
+++ b/apps/web/src/lib/subscription-selection.ts
@@ -6,12 +6,35 @@ const CURRENT_SUBSCRIPTION_STATUS_PRIORITY = [
   "paused",
 ] satisfies Stripe.Subscription.Status[];
 
+const PERSONAL_PLAN_REPLACEMENT_STATUS_PRIORITY = [
+  "active",
+  "trialing",
+  "past_due",
+  "unpaid",
+] satisfies Stripe.Subscription.Status[];
+
 export function selectCurrentSubscription<T extends { status: string }>(
   subscriptions: readonly T[],
 ): T | null {
   for (const status of CURRENT_SUBSCRIPTION_STATUS_PRIORITY) {
     const subscription = subscriptions.find(
       (candidate) => candidate.status === status,
+    );
+    if (subscription) {
+      return subscription;
+    }
+  }
+
+  return null;
+}
+
+export function selectPersonalPlanReplacement<
+  T extends { status: string; cancel_at_period_end: boolean },
+>(subscriptions: readonly T[]): T | null {
+  for (const status of PERSONAL_PLAN_REPLACEMENT_STATUS_PRIORITY) {
+    const subscription = subscriptions.find(
+      (candidate) =>
+        candidate.status === status && !candidate.cancel_at_period_end,
     );
     if (subscription) {
       return subscription;

--- a/apps/web/src/lib/workspace-checkout.test.ts
+++ b/apps/web/src/lib/workspace-checkout.test.ts
@@ -78,6 +78,33 @@ test("provisions a workspace customer and starts per-seat checkout", async () =>
       quantity: 3,
       minimumQuantity: 2,
       workspaceId,
+      personalPlanReplacement: undefined,
+      successUrl: input.successUrl,
+      cancelUrl: input.cancelUrl,
+    },
+  ]);
+});
+
+test("carries a personal plan replacement into Team checkout", async () => {
+  const deps = dependencies();
+  const personalPlanReplacement = {
+    subscriptionId: "sub_personal123",
+    userId: "user-123",
+  };
+
+  await startWorkspaceCheckout(
+    { ...input, personalPlanReplacement },
+    deps.value,
+  );
+
+  assert.deepEqual(deps.checkoutInputs, [
+    {
+      customerId: "cus_team123",
+      priceId: "price_team_monthly",
+      quantity: 3,
+      minimumQuantity: 2,
+      workspaceId,
+      personalPlanReplacement,
       successUrl: input.successUrl,
       cancelUrl: input.cancelUrl,
     },

--- a/apps/web/src/lib/workspace-checkout.ts
+++ b/apps/web/src/lib/workspace-checkout.ts
@@ -4,6 +4,11 @@ export type WorkspaceCheckoutContext = {
   usedSeats: number;
 };
 
+export type PersonalPlanReplacement = {
+  subscriptionId: string;
+  userId: string;
+};
+
 type WorkspaceCustomer = {
   id: string;
   deleted?: boolean;
@@ -34,6 +39,7 @@ type WorkspaceCheckoutDependencies = {
     quantity: number;
     minimumQuantity: number;
     workspaceId: string;
+    personalPlanReplacement?: PersonalPlanReplacement;
     successUrl: string;
     cancelUrl: string;
   }) => Promise<{ url: string | null }>;
@@ -60,6 +66,7 @@ export async function startWorkspaceCheckout(
     successUrl: string;
     cancelUrl: string;
     returnUrl: string;
+    personalPlanReplacement?: PersonalPlanReplacement;
   },
   dependencies: WorkspaceCheckoutDependencies,
 ) {
@@ -136,6 +143,7 @@ export async function startWorkspaceCheckout(
     quantity: input.quantity,
     minimumQuantity: context.usedSeats,
     workspaceId: input.workspaceId,
+    personalPlanReplacement: input.personalPlanReplacement,
     successUrl: input.successUrl,
     cancelUrl: input.cancelUrl,
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes Stripe webhook billing logic and automatic personal subscription cancellation, with validation but real risk of incorrect cancellations or failed webhooks if metadata or ownership checks are wrong.
> 
> **Overview**
> **Team checkout now records which personal Pro subscription to retire**, and a Stripe webhook handler schedules `cancel_at_period_end` on that subscription once the Team sub is active/trialing, with ownership checks and idempotency for already-ending subs.
> 
> **Web Team checkout** looks up the user’s still-renewable personal subscription (`active`, `trialing`, `past_due`, `unpaid`) and passes `replaces_personal_subscription_id` / `replaces_personal_user_id` on checkout and subscription metadata; stale or missing personal Stripe customers are ignored via `isUnavailableStripeCustomerError`.
> 
> **Desktop settings** treat workspace **Team/Enterprise** as the effective plan in Account (hiding personal Pro trial/paused UI and personal “Manage billing”) and avoid flashing **Start Team** while workspace access is still loading on the Teams page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eeb1dd8f3f6b50dbbaf8f8d7e03e3cde9857f35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->