### PR TITLE
Update MCP and plugin compatibility

### DIFF
--- a/.agents/skills/qa-cli-mcp-api/SKILL.md
+++ b/.agents/skills/qa-cli-mcp-api/SKILL.md
@@ -167,12 +167,18 @@ Launch the exact desktop candidate and add a temporary receiver under
 Start `anarlog mcp` through a real MCP client over stdio. Do not validate this
 lane by invoking server handlers directly.
 
-1. Initialize the protocol and run `tools/list`.
+1. Connect with the current MCP lifecycle and run `tools/list`. Repeat the handshake with a legacy `2025-11-25` client.
 2. Require exactly these tools:
    - `list_meetings`
    - `get_meeting`
    - `get_meeting_transcript`
    - `get_recurring_meeting_history`
+   - `export_meeting`
+   - `propose_summary_edit`
+   - `propose_memo_edit`
+   - `list_proposals`
+   - `get_proposal`
+   - `decline_proposal`
 3. Call every tool against the fixture. Verify query and series filters,
    two-page transcript/history traversal, missing IDs, and invalid arguments.
 4. Run `resources/list`, `resources/templates/list`, and `resources/read` for a
@@ -215,9 +221,12 @@ Begin with **Cloud API & Connectors** disabled.
 
 Connect a real Streamable HTTP MCP client to the deployed `/mcp` endpoint.
 
-1. Initialize a session, list tools, and require the same four-tool contract as
-   local MCP. Hosts that only support stateless JSON discovery must still list
-   the four tools without establishing a session first.
+1. Use `server/discover` with MCP `2026-07-28`, list tools without creating a
+   session, and require exactly `list_meetings`, `get_meeting`,
+   `get_meeting_transcript`, `get_recurring_meeting_history`, and
+   `export_meeting`. Verify the required protocol metadata and standard HTTP
+   headers on every modern request. Repeat discovery with a legacy
+   `2025-11-25` stateless client to prove compatibility.
 2. Call every tool and traverse at least two transcript/history pages.
 3. Compare its structured results with the hosted REST responses.
 4. Repeat initialization or a tool call with no credential, a malformed key, a

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official plugins from Fastrepl",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
       "displayName": "Anarlog",
       "source": "./agent-plugins/anarlog",
       "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Fastrepl",
         "email": "founders@anarlog.so",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official plugins from Fastrepl",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "anarlog",
       "source": "./agent-plugins/anarlog",
       "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "category": "Productivity",
       "tags": ["meetings", "notes", "transcripts", "mcp", "oauth"]
     }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official plugins from Fastrepl",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "anarlog",
       "source": "./agent-plugins/anarlog",
       "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Fastrepl",
         "email": "founders@anarlog.so",

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -168,6 +168,8 @@ jobs:
           ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "binaries/char-chrome-native-host"
           ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "binaries/check-permissions"
           ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "resources/cli/anarlog-cli"
+        env:
+          APP_VERSION: ${{ needs.compute-version.outputs.version }}
       - uses: ./.github/actions/apple_cert
         id: apple-cert
         with:
@@ -382,6 +384,8 @@ jobs:
           TAURI_ENV_TARGET_TRIPLE=${{ matrix.target }} cargo xtask prepare-binaries
           ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "binaries/char-chrome-native-host"
           ./scripts/sidecar.sh "./apps/desktop/${{ env.TAURI_CONF_PATH }}" "resources/cli/anarlog-cli"
