### PR TITLE
Optimize blog images with Unpic

### DIFF
--- a/apps/web/src/components/image.tsx
+++ b/apps/web/src/components/image.tsx
@@ -15,6 +15,7 @@ function isGifSource(src: ImageProps["src"]) {
 export const Image = ({
   layout = "constrained",
   background,
+  breakpoints,
   objectFit,
   src,
   ...props
@@ -33,6 +34,8 @@ export const Image = ({
         src={src}
         alt={props.alt}
         title={title}
+        loading={imgProps.loading ?? "lazy"}
+        decoding={imgProps.decoding ?? "async"}
         style={{
           objectFit,
           ...(imgProps.style || {}),
@@ -52,6 +55,7 @@ export const Image = ({
       {...(isExternalUrl ? {} : { transformer: transform })}
       layout={layout}
       background={background}
+      breakpoints={breakpoints}
       title={title}
       style={{
         objectFit: objectFit,

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -1,20 +1,37 @@
 import type { ComponentType } from "react";
 
+import { cn } from "@anlg/utils";
+
+import { Image as OptimizedImage } from "@/components/image";
+
+const BLOG_IMAGE_WIDTH = 796;
+const BLOG_IMAGE_BREAKPOINTS = [320, 480, 640, 796, 1080, 1280, 1592];
+const BLOG_IMAGE_SIZES =
+  "(min-width: 860px) 796px, (min-width: 768px) calc(100vw - 64px), calc(100vw - 40px)";
+
 function Image({
   src,
   alt,
+  className,
+  width = BLOG_IMAGE_WIDTH,
   ...rest
 }: {
   src: string;
   alt?: string;
+  className?: string;
+  width?: number;
   [k: string]: any;
 }) {
   return (
-    <img
+    <OptimizedImage
+      {...rest}
       src={src}
       alt={alt ?? ""}
-      className="my-6 w-full rounded-md"
-      {...rest}
+      className={cn(["my-6 w-full rounded-md", className])}
+      layout="constrained"
+      width={width}
+      breakpoints={BLOG_IMAGE_BREAKPOINTS}
+      sizes={BLOG_IMAGE_SIZES}
     />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-layer image loading changes for blog content; no auth, data, or API impact.
> 
> **Overview**
> Blog MDX images now render through the shared **Unpic** `Image` wrapper instead of a plain `<img>`, with a default width of **796px**, responsive **`sizes`**, and a fixed **`breakpoints`** list so Netlify can serve appropriately sized variants.
> 
> The shared **`Image`** component forwards **`breakpoints`** to `UnpicImage`, and GIF sources still use a native `<img>` but now default to **`loading="lazy"`** and **`decoding="async"`** when not overridden. MDX **`Image`** / **`img`** also accept optional **`className`** and **`width`** while keeping existing layout styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4799585967dae08509d2b50af6e81c518ba6a124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->