### PR TITLE
Use the original icon underscore in mobile typing animation

### DIFF
--- a/apps/mobile/assets/images/anarlog-underscore.svg
+++ b/apps/mobile/assets/images/anarlog-underscore.svg
@@ -1,0 +1,4 @@
+<svg width="64.37" height="35.46" viewBox="166.49 221.65 64.37 35.46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<!-- Underscore from apps/desktop/src-tauri/icons/src/stable.icon/Assets/SVG Image.svg. -->
+<rect x="166.49" y="221.65" width="64.37" height="35.46" rx="6" fill="black"/>
+</svg>

--- a/apps/mobile/src/components/brand-loading-view.tsx
+++ b/apps/mobile/src/components/brand-loading-view.tsx
@@ -18,10 +18,12 @@ import { createStyleHook } from "@/settings/theme-provider";
 const WORDMARK_WIDTH = 200;
 const WORDMARK_HEIGHT = 56;
 const WORDMARK_SOURCE_WIDTH = 1_205;
+const WORDMARK_SCALE = WORDMARK_WIDTH / WORDMARK_SOURCE_WIDTH;
 const REVEAL_STEPS = [154, 357, 538, 714, 786, 1_006, 1_205].map(
-  (width) => (width / WORDMARK_SOURCE_WIDTH) * WORDMARK_WIDTH,
+  (width) => width * WORDMARK_SCALE,
 );
 const FIRST_REVEAL = REVEAL_STEPS[0];
+const CURSOR_GAP = 166.49 * WORDMARK_SCALE - FIRST_REVEAL;
 const LOGO_SHIFT = -(WORDMARK_WIDTH - FIRST_REVEAL) / 2;
 const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);
 
@@ -111,7 +113,7 @@ export function BrandLoadingView({
   }));
   const cursorStyle = useAnimatedStyle(() => ({
     opacity: cursorOpacity.get(),
-    transform: [{ translateX: revealWidth.get() + 4 }],
+    transform: [{ translateX: revealWidth.get() + CURSOR_GAP }],
   }));
 
   return (
@@ -138,7 +140,13 @@ export function BrandLoadingView({
             />
             <Animated.View style={[styles.wordmarkCover, coverStyle]} />
           </View>
-          <Animated.View style={[styles.cursor, cursorStyle]} />
+          <Animated.View style={[styles.cursor, cursorStyle]}>
+            <Image
+              contentFit="contain"
+              source={require("../../assets/images/anarlog-underscore.svg")}
+              style={styles.cursorImage}
+            />
+          </Animated.View>
         </Animated.View>
       </View>
     </View>
@@ -179,11 +187,13 @@ const useStyles = createStyleHook((Colors) => ({
   },
   cursor: {
     position: "absolute",
-    top: 44,
+    top: (WORDMARK_HEIGHT - 334 * WORDMARK_SCALE) / 2 + 221.65 * WORDMARK_SCALE,
     left: 0,
-    width: 14,
-    height: 5,
-    borderRadius: 2.5,
-    backgroundColor: Colors.ink,
+    width: 64.37 * WORDMARK_SCALE,
+    height: 35.46 * WORDMARK_SCALE,
+  },
+  cursorImage: {
+    flex: 1,
+    tintColor: Colors.ink,
   },
 }));


### PR DESCRIPTION
Render the source SVG underscore with wordmark-scaled geometry and spacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Splash/loading UI only; no auth, data, or business logic changes.
> 
> **Overview**
> Aligns the mobile **Anarlog** loading “typing” cursor with the desktop wordmark asset instead of a generic pill shape.
> 
> Adds `anarlog-underscore.svg` (from the desktop icon set) and renders it in `BrandLoadingView` with **wordmark-scaled** size and position. Reveal step widths and cursor horizontal offset now derive from `WORDMARK_SCALE` and a computed `CURSOR_GAP` (replacing a fixed `+4` px nudge), so the underscore tracks the reveal animation at the correct x/y relative to the wordmark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07968659f7ae2b076c1349dbde5cff8c984e5616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->