### PR TITLE
Match mobile Settings to the home screen

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -198,7 +198,7 @@ const useStyles = createStyleHook((Colors) => ({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.md,
     paddingTop: Spacing.sm,
     paddingBottom: Spacing.md,
   },
@@ -211,14 +211,14 @@ const useStyles = createStyleHook((Colors) => ({
   },
   listContent: {
     flexGrow: 1,
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.md,
     paddingBottom: Spacing.lg,
   },
   empty: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.md,
     gap: Spacing.sm,
   },
   emptyTitle: {

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -894,12 +894,12 @@ const useStyles = createStyleHook((Colors) => ({
     flex: 1,
   },
   title: {
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.md,
     ...Typography.title,
     color: Colors.ink,
   },
   summary: {
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.md,
     padding: Spacing.md,
   },
@@ -921,13 +921,13 @@ const useStyles = createStyleHook((Colors) => ({
     color: Colors.ink,
   },
   transcribeStatus: {
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.xs,
     ...Typography.caption,
     color: Colors.muted,
   },
   transcribeAction: {
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.xs,
     ...Typography.captionStrong,
     color: Colors.ink,
@@ -936,7 +936,7 @@ const useStyles = createStyleHook((Colors) => ({
     opacity: 0.6,
   },
   transcript: {
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.sm,
     paddingHorizontal: Spacing.md,
     paddingTop: Spacing.sm,
@@ -957,7 +957,7 @@ const useStyles = createStyleHook((Colors) => ({
   },
   attachments: {
     gap: Spacing.sm,
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.md,
   },
   attachmentLabel: {
@@ -968,7 +968,7 @@ const useStyles = createStyleHook((Colors) => ({
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.xs,
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.sm,
   },
   readOnlyLabel: {
@@ -977,7 +977,7 @@ const useStyles = createStyleHook((Colors) => ({
   },
   body: {
     flex: 1,
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.md,
     paddingTop: Spacing.md,
     ...Typography.body,
     color: Colors.ink,

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -1,21 +1,20 @@
-import { createStyleHook,useColors } from "@/settings/theme-provider";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation } from "@tanstack/react-query";
-import { File,Paths } from "expo-file-system";
+import { File, Paths } from "expo-file-system";
 import * as Linking from "expo-linking";
-import { useLocalSearchParams,useRouter } from "expo-router";
-import { useRef,useState } from "react";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useRef, useState } from "react";
 import {
-Alert,
-InputAccessoryView,
-Keyboard,
-Platform,
-Pressable,
-ScrollView,
-Share,
-Text,
-TextInput,
-View
+  Alert,
+  InputAccessoryView,
+  Keyboard,
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  Text,
+  TextInput,
+  View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -32,38 +31,39 @@ import { StartListeningButton } from "@/components/start-listening-button";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
-import { Spacing,Typography } from "@/constants/theme";
+import { Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
 import { importRecordingIntoSession } from "@/data/import-voice-memo";
 import {
-type NoteAttachment,
-useNoteAttachments,
+  type NoteAttachment,
+  useNoteAttachments,
 } from "@/data/note-attachment-catalog";
 import { insertCapturedNoteAttachmentMarkdown } from "@/data/note-attachment-model";
 import { pickAndCatalogNoteAttachment } from "@/data/note-attachments";
 import {
-restoreNoteAttachmentFromCloud,
-shareNoteAttachment,
+  restoreNoteAttachmentFromCloud,
+  shareNoteAttachment,
 } from "@/data/restore-note-attachment";
 import {
-restoreSessionAudioFromCloud,
-restoreSessionAudioFromPicker,
+  restoreSessionAudioFromCloud,
+  restoreSessionAudioFromPicker,
 } from "@/data/restore-session-audio";
 import {
-deleteSession,
-saveSessionNote,
-saveSessionTitle,
-useSessionDetail,
+  deleteSession,
+  saveSessionNote,
+  saveSessionTitle,
+  useSessionDetail,
 } from "@/data/session";
 import { summarizeSession } from "@/data/summarize";
-import { transcribeSession,useTranscriptionState } from "@/data/transcribe";
+import { transcribeSession, useTranscriptionState } from "@/data/transcribe";
 import { useSessionTranscripts } from "@/data/transcripts";
 import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
-import { applyEditorFormat,type EditorFormat } from "@/lib/editor-format";
+import { applyEditorFormat, type EditorFormat } from "@/lib/editor-format";
 import { env } from "@/lib/env";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
+import { createStyleHook, useColors } from "@/settings/theme-provider";
 
 function BodyEditor({
   accessoryId,
@@ -256,7 +256,12 @@ export default function NoteScreen() {
   const audio = useSessionAudio(id);
   const noteAttachments = useNoteAttachments(id);
   const transcripts = useSessionTranscripts(id);
-  const summarize = useMutation({ mutationFn: async () => { await flush(true); await summarizeSession(id); } });
+  const summarize = useMutation({
+    mutationFn: async () => {
+      await flush(true);
+      await summarizeSession(id);
+    },
+  });
   const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
   const [editorFocused, setEditorFocused] = useState(false);
@@ -734,10 +739,25 @@ export default function NoteScreen() {
               )}
             </Card>
           )}
-          {!listening && (transcripts.length > 0 || data.noteText.trim() !== "") && <View>
-            <Button label={data.summary ? "Regenerate summary" : "Generate summary"} loading={summarize.isPending} variant="ghost" size="small" onPress={() => summarize.mutate()} />
-            {summarize.error && <Text style={styles.summaryText}>{summarize.error.message}</Text>}
-          </View>}
+          {!listening &&
+            (transcripts.length > 0 || data.noteText.trim() !== "") && (
+              <View>
+                <Button
+                  label={
+                    data.summary ? "Regenerate summary" : "Generate summary"
+                  }
+                  loading={summarize.isPending}
+                  variant="ghost"
+                  size="small"
+                  onPress={() => summarize.mutate()}
+                />
+                {summarize.error && (
+                  <Text style={styles.summaryText}>
+                    {summarize.error.message}
+                  </Text>
+                )}
+              </View>
+            )}
           {audio.data && localAudioAvailable && localAudioFile && (
             <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
               <AudioChip

--- a/apps/mobile/src/app/settings.tsx
+++ b/apps/mobile/src/app/settings.tsx
@@ -1,14 +1,15 @@
-import { FieldGroup, Icon } from "@expo/ui";
+import { Icon } from "@expo/ui";
 import { useRouter } from "expo-router";
 
-import { SettingsPage, SettingsRow } from "@/settings/components";
+import { SettingsPage } from "@/settings/components";
+import { SettingsMenuGroup, SettingsMenuLink } from "@/settings/menu";
 
 export default function SettingsScreen() {
   const router = useRouter();
   return (
-    <SettingsPage title="Settings">
-      <FieldGroup.Section>
-        <SettingsRow
+    <SettingsPage title="Settings" layout="menu">
+      <SettingsMenuGroup>
+        <SettingsMenuLink
           title="Account"
           icon={Icon.select({
             ios: "person.crop.circle",
@@ -16,9 +17,9 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/account")}
         />
-      </FieldGroup.Section>
-      <FieldGroup.Section>
-        <SettingsRow
+      </SettingsMenuGroup>
+      <SettingsMenuGroup>
+        <SettingsMenuLink
           title="Sync & storage"
           icon={Icon.select({
             ios: "icloud",
@@ -26,9 +27,9 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/sync")}
         />
-      </FieldGroup.Section>
-      <FieldGroup.Section>
-        <SettingsRow
+      </SettingsMenuGroup>
+      <SettingsMenuGroup>
+        <SettingsMenuLink
           title="Recording"
           icon={Icon.select({
             ios: "mic",
@@ -36,7 +37,7 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/recording")}
         />
-        <SettingsRow
+        <SettingsMenuLink
           title="Transcription & summaries"
           icon={Icon.select({
             ios: "text.bubble",
@@ -44,7 +45,7 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/transcription")}
         />
-        <SettingsRow
+        <SettingsMenuLink
           title="Appearance"
           icon={Icon.select({
             ios: "sun.max",
@@ -52,9 +53,9 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/appearance")}
         />
-      </FieldGroup.Section>
-      <FieldGroup.Section>
-        <SettingsRow
+      </SettingsMenuGroup>
+      <SettingsMenuGroup>
+        <SettingsMenuLink
           title="Privacy"
           icon={Icon.select({
             ios: "hand.raised",
@@ -62,7 +63,7 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/privacy")}
         />
-        <SettingsRow
+        <SettingsMenuLink
           title="Help & about"
           icon={Icon.select({
             ios: "questionmark.circle",
@@ -70,7 +71,7 @@ export default function SettingsScreen() {
           })}
           onPress={() => router.push("/settings/help")}
         />
-      </FieldGroup.Section>
+      </SettingsMenuGroup>
     </SettingsPage>
   );
 }

--- a/apps/mobile/src/components/audio-chip.tsx
+++ b/apps/mobile/src/components/audio-chip.tsx
@@ -103,7 +103,7 @@ const useStyles = createStyleHook((Colors) => ({
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.xs,
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.sm,
     paddingHorizontal: Spacing.sm,
     paddingVertical: Spacing.xs,

--- a/apps/mobile/src/components/recording-sync-card.tsx
+++ b/apps/mobile/src/components/recording-sync-card.tsx
@@ -88,7 +88,7 @@ export function RecordingSyncCard({ audio }: { audio: SessionAudio }) {
 const useStyles = createStyleHook((Colors) => ({
   card: {
     gap: Spacing.sm,
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.sm,
     padding: Spacing.md,
   },

--- a/apps/mobile/src/components/remote-audio-card.tsx
+++ b/apps/mobile/src/components/remote-audio-card.tsx
@@ -66,7 +66,7 @@ const useStyles = createStyleHook((Colors) => ({
     flexDirection: "row",
     alignItems: "flex-start",
     gap: Spacing.sm,
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     marginTop: Spacing.sm,
     padding: Spacing.md,
   },

--- a/apps/mobile/src/components/start-listening-button.tsx
+++ b/apps/mobile/src/components/start-listening-button.tsx
@@ -40,7 +40,7 @@ const useStyles = createStyleHook((Colors) => ({
     alignItems: "center",
     justifyContent: "center",
     gap: Spacing.sm,
-    marginHorizontal: Spacing.lg,
+    marginHorizontal: Spacing.md,
     borderRadius: LISTENING_CONTROL_RADIUS,
     borderCurve: CornerCurve.squircle,
     backgroundColor: Colors.primary,

--- a/apps/mobile/src/settings/components.tsx
+++ b/apps/mobile/src/settings/components.tsx
@@ -61,7 +61,7 @@ export function SettingsPage({
                 ? [
                     scrollContentBackground("hidden"),
                     listSectionSpacing(Spacing.lg),
-                    font({ size: Typography.body.fontSize }),
+                    font({ textStyle: "subheadline" }),
                   ]
                 : undefined
             }

--- a/apps/mobile/src/settings/components.tsx
+++ b/apps/mobile/src/settings/components.tsx
@@ -1,8 +1,13 @@
 import type { IconName } from "@expo/ui";
 import { FieldGroup, Host, Icon, ListItem, Text as NativeText } from "@expo/ui";
+import {
+  font,
+  listSectionSpacing,
+  scrollContentBackground,
+} from "@expo/ui/swift-ui/modifiers";
 import { useRouter } from "expo-router";
 import type { ReactNode } from "react";
-import { Text, View } from "react-native";
+import { Platform, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { IconButton } from "@/components/ui/icon-button";
@@ -16,9 +21,11 @@ import {
 export function SettingsPage({
   title,
   children,
+  layout = "form",
 }: {
   title: string;
   children: ReactNode;
+  layout?: "form" | "menu";
 }) {
   const styles = useStyles();
   const Colors = useColors();
@@ -38,14 +45,31 @@ export function SettingsPage({
         <Text style={styles.title}>{title}</Text>
         <View style={styles.spacer} />
       </View>
-      <Host
-        style={styles.form}
-        colorScheme={colorScheme}
-        seedColor={colorScheme === "dark" ? Colors.muted : Colors.ink}
-        ignoreSafeArea="all"
-      >
-        <FieldGroup>{children}</FieldGroup>
-      </Host>
+      {layout === "menu" ? (
+        <ScrollView contentContainerStyle={styles.menu}>{children}</ScrollView>
+      ) : (
+        <Host
+          style={styles.form}
+          colorScheme={colorScheme}
+          seedColor={colorScheme === "dark" ? Colors.muted : Colors.ink}
+          ignoreSafeArea="all"
+        >
+          <FieldGroup
+            style={{ backgroundColor: Colors.background }}
+            modifiers={
+              Platform.OS === "ios"
+                ? [
+                    scrollContentBackground("hidden"),
+                    listSectionSpacing(Spacing.lg),
+                    font({ size: Typography.body.fontSize }),
+                  ]
+                : undefined
+            }
+          >
+            {children}
+          </FieldGroup>
+        </Host>
+      )}
     </SafeAreaView>
   );
 }
@@ -102,10 +126,17 @@ const useStyles = createStyleHook((Colors) => ({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.md,
   },
   title: { ...Typography.section, color: Colors.ink },
   spacer: { width: ControlSize.default, height: ControlSize.default },
   form: { flex: 1 },
+  menu: {
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.lg,
+    gap: Spacing.lg,
+  },
 }));

--- a/apps/mobile/src/settings/menu.tsx
+++ b/apps/mobile/src/settings/menu.tsx
@@ -1,0 +1,79 @@
+import { Host, Icon, type IconName } from "@expo/ui";
+import { Children, type ReactNode } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { Card } from "@/components/ui/card";
+import { Spacing, Typography } from "@/constants/theme";
+import { createStyleHook, useColors } from "@/settings/theme-provider";
+
+export function SettingsMenuGroup({ children }: { children: ReactNode }) {
+  const styles = useStyles();
+  return (
+    <Card style={styles.card}>
+      {Children.toArray(children).map((child, index) => (
+        <View key={index}>
+          {index > 0 && <View style={styles.separator} />}
+          {child}
+        </View>
+      ))}
+    </Card>
+  );
+}
+
+export function SettingsMenuLink({
+  title,
+  icon,
+  onPress,
+}: {
+  title: string;
+  icon: IconName;
+  onPress: () => void;
+}) {
+  const styles = useStyles();
+  const Colors = useColors();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+    >
+      <Host style={styles.icon} pointerEvents="none">
+        <Icon name={icon} size={20} color={Colors.muted} />
+      </Host>
+      <Text style={styles.title}>{title}</Text>
+      <Host style={styles.chevron} pointerEvents="none">
+        <Icon
+          name={Icon.select({
+            ios: "chevron.right",
+            android: import("@expo/material-symbols/chevron_right.xml"),
+          })}
+          size={12}
+          color={Colors.muted}
+        />
+      </Host>
+    </Pressable>
+  );
+}
+
+const useStyles = createStyleHook((Colors) => ({
+  card: { overflow: "hidden" },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: 64,
+    paddingHorizontal: Spacing.compact,
+    paddingVertical: Spacing.compact,
+    gap: Spacing.compact,
+  },
+  pressed: { backgroundColor: Colors.accentSurface },
+  icon: { width: 24, height: 24 },
+  chevron: { width: 16, height: 20 },
+  title: { ...Typography.bodyStrong, flex: 1, color: Colors.ink },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: Colors.border,
+    marginLeft: Spacing.compact * 2 + 24,
+    marginRight: Spacing.compact,
+  },
+}));


### PR DESCRIPTION
Match the mobile Settings menu to the home screen with shared cards, spacing, and typography, and align horizontal insets across the mobile shell. Native detail forms use a Dynamic Type text style so accessibility text sizes continue to scale.

Validation: mobile typecheck and all 133 mobile tests passed, along with formatting and the common CI checks.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only spacing and settings navigation UI; no changes to auth, sync, or data paths.
> 
> **Overview**
> **Aligns horizontal insets** across home, note, and related components by switching `Spacing.lg` to `Spacing.md` for headers, list content, note editor blocks, and audio/listening controls so edges line up with the home timeline.
> 
> **Rebuilds the root Settings screen** to match that card-based feel: `SettingsPage` gains a `layout="menu"` mode (scroll + grouped cards) while sub-pages keep the existing form `FieldGroup` layout, with iOS form lists getting section spacing and typography modifiers. New `SettingsMenuGroup` / `SettingsMenuLink` replace Expo `FieldGroup.Section` + `SettingsRow` on the top-level settings hub.
> 
> Minor note-screen cleanup (import formatting, expanded summarize mutation) with no behavior change beyond spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55014fa686312144cd475fbb862754d1617a9d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->