### PR TITLE
Fix speaker labeling after resumed capture

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.test.ts
@@ -26,12 +26,14 @@ import {
 import type { Segment } from "~/stt/live-segment";
 
 const {
+  assignSessionTranscriptSpeakerMock,
   assignTranscriptSpeakerMock,
   addSessionParticipantMock,
   createHumanMock,
   useHumansMock,
   useSessionParticipantsMock,
 } = vi.hoisted(() => ({
+  assignSessionTranscriptSpeakerMock: vi.fn(),
   assignTranscriptSpeakerMock: vi.fn(),
   addSessionParticipantMock: vi.fn(),
   createHumanMock: vi.fn(),
@@ -133,12 +135,14 @@ vi.mock("~/session/queries", () => ({
 }));
 
 vi.mock("~/stt/queries", () => ({
+  assignSessionTranscriptSpeaker: assignSessionTranscriptSpeakerMock,
   assignTranscriptSpeaker: assignTranscriptSpeakerMock,
 }));
 
 beforeEach(() => {
   cleanup();
   vi.clearAllMocks();
+  assignSessionTranscriptSpeakerMock.mockResolvedValue(undefined);
   assignTranscriptSpeakerMock.mockResolvedValue(undefined);
   addSessionParticipantMock.mockResolvedValue(undefined);
   createHumanMock.mockResolvedValue("human-new");
@@ -192,6 +196,7 @@ describe("SpeakerAssignPopover", () => {
           ],
         } as Segment,
         transcriptId: "transcript-1",
+        sessionId: "session-1",
         color: "red",
         label: "Speaker 2",
       }),
@@ -239,7 +244,8 @@ describe("SpeakerAssignPopover", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
     await waitFor(() => {
-      expect(assignTranscriptSpeakerMock).toHaveBeenCalledWith({
+      expect(assignSessionTranscriptSpeakerMock).toHaveBeenCalledWith({
+        sessionId: "session-1",
         transcriptId: "transcript-1",
         segmentKey: {
           channel: "RemoteParty",
@@ -248,8 +254,6 @@ describe("SpeakerAssignPopover", () => {
         },
         humanId: "human-1",
         anchorWordId: "word-1",
-        mode: "all",
-        wordIds: ["word-1"],
       });
     });
   });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -25,7 +25,10 @@ import {
   useSessionParticipants,
 } from "~/session/queries";
 import type { Segment } from "~/stt/live-segment";
-import { assignTranscriptSpeaker } from "~/stt/queries";
+import {
+  assignSessionTranscriptSpeaker,
+  assignTranscriptSpeaker,
+} from "~/stt/queries";
 
 export type AssignmentMode = "all" | "segment";
 
@@ -62,16 +65,24 @@ export function SpeakerAssignPopover({
         triggerRef.current?.closest<HTMLElement>(
           "[data-transcript-container]",
         ) ?? null;
-      void preserveScrollPosition(scrollContainer, () =>
-        assignTranscriptSpeaker({
-          transcriptId,
-          segmentKey: segment.key,
-          humanId,
-          anchorWordId,
-          mode: assignmentMode,
-          wordIds: getAssignmentWordIds(segment),
-        }),
-      )
+      const assign = () =>
+        assignmentMode === "all" && sessionId
+          ? assignSessionTranscriptSpeaker({
+              sessionId,
+              transcriptId,
+              segmentKey: segment.key,
+              humanId,
+              anchorWordId,
+            })
+          : assignTranscriptSpeaker({
+              transcriptId,
+              segmentKey: segment.key,
+              humanId,
+              anchorWordId,
+              mode: assignmentMode,
+              wordIds: getAssignmentWordIds(segment),
+            });
+      void preserveScrollPosition(scrollContainer, assign)
         .then(() => {
           trackAnalyticsEvent("participant_assigned", {
             assignment_scope: assignmentMode,
@@ -84,7 +95,7 @@ export function SpeakerAssignPopover({
           console.error("[transcript] failed to assign speaker", error);
         });
     },
-    [handleOpenChange, onAssigned, transcriptId, segment],
+    [handleOpenChange, onAssigned, sessionId, transcriptId, segment],
   );
 
   return (

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -49,6 +49,7 @@ vi.mock("~/db", () => ({
 import {
   applyLiveTranscriptDeltaToDatabase,
   appendTranscriptWordsAndHints,
+  assignSessionTranscriptSpeaker,
   assignTranscriptSpeaker,
   createLiveTranscript,
   createTranscript,
@@ -609,6 +610,115 @@ describe("transcript SQLite queries", () => {
     expect(JSON.parse(String(statement?.params[1]))).toEqual([
       expect.objectContaining({
         word_id: "word-1",
+        type: "user_speaker_assignment",
+      }),
+    ]);
+  });
+
+  it("applies matching speaker assignments across resumed transcripts", async () => {
+    mocks.execute
+      .mockResolvedValueOnce([
+        { id: "transcript-1" },
+        { id: "transcript-2" },
+        { id: "transcript-3" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          words_json: JSON.stringify([
+            {
+              id: "word-1",
+              text: "First",
+              start_ms: 0,
+              end_ms: 500,
+              channel: 1,
+            },
+          ]),
+          speaker_hints_json: JSON.stringify([
+            {
+              id: "word-1:provider_speaker_index",
+              word_id: "word-1",
+              type: "provider_speaker_index",
+              value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+            },
+          ]),
+          content_revision: 0,
+          pending_deltas_json: "[]",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          words_json: JSON.stringify([
+            {
+              id: "word-2",
+              text: "Resumed",
+              start_ms: 0,
+              end_ms: 500,
+              channel: 1,
+            },
+          ]),
+          speaker_hints_json: JSON.stringify([
+            {
+              id: "word-2:provider_speaker_index",
+              word_id: "word-2",
+              type: "provider_speaker_index",
+              value: JSON.stringify({ channel: 1, speaker_index: 0 }),
+            },
+          ]),
+          content_revision: 0,
+          pending_deltas_json: "[]",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          words_json: "[]",
+          speaker_hints_json: "[]",
+          content_revision: 0,
+          pending_deltas_json: JSON.stringify([
+            liveDelta([
+              {
+                id: "word-3",
+                text: "Local",
+                start_ms: 0,
+                end_ms: 500,
+                channel: 0,
+                state: "final",
+              },
+            ]),
+          ]),
+        },
+      ]);
+
+    await assignSessionTranscriptSpeaker({
+      sessionId: "session-1",
+      transcriptId: "transcript-1",
+      segmentKey: {
+        channel: "RemoteParty",
+        speaker_index: 0,
+        speaker_human_id: null,
+      },
+      humanId: "human-1",
+      anchorWordId: "word-1",
+    });
+
+    const updates = mocks.executeTransaction.mock.calls.map(
+      ([statements]) => statements[0],
+    );
+    expect(updates.map((statement) => statement.params[3])).toEqual([
+      "transcript-1",
+      "transcript-2",
+    ]);
+    expect(mocks.executeTransaction).toHaveBeenCalledTimes(2);
+    expect(
+      updates.map((statement) =>
+        JSON.parse(String(statement.params[1])).at(-1),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        word_id: "word-1",
+        type: "user_speaker_assignment",
+      }),
+      expect.objectContaining({
+        word_id: "word-2",
         type: "user_speaker_assignment",
       }),
     ]);

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -12,6 +12,7 @@ import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 import {
   applyLiveTranscriptDelta,
   createTranscriptAccumulator,
+  findSpeakerAssignmentAnchorWordId,
   parseTranscriptWords,
   parseTranscriptHints,
   updateTranscriptHints,
@@ -514,43 +515,119 @@ export function assignTranscriptSpeaker({
   mode?: "all" | "segment";
   wordIds?: string[];
 }): Promise<void> {
-  return mutateTranscript(transcriptId, (store) => {
+  return assignSpeakerInTranscript({
+    transcriptId,
+    segmentKey,
+    humanId,
+    anchorWordId,
+    mode,
+    wordIds,
+  });
+}
+
+export async function assignSessionTranscriptSpeaker({
+  sessionId,
+  transcriptId,
+  segmentKey,
+  humanId,
+  anchorWordId,
+}: {
+  sessionId: string;
+  transcriptId: string;
+  segmentKey: SegmentKey;
+  humanId: string;
+  anchorWordId: string;
+}): Promise<void> {
+  const transcripts = await liveQueryClient.execute<{ id: string }>(
+    `
+      SELECT id
+      FROM transcripts
+      WHERE session_id = ? AND deleted_at IS NULL
+      ORDER BY started_at_ms, created_at, id
+    `,
+    [sessionId],
+  );
+
+  await Promise.all(
+    transcripts.map((transcript) =>
+      assignSpeakerInTranscript({
+        transcriptId: transcript.id,
+        segmentKey,
+        humanId,
+        anchorWordId: transcript.id === transcriptId ? anchorWordId : undefined,
+        mode: "all",
+      }),
+    ),
+  );
+}
+
+async function assignSpeakerInTranscript({
+  transcriptId,
+  segmentKey,
+  humanId,
+  anchorWordId,
+  mode,
+  wordIds,
+}: {
+  transcriptId: string;
+  segmentKey: SegmentKey;
+  humanId: string;
+  anchorWordId?: string;
+  mode?: "all" | "segment";
+  wordIds?: string[];
+}): Promise<void> {
+  let assigned = false;
+  await mutateTranscript(transcriptId, (store) => {
+    const resolvedAnchorWordId =
+      anchorWordId ??
+      findSpeakerAssignmentAnchorWordId(
+        parseTranscriptWords(store, transcriptId),
+        parseTranscriptHints(store, transcriptId),
+        segmentKey,
+      );
+    if (!resolvedAnchorWordId) {
+      return false;
+    }
+
     upsertSpeakerAssignment(
       store,
       transcriptId,
       segmentKey,
       humanId,
-      anchorWordId,
+      resolvedAnchorWordId,
       { mode, wordIds },
     );
-  }).then(() => {
-    if ((mode ?? "all") !== "all") {
-      return;
-    }
-    const channel =
-      segmentKey.channel === "DirectMic"
-        ? 0
-        : segmentKey.channel === "RemoteParty"
-          ? 1
-          : 2;
-    transcriptionCommands
-      .promoteVoiceprintCandidates(
-        transcriptId,
-        channel,
-        typeof segmentKey.speaker_index === "number"
-          ? segmentKey.speaker_index
-          : null,
-        humanId,
-      )
-      .then((result) => {
-        if (result.status === "error") {
-          console.error("[voiceprint] promotion failed", result.error);
-        }
-      })
-      .catch((error) => {
-        console.error("[voiceprint] promotion failed", error);
-      });
+    assigned = true;
+    return true;
   });
+
+  if (!assigned || (mode ?? "all") !== "all") {
+    return;
+  }
+
+  const channel =
+    segmentKey.channel === "DirectMic"
+      ? 0
+      : segmentKey.channel === "RemoteParty"
+        ? 1
+        : 2;
+  void transcriptionCommands
+    .promoteVoiceprintCandidates(
+      transcriptId,
+      channel,
+      typeof segmentKey.speaker_index === "number"
+        ? segmentKey.speaker_index
+        : null,
+      humanId,
+    )
+    .then((result) => {
+      if (result.status === "error") {
+        console.error("[voiceprint] promotion failed", result.error);
+      }
+    })
+    .catch((error) => {
+      console.error("[voiceprint] promotion failed", error);
+    });
 }
 
 export function updateTranscriptSegmentText({
@@ -684,7 +761,7 @@ function parseJsonArray<T>(value: string, rowId: string, field: string): T[] {
 
 async function mutateTranscript(
   transcriptId: string,
-  mutation?: (store: MemoryTranscriptStore) => void,
+  mutation?: (store: MemoryTranscriptStore) => boolean | void,
 ): Promise<void> {
   return enqueueDatabaseWrite(`transcript:${transcriptId}`, async () => {
     for (let attempt = 0; attempt < 5; attempt += 1) {
@@ -733,14 +810,18 @@ async function mutateTranscript(
         transcriptId,
         current.pending_deltas_json,
       );
+      let shouldPersist = true;
       const next = mutation
         ? mutateTranscriptSnapshot(
             materialized.wordsJson,
             materialized.hintsJson,
             transcriptId,
-            mutation,
+            (store) => {
+              shouldPersist = mutation(store) !== false;
+            },
           )
         : materialized;
+      if (!shouldPersist) return;
       const now = new Date().toISOString();
       const [updated = 0] = await executeTransaction([
         {

--- a/apps/desktop/src/stt/utils.test.ts
+++ b/apps/desktop/src/stt/utils.test.ts
@@ -4,6 +4,7 @@ import type { LiveTranscriptDelta } from "@anlg/plugin-transcription";
 
 import {
   createTranscriptAccumulator,
+  findSpeakerAssignmentAnchorWordId,
   mergeTranscriptSegmentAssignments,
   updateTranscriptHints,
   upsertSpeakerAssignment,
@@ -704,6 +705,46 @@ function remoteSpeakerKey(speakerIndex: number | null): SegmentKey {
     speaker_human_id: null,
   } as SegmentKey;
 }
+
+describe("findSpeakerAssignmentAnchorWordId", () => {
+  it("finds the matching speaker in a resumed transcript", () => {
+    expect(
+      findSpeakerAssignmentAnchorWordId(
+        [
+          {
+            id: "speaker-1-word",
+            text: "First",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 1,
+          },
+          {
+            id: "speaker-2-word",
+            text: "Second",
+            start_ms: 100,
+            end_ms: 200,
+            channel: 1,
+          },
+        ],
+        [
+          {
+            id: "speaker-1-word:provider_speaker_index",
+            word_id: "speaker-1-word",
+            type: "provider_speaker_index",
+            value: JSON.stringify({ channel: 1, speaker_index: 1 }),
+          },
+          {
+            id: "speaker-2-word:provider_speaker_index",
+            word_id: "speaker-2-word",
+            type: "provider_speaker_index",
+            value: JSON.stringify({ channel: 1, speaker_index: 2 }),
+          },
+        ],
+        remoteSpeakerKey(2),
+      ),
+    ).toBe("speaker-2-word");
+  });
+});
 
 describe("upsertSpeakerAssignment", () => {
   it("removes a conflicting automatic assignment when a user assigns the speaker", () => {

--- a/apps/desktop/src/stt/utils.ts
+++ b/apps/desktop/src/stt/utils.ts
@@ -332,6 +332,27 @@ export function upsertSpeakerAssignment(
   updateTranscriptHints(store, transcriptId, nextHints);
 }
 
+export function findSpeakerAssignmentAnchorWordId(
+  words: WordWithId[],
+  hints: SpeakerHintWithId[],
+  segmentKey: SegmentKey,
+): string | undefined {
+  const channel =
+    segmentKey.channel === "DirectMic"
+      ? 0
+      : segmentKey.channel === "RemoteParty"
+        ? 1
+        : 2;
+  const speakerIndex = segmentKey.speaker_index;
+
+  return words.find(
+    (word) =>
+      word.channel === channel &&
+      (typeof speakerIndex !== "number" ||
+        findSpeakerIndexForWord(hints, word.id) === speakerIndex),
+  )?.id;
+}
+
 export function mergeTranscriptSegmentAssignments(
   store: TranscriptStore,
   transcriptId: string,


### PR DESCRIPTION
Apply all-speaker assignments across transcript sections created by pause and resume, with regression coverage for derived transcript updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how speaker hints are written across multiple session transcripts and transcript mutation commit behavior; regression tests cover multi-transcript and UI paths.
> 
> **Overview**
> Fixes speaker labeling when capture is **paused and resumed**, where each resume creates a separate transcript row but “Apply to all” only updated the visible chunk.
> 
> **Apply to all** (with a `sessionId`) now calls **`assignSessionTranscriptSpeaker`**, which loads every non-deleted transcript for the session and applies the same channel/speaker-index assignment to each. Other chunks resolve their own anchor word via new **`findSpeakerAssignmentAnchorWordId`** instead of reusing the clicked segment’s word id. **Segment-only** assignments still use **`assignTranscriptSpeaker`** on the current transcript.
> 
> Persistence is refactored through **`assignSpeakerInTranscript`**: transcript mutations can return **`false`** to skip a write when that transcript has no matching speaker, and voiceprint promotion runs only when an assignment actually persisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd0c14bf04551980f15fc4b875ffafcf407894d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->