### PR TITLE
Enforce ZDR and deny data collection on OpenRouter requests

### DIFF
--- a/crates/llm-proxy/src/provider/openrouter.rs
+++ b/crates/llm-proxy/src/provider/openrouter.rs
@@ -1,6 +1,6 @@
 use anlg_openrouter::{
-    Client as OpenRouterClient, Error as OpenRouterError, ProviderPreferences, ProviderSort,
-    ProviderSortUnion,
+    Client as OpenRouterClient, DataCollectionMode, Error as OpenRouterError, ProviderPreferences,
+    ProviderSort, ProviderSortUnion,
 };
 use reqwest::Client;
 use serde::Deserialize;
@@ -94,6 +94,10 @@ impl Provider for OpenRouterProvider {
         let provider_prefs = ProviderPreferences {
             sort: Some(ProviderSortUnion::Simple(ProviderSort::Latency)),
             preferred_min_throughput: None,
+            // Enforce no training / no retention on every request we send through
+            // OpenRouter, regardless of account-wide dashboard defaults.
+            data_collection: Some(DataCollectionMode::Deny),
+            zdr: Some(true),
             ..Default::default()
         };
 


### PR DESCRIPTION
Anarlog Cloud's OpenRouter provider preferences only set `sort: Latency`, so per-request routing did not enforce Zero Data Retention or exclude providers that may train on request data. This sets `data_collection: Deny` and `zdr: true` on every request we send to OpenRouter, so no-training/no-retention holds at the request level regardless of the org's account-wide OpenRouter dashboard defaults.

Context: surfaced while preparing our reply to Google's OAuth verification (Third-Party Data Safety) review for project `useful-shell-447307-d4`, which asked us to detail service configurations that restrict generalized model training on requests routed through OpenRouter.

Validation: `cargo check -p llm-proxy` passed during implementation. `cargo test --locked -p llm-proxy --lib` now passes locally (7 tests), and API CI passed on the published head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound LLM routing constraints and may exclude providers that do not support ZDR/no-collection, affecting availability or latency for OpenRouter traffic.
> 
> **Overview**
> **OpenRouter chat completion requests** now set per-request provider preferences for **zero data retention** and **no training/data collection**, independent of account dashboard defaults.
> 
> In `build_request`, `ProviderPreferences` gains `data_collection: Deny` and `zdr: true` alongside the existing latency sort, serialized into the request body’s `provider` field. The `anlg_openrouter` import adds `DataCollectionMode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b656582bbc315060ea1878e2247fccee6e4e01d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->