### PR TITLE
Keep mobile note titles and metadata visible

### DIFF
--- a/apps/mobile/src/components/session-card.tsx
+++ b/apps/mobile/src/components/session-card.tsx
@@ -1,5 +1,6 @@
 import MenuView, { type MenuAction } from "@expo/ui/community/menu";
 import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import {
@@ -33,6 +34,7 @@ export function SessionCard({
   onPress: () => void;
   onDelete?: () => void;
 }) {
+  const [width, setWidth] = useState<number>();
   const title = session.title || "Untitled";
   const folder = showFolder ? session.folderPath : "";
   const tags = showTags ? session.tags.map((tag) => `#${tag}`).join(" ") : "";
@@ -52,7 +54,9 @@ export function SessionCard({
       accessibilityRole="button"
       onPress={onPress}
       style={({ pressed }) => [
+        styles.card,
         styles.cardContent,
+        { width },
         pressed && styles.cardPressed,
       ]}
     >
@@ -79,30 +83,44 @@ export function SessionCard({
     </Pressable>
   );
 
-  if (!onDelete) return <View style={styles.card}>{content}</View>;
-
   return (
-    <MenuView
-      actions={DELETE_ACTIONS}
-      onPressAction={({ nativeEvent }) => {
-        if (nativeEvent.event === "delete") onDelete();
+    <View
+      onLayout={({ nativeEvent }) => {
+        const nextWidth = nativeEvent.layout.width;
+        // Native MenuView measures its trigger on mount, so wait for this width.
+        setWidth((current) => (current === nextWidth ? current : nextWidth));
       }}
-      shouldOpenOnLongPress
-      style={styles.card}
+      style={styles.row}
     >
-      {content}
-    </MenuView>
+      {onDelete && width != null ? (
+        <MenuView
+          key={width}
+          actions={DELETE_ACTIONS}
+          onPressAction={({ nativeEvent }) => {
+            if (nativeEvent.event === "delete") onDelete();
+          }}
+          shouldOpenOnLongPress
+        >
+          {content}
+        </MenuView>
+      ) : (
+        content
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  row: {
+    alignSelf: "stretch",
+    marginBottom: Spacing.sm,
+  },
   card: {
     minHeight: 64,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: Colors.border,
     borderRadius: Radius.card,
     borderCurve: CornerCurve.squircle,
-    marginBottom: Spacing.sm,
     backgroundColor: Colors.surface,
     overflow: "hidden",
   },


### PR DESCRIPTION
Measure the list row width and pass it to the native menu trigger so note cards fill the available space instead of clipping their contents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout timing change in the mobile session card; no auth, data, or API impact.
> 
> **Overview**
> Fixes **note/session cards clipping titles and metadata** when long-press delete is enabled. The native `MenuView` trigger was sizing before the list row had a final width.
> 
> The card now **measures the row with `onLayout`**, stores that width in state, and applies it to the pressable so the card stretches to the full row. **`MenuView` only mounts after width is known** (with `key={width}` so it re-measures if layout changes); cards without delete still render the same pressable content without waiting on the menu.
> 
> Spacing moves from the inner card style to a **stretching row wrapper** so layout stays consistent whether or not delete is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a89b8a12808061ebe829af946f451ac58635f67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->