### PR TITLE
Add the desktop benchmark harness with a frozen artifact protocol

### DIFF
--- a/.github/workflows/desktop_ci.yaml
+++ b/.github/workflows/desktop_ci.yaml
@@ -428,6 +428,8 @@ jobs:
           retention-days: 7
       - run: cargo check --locked --target ${{ matrix.target }} -p desktop
       - run: cargo test --locked --target ${{ matrix.target }} -p desktop embedded_cli --lib
+      - run: cargo clippy --locked --target ${{ matrix.target }} -p desktop-bench --all-targets --no-deps -- -D warnings
+      - run: cargo test --locked --target ${{ matrix.target }} -p desktop-bench
       - run: cargo test --locked --target ${{ matrix.target }} -p cloudsync
       - run: "cargo test --locked --target ${{ matrix.target }} -p db-core 'cloudsync::' -- --test-threads=1"
       - if: github.event_name == 'workflow_dispatch'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4813,6 +4813,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-bench"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tempfile",
+]
+
+[[package]]
 name = "detect"
 version = "0.1.0"
 dependencies = [

--- a/crates/desktop-bench/Cargo.toml
+++ b/crates/desktop-bench/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "desktop-bench"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Whole-application benchmark harness for the Tauri vs GPUI desktop comparison"
+
+[[bin]]
+name = "anarlog-bench"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sysinfo = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/desktop-bench/PROTOCOL.md
+++ b/crates/desktop-bench/PROTOCOL.md
@@ -1,0 +1,129 @@
+# Benchmark protocol (ANLG-320, schema v1)
+
+This is the operational version of the protocol in
+[ANLG-320](https://linear.app/fastrepl-inc/issue/ANLG-320/migrate-the-desktop-application-from-tauri-to-gpui).
+The issue owns the scenarios, fixtures, metrics list, gates, and caveats; this
+file owns what the harness actually records and how numbers are derived, so a
+result produced today can be compared with one produced after the GPUI port.
+Changing anything below requires bumping `SCHEMA_VERSION` in
+`src/artifact.rs` and adding an entry to the history at the bottom.
+
+## Trial procedure
+
+1. Build both apps in release mode from recorded commit SHAs with devtools and
+   debug-only behaviour disabled. Debug builds are invalid for comparison.
+2. Use a fixed, named machine, plugged in, same display resolution and refresh
+   rate, power mode, OS version, locale, app settings, and fixture version.
+   Record them with `--meta` (see below). Quiesce other workloads.
+3. Use isolated fixture data only; never point a run at a production profile.
+4. Run one warm-up plus five measured trials per (runtime, scenario, fixture):
+   `--warmup-trials 1 --trials 5`. Randomise Tauri/GPUI order between
+   scenarios where practical.
+5. Keep every artifact. Reports are generated from artifacts only; numbers are
+   never hand-copied.
+
+## What one artifact is
+
+One artifact is one trial of one scenario on one fixture with one runtime. It
+is written as pretty-printed JSON to
+`<out>/<runtime>_<scenario>_<fixture>_<trial|warmup><n>_<utc timestamp>.json`.
+
+### Identity and context
+
+| Field                           | Meaning                                                                                  |
+| ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `schema_version`                | `1`. Reports refuse to mix versions.                                                     |
+| `harness`                       | Harness crate name and version, and the `sysinfo` version read from `Cargo.lock`.        |
+| `build.runtime`                 | Label the report groups by: `tauri`, `gpui`, or anything else being compared.            |
+| `build.sha`, `build.channel`    | From `--build-sha` and `--channel`. Always pass the SHA.                                  |
+| `environment`                   | OS name/version/kernel, arch, host name, CPU brand, logical/physical cores, total memory. |
+| `conditions`                    | Free-form `--meta key=value` pairs. Required keys: `power`, `display`, `thermal`, `locale`, `cloudsync` (`off`, `caught-up`, or `catch-up`), `fixture_version`. |
+| `fixture`, `scenario`, `trial`, `warmup` | Scenario/fixture ids from ANLG-320; trial numbers restart at 1 for measured trials. Warm-ups are flagged and excluded from reports. |
+| `started_at`, `ended_at`        | UTC RFC 3339.                                                                            |
+| `command`, `root_pid`           | What was launched (or attached to).                                                      |
+
+### Process set
+
+The harness samples the whole application, not one PID. A process belongs to
+the set when it is the root, a transitive child of the root (by parent PID at
+sample time), or when its name contains an `--include-name` pattern
+(case-insensitive) and it started no earlier than one second before launch.
+The last rule exists because WebKit content/network processes and sidecars can
+be reparented away from the app. The harness never includes itself.
+
+Every process ever seen in the set is listed in `process_set` with pid, parent,
+name, command line, start time, first/last seen offsets, and `matched_by`
+(`root`, `descendant`, `name_pattern`). Validate this list before trusting a
+run: a Tauri run on macOS must show the WebKit helpers, and no run should show
+unrelated processes.
+
+Recommended patterns: Tauri on macOS `--include-name WebKit --include-name anarlog`;
+GPUI `--include-name anarlog`. Threads are never counted as processes.
+
+### Samples
+
+`samples[]` are raw, one per `--interval-ms` (default 1000 ms, floor 200 ms),
+summed over the process set:
+
+| Field              | Definition                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------ |
+| `t_ms`             | Milliseconds since launch (or attach).                                                           |
+| `process_count`    | Live processes in the set.                                                                       |
+| `cpu_percent`      | Sum of per-process CPU since the previous sample; **100.0 = one logical core**. A process contributes 0 in the first sample after it appears (delta semantics). |
+| `memory_bytes`     | Sum of the platform memory metric below.                                                         |
+| `rss_bytes`        | Sum of resident set sizes, kept for cross-checking. It double counts shared pages.                |
+| `disk_read_bytes`, `disk_write_bytes` | Bytes since the previous sample.                                                     |
+| `thread_count`     | Linux only: `/proc/<pid>/task` entries summed over the set. `null` elsewhere.                    |
+
+`memory_metric` names what `memory_bytes` sums:
+
+| Platform | `memory_metric` | Definition                                                                                  |
+| -------- | --------------- | ------------------------------------------------------------------------------------------- |
+| Linux    | `pss`           | `Pss` from `/proc/<pid>/smaps_rollup`, so shared pages are split between processes and the sum over the set is meaningful. Falls back to RSS per process if unreadable. |
+| macOS    | `rss`           | Resident size from the kernel. Physical footprint (`phys_footprint`, what Activity Monitor calls Memory) is **not** yet recorded; treat macOS memory as an upper bound until it is. |
+| Windows  | `rss`           | Working set.                                                                                |
+
+GPU memory, GPU time, energy, wakeups, context switches, and network bytes are
+not sampled in v1. Report them as missing, not zero.
+
+### Summary
+
+Derived from `samples[]` by the harness and re-derivable from them:
+
+| Field                          | Definition                                                                              |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| `cpu_percent`                  | Distribution (count, mean, median, nearest-rank p95, min, max, coefficient of variation) of `cpu_percent`. |
+| `cpu_time_seconds`             | Trapezoidal integral of `cpu_percent` over time divided by 100: core-seconds consumed.  |
+| `memory_bytes`                 | Distribution of `memory_bytes`.                                                         |
+| `memory_plateau_bytes`         | Median of `memory_bytes` for samples at or after `--plateau-after` seconds (default 60). |
+| `memory_growth_bytes_per_min`  | Least-squares slope of `memory_bytes` over minutes for the same window. The soak gate reads this. |
+| `disk_read_bytes_total`, `disk_write_bytes_total` | Sums.                                                                  |
+| `max_process_count`, `max_thread_count` | Maxima.                                                                        |
+
+`end_state` records whether the root exited on its own, its exit code, and
+whether the harness killed the process set at `--duration`. `errors` lists
+sampling problems. A trial whose root exited before the scenario ended is not
+a valid measurement unless the scenario is an exit scenario.
+
+## Reports
+
+`anarlog-bench report --baseline tauri <artifacts...>` groups measured trials
+by (scenario, fixture) and runtime, takes the median across trials for each
+summary metric, prints the coefficient of variation across trials next to it,
+and prints the delta of medians against the baseline. Every listed metric is
+lower-is-better. The report also prints the build SHAs and memory metrics per
+runtime so a mixed or debug comparison is visible on the page.
+
+## Not covered by the harness (needs app-side hooks)
+
+Launch-to-interactive, input-to-paint latency, FPS/long-frame rate,
+React render counts vs GPUI invalidation counts, IPC/live-query counts, SQLite
+query and WAL statistics, CloudSync throughput, and functional correctness per
+scenario require minimal measurement hooks inside both apps (ANLG-320 Phase 2
+"deterministic test hooks"). When they land, they should write into the same
+artifact under a new top-level `app_metrics` object and bump the schema.
+
+## Schema history
+
+- **v1** — process-tree CPU/memory/disk/thread sampling, summaries, conditions
+  metadata, Markdown report.

--- a/crates/desktop-bench/README.md
+++ b/crates/desktop-bench/README.md
@@ -1,0 +1,58 @@
+# desktop-bench
+
+Whole-application benchmark harness for comparing the Tauri and GPUI desktop
+builds under [ANLG-320](https://linear.app/fastrepl-inc/issue/ANLG-320/migrate-the-desktop-application-from-tauri-to-gpui).
+It launches an app, samples its entire process tree (CPU, memory, disk,
+threads), writes one versioned JSON artifact per trial, and renders Markdown
+comparisons from artifacts. The measurement rules live in
+[PROTOCOL.md](./PROTOCOL.md).
+
+## Usage
+
+```sh
+# One warm-up plus five measured 10-minute idle trials of a release Tauri build.
+cargo run --release -p desktop-bench -- run \
+  --runtime tauri --build-sha "$(git rev-parse --short HEAD)" --channel stable \
+  --scenario idle-10m-sync-off --fixture ordinary \
+  --duration 600 --warmup-trials 1 --trials 5 \
+  --include-name WebKit --include-name anarlog \
+  --meta power=plugged --meta display=2560x1440@60 --meta thermal=nominal \
+  --meta locale=en-US --meta cloudsync=off --meta fixture_version=1 \
+  --out bench-results \
+  -- /Applications/Anarlog.app/Contents/MacOS/anarlog
+
+# Same scenario against the GPUI build.
+cargo run --release -p desktop-bench -- run \
+  --runtime gpui --build-sha "$(git rev-parse --short HEAD)" \
+  --scenario idle-10m-sync-off --fixture ordinary \
+  --duration 600 --warmup-trials 1 --trials 5 --include-name anarlog \
+  --meta power=plugged --meta display=2560x1440@60 --meta thermal=nominal \
+  --meta locale=en-US --meta cloudsync=off --meta fixture_version=1 \
+  --out bench-results \
+  -- target/release/anarlog-gpui --db-path fixtures/ordinary/app.db
+
+# Compare.
+cargo run --release -p desktop-bench -- report --baseline tauri bench-results/*.json
+```
+
+`--pid <n>` attaches to a running process instead of launching one (single
+trial, no kill at the end). `--interval-ms` defaults to 1000 and cannot go
+below 200. `--plateau-after` (default 60 s) sets where the memory plateau and
+growth window starts. `--show-app-output` lets the app write to the terminal.
+
+Fixture data and scenario drivers are not part of this crate; the harness
+records the `--scenario` and `--fixture` ids you pass and samples whatever the
+launched command does. Scenario automation and in-app metrics (launch to
+interactive, input latency, render counts) arrive with the Phase 2 test hooks.
+
+## Layout
+
+```
+src/
+  main.rs      CLI (run, report), artifact assembly, environment capture
+  sampler.rs   process-set selection and the sampling loop (sysinfo)
+  artifact.rs  schema v1 types and summary derivation
+  report.rs    artifact loading and Markdown comparison
+  stats.rs     median, percentile, cv, slope, integral
+build.rs       records the pinned sysinfo version in artifacts
+```

--- a/crates/desktop-bench/build.rs
+++ b/crates/desktop-bench/build.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+// Artifacts record tool versions; Cargo does not expose dependency versions to
+// the crate, so read the pinned sysinfo version from the workspace lockfile.
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let lockfile = Path::new(&manifest_dir).join("../../Cargo.lock");
+    println!("cargo:rerun-if-changed={}", lockfile.display());
+
+    let version = std::fs::read_to_string(&lockfile)
+        .ok()
+        .and_then(|lock| locked_version(&lock, "sysinfo"))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=SYSINFO_VERSION={version}");
+}
+
+fn locked_version(lockfile: &str, package: &str) -> Option<String> {
+    let mut lines = lockfile.lines();
+    while let Some(line) = lines.next() {
+        if line.trim() == format!("name = \"{package}\"") {
+            return lines
+                .next()?
+                .trim()
+                .strip_prefix("version = \"")?
+                .strip_suffix('"')
+                .map(str::to_string);
+        }
+    }
+    None
+}

--- a/crates/desktop-bench/src/artifact.rs
+++ b/crates/desktop-bench/src/artifact.rs
@@ -1,0 +1,270 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::stats::{self, Distribution};
+
+/// Bump only with a PROTOCOL.md entry. Reports refuse to mix versions.
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Artifact {
+    pub schema_version: u32,
+    pub harness: Harness,
+    pub build: Build,
+    pub environment: Environment,
+    /// Free-form recorded conditions the harness cannot measure itself:
+    /// power, display, thermal, locale, CloudSync state, etc.
+    pub conditions: BTreeMap<String, String>,
+    pub fixture: String,
+    pub scenario: String,
+    pub trial: u32,
+    pub warmup: bool,
+    pub started_at: String,
+    pub ended_at: String,
+    pub sample_interval_ms: u64,
+    pub plateau_after_seconds: u64,
+    pub command: Option<Vec<String>>,
+    pub root_pid: u32,
+    pub memory_metric: MemoryMetric,
+    pub process_set: Vec<ProcessInfo>,
+    pub samples: Vec<Sample>,
+    pub summary: Summary,
+    pub end_state: EndState,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Harness {
+    pub name: String,
+    pub version: String,
+    pub sysinfo_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Build {
+    /// `tauri`, `gpui`, or another label; the report groups by it.
+    pub runtime: String,
+    pub sha: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Environment {
+    pub os_name: Option<String>,
+    pub os_version: Option<String>,
+    pub kernel_version: Option<String>,
+    pub arch: String,
+    pub host_name: Option<String>,
+    pub cpu_brand: Option<String>,
+    pub logical_cores: usize,
+    pub physical_cores: Option<usize>,
+    pub total_memory_bytes: u64,
+}
+
+/// Which per-process memory figure `Sample::memory_bytes` sums. RSS
+/// double-counts shared pages across processes; PSS does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryMetric {
+    /// Linux `/proc/<pid>/smaps_rollup` Pss, summed over the process set.
+    Pss,
+    /// Resident set size as reported by the OS, summed over the process set.
+    Rss,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub parent_pid: Option<u32>,
+    pub name: String,
+    pub cmd: Vec<String>,
+    pub start_time_unix: u64,
+    pub first_seen_ms: u64,
+    pub last_seen_ms: u64,
+    pub matched_by: ProcessMatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessMatch {
+    Root,
+    Descendant,
+    /// Matched `--include-name` and started at or after launch; catches
+    /// helpers that were reparented away from the app (WebKit, sidecars).
+    NamePattern,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Sample {
+    pub t_ms: u64,
+    pub process_count: usize,
+    /// Sum over the process set; 100.0 is one logical core.
+    pub cpu_percent: f64,
+    pub memory_bytes: u64,
+    pub rss_bytes: u64,
+    pub disk_read_bytes: u64,
+    pub disk_write_bytes: u64,
+    pub thread_count: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Summary {
+    pub duration_ms: u64,
+    pub sample_count: usize,
+    pub cpu_percent: Option<Distribution>,
+    /// Integral of `cpu_percent` over time, in core-seconds.
+    pub cpu_time_seconds: f64,
+    pub memory_bytes: Option<Distribution>,
+    /// Median `memory_bytes` of samples after `plateau_after_seconds`.
+    pub memory_plateau_bytes: Option<f64>,
+    /// Least-squares slope of `memory_bytes` after `plateau_after_seconds`.
+    pub memory_growth_bytes_per_min: Option<f64>,
+    pub disk_read_bytes_total: u64,
+    pub disk_write_bytes_total: u64,
+    pub max_process_count: usize,
+    pub max_thread_count: Option<usize>,
+}
+
+impl Summary {
+    pub fn from_samples(samples: &[Sample], plateau_after_seconds: u64) -> Self {
+        let t_seconds: Vec<f64> = samples.iter().map(|s| s.t_ms as f64 / 1000.0).collect();
+        let cpu: Vec<f64> = samples.iter().map(|s| s.cpu_percent).collect();
+        let memory: Vec<f64> = samples.iter().map(|s| s.memory_bytes as f64).collect();
+
+        let plateau_start_ms = plateau_after_seconds * 1000;
+        let plateau: Vec<&Sample> = samples
+            .iter()
+            .filter(|s| s.t_ms >= plateau_start_ms)
+            .collect();
+        let plateau_minutes: Vec<f64> = plateau.iter().map(|s| s.t_ms as f64 / 60_000.0).collect();
+        let plateau_memory: Vec<f64> = plateau.iter().map(|s| s.memory_bytes as f64).collect();
+
+        Self {
+            duration_ms: samples.last().map(|s| s.t_ms).unwrap_or(0),
+            sample_count: samples.len(),
+            cpu_percent: Distribution::of(&cpu),
+            cpu_time_seconds: stats::integrate(&t_seconds, &cpu) / 100.0,
+            memory_bytes: Distribution::of(&memory),
+            memory_plateau_bytes: (!plateau_memory.is_empty())
+                .then(|| stats::median(&plateau_memory)),
+            memory_growth_bytes_per_min: stats::slope(&plateau_minutes, &plateau_memory),
+            disk_read_bytes_total: samples.iter().map(|s| s.disk_read_bytes).sum(),
+            disk_write_bytes_total: samples.iter().map(|s| s.disk_write_bytes).sum(),
+            max_process_count: samples.iter().map(|s| s.process_count).max().unwrap_or(0),
+            max_thread_count: samples.iter().filter_map(|s| s.thread_count).max(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndState {
+    pub root_exited: bool,
+    pub exit_code: Option<i32>,
+    pub killed_by_harness: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(t_ms: u64, cpu: f64, memory: u64) -> Sample {
+        Sample {
+            t_ms,
+            process_count: 2,
+            cpu_percent: cpu,
+            memory_bytes: memory,
+            rss_bytes: memory,
+            disk_read_bytes: 10,
+            disk_write_bytes: 5,
+            thread_count: Some(8),
+        }
+    }
+
+    #[test]
+    fn summary_integrates_cpu_and_fits_memory_growth_after_plateau() {
+        let samples = vec![
+            sample(0, 200.0, 100),
+            sample(1000, 200.0, 900),
+            sample(2000, 100.0, 1000),
+            sample(62_000, 100.0, 1600),
+            sample(122_000, 100.0, 2200),
+        ];
+        let summary = Summary::from_samples(&samples, 2);
+
+        assert_eq!(summary.sample_count, 5);
+        assert_eq!(summary.duration_ms, 122_000);
+        // 2 cores for 1s, 1.5 cores for 1s, then 1 core for 120s.
+        assert!((summary.cpu_time_seconds - 123.5).abs() < 1e-9);
+        assert_eq!(summary.memory_plateau_bytes, Some(1600.0));
+        assert!((summary.memory_growth_bytes_per_min.unwrap() - 600.0).abs() < 1e-6);
+        assert_eq!(summary.disk_read_bytes_total, 50);
+        assert_eq!(summary.max_process_count, 2);
+        assert_eq!(summary.max_thread_count, Some(8));
+    }
+
+    #[test]
+    fn summary_of_no_samples_is_empty_not_a_panic() {
+        let summary = Summary::from_samples(&[], 60);
+        assert_eq!(summary.sample_count, 0);
+        assert!(summary.cpu_percent.is_none());
+        assert!(summary.memory_plateau_bytes.is_none());
+        assert!(summary.memory_growth_bytes_per_min.is_none());
+    }
+
+    #[test]
+    fn artifact_round_trips_through_json() {
+        let artifact = Artifact {
+            schema_version: SCHEMA_VERSION,
+            harness: Harness {
+                name: "anarlog-bench".into(),
+                version: "0.1.0".into(),
+                sysinfo_version: "0.38".into(),
+            },
+            build: Build {
+                runtime: "gpui".into(),
+                sha: Some("abc".into()),
+                channel: None,
+            },
+            environment: Environment {
+                os_name: Some("Linux".into()),
+                os_version: None,
+                kernel_version: None,
+                arch: "x86_64".into(),
+                host_name: None,
+                cpu_brand: None,
+                logical_cores: 4,
+                physical_cores: Some(2),
+                total_memory_bytes: 1,
+            },
+            conditions: BTreeMap::from([("power".to_string(), "plugged".to_string())]),
+            fixture: "ordinary".into(),
+            scenario: "idle".into(),
+            trial: 1,
+            warmup: false,
+            started_at: "2026-09-05T00:00:00Z".into(),
+            ended_at: "2026-09-05T00:00:01Z".into(),
+            sample_interval_ms: 1000,
+            plateau_after_seconds: 0,
+            command: Some(vec!["app".into()]),
+            root_pid: 42,
+            memory_metric: MemoryMetric::Pss,
+            process_set: vec![],
+            samples: vec![sample(0, 1.0, 1)],
+            summary: Summary::from_samples(&[sample(0, 1.0, 1)], 0),
+            end_state: EndState {
+                root_exited: false,
+                exit_code: None,
+                killed_by_harness: true,
+            },
+            errors: vec![],
+        };
+
+        let json = serde_json::to_string(&artifact).unwrap();
+        let parsed: Artifact = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.schema_version, SCHEMA_VERSION);
+        assert_eq!(parsed.memory_metric, MemoryMetric::Pss);
+        assert_eq!(parsed.samples, artifact.samples);
+        assert!(json.contains("\"memory_metric\":\"pss\""));
+    }
+}

--- a/crates/desktop-bench/src/main.rs
+++ b/crates/desktop-bench/src/main.rs
@@ -1,0 +1,388 @@
+mod artifact;
+mod report;
+mod sampler;
+mod stats;
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Context as _;
+use clap::{Args, Parser, Subcommand};
+use sysinfo::System;
+
+use crate::artifact::{Artifact, Build, Environment, Harness, SCHEMA_VERSION, Summary};
+use crate::sampler::SamplerConfig;
+
+/// Conditions PROTOCOL.md requires every comparable run to record.
+const REQUIRED_CONDITIONS: &[&str] = &[
+    "power",
+    "display",
+    "thermal",
+    "locale",
+    "cloudsync",
+    "fixture_version",
+];
+
+#[derive(Parser)]
+#[command(
+    name = "anarlog-bench",
+    about = "Whole-application benchmark harness for the Tauri vs GPUI desktop comparison (ANLG-320)"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Launch (or attach to) the app, sample its whole process tree, and write
+    /// one JSON artifact per trial.
+    Run(Box<RunArgs>),
+    /// Render a Markdown comparison from artifact files.
+    Report(ReportArgs),
+}
+
+#[derive(Args)]
+struct RunArgs {
+    /// Runtime label the report groups by, e.g. `tauri` or `gpui`.
+    #[arg(long)]
+    runtime: String,
+    /// Scenario id from the protocol, e.g. `idle-10m-sync-off`.
+    #[arg(long)]
+    scenario: String,
+    /// Fixture id, e.g. `ordinary` or `power-user`.
+    #[arg(long)]
+    fixture: String,
+    /// Build SHA of the app under test.
+    #[arg(long)]
+    build_sha: Option<String>,
+    /// Release channel of the app under test (`stable`, `staging`, ...).
+    #[arg(long)]
+    channel: Option<String>,
+    /// Sampling interval in milliseconds.
+    #[arg(long, default_value_t = 1000)]
+    interval_ms: u64,
+    /// Stop after this many seconds. Defaults to sampling until the root exits.
+    #[arg(long)]
+    duration: Option<u64>,
+    /// Samples before this offset are excluded from plateau and growth figures.
+    #[arg(long, default_value_t = 60)]
+    plateau_after: u64,
+    /// Measured trials to run. Each trial relaunches the command.
+    #[arg(long, default_value_t = 1)]
+    trials: u32,
+    /// Warm-up trials to run first; their artifacts are flagged and excluded
+    /// from reports.
+    #[arg(long, default_value_t = 0)]
+    warmup_trials: u32,
+    /// Case-insensitive process-name substrings to include even when the OS
+    /// reparents them (e.g. `WebKit`, `anarlog`).
+    #[arg(long = "include-name")]
+    include_names: Vec<String>,
+    /// Recorded run conditions as key=value (power, display, thermal, locale,
+    /// cloudsync, ...). Repeatable.
+    #[arg(long = "meta", value_parser = parse_key_value)]
+    conditions: Vec<(String, String)>,
+    /// Directory for artifacts.
+    #[arg(long, default_value = "bench-results")]
+    out: PathBuf,
+    /// Attach to a running process instead of spawning one. Incompatible with
+    /// `--trials` > 1 and with a command.
+    #[arg(long, conflicts_with = "command")]
+    pid: Option<u32>,
+    /// Let the app under test write to this terminal.
+    #[arg(long)]
+    show_app_output: bool,
+    /// Command to launch, after `--`.
+    #[arg(last = true)]
+    command: Vec<String>,
+}
+
+#[derive(Args)]
+struct ReportArgs {
+    /// Runtime whose medians the deltas are relative to.
+    #[arg(long, default_value = "tauri")]
+    baseline: String,
+    /// Artifact JSON files.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+}
+
+fn parse_key_value(raw: &str) -> Result<(String, String), String> {
+    raw.split_once('=')
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .filter(|(k, _)| !k.is_empty())
+        .ok_or_else(|| format!("expected key=value, got {raw:?}"))
+}
+
+fn main() -> anyhow::Result<()> {
+    match Cli::parse().command {
+        Commands::Run(args) => run(*args),
+        Commands::Report(args) => {
+            let artifacts = report::load(&args.files)?;
+            print!("{}", report::render_markdown(&artifacts, &args.baseline));
+            Ok(())
+        }
+    }
+}
+
+fn run(args: RunArgs) -> anyhow::Result<()> {
+    if args.pid.is_none() && args.command.is_empty() {
+        anyhow::bail!("pass a command after `--` or attach with --pid");
+    }
+    if args.pid.is_some() && (args.trials != 1 || args.warmup_trials != 0) {
+        anyhow::bail!("--pid cannot relaunch the app; use --trials 1 without warm-ups");
+    }
+    std::fs::create_dir_all(&args.out)
+        .with_context(|| format!("failed to create {}", args.out.display()))?;
+
+    let environment = environment();
+    let conditions: BTreeMap<String, String> = args.conditions.iter().cloned().collect();
+    let missing = missing_conditions(&conditions);
+    if !missing.is_empty() {
+        eprintln!(
+            "[anarlog-bench] warning: not comparable under PROTOCOL.md, missing --meta {}",
+            missing.join(", ")
+        );
+    }
+    let config = SamplerConfig {
+        interval: Duration::from_millis(args.interval_ms),
+        duration: args.duration.map(Duration::from_secs),
+        include_names: args.include_names.clone(),
+        kill_at_end: args.pid.is_none(),
+    };
+
+    let total = args.warmup_trials + args.trials;
+    for index in 0..total {
+        let warmup = index < args.warmup_trials;
+        let trial = if warmup {
+            index + 1
+        } else {
+            index + 1 - args.warmup_trials
+        };
+        let label = if warmup { "warm-up" } else { "trial" };
+        eprintln!(
+            "[anarlog-bench] {label} {trial}/{}: {} {} on {}",
+            if warmup {
+                args.warmup_trials
+            } else {
+                args.trials
+            },
+            args.runtime,
+            args.scenario,
+            args.fixture
+        );
+
+        let started_at = chrono::Utc::now();
+        let launch_time_unix = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let (root_pid, child) = match args.pid {
+            Some(pid) => (pid, None),
+            None => {
+                let mut command = Command::new(&args.command[0]);
+                command.args(&args.command[1..]);
+                if !args.show_app_output {
+                    command.stdout(Stdio::null()).stderr(Stdio::null());
+                }
+                let child = command
+                    .spawn()
+                    .with_context(|| format!("failed to launch {:?}", args.command))?;
+                (child.id(), Some(child))
+            }
+        };
+
+        let outcome = sampler::run(root_pid, child, launch_time_unix, &config);
+        let ended_at = chrono::Utc::now();
+        let summary = Summary::from_samples(&outcome.samples, args.plateau_after);
+
+        let artifact = Artifact {
+            schema_version: SCHEMA_VERSION,
+            harness: Harness {
+                name: env!("CARGO_PKG_NAME").to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                sysinfo_version: sysinfo_version(),
+            },
+            build: Build {
+                runtime: args.runtime.clone(),
+                sha: args.build_sha.clone(),
+                channel: args.channel.clone(),
+            },
+            environment: environment.clone(),
+            conditions: conditions.clone(),
+            fixture: args.fixture.clone(),
+            scenario: args.scenario.clone(),
+            trial,
+            warmup,
+            started_at: started_at.to_rfc3339(),
+            ended_at: ended_at.to_rfc3339(),
+            sample_interval_ms: args.interval_ms,
+            plateau_after_seconds: args.plateau_after,
+            command: (!args.command.is_empty()).then(|| args.command.clone()),
+            root_pid,
+            memory_metric: outcome.memory_metric,
+            process_set: outcome.process_set,
+            samples: outcome.samples,
+            summary,
+            end_state: outcome.end_state,
+            errors: outcome.errors,
+        };
+
+        let file_name = format!(
+            "{}_{}_{}_{}{}_{}.json",
+            sanitize(&args.runtime),
+            sanitize(&args.scenario),
+            sanitize(&args.fixture),
+            if warmup { "warmup" } else { "trial" },
+            trial,
+            started_at.format("%Y%m%dT%H%M%SZ")
+        );
+        let path = args.out.join(file_name);
+        std::fs::write(&path, serde_json::to_vec_pretty(&artifact)?)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        eprintln!(
+            "[anarlog-bench] wrote {} ({} samples, {} processes, cpu median {}, memory median {})",
+            path.display(),
+            artifact.summary.sample_count,
+            artifact.process_set.len(),
+            artifact
+                .summary
+                .cpu_percent
+                .as_ref()
+                .map(|d| format!("{:.1}%", d.median))
+                .unwrap_or_else(|| "n/a".into()),
+            artifact
+                .summary
+                .memory_bytes
+                .as_ref()
+                .map(|d| format!("{:.1} MiB", d.median / 1024.0 / 1024.0))
+                .unwrap_or_else(|| "n/a".into()),
+        );
+        if artifact.end_state.root_exited && artifact.summary.sample_count == 0 {
+            anyhow::bail!("the app exited before the first sample; check the command");
+        }
+    }
+    Ok(())
+}
+
+fn environment() -> Environment {
+    let mut system = System::new();
+    system.refresh_cpu_list(sysinfo::CpuRefreshKind::nothing());
+    system.refresh_memory();
+    Environment {
+        os_name: System::name(),
+        os_version: System::os_version(),
+        kernel_version: System::kernel_version(),
+        arch: System::cpu_arch(),
+        host_name: System::host_name(),
+        cpu_brand: system.cpus().first().map(|cpu| cpu.brand().to_string()),
+        logical_cores: system.cpus().len(),
+        physical_cores: System::physical_core_count(),
+        total_memory_bytes: system.total_memory(),
+    }
+}
+
+fn sysinfo_version() -> String {
+    env!("SYSINFO_VERSION").to_string()
+}
+
+fn missing_conditions(conditions: &BTreeMap<String, String>) -> Vec<&'static str> {
+    REQUIRED_CONDITIONS
+        .iter()
+        .copied()
+        .filter(|key| !conditions.contains_key(*key))
+        .collect()
+}
+
+fn sanitize(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_value_parsing_trims_and_rejects_missing_keys() {
+        assert_eq!(
+            parse_key_value(" power = plugged ").unwrap(),
+            ("power".to_string(), "plugged".to_string())
+        );
+        assert!(parse_key_value("=x").is_err());
+        assert!(parse_key_value("novalue").is_err());
+    }
+
+    #[test]
+    fn missing_conditions_lists_only_absent_required_keys() {
+        let conditions = BTreeMap::from([
+            ("power".to_string(), "plugged".to_string()),
+            ("display".to_string(), "x".to_string()),
+            ("extra".to_string(), "y".to_string()),
+        ]);
+        assert_eq!(
+            missing_conditions(&conditions),
+            vec!["thermal", "locale", "cloudsync", "fixture_version"]
+        );
+    }
+
+    #[test]
+    fn file_name_components_are_filesystem_safe() {
+        assert_eq!(sanitize("idle 10m/sync:off"), "idle_10m_sync_off");
+        assert_eq!(sanitize("power-user"), "power-user");
+    }
+
+    #[test]
+    fn cli_requires_a_command_or_pid() {
+        let cli = Cli::try_parse_from([
+            "anarlog-bench",
+            "run",
+            "--runtime",
+            "gpui",
+            "--scenario",
+            "idle",
+            "--fixture",
+            "ordinary",
+            "--meta",
+            "power=plugged",
+            "--",
+            "/bin/sleep",
+            "5",
+        ])
+        .unwrap();
+        let Commands::Run(args) = cli.command else {
+            panic!("expected run");
+        };
+        assert_eq!(args.command, vec!["/bin/sleep", "5"]);
+        assert_eq!(
+            args.conditions,
+            vec![("power".to_string(), "plugged".to_string())]
+        );
+
+        assert!(
+            Cli::try_parse_from([
+                "anarlog-bench",
+                "run",
+                "--runtime",
+                "gpui",
+                "--scenario",
+                "idle",
+                "--fixture",
+                "ordinary",
+                "--pid",
+                "1",
+                "--",
+                "app",
+            ])
+            .is_err()
+        );
+    }
+}

--- a/crates/desktop-bench/src/report.rs
+++ b/crates/desktop-bench/src/report.rs
@@ -1,0 +1,340 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use anyhow::Context as _;
+
+use crate::artifact::{Artifact, SCHEMA_VERSION};
+use crate::stats;
+
+const MIB: f64 = 1024.0 * 1024.0;
+
+type Extract = fn(&Artifact) -> Option<f64>;
+
+/// Metrics compared across runtimes. Lower is better for every one of them.
+const METRICS: &[(&str, Extract)] = &[
+    ("CPU median (% of one core)", |a| {
+        a.summary.cpu_percent.as_ref().map(|d| d.median)
+    }),
+    ("CPU p95 (%)", |a| {
+        a.summary.cpu_percent.as_ref().map(|d| d.p95)
+    }),
+    ("CPU peak (%)", |a| {
+        a.summary.cpu_percent.as_ref().map(|d| d.max)
+    }),
+    ("CPU time (core-seconds)", |a| {
+        Some(a.summary.cpu_time_seconds)
+    }),
+    ("Memory median (MiB)", |a| {
+        a.summary.memory_bytes.as_ref().map(|d| d.median / MIB)
+    }),
+    ("Memory peak (MiB)", |a| {
+        a.summary.memory_bytes.as_ref().map(|d| d.max / MIB)
+    }),
+    ("Memory plateau (MiB)", |a| {
+        a.summary.memory_plateau_bytes.map(|b| b / MIB)
+    }),
+    ("Memory growth (MiB/min)", |a| {
+        a.summary.memory_growth_bytes_per_min.map(|b| b / MIB)
+    }),
+    ("Disk read (MiB)", |a| {
+        Some(a.summary.disk_read_bytes_total as f64 / MIB)
+    }),
+    ("Disk write (MiB)", |a| {
+        Some(a.summary.disk_write_bytes_total as f64 / MIB)
+    }),
+    ("Max process count", |a| {
+        Some(a.summary.max_process_count as f64)
+    }),
+];
+
+pub fn load(paths: &[impl AsRef<Path>]) -> anyhow::Result<Vec<Artifact>> {
+    let mut artifacts = Vec::with_capacity(paths.len());
+    for path in paths {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let artifact: Artifact = serde_json::from_str(&text)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        if artifact.schema_version != SCHEMA_VERSION {
+            anyhow::bail!(
+                "{} has schema_version {} but this harness reports version {}",
+                path.display(),
+                artifact.schema_version,
+                SCHEMA_VERSION
+            );
+        }
+        artifacts.push(artifact);
+    }
+    Ok(artifacts)
+}
+
+/// Markdown comparison grouped by scenario and fixture. Warm-up trials are
+/// excluded. Each cell is the median across measured trials with the
+/// coefficient of variation across those trials; deltas compare medians
+/// against `baseline`.
+pub fn render_markdown(artifacts: &[Artifact], baseline: &str) -> String {
+    let mut out = String::new();
+    let measured: Vec<&Artifact> = artifacts.iter().filter(|a| !a.warmup).collect();
+    let warmups = artifacts.len() - measured.len();
+
+    writeln!(out, "# Benchmark comparison").unwrap();
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "{} artifacts, {} measured trials, {} warm-up trials excluded. Schema v{}. Cells are `median (cv)` across trials; Δ compares medians against `{}`. Lower is better for every metric.",
+        artifacts.len(),
+        measured.len(),
+        warmups,
+        SCHEMA_VERSION,
+        baseline
+    )
+    .unwrap();
+
+    let mut groups: BTreeMap<(String, String), BTreeMap<String, Vec<&Artifact>>> = BTreeMap::new();
+    for artifact in &measured {
+        groups
+            .entry((artifact.scenario.clone(), artifact.fixture.clone()))
+            .or_default()
+            .entry(artifact.build.runtime.clone())
+            .or_default()
+            .push(artifact);
+    }
+
+    for ((scenario, fixture), by_runtime) in &groups {
+        writeln!(out).unwrap();
+        writeln!(out, "## Scenario `{scenario}`, fixture `{fixture}`").unwrap();
+        writeln!(out).unwrap();
+
+        let memory_metrics: Vec<String> = by_runtime
+            .iter()
+            .map(|(runtime, runs)| {
+                let metrics: std::collections::BTreeSet<String> = runs
+                    .iter()
+                    .map(|a| format!("{:?}", a.memory_metric).to_lowercase())
+                    .collect();
+                format!(
+                    "{runtime}: {}",
+                    metrics.into_iter().collect::<Vec<_>>().join("/")
+                )
+            })
+            .collect();
+        writeln!(
+            out,
+            "Memory metric by runtime: {}.",
+            memory_metrics.join(", ")
+        )
+        .unwrap();
+        let shas: Vec<String> = by_runtime
+            .iter()
+            .map(|(runtime, runs)| {
+                let shas: std::collections::BTreeSet<&str> =
+                    runs.iter().filter_map(|a| a.build.sha.as_deref()).collect();
+                format!(
+                    "{runtime}: {}",
+                    if shas.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        shas.into_iter().collect::<Vec<_>>().join(", ")
+                    }
+                )
+            })
+            .collect();
+        writeln!(out, "Build SHA by runtime: {}.", shas.join("; ")).unwrap();
+        writeln!(out).unwrap();
+
+        let runtimes: Vec<&String> = by_runtime.keys().collect();
+        write!(out, "| Metric |").unwrap();
+        for runtime in &runtimes {
+            write!(out, " {runtime} (n={}) |", by_runtime[*runtime].len()).unwrap();
+        }
+        for runtime in runtimes.iter().filter(|r| r.as_str() != baseline) {
+            write!(out, " Δ {runtime} vs {baseline} |").unwrap();
+        }
+        writeln!(out).unwrap();
+        write!(out, "| --- |").unwrap();
+        for _ in &runtimes {
+            write!(out, " ---: |").unwrap();
+        }
+        for _ in runtimes.iter().filter(|r| r.as_str() != baseline) {
+            write!(out, " ---: |").unwrap();
+        }
+        writeln!(out).unwrap();
+
+        for (label, extract) in METRICS {
+            write!(out, "| {label} |").unwrap();
+            let medians: BTreeMap<&String, Option<f64>> = runtimes
+                .iter()
+                .map(|runtime| {
+                    let values: Vec<f64> = by_runtime[*runtime]
+                        .iter()
+                        .filter_map(|artifact| extract(artifact))
+                        .collect();
+                    let cell = aggregate(&values);
+                    write!(out, " {} |", format_cell(cell)).unwrap();
+                    (*runtime, cell.map(|(median, _)| median))
+                })
+                .collect();
+            let base = medians.get(&baseline.to_string()).copied().flatten();
+            for runtime in runtimes.iter().filter(|r| r.as_str() != baseline) {
+                let delta = match (base, medians[*runtime]) {
+                    (Some(b), Some(v)) if b != 0.0 => Some((v - b) / b * 100.0),
+                    _ => None,
+                };
+                write!(out, " {} |", format_delta(delta)).unwrap();
+            }
+            writeln!(out).unwrap();
+        }
+    }
+    out
+}
+
+fn aggregate(values: &[f64]) -> Option<(f64, Option<f64>)> {
+    if values.is_empty() {
+        return None;
+    }
+    let median = stats::median(values);
+    let mean = stats::mean(values);
+    let cv = (mean != 0.0 && values.len() > 1).then(|| stats::std_dev(values) / mean);
+    Some((median, cv))
+}
+
+fn format_cell(cell: Option<(f64, Option<f64>)>) -> String {
+    match cell {
+        None => "—".to_string(),
+        Some((median, None)) => format_number(median),
+        Some((median, Some(cv))) => format!("{} (cv {:.0}%)", format_number(median), cv * 100.0),
+    }
+}
+
+fn format_number(value: f64) -> String {
+    if value.abs() >= 100.0 {
+        format!("{value:.0}")
+    } else if value.abs() >= 10.0 {
+        format!("{value:.1}")
+    } else {
+        format!("{value:.2}")
+    }
+}
+
+fn format_delta(delta: Option<f64>) -> String {
+    match delta {
+        None => "—".to_string(),
+        Some(d) => format!("{d:+.1}%"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::artifact::*;
+
+    fn artifact(runtime: &str, trial: u32, warmup: bool, cpu: f64, memory: f64) -> Artifact {
+        let sample = Sample {
+            t_ms: 0,
+            process_count: 1,
+            cpu_percent: cpu,
+            memory_bytes: memory as u64,
+            rss_bytes: memory as u64,
+            disk_read_bytes: 0,
+            disk_write_bytes: 0,
+            thread_count: None,
+        };
+        Artifact {
+            schema_version: SCHEMA_VERSION,
+            harness: Harness {
+                name: "anarlog-bench".into(),
+                version: "test".into(),
+                sysinfo_version: "test".into(),
+            },
+            build: Build {
+                runtime: runtime.into(),
+                sha: Some(format!("{runtime}-sha")),
+                channel: None,
+            },
+            environment: Environment {
+                os_name: None,
+                os_version: None,
+                kernel_version: None,
+                arch: "x86_64".into(),
+                host_name: None,
+                cpu_brand: None,
+                logical_cores: 1,
+                physical_cores: None,
+                total_memory_bytes: 0,
+            },
+            conditions: BTreeMap::new(),
+            fixture: "ordinary".into(),
+            scenario: "idle".into(),
+            trial,
+            warmup,
+            started_at: String::new(),
+            ended_at: String::new(),
+            sample_interval_ms: 1000,
+            plateau_after_seconds: 0,
+            command: None,
+            root_pid: 1,
+            memory_metric: MemoryMetric::Rss,
+            process_set: vec![],
+            samples: vec![sample.clone()],
+            summary: Summary::from_samples(&[sample], 0),
+            end_state: EndState {
+                root_exited: false,
+                exit_code: None,
+                killed_by_harness: true,
+            },
+            errors: vec![],
+        }
+    }
+
+    #[test]
+    fn report_uses_trial_medians_and_excludes_warmups() {
+        let artifacts = vec![
+            artifact("tauri", 0, true, 900.0, 1.0),
+            artifact("tauri", 1, false, 100.0, 200.0 * MIB),
+            artifact("tauri", 2, false, 120.0, 200.0 * MIB),
+            artifact("tauri", 3, false, 80.0, 200.0 * MIB),
+            artifact("gpui", 1, false, 50.0, 100.0 * MIB),
+            artifact("gpui", 2, false, 50.0, 100.0 * MIB),
+        ];
+        let markdown = render_markdown(&artifacts, "tauri");
+
+        assert!(markdown.contains("5 measured trials, 1 warm-up trials excluded"));
+        assert!(markdown.contains("| gpui (n=2) |"));
+        assert!(markdown.contains("| tauri (n=3) |"));
+        let cpu_row = markdown
+            .lines()
+            .find(|line| line.starts_with("| CPU median"))
+            .unwrap();
+        assert!(cpu_row.contains("| 50.0 (cv 0%) |"), "{cpu_row}");
+        assert!(cpu_row.contains("| 100 (cv 16%) |"), "{cpu_row}");
+        assert!(cpu_row.ends_with("| -50.0% |"), "{cpu_row}");
+        let memory_row = markdown
+            .lines()
+            .find(|line| line.starts_with("| Memory median"))
+            .unwrap();
+        assert!(
+            memory_row.contains("| 100 (cv 0%) |") && memory_row.contains("| 200 (cv 0%) |"),
+            "{memory_row}"
+        );
+        assert!(markdown.contains("Build SHA by runtime: gpui: gpui-sha; tauri: tauri-sha."));
+    }
+
+    #[test]
+    fn load_rejects_other_schema_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("old.json");
+        let mut artifact = artifact("tauri", 1, false, 1.0, 1.0);
+        artifact.schema_version = SCHEMA_VERSION + 1;
+        std::fs::write(&path, serde_json::to_string(&artifact).unwrap()).unwrap();
+
+        let error = load(&[&path]).err().unwrap().to_string();
+        assert!(error.contains("schema_version"), "{error}");
+
+        artifact.schema_version = SCHEMA_VERSION;
+        std::fs::write(&path, serde_json::to_string(&artifact).unwrap()).unwrap();
+        assert_eq!(load(&[&path]).unwrap().len(), 1);
+    }
+}

--- a/crates/desktop-bench/src/sampler.rs
+++ b/crates/desktop-bench/src/sampler.rs
@@ -1,0 +1,348 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::process::Child;
+use std::time::{Duration, Instant};
+
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+use crate::artifact::{EndState, MemoryMetric, ProcessInfo, ProcessMatch, Sample};
+
+/// Processes whose start time is within this many seconds before launch still
+/// count as launched by the app; `start_time` has one-second resolution.
+const START_TIME_SLACK_SECONDS: u64 = 1;
+
+pub struct SamplerConfig {
+    pub interval: Duration,
+    /// `None` samples until the root process exits.
+    pub duration: Option<Duration>,
+    pub include_names: Vec<String>,
+    /// Kill the whole process set when the duration elapses. Only sensible
+    /// when the harness spawned the process.
+    pub kill_at_end: bool,
+}
+
+pub struct Outcome {
+    pub samples: Vec<Sample>,
+    pub process_set: Vec<ProcessInfo>,
+    pub end_state: EndState,
+    pub errors: Vec<String>,
+    pub memory_metric: MemoryMetric,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    pub pid: u32,
+    pub parent: Option<u32>,
+    pub name: String,
+    pub start_time_unix: u64,
+}
+
+/// Decides which live processes belong to the app under test: the root, its
+/// transitive descendants, and any process matching `include_names` that
+/// started at or after launch. The last rule catches helpers that the OS
+/// reparents (WebKit content processes, sidecars). `exclude` is the harness
+/// itself, whose name and start time would otherwise match a broad pattern.
+pub fn select_process_set(
+    root: u32,
+    exclude: u32,
+    candidates: &[Candidate],
+    include_names: &[String],
+    launch_time_unix: u64,
+) -> BTreeMap<u32, ProcessMatch> {
+    let mut selected = BTreeMap::new();
+    selected.insert(root, ProcessMatch::Root);
+
+    let mut children_of: HashMap<u32, Vec<u32>> = HashMap::new();
+    for candidate in candidates {
+        if let Some(parent) = candidate.parent {
+            children_of.entry(parent).or_default().push(candidate.pid);
+        }
+    }
+    let mut stack = vec![root];
+    let mut visited = HashSet::from([root]);
+    while let Some(pid) = stack.pop() {
+        for &child in children_of.get(&pid).into_iter().flatten() {
+            if visited.insert(child) {
+                selected.insert(child, ProcessMatch::Descendant);
+                stack.push(child);
+            }
+        }
+    }
+
+    let patterns: Vec<String> = include_names.iter().map(|p| p.to_lowercase()).collect();
+    if patterns.is_empty() {
+        return selected;
+    }
+    let earliest = launch_time_unix.saturating_sub(START_TIME_SLACK_SECONDS);
+    for candidate in candidates {
+        if candidate.pid == exclude
+            || selected.contains_key(&candidate.pid)
+            || candidate.start_time_unix < earliest
+        {
+            continue;
+        }
+        let name = candidate.name.to_lowercase();
+        if patterns.iter().any(|pattern| name.contains(pattern)) {
+            selected.insert(candidate.pid, ProcessMatch::NamePattern);
+        }
+    }
+    selected
+}
+
+fn refresh_kind() -> ProcessRefreshKind {
+    ProcessRefreshKind::nothing()
+        .with_cpu()
+        .with_memory()
+        .with_disk_usage()
+        .with_tasks()
+        .with_cmd(UpdateKind::OnlyIfNotSet)
+}
+
+pub fn run(
+    root_pid: u32,
+    mut child: Option<Child>,
+    launch_time_unix: u64,
+    config: &SamplerConfig,
+) -> Outcome {
+    let mut system = System::new();
+    let mut samples = Vec::new();
+    let mut registry: BTreeMap<u32, ProcessInfo> = BTreeMap::new();
+    let mut errors = Vec::new();
+    let mut end_state = EndState {
+        root_exited: false,
+        exit_code: None,
+        killed_by_harness: false,
+    };
+    let memory_metric = if cfg!(target_os = "linux") {
+        MemoryMetric::Pss
+    } else {
+        MemoryMetric::Rss
+    };
+
+    let interval = config.interval.max(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+    let started = Instant::now();
+    // CPU usage is a delta between refreshes; prime it before the first sample.
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind());
+
+    loop {
+        std::thread::sleep(interval);
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind());
+        let t_ms = started.elapsed().as_millis() as u64;
+
+        let candidates: Vec<Candidate> = system
+            .processes()
+            .values()
+            .filter(|process| process.thread_kind().is_none())
+            .map(|process| Candidate {
+                pid: process.pid().as_u32(),
+                parent: process.parent().map(|pid| pid.as_u32()),
+                name: process.name().to_string_lossy().into_owned(),
+                start_time_unix: process.start_time(),
+            })
+            .collect();
+        let selected = select_process_set(
+            root_pid,
+            std::process::id(),
+            &candidates,
+            &config.include_names,
+            launch_time_unix,
+        );
+
+        let mut sample = Sample {
+            t_ms,
+            process_count: 0,
+            cpu_percent: 0.0,
+            memory_bytes: 0,
+            rss_bytes: 0,
+            disk_read_bytes: 0,
+            disk_write_bytes: 0,
+            thread_count: None,
+        };
+        let mut root_alive = false;
+        for (&pid, &matched_by) in &selected {
+            let Some(process) = system.process(Pid::from_u32(pid)) else {
+                continue;
+            };
+            if pid == root_pid {
+                root_alive = true;
+            }
+            sample.process_count += 1;
+            sample.cpu_percent += f64::from(process.cpu_usage());
+            sample.rss_bytes += process.memory();
+            sample.memory_bytes += match memory_metric {
+                MemoryMetric::Pss => pss_bytes(pid).unwrap_or_else(|| process.memory()),
+                MemoryMetric::Rss => process.memory(),
+            };
+            let disk = process.disk_usage();
+            sample.disk_read_bytes += disk.read_bytes;
+            sample.disk_write_bytes += disk.written_bytes;
+            if let Some(tasks) = process.tasks() {
+                // `tasks` lists the non-main threads; the process itself is the main thread.
+                *sample.thread_count.get_or_insert(0) += tasks.len() + 1;
+            }
+
+            registry
+                .entry(pid)
+                .and_modify(|info| info.last_seen_ms = t_ms)
+                .or_insert_with(|| ProcessInfo {
+                    pid,
+                    parent_pid: process.parent().map(|p| p.as_u32()),
+                    name: process.name().to_string_lossy().into_owned(),
+                    cmd: process
+                        .cmd()
+                        .iter()
+                        .map(|arg| arg.to_string_lossy().into_owned())
+                        .collect(),
+                    start_time_unix: process.start_time(),
+                    first_seen_ms: t_ms,
+                    last_seen_ms: t_ms,
+                    matched_by,
+                });
+        }
+        samples.push(sample);
+
+        if let Some(child) = child.as_mut() {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    end_state.root_exited = true;
+                    end_state.exit_code = status.code();
+                    break;
+                }
+                Ok(None) => {}
+                Err(error) => errors.push(format!("failed to poll child process: {error}")),
+            }
+        } else if !root_alive {
+            end_state.root_exited = true;
+            break;
+        }
+
+        if let Some(duration) = config.duration
+            && started.elapsed() >= duration
+        {
+            if config.kill_at_end {
+                // Helpers first so the root cannot respawn them on the way out.
+                for pid in selected.keys().filter(|pid| **pid != root_pid) {
+                    if let Some(process) = system.process(Pid::from_u32(*pid)) {
+                        process.kill();
+                    }
+                }
+                if let Some(child) = child.as_mut() {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                } else if let Some(process) = system.process(Pid::from_u32(root_pid)) {
+                    process.kill();
+                }
+                end_state.killed_by_harness = true;
+            }
+            break;
+        }
+    }
+
+    Outcome {
+        samples,
+        process_set: registry.into_values().collect(),
+        end_state,
+        errors,
+        memory_metric,
+    }
+}
+
+/// Proportional set size from `/proc/<pid>/smaps_rollup`, which shares pages
+/// fairly between processes so a sum over the tree does not double count.
+#[cfg(target_os = "linux")]
+fn pss_bytes(pid: u32) -> Option<u64> {
+    let rollup = std::fs::read_to_string(format!("/proc/{pid}/smaps_rollup")).ok()?;
+    parse_pss_kib(&rollup).map(|kib| kib * 1024)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn pss_bytes(_pid: u32) -> Option<u64> {
+    None
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_pss_kib(smaps_rollup: &str) -> Option<u64> {
+    smaps_rollup
+        .lines()
+        .find_map(|line| line.strip_prefix("Pss:"))
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|value| value.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(pid: u32, parent: Option<u32>, name: &str, start: u64) -> Candidate {
+        Candidate {
+            pid,
+            parent,
+            name: name.to_string(),
+            start_time_unix: start,
+        }
+    }
+
+    #[test]
+    fn process_set_includes_transitive_descendants() {
+        let candidates = [
+            candidate(1, None, "init", 0),
+            candidate(100, Some(1), "app", 1000),
+            candidate(101, Some(100), "helper", 1000),
+            candidate(102, Some(101), "grandchild", 1001),
+            candidate(200, Some(1), "unrelated", 1000),
+        ];
+        let set = select_process_set(100, 1, &candidates, &[], 1000);
+        assert_eq!(
+            set,
+            BTreeMap::from([
+                (100, ProcessMatch::Root),
+                (101, ProcessMatch::Descendant),
+                (102, ProcessMatch::Descendant),
+            ])
+        );
+    }
+
+    #[test]
+    fn name_pattern_catches_reparented_helpers_started_after_launch() {
+        let candidates = [
+            candidate(1, None, "launchd", 0),
+            candidate(100, Some(1), "Anarlog", 1000),
+            candidate(300, Some(1), "com.apple.WebKit.WebContent", 1000),
+            candidate(301, Some(1), "com.apple.WebKit.Networking", 999),
+            candidate(302, Some(1), "com.apple.WebKit.WebContent", 500),
+            candidate(303, Some(1), "Safari", 1000),
+        ];
+        let set = select_process_set(100, 1, &candidates, &["webkit".to_string()], 1000);
+        assert_eq!(set.get(&300), Some(&ProcessMatch::NamePattern));
+        assert_eq!(set.get(&301), Some(&ProcessMatch::NamePattern));
+        assert_eq!(set.get(&302), None, "started long before launch");
+        assert_eq!(set.get(&303), None);
+    }
+
+    #[test]
+    fn descendants_win_over_name_matches_and_cycles_terminate() {
+        let candidates = [
+            candidate(100, Some(101), "app", 1000),
+            candidate(101, Some(100), "WebKit", 1000),
+        ];
+        let set = select_process_set(100, 1, &candidates, &["webkit".to_string()], 1000);
+        assert_eq!(set.get(&101), Some(&ProcessMatch::Descendant));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn harness_never_selects_itself_even_when_its_name_matches() {
+        let candidates = [
+            candidate(50, Some(1), "anarlog-bench", 1000),
+            candidate(100, Some(50), "anarlog-gpui", 1000),
+        ];
+        let set = select_process_set(100, 50, &candidates, &["anarlog".to_string()], 1000);
+        assert_eq!(set, BTreeMap::from([(100, ProcessMatch::Root)]));
+    }
+
+    #[test]
+    fn parses_pss_from_smaps_rollup() {
+        let rollup = "00400000-7fff Rss:  1234 kB\nRss:                1234 kB\nPss:                 567 kB\nPss_Anon:            100 kB\n";
+        assert_eq!(parse_pss_kib(rollup), Some(567));
+        assert_eq!(parse_pss_kib("Rss: 1 kB\n"), None);
+    }
+}

--- a/crates/desktop-bench/src/stats.rs
+++ b/crates/desktop-bench/src/stats.rs
@@ -1,0 +1,143 @@
+use serde::{Deserialize, Serialize};
+
+/// Distribution summary for one metric over a run. `cv` is the coefficient of
+/// variation (population standard deviation / mean), `None` when the mean is 0.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Distribution {
+    pub count: usize,
+    pub mean: f64,
+    pub median: f64,
+    pub p95: f64,
+    pub min: f64,
+    pub max: f64,
+    pub cv: Option<f64>,
+}
+
+impl Distribution {
+    pub fn of(values: &[f64]) -> Option<Self> {
+        if values.is_empty() {
+            return None;
+        }
+        let mean = mean(values);
+        Some(Self {
+            count: values.len(),
+            mean,
+            median: median(values),
+            p95: percentile(values, 95.0),
+            min: values.iter().copied().fold(f64::INFINITY, f64::min),
+            max: values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+            cv: (mean != 0.0).then(|| std_dev(values) / mean),
+        })
+    }
+}
+
+pub fn mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+pub fn median(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let mid = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    } else {
+        sorted[mid]
+    }
+}
+
+/// Nearest-rank percentile; `p` in 0..=100.
+pub fn percentile(values: &[f64], p: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let rank = ((p / 100.0) * sorted.len() as f64).ceil() as usize;
+    sorted[rank.clamp(1, sorted.len()) - 1]
+}
+
+pub fn std_dev(values: &[f64]) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+    let m = mean(values);
+    (values.iter().map(|v| (v - m).powi(2)).sum::<f64>() / values.len() as f64).sqrt()
+}
+
+/// Least-squares slope of `y` over `x`. Used for memory growth per minute.
+pub fn slope(x: &[f64], y: &[f64]) -> Option<f64> {
+    if x.len() != y.len() || x.len() < 2 {
+        return None;
+    }
+    let mx = mean(x);
+    let my = mean(y);
+    let denominator: f64 = x.iter().map(|xi| (xi - mx).powi(2)).sum();
+    if denominator == 0.0 {
+        return None;
+    }
+    let numerator: f64 = x.iter().zip(y).map(|(xi, yi)| (xi - mx) * (yi - my)).sum();
+    Some(numerator / denominator)
+}
+
+/// Trapezoidal integral of `values` sampled at `t_seconds`.
+pub fn integrate(t_seconds: &[f64], values: &[f64]) -> f64 {
+    t_seconds
+        .windows(2)
+        .zip(values.windows(2))
+        .map(|(t, v)| (t[1] - t[0]) * (v[0] + v[1]) / 2.0)
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_handles_even_and_odd_counts() {
+        assert_eq!(median(&[3.0, 1.0, 2.0]), 2.0);
+        assert_eq!(median(&[4.0, 1.0, 3.0, 2.0]), 2.5);
+        assert_eq!(median(&[]), 0.0);
+    }
+
+    #[test]
+    fn percentile_uses_nearest_rank() {
+        let values: Vec<f64> = (1..=100).map(f64::from).collect();
+        assert_eq!(percentile(&values, 95.0), 95.0);
+        assert_eq!(percentile(&values, 100.0), 100.0);
+        assert_eq!(percentile(&values, 0.0), 1.0);
+        assert_eq!(percentile(&[7.0], 95.0), 7.0);
+    }
+
+    #[test]
+    fn distribution_reports_cv_only_for_nonzero_mean() {
+        let d = Distribution::of(&[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]).unwrap();
+        assert_eq!(d.mean, 5.0);
+        assert_eq!(d.median, 4.5);
+        assert_eq!(d.max, 9.0);
+        assert!((d.cv.unwrap() - 0.4).abs() < 1e-12);
+        assert_eq!(Distribution::of(&[0.0, 0.0]).unwrap().cv, None);
+        assert!(Distribution::of(&[]).is_none());
+    }
+
+    #[test]
+    fn slope_recovers_linear_growth() {
+        let x = [0.0, 1.0, 2.0, 3.0];
+        let y = [10.0, 12.0, 14.0, 16.0];
+        assert!((slope(&x, &y).unwrap() - 2.0).abs() < 1e-12);
+        assert_eq!(slope(&[1.0], &[1.0]), None);
+        assert_eq!(slope(&[1.0, 1.0], &[1.0, 2.0]), None);
+    }
+
+    #[test]
+    fn integrate_is_trapezoidal() {
+        assert_eq!(integrate(&[0.0, 1.0, 2.0], &[100.0, 100.0, 100.0]), 200.0);
+        assert_eq!(integrate(&[0.0, 2.0], &[0.0, 100.0]), 100.0);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** [ANLG-320](https://linear.app/fastrepl-inc/issue/ANLG-320/migrate-the-desktop-application-from-tauri-to-gpui) Phase 0 starts with "implement the benchmark harness and freeze the protocol before optimization or UI porting", and the stop conditions after Phase 0 and Phase 3 depend on numbers from it. Nothing measures whole-application CPU and memory across the process tree (Tauri's WebKit helpers, sidecars) in a reproducible, versioned format, so the existing 1.4.19 evidence in the issue remains an uncontrolled snapshot.

**Fix:** Add `crates/desktop-bench` (`anarlog-bench`), a two-command harness:

- `run` launches (or attaches to) a build, samples the entire process tree at a fixed interval, and writes one schema-v1 JSON artifact per trial. The process set is the root, its transitive descendants, and any process whose name matches `--include-name` and started at or after launch, which is how reparented WebKit content/network processes and sidecars get attributed (the issue explicitly warns parent PID alone is not enough). Every process ever seen is recorded with pid, parent, command line, start time, and the rule that matched it, so a run's process set can be audited. Per sample: CPU (100 = one logical core), memory (Linux PSS from `smaps_rollup` so summing over processes does not double count shared pages; RSS elsewhere, with RSS always recorded alongside), disk deltas, thread count. Summaries: distributions with median/p95/cv, CPU core-seconds, memory plateau and least-squares growth after a `--plateau-after` offset (the soak gate's input). `--warmup-trials`/`--trials` implement the 1 + 5 procedure; `--meta key=value` records power/display/thermal/locale/CloudSync state and warns when the protocol's required keys are missing.
- `report` loads artifacts, refuses to mix schema versions, excludes warm-ups, and renders a Markdown table per (scenario, fixture) with per-runtime medians across trials, cv, and deltas against a baseline, plus the build SHAs and memory metric per runtime so a mixed or debug comparison is visible on the page.

`PROTOCOL.md` is the frozen operational protocol: field definitions, process-set rules, per-platform memory metric definitions, summary math, and an explicit list of what v1 does not measure (launch-to-interactive, input-to-paint, render/invalidation counts, IPC/SQLite/CloudSync counters, GPU/energy), which need the Phase 2 in-app hooks and a schema bump. Any change to the definitions requires bumping `SCHEMA_VERSION`.

Decisions worth a look:

- Built on `sysinfo` (already a workspace dependency); threads are filtered out of the process walk because `with_tasks()` lists them as processes on Linux.
- macOS records RSS, not `phys_footprint`, until a `proc_pid_rusage` path is added; PROTOCOL.md flags macOS memory as an upper bound. The issue asks for physical footprint, so this is the first follow-up.
- The harness excludes its own pid from name matching. Without that, `--include-name anarlog` selected `anarlog-bench` itself and the end-of-duration kill took the harness down before it wrote the artifact (found during the smoke run below).
- CI: clippy (`--no-deps -D warnings`) and tests added to the Linux desktop job; the macOS workspace test picks the crate up automatically.

## Verification

- `cargo clippy --locked -p desktop-bench --all-targets --no-deps -- -D warnings`
- `cargo test --locked -p desktop-bench` (19 tests: stats, summary derivation, JSON round-trip, process-set selection incl. reparented helpers/cycles/self-exclusion, PSS parsing, report aggregation and schema rejection, CLI parsing)
- `cargo metadata --locked`; `pnpm exec dprint check` on changed files
- Smoke on Linux: `run` against `bash -c 'yes > /dev/null & sleep 30'` with `--warmup-trials 1 --trials 2 --duration 4` captured 3 processes (root + 2 descendants), CPU median 99.5%, PSS 0.85 MiB vs summed RSS 7.8 MiB, and killed the tree cleanly; `run` against the GPUI shell from #7356 for 6 s captured the startup spike (103% at t=1s) then 0% idle at a 95.8 MiB PSS plateau with 24 threads; `report --baseline tauri` rendered both runtimes with deltas.
- Attached (`--pid`) to the running Tauri **debug** dev build (`turbo dev:desktop` on Linux/WebKitGTK) for 20 s with `--include-name WebKit`: the process set recorded the `desktop` root plus `WebKitNetworkProcess` and `WebKitWebProcess`, 60 threads, 960 MiB PSS, 3% idle CPU. Debug numbers are not comparable per the protocol; this validates attribution on a real Tauri tree.
- Not run: macOS/Windows.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cabe7429-879f-4f41-99ac-23f429a71ade?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cabe7429-879f-4f41-99ac-23f429a71ade&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