+        env:
+          APP_VERSION: ${{ needs.compute-version.outputs.version }}
       - run: |
           BUILD_ARGS=(
             --ci
@@ -600,6 +604,8 @@ jobs:
           ./scripts/sidecar.sh \
             "./apps/desktop/${{ env.TAURI_CONF_PATH }}" \
             resources/cli/anarlog-cli
+        env:
+          APP_VERSION: ${{ needs.compute-version.outputs.version }}
       - name: Build Windows app
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -990,7 +990,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2445,6 +2445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,7 +2728,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3548,7 +3554,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4175,6 +4181,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,6 +4218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4250,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4902,7 +4942,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5459,7 +5499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9436,7 +9476,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10890,7 +10930,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11167,7 +11207,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11331,7 +11371,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -12145,7 +12185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13533,7 +13573,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14176,18 +14216,19 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.5.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "indexmap 2.14.0",
  "oauth2",
  "pastey",
  "pin-project-lite",
@@ -14210,15 +14251,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.5.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -14480,7 +14521,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14493,7 +14534,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14572,7 +14613,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15467,7 +15508,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 4.0.0",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -15716,7 +15757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16059,9 +16100,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "c25ac7aff0abd1dbc474536e40416e1102c7dd9bfba0b9861c6d357f835dcfb4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -16086,7 +16127,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -18685,7 +18725,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19686,7 +19726,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20174,7 +20214,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21592,7 +21632,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,7 +386,7 @@ windows = "0.62.2"
 windows-core = "0.62.2"
 xcap = "0.9.3"
 
-rmcp = "1.4"
+rmcp = "3.2"
 rustls = { version = "0.23", default-features = false }
 sqlx = { version = "=0.9.0-alpha.1", default-features = false }
 sys-locale = "0.3.2"

--- a/agent-plugins/anarlog/.claude-plugin/plugin.json
+++ b/agent-plugins/anarlog/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "anarlog",
   "displayName": "Anarlog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",

--- a/agent-plugins/anarlog/.codex-plugin/plugin.json
+++ b/agent-plugins/anarlog/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anarlog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",

--- a/agent-plugins/anarlog/.cursor-plugin/plugin.json
+++ b/agent-plugins/anarlog/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anarlog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",

--- a/agent-plugins/anarlog/plugin.json
+++ b/agent-plugins/anarlog/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "anarlog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Query and export Anarlog meetings through Cloud MCP or the local CLI.",
   "author": {
     "name": "Fastrepl",

--- a/apps/cli/src/analytics.rs
+++ b/apps/cli/src/analytics.rs
@@ -29,7 +29,7 @@ pub fn capture_command_completed(command: &str, outcome: &str, duration: Duratio
             "$session_id": new_id(),
             "surface": "cli",
             "analytics_schema_version": 1,
-            "app_version": env!("CARGO_PKG_VERSION"),
+            "app_version": anarlog_cli::VERSION,
             "command": command,
             "outcome": outcome,
             "duration_ms": duration.as_millis(),

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -7,7 +7,7 @@ use anlg_agent_access::{DEFAULT_TRANSCRIPT_LIMIT, MAX_TRANSCRIPT_LIMIT};
 #[derive(Debug, Parser)]
 #[command(
     name = "anarlog",
-    version,
+    version = crate::VERSION,
     about = "Access Anarlog from the command line"
 )]
 pub struct Args {
@@ -393,6 +393,11 @@ mod tests {
         let contract: serde_json::Value =
             serde_json::from_str(&cli_docs::generate_json(&Args::command())).unwrap();
         insta::assert_json_snapshot!("cli_contract", canonicalize_json(contract));
+    }
+
+    #[test]
+    fn version_uses_the_build_version() {
+        assert_eq!(Args::command().get_version(), Some(crate::VERSION));
     }
 
     fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {

--- a/apps/cli/src/cloud.rs
+++ b/apps/cli/src/cloud.rs
@@ -45,7 +45,7 @@ impl CloudClient {
     fn new(base_url: &str, access_token: String) -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
-            .user_agent(format!("anarlog-cli/{}", env!("CARGO_PKG_VERSION")))
+            .user_agent(format!("anarlog-cli/{}", crate::VERSION))
             .build()
             .map_err(|error| Error::operation("create Cloud API client", error.to_string()))?;
         Ok(Self {

--- a/apps/cli/src/commands/auth/mod.rs
+++ b/apps/cli/src/commands/auth/mod.rs
@@ -216,7 +216,7 @@ async fn verify_and_build_session(tokens: CallbackTokens) -> Result<Session> {
     let claims = decode_token_claims(&tokens.access_token)?;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
-        .user_agent(format!("anarlog-cli/{}", env!("CARGO_PKG_VERSION")))
+        .user_agent(format!("anarlog-cli/{}", crate::VERSION))
         .build()
         .map_err(|error| Error::operation("verify login", error.to_string()))?;
     let response = client

--- a/apps/cli/src/commands/doctor.rs
+++ b/apps/cli/src/commands/doctor.rs
@@ -60,7 +60,7 @@ async fn inspect(args: &Args) -> Result<DoctorReport> {
     }
 
     Ok(DoctorReport {
-        cli_version: env!("CARGO_PKG_VERSION"),
+        cli_version: crate::VERSION,
         ready: database.opened_read_only && database.schema_ready,
         database,
     })

--- a/apps/cli/src/error_reporting.rs
+++ b/apps/cli/src/error_reporting.rs
@@ -12,7 +12,7 @@ pub fn init() -> Option<sentry::ClientInitGuard> {
         .or_else(|| option_env!("SENTRY_DSN").map(ToOwned::to_owned))?;
     let guard = sentry::init(sentry::ClientOptions {
         dsn: dsn.parse().ok(),
-        release: Some(format!("anarlog-cli@{}", env!("CARGO_PKG_VERSION")).into()),
+        release: Some(format!("anarlog-cli@{}", anarlog_cli::VERSION).into()),
         environment: Some(if cfg!(debug_assertions) {
             "development".into()
         } else {

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -12,6 +12,11 @@ pub use cli::Args;
 pub use error::{Error, Result};
 pub use output::JSON_SCHEMA_VERSION;
 
+pub const VERSION: &str = match option_env!("APP_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
 pub async fn run(mut args: Args) -> Result<u8> {
     if let cli::Command::Auth { command } = &args.command {
         commands::auth::run(command, args.json).await?;

--- a/apps/cli/src/mcp.rs
+++ b/apps/cli/src/mcp.rs
@@ -292,11 +292,8 @@ impl ServerHandler for AnarlogMcpServer {
                 .enable_resources()
                 .build(),
         )
-        .with_protocol_version(ProtocolVersion::LATEST)
-        .with_server_info(Implementation::new(
-            "anarlog",
-            env!("CARGO_PKG_VERSION"),
-        ))
+        .with_protocol_version(ProtocolVersion::V_2026_07_28)
+        .with_server_info(Implementation::new("anarlog", crate::VERSION))
         .with_instructions(
             "Local access to Anarlog meeting data. Start with list_meetings to resolve a meeting_id, then call get_meeting for notes, summaries, participants, and action items. Request transcript pages with get_meeting_transcript and continue with pagination.next_offset; each page is capped at 500 words. Use get_recurring_meeting_history for series context. Use export_meeting only when the task needs the complete record including transcripts. To persist an edit, call propose_summary_edit or propose_memo_edit; the result stays pending until a human applies it in the desktop app. List or inspect staged work with list_proposals and get_proposal. decline_proposal discards a pending proposal without changing the meeting. Never invent meeting titles, dates, or ids. If list_meetings returns no meetings, say so. Never access SQLite directly, or claim a proposal was applied. Documentation: https://docs.anarlog.so",
         )
@@ -307,8 +304,6 @@ impl ServerHandler for AnarlogMcpServer {
         params: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> std::result::Result<ListResourcesResult, McpError> {
-        use rmcp::model::AnnotateAble;
-
         let offset = params
             .and_then(|params| params.cursor)
             .map(|cursor| {
@@ -339,18 +334,15 @@ impl ServerHandler for AnarlogMcpServer {
                 } else {
                     meeting.title
                 };
-                RawResource::new(format!("anarlog://meetings/{}", meeting.id), name)
+                Resource::new(format!("anarlog://meetings/{}", meeting.id), name)
                     .with_description("Anarlog meeting context")
                     .with_mime_type("text/markdown")
-                    .no_annotation()
             })
             .collect();
 
-        Ok(ListResourcesResult {
-            meta: None,
-            next_cursor,
-            resources,
-        })
+        let mut result = ListResourcesResult::with_all_items(resources);
+        result.next_cursor = next_cursor;
+        Ok(result)
     }
 
     async fn list_resource_templates(
@@ -358,24 +350,19 @@ impl ServerHandler for AnarlogMcpServer {
         _params: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> std::result::Result<ListResourceTemplatesResult, McpError> {
-        use rmcp::model::AnnotateAble;
-
         Ok(ListResourceTemplatesResult::with_all_items(vec![
-            RawResourceTemplate::new("anarlog://meetings/{meeting_id}", "Anarlog meeting")
+            ResourceTemplate::new("anarlog://meetings/{meeting_id}", "Anarlog meeting")
                 .with_description("Meeting metadata, note, summaries, people, and action items")
-                .with_mime_type("text/markdown")
-                .no_annotation(),
-            RawResourceTemplate::new(
+                .with_mime_type("text/markdown"),
+            ResourceTemplate::new(
                 "anarlog://meetings/{meeting_id}/transcript{?offset,limit}",
                 "Anarlog meeting transcript",
             )
             .with_description("A bounded page of meeting transcript text")
-            .with_mime_type("text/plain")
-            .no_annotation(),
-            RawResourceTemplate::new("anarlog://series/{series_id}", "Anarlog meeting series")
+            .with_mime_type("text/plain"),
+            ResourceTemplate::new("anarlog://series/{series_id}", "Anarlog meeting series")
                 .with_description("Recurring meeting history")
-                .with_mime_type("text/markdown")
-                .no_annotation(),
+                .with_mime_type("text/markdown"),
         ]))
     }
 
@@ -383,7 +370,7 @@ impl ServerHandler for AnarlogMcpServer {
         &self,
         params: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> std::result::Result<ReadResourceResult, McpError> {
+    ) -> std::result::Result<ReadResourceResponse, McpError> {
         let request = parse_resource_uri(&params.uri)?;
         let contents = match request {
             ResourceRequest::Meeting { meeting_id } => {
@@ -445,7 +432,7 @@ impl ServerHandler for AnarlogMcpServer {
             }
         };
 
-        Ok(ReadResourceResult::new(vec![contents]))
+        Ok(ReadResourceResult::new(vec![contents]).into())
     }
 }
 
@@ -542,6 +529,7 @@ fn command_error(error: access::Error) -> McpError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmcp::transport::{IntoTransport, Transport};
     use serde_json::Value;
 
     #[test]
@@ -568,6 +556,7 @@ mod tests {
     async fn server_advertises_tools_and_resources() {
         let db = Arc::new(anlg_db_core::Db::connect_memory_plain().await.unwrap());
         let info = AnarlogMcpServer::new(db).get_info();
+        assert_eq!(info.protocol_version, ProtocolVersion::V_2026_07_28);
         assert!(info.capabilities.tools.is_some());
         assert!(info.capabilities.resources.is_some());
         let instructions = info.instructions.unwrap();
@@ -702,8 +691,8 @@ mod tests {
             .iter()
             .map(|template| {
                 (
-                    template.raw.name.clone(),
-                    template.raw.uri_template.clone(),
+                    template.name.clone(),
+                    template.uri_template.clone(),
                     template.annotations.clone(),
                 )
             })
@@ -734,13 +723,72 @@ mod tests {
             assert!(mcp_skill.contains(uri), "Anarlog skill is missing `{uri}`");
         }
         assert_eq!(resources.len(), 1);
-        assert_eq!(resources[0].raw.name, "Planning");
-        assert_eq!(resources[0].raw.uri, "anarlog://meetings/meeting-1");
+        assert_eq!(resources[0].name, "Planning");
+        assert_eq!(resources[0].uri, "anarlog://meetings/meeting-1");
         assert!(resources[0].annotations.is_none());
 
         client.cancel().await.unwrap();
         let server = server_handle.await.unwrap().unwrap();
         server.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn current_client_discovers_and_lists_tools_without_initialize() {
+        let db = Arc::new(anlg_db_core::Db::connect_memory_plain().await.unwrap());
+        anlg_db_app::prepare_schema(&db).await.unwrap();
+        let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+        let server = AnarlogMcpServer::new(db);
+        let server_task =
+            tokio::spawn(async move { server.serve(server_transport).await.unwrap() });
+        let mut client = IntoTransport::<rmcp::RoleClient, _, _>::into_transport(client_transport);
+
+        let mut discover = DiscoverRequest::new(DiscoverRequestParams {});
+        discover.extensions.insert(current_client_meta());
+        client
+            .send(ClientJsonRpcMessage::request(
+                ClientRequest::DiscoverRequest(discover),
+                RequestId::Number(1),
+            ))
+            .await
+            .unwrap();
+        let discover = client.receive().await.unwrap();
+        let discover = serde_json::to_value(discover).unwrap();
+        assert!(
+            discover["result"]["supportedVersions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|version| version == "2026-07-28")
+        );
+
+        let mut list_tools = ListToolsRequest {
+            method: Default::default(),
+            params: None,
+            extensions: Default::default(),
+        };
+        list_tools.extensions.insert(current_client_meta());
+        client
+            .send(ClientJsonRpcMessage::request(
+                ClientRequest::ListToolsRequest(list_tools),
+                RequestId::Number(2),
+            ))
+            .await
+            .unwrap();
+        let tools = client.receive().await.unwrap();
+        let tools = serde_json::to_value(tools).unwrap();
+        assert_eq!(tools["result"]["resultType"], "complete");
+        assert_eq!(tools["result"]["tools"].as_array().unwrap().len(), 10);
+
+        drop(client);
+        server_task.await.unwrap().cancel().await.unwrap();
+    }
+
+    fn current_client_meta() -> RequestMetaObject {
+        RequestMetaObject::with_client_context(
+            ProtocolVersion::V_2026_07_28,
+            Implementation::new("anarlog-test", "1.0.0"),
+            ClientCapabilities::default(),
+        )
     }
 
     fn canonicalize_json(value: Value) -> Value {

--- a/apps/cli/src/snapshots/anarlog_cli__mcp__tests__mcp_contract.snap
+++ b/apps/cli/src/snapshots/anarlog_cli__mcp__tests__mcp_contract.snap
@@ -4,7 +4,7 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
 ---
 {
   "instructions": "Local access to Anarlog meeting data. Start with list_meetings to resolve a meeting_id, then call get_meeting for notes, summaries, participants, and action items. Request transcript pages with get_meeting_transcript and continue with pagination.next_offset; each page is capped at 500 words. Use get_recurring_meeting_history for series context. Use export_meeting only when the task needs the complete record including transcripts. To persist an edit, call propose_summary_edit or propose_memo_edit; the result stays pending until a human applies it in the desktop app. List or inspect staged work with list_proposals and get_proposal. decline_proposal discards a pending proposal without changing the meeting. Never invent meeting titles, dates, or ids. If list_meetings returns no meetings, say so. Never access SQLite directly, or claim a proposal was applied. Documentation: https://docs.anarlog.so",
-  "protocol_version": "2025-11-25",
+  "protocol_version": "2026-07-28",
   "resource_templates": [
     {
       "description": "Meeting metadata, note, summaries, people, and action items",
@@ -45,7 +45,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "required": [
           "proposal_id"
         ],
-        "title": "DeclineProposalInput",
         "type": "object"
       },
       "name": "decline_proposal",
@@ -127,7 +126,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "required": [
           "meeting_id"
         ],
-        "title": "GetMeetingInput",
         "type": "object"
       },
       "name": "export_meeting",
@@ -410,7 +408,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "required": [
           "meeting_id"
         ],
-        "title": "GetMeetingInput",
         "type": "object"
       },
       "name": "get_meeting",
@@ -648,7 +645,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "required": [
           "meeting_id"
         ],
-        "title": "GetMeetingTranscriptInput",
         "type": "object"
       },
       "name": "get_meeting_transcript",
@@ -742,7 +738,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "required": [
           "proposal_id"
         ],
-        "title": "GetProposalInput",
         "type": "object"
       },
       "name": "get_proposal",
@@ -843,7 +838,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
         "required": [
           "meeting_id"
         ],
-        "title": "GetRecurringMeetingHistoryInput",
         "type": "object"
       },
       "name": "get_recurring_meeting_history",
@@ -1000,7 +994,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
             ]
           }
         },
-        "title": "ListMeetingsInput",
         "type": "object"
       },
       "name": "list_meetings",
@@ -1157,7 +1150,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
             ]
           }
         },
-        "title": "ListProposalsInput",
         "type": "object"
       },
       "name": "list_proposals",
@@ -1303,7 +1295,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
           "meeting_id",
           "content"
         ],
-        "title": "ProposeMemoInput",
         "type": "object"
       },
       "name": "propose_memo_edit",
@@ -1394,7 +1385,6 @@ expression: "canonicalize_json(serde_json::json!({\n    \"protocol_version\": in
           "meeting_id",
           "content"
         ],
-        "title": "ProposeSummaryInput",
         "type": "object"
       },
       "name": "propose_summary_edit",

--- a/crates/api-cloud/src/mcp.rs
+++ b/crates/api-cloud/src/mcp.rs
@@ -177,7 +177,7 @@ impl CloudMcpServer {
 impl ServerHandler for CloudMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_protocol_version(ProtocolVersion::LATEST)
+            .with_protocol_version(ProtocolVersion::V_2026_07_28)
             .with_server_info(Implementation::new(
                 "anarlog",
                 env!("CARGO_PKG_VERSION"),
@@ -205,8 +205,8 @@ fn user_id(auth: Option<anlg_api_auth::AuthContext>) -> Option<String> {
     auth.map(|auth| auth.claims.sub)
 }
 
-fn oauth_security_meta() -> Meta {
-    let mut meta = Meta::new();
+fn oauth_security_meta() -> MetaObject {
+    let mut meta = MetaObject::new();
     meta.insert(
         "securitySchemes".to_string(),
         serde_json::json!([{
@@ -218,7 +218,7 @@ fn oauth_security_meta() -> Meta {
 }
 
 fn authentication_required(state: &AppState) -> CallToolResult {
-    let mut meta = Meta::new();
+    let mut meta = MetaObject::new();
     meta.insert(
         "mcp/www_authenticate".to_string(),
         serde_json::json!([state.oauth().challenge(Some((
@@ -226,7 +226,7 @@ fn authentication_required(state: &AppState) -> CallToolResult {
             "Connect your Anarlog account to use this tool",
         )))]),
     );
-    CallToolResult::error(vec![Content::text(
+    CallToolResult::error(vec![ContentBlock::text(
         "Connect your Anarlog account to use this tool.",
     )])
     .with_meta(Some(meta))
@@ -251,6 +251,18 @@ fn command_error(error: crate::CloudApiError) -> McpError {
 mod tests {
     use super::*;
     use crate::CloudApiConfig;
+
+    #[test]
+    fn server_advertises_the_current_protocol() {
+        let state = AppState::new(
+            CloudApiConfig::new("https://auth.example.com", "service-role-key").unwrap(),
+        );
+
+        assert_eq!(
+            CloudMcpServer { state }.get_info().protocol_version,
+            ProtocolVersion::V_2026_07_28
+        );
+    }
 
     #[test]
     fn every_hosted_tool_declares_oauth_security() {

--- a/crates/api-cloud/src/routes.rs
+++ b/crates/api-cloud/src/routes.rs
@@ -712,7 +712,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
     }
 
     #[tokio::test]
-    async fn mcp_supports_stateless_tool_discovery_on_the_public_api_host() {
+    async fn mcp_supports_current_stateless_tool_discovery_on_the_public_api_host() {
         let server = MockServer::start().await;
         let key = format!("anl_{}", "a".repeat(64));
         let key_hash = Sha256::digest(key.as_bytes())
@@ -728,7 +728,7 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                     "status": "ok",
                 }])),
             )
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         let state =
@@ -739,19 +739,59 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
         ));
 
         let response = app
+            .clone()
             .oneshot(
                 Request::post("/mcp")
                     .header("host", "api.anarlog.so")
                     .header("authorization", format!("Bearer {key}"))
                     .header("content-type", "application/json")
                     .header("accept", "application/json, text/event-stream")
-                    .header("mcp-protocol-version", "2025-06-18")
+                    .header("mcp-protocol-version", "2026-07-28")
+                    .header("mcp-method", "server/discover")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "server/discover",
+                            "params": {
+                                "_meta": current_mcp_meta(),
+                            },
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert!(
+            body["result"]["supportedVersions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|version| version == "2026-07-28")
+        );
+
+        let response = app
+            .oneshot(
+                Request::post("/mcp")
+                    .header("host", "api.anarlog.so")
+                    .header("authorization", format!("Bearer {key}"))
+                    .header("content-type", "application/json")
+                    .header("accept", "application/json, text/event-stream")
+                    .header("mcp-protocol-version", "2026-07-28")
+                    .header("mcp-method", "tools/list")
                     .body(Body::from(
                         serde_json::json!({
                             "jsonrpc": "2.0",
                             "id": 1,
                             "method": "tools/list",
-                            "params": {},
+                            "params": {
+                                "_meta": current_mcp_meta(),
+                            },
                         })
                         .to_string(),
                     ))
@@ -782,6 +822,17 @@ kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\
                 .iter()
                 .any(|tool| tool["name"] == "export_meeting")
         );
+    }
+
+    fn current_mcp_meta() -> serde_json::Value {
+        serde_json::json!({
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "anarlog-test",
+                "version": "1.0.0",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+        })
     }
 
     #[tokio::test]

--- a/crates/api-research/src/mcp/server.rs
+++ b/crates/api-research/src/mcp/server.rs
@@ -76,7 +76,7 @@ impl ServerHandler for ResearchMcpServer {
                 .enable_prompts()
                 .build(),
         )
-        .with_protocol_version(ProtocolVersion::V_2024_11_05)
+        .with_protocol_version(ProtocolVersion::V_2026_07_28)
         .with_server_info(Implementation::new(
             "anarlog-research",
             env!("CARGO_PKG_VERSION"),
@@ -91,24 +91,20 @@ impl ServerHandler for ResearchMcpServer {
         _params: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, McpError> {
-        Ok(ListPromptsResult {
-            prompts: vec![Prompt::new(
-                "research_chat",
-                Some("System prompt for the Char research chat"),
-                None::<Vec<PromptArgument>>,
-            )],
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(ListPromptsResult::with_all_items(vec![Prompt::new(
+            "research_chat",
+            Some("System prompt for the Char research chat"),
+            None::<Vec<PromptArgument>>,
+        )]))
     }
 
     async fn get_prompt(
         &self,
         params: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<GetPromptResult, McpError> {
+    ) -> Result<GetPromptResponse, McpError> {
         match params.name.as_str() {
-            "research_chat" => prompts::research_chat(),
+            "research_chat" => prompts::research_chat().map(Into::into),
             _ => Err(McpError::invalid_params(
                 format!("Unknown prompt: {}", params.name),
                 None,

--- a/crates/api-research/src/mcp/tools/get_contents.rs
+++ b/crates/api-research/src/mcp/tools/get_contents.rs
@@ -12,7 +12,7 @@ pub(crate) async fn get_contents(
         .await
         .map_err(|e: anlg_exa::Error| McpError::internal_error(e.to_string(), None))?;
 
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string(&response)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?,
     )]))

--- a/crates/api-research/src/mcp/tools/read_url.rs
+++ b/crates/api-research/src/mcp/tools/read_url.rs
@@ -12,5 +12,5 @@ pub(crate) async fn read_url(
         .await
         .map_err(|e: anlg_jina::Error| McpError::internal_error(e.to_string(), None))?;
 
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
 }

--- a/crates/api-research/src/mcp/tools/search.rs
+++ b/crates/api-research/src/mcp/tools/search.rs
@@ -12,7 +12,7 @@ pub(crate) async fn search(
         .await
         .map_err(|e: anlg_exa::Error| McpError::internal_error(e.to_string(), None))?;
 
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string(&response)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?,
     )]))

--- a/crates/mcp/src/prompt.rs
+++ b/crates/mcp/src/prompt.rs
@@ -8,9 +8,8 @@ pub fn render_prompt<T: Template + Default>(
         .render()
         .map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
-    Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-        PromptMessageRole::Assistant,
-        content,
-    )])
-    .with_description(description))
+    Ok(
+        GetPromptResult::new(vec![PromptMessage::new_text(Role::Assistant, content)])
+            .with_description(description),
+    )
 }

--- a/crates/mcp/src/service.rs
+++ b/crates/mcp/src/service.rs
@@ -33,7 +33,7 @@ where
         factory,
         StreamableHttpServerConfig::default()
             .with_allowed_hosts(ALLOWED_HTTP_HOSTS)
-            .with_stateful_mode(false)
+            .with_legacy_session_mode(false)
             .with_json_response(true),
     )
 }

--- a/docs/reference/mcp.mdx
+++ b/docs/reference/mcp.mdx
@@ -3,7 +3,7 @@ title: "MCP reference"
 description: "Tools, resources, limits, and transport details exposed by Anarlog MCP."
 ---
 
-Run the server with `anarlog mcp`. It uses the MCP `2025-11-25` protocol over stdio. Meeting reads are local and idempotent. Proposal tools can insert or decline staged edits; they never apply those edits. The desktop app only needs to have created the database once. Open it to review and apply pending proposals.
+Run the server with `anarlog mcp`. It supports the current MCP `2026-07-28` protocol over stdio while remaining compatible with earlier MCP clients. Meeting reads are local and idempotent. Proposal tools can insert or decline staged edits; they never apply those edits. The desktop app only needs to have created the database once. Open it to review and apply pending proposals.
 
 ## Tools
 

--- a/plugins/importer/src/connected_mcp.rs
+++ b/plugins/importer/src/connected_mcp.rs
@@ -168,10 +168,10 @@ pub async fn begin_connection(
         .await
         .map_err(|error| auth_error(provider, error))?;
     let metadata = manager
-        .discover_metadata()
+        .resolve_metadata()
         .await
         .map_err(|error| auth_error(provider, error))?;
-    manager.set_metadata(metadata);
+    manager.set_metadata(metadata.metadata);
     let scopes = manager.select_scopes(None, &[]);
     let scope_refs = scopes.iter().map(String::as_str).collect::<Vec<_>>();
     let client = manager

--- a/scripts/publish-anarlog-skill.test.mjs
+++ b/scripts/publish-anarlog-skill.test.mjs
@@ -42,7 +42,7 @@ test("plugin manifests use one stable identity and version", async () => {
   for (const manifestPath of PLUGIN_MANIFESTS) {
     const manifest = await readJson(manifestPath);
     assert.equal(manifest.name, "anarlog");
-    assert.equal(manifest.version, "1.1.0");
+    assert.equal(manifest.version, "1.2.0");
     assert.equal(manifest.license, "MIT");
   }
 


### PR DESCRIPTION
Upgrade Anarlog to MCP 2026-07-28 while preserving legacy-client support. Fix packaged CLI version reporting across desktop release builds and publish the Anarlog agent plugin as 1.2.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MCP protocol and dependency major upgrades affect local, hosted, and OAuth-connected clients; incorrect versioning or discovery behavior could break agent integrations and release telemetry.
> 
> **Overview**
> This PR **bumps Anarlog to MCP `2026-07-28`** by upgrading workspace `rmcp` to **3.2** and retargeting local stdio MCP, hosted Cloud MCP, research MCP, and streamable HTTP config (`legacy_session_mode`) to the new SDK types and lifecycle (e.g. `server/discover`, stateless `tools/list` with protocol metadata).
> 
> **Packaged CLI version reporting** now uses a shared `VERSION` constant from optional compile-time `APP_VERSION`; desktop release jobs pass the computed app version when building the bundled `anarlog-cli` so `--version`, doctor, telemetry, and user agents match the desktop release instead of the crate-only version.
> 
> **Agent plugin 1.2.0** is published across marketplace manifests, with QA skill and MCP docs updated for the expanded local tool contract, modern remote discovery, and legacy `2025-11-25` compatibility checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff52852418787a34f36101053f373e5641bff916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->