### PR TITLE
Place the macOS tray icon left of Wi-Fi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17299,6 +17299,7 @@ dependencies = [
  "host",
  "intercept",
  "libloading 0.8.9",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "open",

--- a/plugins/tray/Cargo.toml
+++ b/plugins/tray/Cargo.toml
@@ -42,6 +42,7 @@ unicode-width = { workspace = true }
 libloading = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusItem"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSUserDefaults"] }
 tray-icon = { version = "0.24.2", default-features = false }

--- a/plugins/tray/src/macos_position.rs
+++ b/plugins/tray/src/macos_position.rs
@@ -2,12 +2,25 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 static WANTED_VISIBLE: AtomicBool = AtomicBool::new(true);
 
+// Bump when the seeding rule changes so installs placed by an older rule get
+// re-seeded once. 1.4.20 seeded 0, which parked the icon next to Control Center.
+const SEED_VERSION: isize = 2;
+
 pub fn preferred_position_key(autosave_name: &str) -> String {
     format!("NSStatusItem Preferred Position {autosave_name}")
 }
 
 pub fn visibility_key(autosave_name: &str) -> String {
     format!("NSStatusItem Visible {autosave_name}")
+}
+
+pub fn seed_version_key(autosave_name: &str) -> String {
+    format!("{autosave_name} position seed version")
+}
+
+// Only seed when unset so a user ⌘-drag keeps winning on later launches.
+pub fn should_seed(has_position: bool, seeded_version: isize) -> bool {
+    !has_position || seeded_version < SEED_VERSION
 }
 
 pub fn set_wanted_visible(visible: bool) {
@@ -18,20 +31,50 @@ pub fn wanted_visible() -> bool {
     WANTED_VISIBLE.load(Ordering::SeqCst)
 }
 
+// AppKit orders status items by preferred position, measured from the right
+// edge of the status area, so anything above Wi-Fi's own value lands to its
+// left. Without a Wi-Fi reference (key missing, or the sandbox denying reads
+// of Control Center's domain) we leave the position unset and let AppKit use
+// its default slot at the left end of the status items.
+pub fn seed_position(wifi_position: Option<f64>) -> Option<f64> {
+    wifi_position.map(|position| position + 1.0)
+}
+
+// Control Center autosaves the system extras (Wi-Fi, Bluetooth, ...) in its
+// own defaults domain with the same key format as third-party status items.
+#[cfg(target_os = "macos")]
+fn wifi_position() -> Option<f64> {
+    use objc2::AllocAnyThread;
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::initWithSuiteName(
+        NSUserDefaults::alloc(),
+        Some(&NSString::from_str("com.apple.controlcenter")),
+    )?;
+    let key = NSString::from_str(&preferred_position_key("WiFi"));
+    defaults.objectForKey(&key)?;
+    Some(defaults.doubleForKey(&key))
+}
+
 #[cfg(target_os = "macos")]
 pub fn seed_default_position(autosave_name: &str) {
     use objc2_foundation::{NSString, NSUserDefaults};
 
     let defaults = NSUserDefaults::standardUserDefaults();
     let key = NSString::from_str(&preferred_position_key(autosave_name));
-    if defaults.objectForKey(&key).is_some() {
+    let version_key = NSString::from_str(&seed_version_key(autosave_name));
+    if !should_seed(
+        defaults.objectForKey(&key).is_some(),
+        defaults.integerForKey(&version_key),
+    ) {
         return;
     }
 
-    // AppKit treats this as distance from the right edge of the status area.
-    // 0 claims the rightmost third-party slot, just left of system extras.
-    // Only seed when unset so a user ⌘-drag keeps winning on later launches.
-    defaults.setDouble_forKey(0.0, &key);
+    defaults.setInteger_forKey(SEED_VERSION, &version_key);
+    match seed_position(wifi_position()) {
+        Some(position) => defaults.setDouble_forKey(position, &key),
+        None => defaults.removeObjectForKey(&key),
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -73,7 +116,10 @@ pub fn apply_autosave_name(app: &tauri::AppHandle<tauri::Wry>, autosave_name: &'
 
 #[cfg(test)]
 mod tests {
-    use super::{preferred_position_key, visibility_key};
+    use super::{
+        SEED_VERSION, preferred_position_key, seed_position, seed_version_key, should_seed,
+        visibility_key,
+    };
 
     #[test]
     fn preferred_position_key_matches_appkit_convention() {
@@ -81,6 +127,37 @@ mod tests {
             preferred_position_key("anlg-tray"),
             "NSStatusItem Preferred Position anlg-tray"
         );
+    }
+
+    #[test]
+    fn seed_version_key_stays_out_of_the_appkit_namespace() {
+        assert_eq!(
+            seed_version_key("anlg-tray"),
+            "anlg-tray position seed version"
+        );
+    }
+
+    #[test]
+    fn seed_position_lands_just_left_of_wifi() {
+        assert_eq!(seed_position(Some(211.0)), Some(212.0));
+    }
+
+    #[test]
+    fn seed_position_defers_to_appkit_without_wifi() {
+        assert_eq!(seed_position(None), None);
+    }
+
+    #[test]
+    fn seeds_fresh_installs_and_positions_from_older_rules() {
+        assert!(should_seed(false, 0));
+        assert!(should_seed(true, 0));
+        assert!(should_seed(true, SEED_VERSION - 1));
+    }
+
+    #[test]
+    fn keeps_a_position_already_seeded_by_the_current_rule() {
+        assert!(!should_seed(true, SEED_VERSION));
+        assert!(!should_seed(true, SEED_VERSION + 1));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** 1.4.20 seeded `NSStatusItem Preferred Position anlg-tray` to `0`, which AppKit resolves as the rightmost slot — the a_ item ended up between Now Playing and Control Center, to the right of Wi‑Fi and the other system extras, instead of at the right end of the third‑party icons.

**Fix:** AppKit orders status items by preferred position (distance from the right edge), and Control Center stores Wi‑Fi's under `com.apple.controlcenter` / `NSStatusItem Preferred Position WiFi`. On first launch we now read that value and seed ours to `wifi + 1`, so the icon lands immediately left of Wi‑Fi. A small seed‑version marker re‑applies the rule once for installs that were seeded by the 1.4.20 rule; after that a user ⌘‑drag keeps winning as before. If Wi‑Fi's position can't be read (missing key, or the App Store sandbox denying reads of another domain), the key is left unset so AppKit uses its default slot at the left end of the status items rather than parking the icon next to Control Center.

## Verification

- `cargo test -p tauri-plugin-anlg-tray --lib` (Linux): 25 passed, incl. new `macos_position` tests for the seed value and re‑seed rule.
- The macOS‑only `NSUserDefaults` calls (`initWithSuiteName`, `integerForKey`, `setInteger_forKey`, `removeObjectForKey`) were cross‑checked against `objc2 0.6.4` / `objc2-foundation 0.3.2` with `cargo check`/`clippy -D warnings --target aarch64-apple-darwin` in a scratch crate; a full `--target aarch64-apple-darwin` check of the plugin is not possible on Linux (`aws-lc-sys` needs the macOS SDK).
- `cargo fmt --check`, `dprint fmt`/`check` on the changed files.
- Not run: launching on macOS to observe the placement (no macOS host in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f1e1c7-4fa6-497f-b2b6-6f68b1899a44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f1e1c7-4fa6-497f-b2b6-6f68b1899a44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

