### PR TITLE
Fix Stripe service deployment

### DIFF
--- a/apps/stripe/Dockerfile
+++ b/apps/stripe/Dockerfile
@@ -11,11 +11,13 @@ FROM node-base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/stripe/package.json apps/stripe/package.json
 COPY packages/supabase/package.json packages/supabase/package.json
+COPY packages/user-error/package.json packages/user-error/package.json
 RUN pnpm fetch --prod --filter @anlg/stripe
 
 FROM deps AS build
 COPY apps/stripe apps/stripe
 COPY packages/supabase packages/supabase
+COPY packages/user-error packages/user-error
 RUN pnpm install --filter @anlg/stripe --frozen-lockfile
 RUN pnpm deploy --filter @anlg/stripe --prod --legacy /runtime
 


### PR DESCRIPTION
Copy the shared user-error workspace package into the Stripe Docker build so pnpm can resolve and deploy the service.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile change with no runtime logic or security impact.
> 
> **Overview**
> Fixes Stripe service deployment by copying the **`packages/user-error`** workspace package into the Docker image in both the **deps** and **build** stages, matching how **`packages/supabase`** is already handled.
> 
> Without these `COPY` steps, **`pnpm fetch`**, **`install`**, and **`deploy`** for `@anlg/stripe` could not resolve **`@anlg/user-error`**, which the app imports (e.g. in error reporting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d36e51fc1368caf05169e84244877e1e32369751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->