### PR TITLE
Restore Team comment access workflow

### DIFF
--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -1,12 +1,4 @@
-import {
-  Chat,
-  Check,
-  CircleNotch,
-  Clock,
-  SignIn,
-  Trash,
-  X,
-} from "@phosphor-icons/react";
+import { Check, CircleNotch, Clock, SignIn, X } from "@phosphor-icons/react";
 import {
   useInfiniteQuery,
   useMutation,
@@ -14,13 +6,8 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 
-import { Avatar } from "@anlg/ui/components/avatar";
 import { cn } from "@anlg/utils";
 
-import {
-  useDeleteSharedNoteComment,
-  useSharedNoteComments,
-} from "@/components/shared-note-comments-data";
 import {
   sharedPrimaryButtonClassName,
   sharedSecondaryButtonClassName,
@@ -32,17 +19,11 @@ import {
   requestSharedNoteCommentAccess,
   reviewSharedNoteAccessRequest,
 } from "@/functions/shared-notes";
-import {
-  canComposeSharedNoteComments,
-  formatSharedNoteAccessRequestDescription,
-  hasSharedNoteCollaborationAccess,
-  truncateSharedNoteCommentQuote,
-} from "@/lib/shared-note-collaboration";
+import { formatSharedNoteAccessRequestDescription } from "@/lib/shared-note-collaboration";
 import type {
   SessionAccessRequestState,
   SessionShareAccessCursor,
   SharedNoteCapability,
-  SharedNoteComment,
 } from "@/lib/shared-notes";
 
 const accessRequestQueryKey = (shareId: string) => [
@@ -69,7 +50,8 @@ export function SharedNoteCollaboration({
 }) {
   const queryClient = useQueryClient();
   const signedIn = currentUserId !== null;
-  const commentsQuery = useSharedNoteComments({ enabled: signedIn, shareId });
+  const canCompose =
+    manageAccess || capability === "commenter" || capability === "editor";
   const accessRequestQuery = useQuery({
     queryKey: accessRequestQueryKey(shareId),
     queryFn: async () => {
@@ -79,7 +61,7 @@ export function SharedNoteCollaboration({
       }
       return result.request;
     },
-    enabled: signedIn && !manageAccess,
+    enabled: signedIn && !canCompose,
     retry: false,
   });
   const managerAccessQuery = useInfiniteQuery({
@@ -102,7 +84,6 @@ export function SharedNoteCollaboration({
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     retry: false,
   });
-  const deleteMutation = useDeleteSharedNoteComment({ shareId });
   const requestMutation = useMutation({
     mutationFn: async () => {
       const result = await requestSharedNoteCommentAccess({ data: shareId });
@@ -156,274 +137,66 @@ export function SharedNoteCollaboration({
       });
     },
   });
-  const hasCollaborationAccess = hasSharedNoteCollaborationAccess(
-    commentsQuery.data?.pages[0],
-  );
-  const canCompose = canComposeSharedNoteComments({
-    capability,
-    hasCollaborationAccess,
-    manageAccess,
-  });
-  const comments = [...(commentsQuery.data?.pages ?? [])]
-    .reverse()
-    .flatMap((page) => (page.status === "ready" ? page.comments : []));
-  const accessRequest = accessRequestQuery.data ?? null;
   const pendingManagerRequests = (managerAccessQuery.data?.pages ?? [])
     .flatMap((page) => page.entries)
     .filter(
       (entry) => entry.entryType === "request" && entry.status === "pending",
     );
 
+  if (signedIn && canCompose && !manageAccess) return null;
+  if (
+    manageAccess &&
+    !managerAccessQuery.isPending &&
+    !managerAccessQuery.isError &&
+    !managerAccessQuery.hasNextPage &&
+    pendingManagerRequests.length === 0
+  ) {
+    return null;
+  }
+
   return (
     <section
-      aria-labelledby="shared-note-comments-heading"
-      className="surface border-color-subtle mt-6 rounded-3xl border px-6 py-7 shadow-sm sm:px-10"
+      aria-label="Comment access"
+      className="surface-subtle border-color-subtle mt-8 rounded-2xl border px-4 py-4 sm:px-5"
     >
-      <div className="flex items-start justify-between gap-5">
-        <div>
-          <div className="text-color flex items-center gap-2">
-            <Chat className="size-5" aria-hidden="true" />
-            <h2
-              id="shared-note-comments-heading"
-              className="font-mono text-lg font-medium"
-            >
-              Comments
-            </h2>
-          </div>
-          <p className="text-color-muted mt-1 text-sm leading-6">
-            A private conversation for people with access to this note.
-          </p>
-        </div>
-        {hasCollaborationAccess && commentsQuery.isSuccess && (
-          <span className="surface-subtle text-color-muted rounded-full px-3 py-1 font-mono text-xs">
-            {comments.length}
-            {commentsQuery.hasNextPage ? "+" : ""}
-          </span>
-        )}
-      </div>
-
       {!signedIn ? (
         <SignInToCollaborate returnPath={returnPath} />
+      ) : manageAccess ? (
+        <ManagerRequests
+          error={
+            managerAccessQuery.isError ||
+            managerAccessQuery.isFetchNextPageError ||
+            reviewMutation.isError
+          }
+          hasEarlierRequests={managerAccessQuery.hasNextPage}
+          loading={managerAccessQuery.isPending}
+          loadingEarlier={managerAccessQuery.isFetchingNextPage}
+          pendingRequestId={
+            reviewMutation.isPending
+              ? (reviewMutation.variables?.requestId ?? null)
+              : null
+          }
+          requests={pendingManagerRequests}
+          onLoadEarlier={() => managerAccessQuery.fetchNextPage()}
+          onReview={(requestId, decision, capability) =>
+            reviewMutation.mutate({ capability, decision, requestId })
+          }
+        />
       ) : (
-        <>
-          {commentsQuery.isPending ||
-          commentsQuery.isError ||
-          hasCollaborationAccess ? (
-            <CommentList
-              comments={comments}
-              error={
-                (commentsQuery.isError &&
-                  !commentsQuery.isFetchNextPageError) ||
-                deleteMutation.isError
-              }
-              hasEarlier={commentsQuery.hasNextPage}
-              loading={commentsQuery.isPending}
-              loadingEarlier={commentsQuery.isFetchingNextPage}
-              loadEarlierError={commentsQuery.isFetchNextPageError}
-              manageAccess={manageAccess}
-              deletingCommentId={deleteMutation.variables ?? null}
-              deletePending={deleteMutation.isPending}
-              onDelete={(commentId) => deleteMutation.mutate(commentId)}
-              onLoadEarlier={() => void commentsQuery.fetchNextPage()}
-            />
-          ) : (
-            <p className="surface-subtle text-color-muted mt-6 rounded-2xl px-4 py-4 text-sm leading-6">
-              Comments are available after the note owner grants your account
-              access.
-            </p>
-          )}
-
-          {canCompose && (
-            <p className="border-color-subtle text-color-muted mt-6 border-t pt-5 text-sm leading-6">
-              Select text in the note to comment. Comments are visible only to
-              people who can open this note.
-            </p>
-          )}
-
-          {!canCompose &&
-            !manageAccess &&
-            !commentsQuery.isPending &&
-            !commentsQuery.isError && (
-              <AccessRequestPanel
-                request={accessRequest}
-                error={
-                  accessRequestQuery.isError ||
-                  requestMutation.isError ||
-                  cancelRequestMutation.isError
-                }
-                loading={accessRequestQuery.isPending}
-                pending={
-                  requestMutation.isPending || cancelRequestMutation.isPending
-                }
-                onCancel={(requestId) =>
-                  cancelRequestMutation.mutate(requestId)
-                }
-                onRequest={() => requestMutation.mutate()}
-              />
-            )}
-
-          {manageAccess && (
-            <ManagerRequests
-              error={
-                managerAccessQuery.isError ||
-                managerAccessQuery.isFetchNextPageError ||
-                reviewMutation.isError
-              }
-              hasEarlierRequests={managerAccessQuery.hasNextPage}
-              loading={managerAccessQuery.isPending}
-              loadingEarlier={managerAccessQuery.isFetchingNextPage}
-              pendingRequestId={
-                reviewMutation.isPending
-                  ? (reviewMutation.variables?.requestId ?? null)
-                  : null
-              }
-              requests={pendingManagerRequests}
-              onLoadEarlier={() => managerAccessQuery.fetchNextPage()}
-              onReview={(requestId, decision, capability) =>
-                reviewMutation.mutate({ capability, decision, requestId })
-              }
-            />
-          )}
-        </>
+        <AccessRequestPanel
+          request={accessRequestQuery.data ?? null}
+          error={
+            accessRequestQuery.isError ||
+            requestMutation.isError ||
+            cancelRequestMutation.isError
+          }
+          loading={accessRequestQuery.isPending}
+          pending={requestMutation.isPending || cancelRequestMutation.isPending}
+          onCancel={(requestId) => cancelRequestMutation.mutate(requestId)}
+          onRequest={() => requestMutation.mutate()}
+        />
       )}
     </section>
-  );
-}
-
-function CommentList({
-  comments,
-  deletePending,
-  deletingCommentId,
-  error,
-  hasEarlier,
-  loading,
-  loadingEarlier,
-  loadEarlierError,
-  manageAccess,
-  onDelete,
-  onLoadEarlier,
-}: {
-  comments: SharedNoteComment[];
-  deletePending: boolean;
-  deletingCommentId: string | null;
-  error: boolean;
-  hasEarlier: boolean;
-  loading: boolean;
-  loadingEarlier: boolean;
-  loadEarlierError: boolean;
-  manageAccess: boolean;
-  onDelete: (commentId: string) => void;
-  onLoadEarlier: () => void;
-}) {
-  if (loading) {
-    return (
-      <div className="text-color-muted mt-6 flex items-center gap-2 text-sm">
-        <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
-        Loading comments…
-      </div>
-    );
-  }
-  if (error) {
-    return (
-      <p className="mt-6 text-sm text-red-700" role="status">
-        Comments couldn’t be loaded right now.
-      </p>
-    );
-  }
-  if (!comments.length) {
-    return (
-      <p className="surface-subtle text-color-muted mt-6 rounded-2xl px-4 py-4 text-sm leading-6">
-        No comments yet.
-      </p>
-    );
-  }
-
-  return (
-    <>
-      {hasEarlier && (
-        <button
-          type="button"
-          className={cn([sharedSecondaryButtonClassName, "mt-6"])}
-          disabled={loadingEarlier}
-          onClick={onLoadEarlier}
-        >
-          {loadingEarlier && (
-            <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
-          )}
-          Load earlier comments
-        </button>
-      )}
-      {loadEarlierError && (
-        <p className="mt-3 text-sm text-red-700" role="status">
-          Earlier comments couldn’t be loaded. Please try again.
-        </p>
-      )}
-      <ol className="border-color-subtle mt-6 divide-y border-y">
-        {comments.map((comment) => {
-          const canDelete = comment.isAuthor || manageAccess;
-          const deleting =
-            deletePending && deletingCommentId === comment.commentId;
-          return (
-            <li
-              key={comment.commentId}
-              id={`shared-comment-${comment.commentId}`}
-              className="py-5"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex min-w-0 items-center gap-2.5">
-                  <Avatar
-                    seed={
-                      comment.isAuthor
-                        ? "shared-note:you"
-                        : "shared-note:collaborator"
-                    }
-                    label={comment.isAuthor ? "You" : "Collaborator"}
-                    size={28}
-                  />
-                  <div>
-                    <p className="text-color font-mono text-sm font-medium">
-                      {comment.isAuthor ? "You" : "Collaborator"}
-                    </p>
-                    <time
-                      className="text-color-muted mt-0.5 block text-xs"
-                      dateTime={comment.createdAt}
-                    >
-                      {formatCommentDate(comment.createdAt)}
-                    </time>
-                  </div>
-                </div>
-                {canDelete && (
-                  <button
-                    type="button"
-                    className="text-color-muted hover:text-color rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden disabled:opacity-50"
-                    aria-label="Delete comment"
-                    disabled={deletePending}
-                    onClick={() => onDelete(comment.commentId)}
-                  >
-                    {deleting ? (
-                      <CircleNotch
-                        className="size-4 animate-spin"
-                        aria-hidden="true"
-                      />
-                    ) : (
-                      <Trash className="size-4" aria-hidden="true" />
-                    )}
-                  </button>
-                )}
-              </div>
-              {comment.anchor && (
-                <p className="border-color-subtle text-color-muted mt-3 truncate border-l-2 pl-3 text-xs leading-5">
-                  {truncateSharedNoteCommentQuote(comment.anchor.quoteExact)}
-                </p>
-              )}
-              <p className="text-color mt-3 text-sm leading-6 whitespace-pre-wrap">
-                {comment.body}
-              </p>
-            </li>
-          );
-        })}
-      </ol>
-    </>
   );
 }
 
@@ -433,7 +206,7 @@ function SignInToCollaborate({ returnPath }: { returnPath: string }) {
     redirect: returnPath,
   });
   return (
-    <div className="surface-subtle border-color-subtle mt-6 rounded-2xl border px-4 py-5 sm:flex sm:items-center sm:justify-between sm:gap-5">
+    <div className="sm:flex sm:items-center sm:justify-between sm:gap-5">
       <div>
         <p className="text-color font-mono text-sm font-medium">
           Sign in to join the conversation
@@ -470,7 +243,7 @@ function AccessRequestPanel({
 }) {
   if (loading) {
     return (
-      <div className="border-color-subtle text-color-muted mt-6 flex items-center gap-2 border-t pt-5 text-sm">
+      <div className="text-color-muted flex items-center gap-2 text-sm">
         <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
         Checking comment access…
       </div>
@@ -490,52 +263,48 @@ function AccessRequestPanel({
           : "Ask the note owner for permission to join the conversation.";
 
   return (
-    <div className="border-color-subtle mt-6 border-t pt-5">
-      <div className="sm:flex sm:items-center sm:justify-between sm:gap-5">
-        <div>
-          <p className="text-color flex items-center gap-2 font-mono text-sm font-medium">
-            {isPending && <Clock className="size-4" aria-hidden="true" />}
-            {isApproved ? "Comment access approved" : "Want to comment?"}
-          </p>
-          <p className="text-color-muted mt-1 text-sm leading-6">
-            {description}
-          </p>
-        </div>
-        <div className="mt-4 flex shrink-0 gap-2 sm:mt-0">
-          {isPending ? (
-            <button
-              type="button"
-              className={sharedSecondaryButtonClassName}
-              disabled={pending}
-              onClick={() => onCancel(request.requestId)}
-            >
-              Cancel request
-            </button>
-          ) : isApproved ? (
-            <button
-              type="button"
-              className={sharedPrimaryButtonClassName}
-              onClick={() => window.location.reload()}
-            >
-              Reload note
-            </button>
-          ) : (
-            <button
-              type="button"
-              className={sharedPrimaryButtonClassName}
-              disabled={pending}
-              onClick={onRequest}
-            >
-              {pending ? "Requesting…" : "Request comment access"}
-            </button>
-          )}
-        </div>
-      </div>
-      {error && (
-        <p className="mt-3 text-sm text-red-700" role="status">
-          Comment access couldn’t be updated. Try again.
+    <div className="sm:flex sm:items-center sm:justify-between sm:gap-5">
+      <div>
+        <p className="text-color flex items-center gap-2 font-mono text-sm font-medium">
+          {isPending && <Clock className="size-4" aria-hidden="true" />}
+          {isApproved ? "Comment access approved" : "Want to comment?"}
         </p>
-      )}
+        <p className="text-color-muted mt-1 text-sm leading-6">{description}</p>
+        {error && (
+          <p className="mt-2 text-sm text-red-700" role="status">
+            Comment access couldn’t be updated. Try again.
+          </p>
+        )}
+      </div>
+      <div className="mt-4 flex shrink-0 gap-2 sm:mt-0">
+        {isPending ? (
+          <button
+            type="button"
+            className={sharedSecondaryButtonClassName}
+            disabled={pending}
+            onClick={() => onCancel(request.requestId)}
+          >
+            Cancel request
+          </button>
+        ) : isApproved ? (
+          <button
+            type="button"
+            className={sharedPrimaryButtonClassName}
+            onClick={() => window.location.reload()}
+          >
+            Reload note
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={sharedPrimaryButtonClassName}
+            disabled={pending}
+            onClick={onRequest}
+          >
+            {pending ? "Requesting…" : "Request comment access"}
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -568,17 +337,19 @@ function ManagerRequests({
   }>;
 }) {
   if (loading) {
-    return null;
-  }
-  if (!requests.length && !hasEarlierRequests && !error) {
-    return null;
+    return (
+      <div className="text-color-muted flex items-center gap-2 text-sm">
+        <CircleNotch className="size-4 animate-spin" aria-hidden="true" />
+        Checking access requests…
+      </div>
+    );
   }
 
   return (
-    <div className="border-color-subtle mt-6 border-t pt-5">
-      <h3 className="text-color font-mono text-sm font-medium">
-        Access requests
-      </h3>
+    <div>
+      <h2 className="text-color font-mono text-sm font-medium">
+        Comment access requests
+      </h2>
       {requests.length > 0 && (
         <ul className="mt-3 space-y-2">
           {requests.map((request) => {
@@ -586,7 +357,7 @@ function ManagerRequests({
             return (
               <li
                 key={request.entryId}
-                className="surface-subtle rounded-2xl px-4 py-3 sm:flex sm:items-center sm:justify-between sm:gap-4"
+                className="surface rounded-xl px-3 py-3 sm:flex sm:items-center sm:justify-between sm:gap-4"
               >
                 <div>
                   <p className="text-color text-sm font-medium">
@@ -663,11 +434,4 @@ function ManagerRequests({
       )}
     </div>
   );
-}
-
-function formatCommentDate(value: string) {
-  return new Intl.DateTimeFormat("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
 }

--- a/apps/web/src/components/shared-note-editable-viewer.tsx
+++ b/apps/web/src/components/shared-note-editable-viewer.tsx
@@ -32,6 +32,7 @@ export function SharedNoteEditableViewer({
   actions,
   authenticatedNote,
   chat,
+  collaboration,
   fallbackAccessLabel,
   fallbackSnapshot,
   meetingMetadata,
@@ -47,6 +48,7 @@ export function SharedNoteEditableViewer({
   // always answers about the content currently on screen, and lives inside
   // this shareId-keyed subtree so its state resets on navigation.
   chat?: (snapshot: SharedNoteSnapshot) => React.ReactNode;
+  collaboration?: React.ReactNode;
   fallbackAccessLabel?: string;
   fallbackSnapshot?: SharedNoteSnapshot | null;
   meetingMetadata?: {
@@ -150,6 +152,7 @@ export function SharedNoteEditableViewer({
             : accessLabel
       }
       actions={actions}
+      collaboration={collaborationActive ? collaboration : undefined}
       documentContent={
         <SharedNoteReader
           canCompose={canComposeComments}

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -46,6 +46,7 @@ export const sharedSecondaryButtonClassName = cn([
 export function SharedNoteViewer({
   accessLabel,
   actions,
+  collaboration,
   documentContent,
   headerActions,
   meetingMetadata,
@@ -56,6 +57,7 @@ export function SharedNoteViewer({
 }: {
   accessLabel: string;
   actions?: React.ReactNode;
+  collaboration?: React.ReactNode;
   documentContent?: React.ReactNode;
   headerActions?: React.ReactNode;
   meetingMetadata?: Pick<
@@ -143,6 +145,7 @@ export function SharedNoteViewer({
           )}
         </div>
       </article>
+      {collaboration}
     </SharedNoteShell>
   );
 }

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -6,6 +6,7 @@ import {
   StableSharedNoteActions,
 } from "@/components/shared-note-actions";
 import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
+import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
@@ -168,6 +169,15 @@ function Component() {
         revokedBehavior="read-only"
         signedIn={user !== null}
         accessLabel={accessLabel}
+        collaboration={
+          <SharedNoteCollaboration
+            capability={authenticatedNote?.capability ?? "viewer"}
+            currentUserId={user?.id ?? null}
+            manageAccess={authenticatedNote?.manageAccess ?? false}
+            returnPath={returnPath}
+            shareId={snapshot.shareId}
+          />
+        }
         actions={
           authenticatedNote ? (
             <AccountSharedNoteActions

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -5,6 +5,7 @@ import { useCallback } from "react";
 import { useShareRouteContinuation } from "@/components/share-route-continuation";
 import { LinkSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
+import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
@@ -238,6 +239,15 @@ export function LinkSharedNoteClient({
           shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)
             ? formatAuthenticatedSharedNoteAccessLabel(authenticatedNote)
             : "Anyone with the link · View only"
+        }
+        collaboration={
+          <SharedNoteCollaboration
+            capability={authenticatedNote?.capability ?? "viewer"}
+            currentUserId={currentUserId}
+            manageAccess={authenticatedNote?.manageAccess ?? false}
+            returnPath={returnPath}
+            shareId={validShareId.data}
+          />
         }
         actions={
           <LinkSharedNoteActions

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 
 import { PublicSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
+import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import { SharedNoteEditableViewer } from "@/components/shared-note-editable-viewer";
 import {
@@ -131,6 +132,15 @@ function Component() {
         revokedBehavior="read-only"
         signedIn={user !== null}
         accessLabel={accessLabel}
+        collaboration={
+          <SharedNoteCollaboration
+            capability={authenticatedNote?.capability ?? "viewer"}
+            currentUserId={user?.id ?? null}
+            manageAccess={authenticatedNote?.manageAccess ?? false}
+            returnPath={returnPath}
+            shareId={snapshot.shareId}
+          />
+        }
         actions={
           <PublicSharedNoteActions
             canEdit={authenticatedNote?.capability === "editor"}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes permission gating and where users request or approve comment access relative to the comment UI; wrong early-return or query enablement could hide workflows or show stale panels.
> 
> **Overview**
> **Refactors shared-note collaboration** so `SharedNoteCollaboration` handles only **comment access** (sign-in, request/cancel comment access, owner approve/deny)—not the comment thread. The large **Comments** section, `CommentList`, comment queries, and delete flow are **removed** from that component; users who already have comment/editor capability no longer see this block at all.
> 
> **Wires the panel through the viewer layout:** `SharedNoteViewer` and `SharedNoteEditableViewer` accept an optional **`collaboration`** slot rendered below the note article (only when collaboration is active—signed in and access not revoked). All three share routes (`$shareId`, link, public) pass `SharedNoteCollaboration` through that prop.
> 
> **UI/behavior tweaks:** slimmer “Comment access” styling, access-request query gated on `!canCompose` (capability-based), managers get a loading state and the section hides when there are no pending requests, and inline error placement in the access-request panel is adjusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60acb3524a037f22d0de4e518db2b74a6f1d299f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->