### PR TITLE
Add Jamie alternatives SEO guide

### DIFF
--- a/apps/web/content/articles/figures.json
+++ b/apps/web/content/articles/figures.json
@@ -185,6 +185,7 @@
   "is-ai-notetaking-legal": [],
   "is-fireflies-ai-safe": [],
   "is-otter-ai-safe": [],
+  "jamie-ai-alternatives": [],
   "local-ai-meeting-notes": [],
   "local-ai-privacy-tools": [],
   "mac-productivity-apps": [],

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -105,6 +105,8 @@ Jamie is the closest alternative here when you like Granola's quiet, bot-free me
 
 Jamie and Granola are both designed to stay out of the participant list. Jamie leans harder into multilingual capture and speaker memory; Granola leans into the human-guided notepad and collaborative meeting context.
 
+If Jamie is the product you are replacing, the [Jamie AI alternatives guide](/blog/jamie-ai-alternatives/) compares the best options by storage, capture, and workflow.
+
 ## 3. Tactiq: best for live transcription in browser meetings
 
 [Tactiq](https://tactiq.io/) is a browser extension for Google Meet, Zoom, and Microsoft Teams. It displays a live transcript beside the meeting without sending a separate participant into the call.

--- a/apps/web/content/articles/jamie-ai-alternatives.mdx
+++ b/apps/web/content/articles/jamie-ai-alternatives.mdx
@@ -1,0 +1,217 @@
+---
+meta_title: "5 Best Jamie AI Alternatives in 2026"
+display_title: "Jamie AI Alternatives for More Control Over Meeting Notes"
+meta_description: "Compare five Jamie AI alternatives for local-first notes, note-first workflows, live browser transcription, sales follow-up, and self-hosted meeting AI."
+author: "John Jeong"
+featured: false
+category: "Comparisons"
+date: "2026-09-05"
+---
+
+Jamie is a polished AI note taker for people who want meeting notes without adding a bot to the call. It works across online, hybrid, and in-person meetings, supports more than 100 languages, remembers speakers, and keeps the resulting notes in a managed workspace.
+
+That combination is strong, but it is not universal. You may want the meeting record stored locally, a notepad that starts with your own observations, a transcript that appears live in the browser, a more generous free sales workflow, or an open-source stack you can run yourself.
+
+This guide compares five Jamie AI alternatives by those reasons to switch. Pricing and product claims were checked on September 5, 2026.
+
+## The short answer
+
+- **Choose Anarlog** if the canonical meeting record should stay local and you want open-source code, Markdown export, and control over the AI provider.
+- **Choose Granola** if you want to keep taking rough notes during the meeting and have AI complete them afterward.
+- **Choose Tactiq** if you want a live transcript inside browser-based Zoom, Google Meet, or Microsoft Teams calls.
+- **Choose Fathom** if a generous free tier and sales follow-up matter more than bot-free capture.
+- **Choose Meetily** if you want an open-source, self-managed local meeting assistant.
+- **Stay with Jamie** if you want a managed bot-free app with multilingual notes, speaker memory, mobile capture, European hosting, and business integrations.
+
+![Jamie workspace showing a generated meeting note and Ask AI](/images/blog/library/products/jamie/meeting-notes/2026-07-22-meeting-notes.webp)
+
+*Jamie's first-party product image shows the current meeting-note workspace and Ask AI entry point. Source: [Jamie](https://www.meetjamie.ai/en/blog/ai-note-taker).*
+
+## Why people look for a Jamie alternative
+
+[Jamie](https://www.meetjamie.ai/en) captures audio from the device rather than joining as another participant. Its current site lists Mac, Windows, iOS, and Android downloads; online and in-person capture; speaker recognition; cross-meeting questions; and notes in more than 100 languages.
+
+The constraints become clearer on [Jamie's pricing page](https://www.meetjamie.ai/pricing):
+
+- **Free:** 10 meetings per month, with a 30-minute limit per meeting.
+- **Plus:** 20 meetings per month and a two-hour limit, at €25 per month or €21 per month billed annually.
+- **Pro:** unlimited meetings with a five-hour limit, at €47 per month or €39 per month billed annually.
+- **Team:** unlimited meetings for 2–10 seats, listed at €39 per seat per month plus applicable VAT.
+- **Enterprise:** custom annual pricing for organizations with 10 or more seats.
+
+Jamie is also specific about its security model. Its [security page](https://www.meetjamie.ai/security) says meeting data is stored and processed within the EEA, Switzerland, and the UK; audio is deleted after transcription; data is encrypted in transit with TLS 1.2 and at rest with AES-256; and customer data is not used to train models. Jamie lists ISO 27001 certification, GDPR compliance, and DORA alignment. Its pricing comparison marks SOC 2 Type II as pending, so buyers should not treat that certification as complete.
+
+Those are meaningful controls, but they still describe a managed cloud service. Audio deletion is not the same as keeping the transcript and notes only on your computer. If local ownership, self-hosting, live transcription, or a different workflow is the actual requirement, one of the alternatives below will fit better.
+
+## Jamie AI alternatives compared
+
+| Tool | Best for | Capture model | Starting point | Main tradeoff |
+| --- | --- | --- | --- | --- |
+| Anarlog | Local-first meeting records and AI-provider choice | Desktop system-audio capture, no meeting bot | Free; Pro $15/month or $150/year | No unattended meeting bot; macOS is the most mature build |
+| Granola | A human-guided notepad that AI completes | Device capture, no meeting bot | Free plan; Business from $14/user/month | Record remains in a managed workspace |
+| Tactiq | Live transcription in browser meetings | Browser extension, no separate participant | Free plan; Pro from $8/user/month annually | Best when meetings happen in supported browser workflows |
+| Fathom | Sales follow-up and a generous free individual plan | Bot capture, with bot-free capture in beta | Free individual plan | Meeting record lives in Fathom's cloud workspace |
+| Meetily | Open-source local or self-hosted meeting AI | Local app and self-managed workflow | Free Community Edition | More setup and operational responsibility |
+
+## 1. Anarlog: best for local-first meeting records
+
+[Anarlog](https://anarlog.so/) is the Jamie alternative for people who want meeting notes to become durable local data instead of entries in another vendor's workspace.
+
+![Anarlog meeting summary with recent meetings in the sidebar](/images/blog/library/products/anarlog/desktop/2026-08-20-meeting-summary.jpg)
+
+*Anarlog keeps a structured summary beside the local meeting history.*
+
+The desktop app captures microphone and system audio without adding a bot to Zoom, Google Meet, Microsoft Teams, or another call. Transcripts, notes, and summaries are stored in local SQLite. You can export Markdown, use your own API keys, or run local models through tools such as Ollama and LM Studio.
+
+Anarlog is also open source. That matters when “private” needs to mean more than a vendor trust page: a technical team can inspect the capture, storage, and AI paths directly.
+
+**Choose Anarlog when:**
+
+- the canonical meeting record should stay on your device;
+- you want to choose which transcription and language-model provider processes a meeting;
+- Markdown export and long-term portability matter;
+- open-source auditability is part of the security review;
+- you want bot-free capture without putting every meeting into a cloud archive.
+
+**Consider the tradeoffs:**
+
+- Anarlog cannot attend a meeting when your computer is absent.
+- macOS is the most mature build; Windows and Linux builds are in beta.
+- Local ownership makes backup and device access controls your responsibility.
+- It does not try to replace a revenue-intelligence platform.
+
+The [Free plan](/pricing/) includes local transcription and bring-your-own-key workflows. Pro costs $15 per month or $150 per year and adds managed transcription, cloud AI, encrypted CloudSync, and calendar integrations. Read the [local AI meeting notes guide](/blog/local-ai-meeting-notes/) for the architectural details.
+
+## 2. Granola: best for people who still take notes
+
+[Granola](https://www.granola.ai/) is the closest alternative when you like Jamie's quiet, bot-free capture but want your own notes to guide the final document.
+
+![Granola notepad beside a video call with background transcription active](/images/blog/library/products/granola/notepad/2026-07-19-meeting-note.jpg)
+
+*Granola's first-party product image shows the notepad working beside a call without another participant joining. Source: [Granola](https://www.granola.ai/).*
+
+During a meeting, you type the fragments you consider important. Granola captures the conversation in the background and expands those notes afterward. Jamie is more hands-off: it creates the meeting record for you, then lets you search and question it.
+
+That difference sounds small, but it changes how the product feels. Granola suits people who stay engaged by writing and want AI to fill gaps. Jamie suits people who want to stop writing altogether.
+
+**Choose Granola when:**
+
+- your rough notes should shape the AI output;
+- a collaborative, polished notepad is the center of the workflow;
+- you want bot-free capture across desktop and mobile;
+- a lower-cost team plan matters more than Jamie's speaker memory and enterprise controls.
+
+**Consider the tradeoffs:**
+
+- Notes and transcripts remain in Granola's managed workspace.
+- The workflow is less useful if you do not want to take any notes yourself.
+- It is not an open-source or self-hosted replacement.
+
+Granola's [Business plan](https://www.granola.ai/pricing) starts at $14 per user per month. Our [Granola alternatives guide](/blog/granola-ai-alternatives/) compares the storage and capture models in more detail.
+
+## 3. Tactiq: best for a live browser transcript
+
+[Tactiq](https://tactiq.io/) is built around a live transcript beside the meeting. Its extension supports browser-based Google Meet, Zoom, and Microsoft Teams workflows without adding a separate participant to the call.
+
+![Tactiq Sidebar running inside a Zoom meeting with transcript-capture instructions](/images/blog/library/products/tactiq/zoom/2026-08-30-sidebar.png)
+
+*The official Zoom Marketplace listing shows Tactiq Sidebar running inside Zoom. Source: [Zoom App Marketplace](https://marketplace.zoom.us/apps/Zep8ayo7TwC0qIU6CQJmaQ).*
+
+Jamie focuses on the record produced after capture: structured notes, transcripts, action items, speaker memory, and Ask AI. Tactiq is a better fit when seeing the words during the call is itself useful—for accessibility, quoting a customer accurately, or highlighting a point before the discussion moves on.
+
+**Choose Tactiq when:**
+
+- you need a live transcript during the meeting;
+- most calls happen in supported browser workflows;
+- a lightweight extension is easier to approve than a full desktop recorder;
+- the starting price matters.
+
+**Consider the tradeoffs:**
+
+- Browser-first capture is narrower than a desktop app that can listen to broader system audio.
+- It is not a local-first meeting archive.
+- Your workflow depends on the extension and supported meeting surfaces.
+
+Tactiq's [pricing page](https://tactiq.io/buy) lists a free plan and Pro at $8 per user per month when billed annually. See the [Tactiq alternatives guide](/blog/tactiq-alternatives/) if browser capture is not enough.
+
+## 4. Fathom: best for free sales follow-up
+
+[Fathom](https://www.fathom.video/) is the strongest alternative here when the real job is turning sales calls into summaries, follow-ups, and CRM updates without paying for every individual user.
+
+![Fathom Recap showing an AI summary, action items, and meeting details](/images/blog/library/products/fathom/meeting-recap/2026-08-30-recap.webp)
+
+*Fathom's Recap keeps the recording, summary, action items, and CRM context in one workspace. Source: [Fathom](https://www.fathom.video/).*
+
+Its [pricing page](https://www.fathom.ai/pricing) says the individual plan includes unlimited recordings and transcriptions. Team plans start at $19 per user per month, or $15 per user per month billed annually, with a two-user minimum. Fathom supports bot-based capture and lists bot-free capture as a beta option.
+
+**Choose Fathom when:**
+
+- the free plan needs to handle a real weekly meeting load;
+- sales summaries and CRM handoff matter more than a quiet meeting experience;
+- recordings and team collaboration should live in one shared cloud workspace;
+- you want to prove the workflow before buying a team plan.
+
+**Consider the tradeoffs:**
+
+- The standard workflow is built around a meeting bot.
+- The meeting record remains in Fathom's cloud workspace.
+- Enterprise compliance features can require a higher tier.
+
+The [Fathom alternatives guide](/blog/fathom-ai-alternatives/) covers the capture and storage differences in more detail.
+
+## 5. Meetily: best for a self-managed open-source setup
+
+[Meetily](https://meetily.ai/) is the Jamie alternative for technical users who want a local or self-hosted meeting assistant and are comfortable operating more of the stack themselves.
+
+![Meetily transcript beside a generated summary, decisions, and action items](/images/blog/library/products/meetily/meeting-summary/2026-07-19-summary.png)
+
+*Meetily's official repository screenshot shows its transcript and generated meeting record side by side. Source: [Meetily](https://github.com/Zackriya-Solutions/meetily/blob/main/docs/summary.png).*
+
+The Community Edition is free and open source. Meetily's current site lists Pro at $10 per user per month billed annually, plus custom organizational and enterprise options. Local models and self-hosting can keep more of the workflow under your control.
+
+**Choose Meetily when:**
+
+- open-source software is a requirement;
+- you want local transcription or a self-hosted deployment;
+- your team is comfortable troubleshooting models, hardware, and infrastructure;
+- the managed polish of Jamie matters less than operational control.
+
+**Consider the tradeoffs:**
+
+- A self-managed stack requires more setup and maintenance.
+- Product polish and support differ between community and paid deployments.
+- You need to verify the exact processing path for the models and services you configure.
+
+For a wider comparison, read [open-source meeting transcription software](/blog/open-source-meeting-transcription-software/).
+
+## Which Jamie alternative should you choose?
+
+Start with the reason Jamie no longer fits.
+
+- If the issue is **where the record lives**, choose **Anarlog** or **Meetily**.
+- If you want to **keep writing your own notes**, choose **Granola**.
+- If you need to **read the transcript during the call**, choose **Tactiq**.
+- If the priority is **free sales follow-up and CRM workflow**, choose **Fathom**.
+- If you mainly want a **polished, multilingual, bot-free managed service**, stay with **Jamie**.
+
+Do not choose from a generic feature count. Test one representative meeting and inspect the resulting record: where it is stored, what can be exported, what gets sent to an AI provider, and how much work remains before the notes are useful.
+
+## Frequently asked questions
+
+### What is the best Jamie AI alternative?
+
+Anarlog is the best fit when local ownership and AI-provider choice are the reason for switching. Granola is the closest note-first bot-free workflow, Tactiq is better for live browser transcription, Fathom is stronger for free sales follow-up, and Meetily is the self-managed open-source option.
+
+### Is there a free alternative to Jamie?
+
+Yes. Anarlog is free for local transcription and bring-your-own-key workflows. Fathom offers a free individual plan with unlimited recordings and transcriptions. Tactiq, Granola, and Meetily also have free starting points, although their limits and operating models differ.
+
+### Which Jamie alternatives are also bot-free?
+
+Anarlog, Granola, Tactiq, and Meetily are built around capture without a visible meeting participant. Fathom's standard workflow uses a bot and its bot-free option is currently described as beta. Our [bot-free AI meeting assistant guide](/blog/ai-meeting-notes-without-bot/) explains why capture method and storage model are separate decisions.
+
+### Is Jamie AI private?
+
+Jamie publishes a substantial privacy and security baseline: European storage and processing, audio deletion after transcription, encryption in transit and at rest, no model training on customer data, GDPR compliance, and ISO 27001 certification. It is still a managed cloud service, so buyers who require local-only records or self-hosting should evaluate Anarlog or Meetily instead.
+
+Anarlog is free for local transcription and private, bot-free meeting notes. [Download Anarlog](https://anarlog.so/download/apple-silicon) and test it on one real meeting before moving your archive.

--- a/apps/web/content/articles/meetgeek-alternatives.mdx
+++ b/apps/web/content/articles/meetgeek-alternatives.mdx
@@ -87,6 +87,8 @@ Choose Jamie over MeetGeek when a visible meeting assistant is the main problem 
 
 Choose Anarlog instead when the deeper requirement is file ownership, open-source auditability, or choosing the AI stack yourself.
 
+See the [Jamie AI alternatives guide](/blog/jamie-ai-alternatives/) for a focused comparison of bot-free, local-first, browser-based, and self-hosted options.
+
 ## 3. Tactiq: best browser extension alternative
 
 [Tactiq](https://tactiq.io/) is built around live in-meeting transcription from the browser. It supports Google Meet, Zoom, and Microsoft Teams, and its homepage says it supports over 60 languages. Its [pricing page](https://tactiq.io/buy) lists a free plan, Pro at $8/user/month billed annually, Team at $16.67/user/month billed annually, Business at $29.17/user/month billed annually, and custom Enterprise pricing.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content-only marketing/SEO changes with no application logic, auth, or data handling impact.
> 
> **Overview**
> Adds a new comparison article at **`jamie-ai-alternatives.mdx`** targeting Jamie switchers: shortlist (Anarlog, Granola, Tactiq, Fathom, Meetily), comparison table, per-product sections with pricing/security context, decision flow, and FAQs.
> 
> Registers the slug in **`figures.json`** with an empty figures list (no generated diagrams for this post yet). **Granola** and **MeetGeek** alternatives posts now link to `/blog/jamie-ai-alternatives/` for readers evaluating Jamie specifically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5320b9d6faadd359e4a116d8aa3eba02ea954941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->