### PR TITLE
Open mobile search in a Liquid Glass palette

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,66 +1,35 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useRouter } from "expo-router";
 import { useRef, useState } from "react";
-import {
-  Platform,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useAuth } from "@/auth/context";
 import { ActionButtonCard } from "@/components/action-button-card";
+import { SearchPalette } from "@/components/search-palette";
 import { SessionCard } from "@/components/session-card";
 import { StartListeningButton } from "@/components/start-listening-button";
 import { IconButton } from "@/components/ui/icon-button";
 import { UserAvatarButton } from "@/components/user-avatar";
-import { Colors, ControlSize, Spacing, Typography } from "@/constants/theme";
-import { useSessionSearch } from "@/data/search";
+import { Colors, Spacing, Typography } from "@/constants/theme";
 import { createSession, deleteSession } from "@/data/session";
 import { useSidebarItemPreferences } from "@/data/sidebar-preferences";
 import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
-import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
 
 const ACTION_BUTTON_CARD_DISMISSED_KEY = "action-button-card-dismissed";
 
-function SearchAnalytics({ resultCount }: { resultCount: number }) {
-  useMountEffect(() => {
-    captureAnalytics("search_performed", {
-      entry_point: "mobile_home",
-      result_count: resultCount,
-      entity_types: ["note"],
-    });
-  });
-  return null;
-}
-
 export default function HomeScreen() {
   const router = useRouter();
   const auth = useAuth();
   const { items, isLoading } = useTimelineSessions();
   const sidebarPreferences = useSidebarItemPreferences();
-  const [query, setQuery] = useState<string | null>(null);
-  const [settledSearchQuery, setSettledSearchQuery] = useState("");
+  const [searching, setSearching] = useState(false);
   const [showActionButtonCard, setShowActionButtonCard] = useState(false);
-  const searching = query !== null;
-  const search = useSessionSearch(query ?? "");
   // Ref, not state: two taps in the same frame both pass a state check.
   const busyRef = useRef(false);
-  const searchAnalyticsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  useMountEffect(() => () => {
-    if (searchAnalyticsTimerRef.current) {
-      clearTimeout(searchAnalyticsTimerRef.current);
-    }
-  });
 
   useMountEffect(() => {
     if (Platform.OS !== "ios") return;
@@ -81,32 +50,6 @@ export default function HomeScreen() {
       active = false;
     };
   });
-
-  const handleSearchChange = (value: string) => {
-    setQuery(value);
-    if (searchAnalyticsTimerRef.current) {
-      clearTimeout(searchAnalyticsTimerRef.current);
-      searchAnalyticsTimerRef.current = null;
-    }
-    const term = value.trim();
-    if (term === "") {
-      setSettledSearchQuery("");
-      return;
-    }
-    searchAnalyticsTimerRef.current = setTimeout(() => {
-      searchAnalyticsTimerRef.current = null;
-      setSettledSearchQuery(term);
-    }, 300);
-  };
-
-  const closeSearch = () => {
-    if (searchAnalyticsTimerRef.current) {
-      clearTimeout(searchAnalyticsTimerRef.current);
-      searchAnalyticsTimerRef.current = null;
-    }
-    setSettledSearchQuery("");
-    setQuery(null);
-  };
 
   const handleDelete = async (session: TimelineSession) => {
     const confirmed = await confirmDestructive(
@@ -162,43 +105,23 @@ export default function HomeScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.header}>
-        {searching ? (
-          <>
-            <TextInput
-              style={styles.searchInput}
-              autoFocus
-              value={query ?? ""}
-              onChangeText={handleSearchChange}
-              placeholder="Search meetings"
-              placeholderTextColor={Colors.muted}
-            />
-            <IconButton
-              accessibilityLabel="Close search"
-              icon="close"
-              onPress={closeSearch}
-            />
-          </>
-        ) : (
-          <>
-            <UserAvatarButton
-              accessibilityLabel="Open settings"
-              onPress={() => router.push("/settings")}
-              user={auth.session?.user ?? null}
-            />
-            <View style={styles.headerActions}>
-              <IconButton
-                accessibilityLabel="Create new note"
-                icon="new-note"
-                onPress={() => void createAndOpen()}
-              />
-              <IconButton
-                accessibilityLabel="Search meetings"
-                icon="search"
-                onPress={() => setQuery("")}
-              />
-            </View>
-          </>
-        )}
+        <UserAvatarButton
+          accessibilityLabel="Open settings"
+          onPress={() => router.push("/settings")}
+          user={auth.session?.user ?? null}
+        />
+        <View style={styles.headerActions}>
+          <IconButton
+            accessibilityLabel="Create new note"
+            icon="new-note"
+            onPress={() => void createAndOpen()}
+          />
+          <IconButton
+            accessibilityLabel="Search meetings"
+            icon="search"
+            onPress={() => setSearching(true)}
+          />
+        </View>
       </View>
 
       <ScrollView
@@ -206,83 +129,58 @@ export default function HomeScreen() {
         contentContainerStyle={styles.listContent}
         keyboardShouldPersistTaps="handled"
       >
-        {searching ? (
-          <>
-            {settledSearchQuery !== "" &&
-              settledSearchQuery === query.trim() &&
-              !search.isLoading && (
-                <SearchAnalytics
-                  key={settledSearchQuery}
-                  resultCount={search.results.length}
-                />
-              )}
-            {query.trim() !== "" &&
-              !search.isLoading &&
-              search.results.length === 0 && (
-                <View style={styles.empty}>
-                  <Text style={styles.emptyBody}>No matches</Text>
-                </View>
-              )}
-            {search.results.map((session) => (
-              <SessionCard
-                key={session.id}
-                session={session}
-                showFolder={sidebarPreferences.showFolder}
-                showTags={sidebarPreferences.showTags}
-                onPress={() => {
-                  captureAnalytics("search_result_opened", {
-                    entry_point: "mobile_home",
-                    result_type: "session",
-                  });
-                  router.push(`/note/${session.id}`);
-                }}
-                onDelete={() => void handleDelete(session)}
-              />
-            ))}
-          </>
-        ) : (
-          <>
-            {showActionButtonCard && (
-              <ActionButtonCard
-                onConfigure={() => router.push("/action-button")}
-                onDismiss={dismissActionButtonCard}
-              />
-            )}
-            {!isLoading && items.length === 0 && (
-              <View style={styles.empty}>
-                <Text style={styles.emptyTitle}>No meetings yet</Text>
-                <Text style={styles.emptyBody}>
-                  Start listening or create a new note.
-                </Text>
-              </View>
-            )}
-            {items.map((item) => {
-              if (item.type === "header") {
-                return (
-                  <Text key={item.key} style={styles.sectionLabel}>
-                    {item.label}
-                  </Text>
-                );
-              }
-              return (
-                <SessionCard
-                  key={item.key}
-                  session={item.session}
-                  showFolder={sidebarPreferences.showFolder}
-                  showTags={sidebarPreferences.showTags}
-                  onPress={() => router.push(`/note/${item.session.id}`)}
-                  onDelete={() => void handleDelete(item.session)}
-                />
-              );
-            })}
-          </>
+        {showActionButtonCard && (
+          <ActionButtonCard
+            onConfigure={() => router.push("/action-button")}
+            onDismiss={dismissActionButtonCard}
+          />
         )}
+        {!isLoading && items.length === 0 && (
+          <View style={styles.empty}>
+            <Text style={styles.emptyTitle}>No meetings yet</Text>
+            <Text style={styles.emptyBody}>
+              Start listening or create a new note.
+            </Text>
+          </View>
+        )}
+        {items.map((item) => {
+          if (item.type === "header") {
+            return (
+              <Text key={item.key} style={styles.sectionLabel}>
+                {item.label}
+              </Text>
+            );
+          }
+          return (
+            <SessionCard
+              key={item.key}
+              session={item.session}
+              showFolder={sidebarPreferences.showFolder}
+              showTags={sidebarPreferences.showTags}
+              onPress={() => router.push(`/note/${item.session.id}`)}
+              onDelete={() => void handleDelete(item.session)}
+            />
+          );
+        })}
       </ScrollView>
 
-      {!searching && (
-        <StartListeningButton
-          bottomSpacing={Spacing.xs}
-          onPress={() => void createAndOpen("?listen=1")}
+      <StartListeningButton
+        bottomSpacing={Spacing.xs}
+        onPress={() => void createAndOpen("?listen=1")}
+      />
+      {searching && (
+        <SearchPalette
+          onClose={() => setSearching(false)}
+          onOpenSession={(session) => {
+            setSearching(false);
+            router.push(`/note/${session.id}`);
+          }}
+          onDeleteSession={(session) => {
+            setSearching(false);
+            requestAnimationFrame(() => {
+              void handleDelete(session);
+            });
+          }}
         />
       )}
     </SafeAreaView>
@@ -305,15 +203,6 @@ const styles = StyleSheet.create({
   headerActions: {
     flexDirection: "row",
     gap: Spacing.xs,
-  },
-  searchInput: {
-    flex: 1,
-    height: ControlSize.compact,
-    marginRight: Spacing.sm,
-    paddingVertical: Spacing.sm,
-    ...Typography.body,
-    color: Colors.ink,
-    textAlignVertical: "center",
   },
   list: {
     flex: 1,

--- a/apps/mobile/src/components/search-palette.tsx
+++ b/apps/mobile/src/components/search-palette.tsx
@@ -121,7 +121,7 @@ export function SearchPalette({
               />
             )}
             <View style={styles.searchBar}>
-              <NativeIcon name="search" size={20} color={Colors.muted} />
+              <NativeIcon name="search" size={16} color={Colors.muted} />
               <TextInput
                 ref={inputRef}
                 accessibilityLabel="Search meetings"
@@ -138,7 +138,7 @@ export function SearchPalette({
                 <IconButton
                   accessibilityLabel="Clear search"
                   icon="close"
-                  iconSize={20}
+                  iconSize={16}
                   onPress={() => {
                     handleSearchChange("");
                     inputRef.current?.focus();

--- a/apps/mobile/src/components/search-palette.tsx
+++ b/apps/mobile/src/components/search-palette.tsx
@@ -1,0 +1,256 @@
+import {
+  GlassView,
+  isGlassEffectAPIAvailable,
+  isLiquidGlassAvailable,
+} from "expo-glass-effect";
+import { useRef, useState } from "react";
+import {
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { SessionCard } from "@/components/session-card";
+import { IconButton } from "@/components/ui/icon-button";
+import { NativeIcon } from "@/components/ui/native-icon";
+import {
+  Colors,
+  CornerCurve,
+  Radius,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
+import { useSessionSearch } from "@/data/search";
+import { useSidebarItemPreferences } from "@/data/sidebar-preferences";
+import type { TimelineSession } from "@/data/timeline";
+import { captureAnalytics } from "@/lib/analytics";
+import { useMountEffect } from "@/lib/use-mount-effect";
+
+function SearchAnalytics({ resultCount }: { resultCount: number }) {
+  useMountEffect(() => {
+    captureAnalytics("search_performed", {
+      entry_point: "mobile_home",
+      result_count: resultCount,
+      entity_types: ["note"],
+    });
+  });
+  return null;
+}
+
+export function SearchPalette({
+  onClose,
+  onOpenSession,
+  onDeleteSession,
+}: {
+  onClose: () => void;
+  onOpenSession: (session: TimelineSession) => void;
+  onDeleteSession: (session: TimelineSession) => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const sidebarPreferences = useSidebarItemPreferences();
+  const [query, setQuery] = useState("");
+  const [settledQuery, setSettledQuery] = useState("");
+  const search = useSessionSearch(query);
+  const inputRef = useRef<TextInput>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasQuery = query.trim() !== "";
+  const hasGlass = isGlassEffectAPIAvailable() && isLiquidGlassAvailable();
+
+  useMountEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  });
+
+  const handleSearchChange = (value: string) => {
+    setQuery(value);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    const term = value.trim();
+    if (!term) {
+      timerRef.current = null;
+      setSettledQuery("");
+      return;
+    }
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setSettledQuery(term);
+    }, 300);
+  };
+
+  return (
+    <Modal
+      transparent
+      visible
+      onRequestClose={onClose}
+      onShow={() => inputRef.current?.focus()}
+      statusBarTranslucent
+      navigationBarTranslucent
+    >
+      <Pressable accessible={false} onPress={onClose} style={styles.backdrop} />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        pointerEvents="box-none"
+        style={styles.keyboard}
+      >
+        <View
+          pointerEvents="box-none"
+          style={[
+            styles.overlay,
+            {
+              paddingTop: insets.top + Spacing.md,
+              paddingBottom: insets.bottom + Spacing.md,
+            },
+          ]}
+        >
+          <View
+            accessibilityViewIsModal
+            onAccessibilityEscape={onClose}
+            style={[styles.palette, !hasGlass && styles.fallback]}
+          >
+            {hasGlass && (
+              <GlassView
+                colorScheme="light"
+                glassEffectStyle="regular"
+                pointerEvents="none"
+                style={StyleSheet.absoluteFill}
+              />
+            )}
+            <View style={styles.searchBar}>
+              <NativeIcon name="search" size={20} color={Colors.muted} />
+              <TextInput
+                ref={inputRef}
+                accessibilityLabel="Search meetings"
+                autoCapitalize="none"
+                autoCorrect={false}
+                onChangeText={handleSearchChange}
+                placeholder="Search meetings"
+                placeholderTextColor={Colors.muted}
+                returnKeyType="search"
+                style={styles.input}
+                value={query}
+              />
+              {query !== "" && (
+                <IconButton
+                  accessibilityLabel="Clear search"
+                  icon="close"
+                  iconSize={20}
+                  onPress={() => {
+                    handleSearchChange("");
+                    inputRef.current?.focus();
+                  }}
+                  tone="muted"
+                />
+              )}
+            </View>
+            {settledQuery !== "" &&
+              settledQuery === query.trim() &&
+              !search.isLoading && (
+                <SearchAnalytics
+                  key={settledQuery}
+                  resultCount={search.results.length}
+                />
+              )}
+            <FlatList
+              data={search.results}
+              keyExtractor={(session) => session.id}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              style={styles.results}
+              contentContainerStyle={styles.resultContent}
+              ListEmptyComponent={
+                <Text style={styles.empty} accessibilityLiveRegion="polite">
+                  {!hasQuery
+                    ? "Search by title or note content"
+                    : search.isLoading
+                      ? "Searching…"
+                      : "No matches"}
+                </Text>
+              }
+              renderItem={({ item }) => (
+                <SessionCard
+                  session={item}
+                  showFolder={sidebarPreferences.showFolder}
+                  showTags={sidebarPreferences.showTags}
+                  variant="plain"
+                  onPress={() => {
+                    captureAnalytics("search_result_opened", {
+                      entry_point: "mobile_home",
+                      result_type: "session",
+                    });
+                    onOpenSession(item);
+                  }}
+                  onDelete={() => onDeleteSession(item)}
+                />
+              )}
+            />
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: Colors.scrim,
+  },
+  overlay: {
+    flex: 1,
+    paddingHorizontal: Spacing.md,
+  },
+  keyboard: {
+    flex: 1,
+  },
+  palette: {
+    width: "100%",
+    maxWidth: 560,
+    maxHeight: "100%",
+    alignSelf: "center",
+    flexShrink: 1,
+    borderRadius: Radius.panel,
+    borderCurve: CornerCurve.squircle,
+    overflow: "hidden",
+  },
+  fallback: {
+    backgroundColor: Colors.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
+  },
+  searchBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingLeft: Spacing.md,
+    paddingRight: Spacing.sm,
+    paddingVertical: Spacing.sm,
+    gap: Spacing.xs,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
+  },
+  input: {
+    flex: 1,
+    minHeight: 44,
+    paddingHorizontal: Spacing.sm,
+    ...Typography.body,
+    color: Colors.ink,
+  },
+  results: {
+    flexGrow: 0,
+    flexShrink: 1,
+    maxHeight: 440,
+  },
+  resultContent: {
+    padding: Spacing.sm,
+  },
+  empty: {
+    padding: Spacing.md,
+    ...Typography.body,
+    color: Colors.muted,
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/src/components/search-palette.tsx
+++ b/apps/mobile/src/components/search-palette.tsx
@@ -236,6 +236,7 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: 44,
     paddingHorizontal: Spacing.sm,
+    transform: [{ translateY: -2 }],
     ...Typography.body,
     color: Colors.ink,
   },

--- a/apps/mobile/src/components/session-card.tsx
+++ b/apps/mobile/src/components/session-card.tsx
@@ -27,12 +27,14 @@ export function SessionCard({
   showTags,
   onPress,
   onDelete,
+  variant = "card",
 }: {
   session: TimelineSession;
   showFolder: boolean;
   showTags: boolean;
   onPress: () => void;
   onDelete?: () => void;
+  variant?: "card" | "plain";
 }) {
   const [width, setWidth] = useState<number>();
   const title = session.title || "Untitled";
@@ -56,6 +58,7 @@ export function SessionCard({
       style={({ pressed }) => [
         styles.card,
         styles.cardContent,
+        variant === "plain" && styles.cardPlain,
         { width },
         pressed && styles.cardPressed,
       ]}
@@ -132,6 +135,10 @@ const styles = StyleSheet.create({
   },
   cardPressed: {
     backgroundColor: Colors.accentSurface,
+  },
+  cardPlain: {
+    borderColor: "transparent",
+    backgroundColor: "transparent",
   },
   title: {
     ...Typography.bodyStrong,


### PR DESCRIPTION
Keep search results over the timeline in a keyboard-aware native glass overlay. Dismiss by tapping outside, with a small control for clearing the query and a solid fallback on unsupported devices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor on the mobile home screen with search logic moved into a new component; behavior and analytics are largely preserved with no backend or auth changes.
> 
> **Overview**
> **Mobile home search** no longer swaps the header and timeline for an inline `TextInput` and result list. Tapping search opens a new **`SearchPalette`** modal that keeps the meeting timeline visible underneath.
> 
> The palette is a keyboard-aware overlay with scrim dismiss, auto-focused query field, clear control, debounced `useSessionSearch`, and the same search analytics events. It uses **`expo-glass-effect`** when available, with a solid bordered fallback otherwise. Results render in a `FlatList` with richer empty states; open/delete close the palette first (delete is deferred via `requestAnimationFrame` so the destructive confirm can show cleanly).
> 
> **`SessionCard`** gains an optional **`plain`** variant (transparent background/border) for results inside the palette. Home screen code for inline search styling and header search mode is removed; **`StartListeningButton`** stays on screen while search is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d0b995f7c38c1d6844868fb322160607c1266e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->