### PR TITLE
Fix Linux AppImage startup and capture readiness

### DIFF
--- a/crates/audio-actual/src/speaker/linux.rs
+++ b/crates/audio-actual/src/speaker/linux.rs
@@ -58,6 +58,36 @@ struct PipeWireUserData {
     scratch: Vec<f32>,
 }
 
+fn update_pipewire_initialization(
+    init_tx: &mut Option<std::sync::mpsc::Sender<Result<()>>>,
+    state: &pw::stream::StreamState,
+    sample_rate: u32,
+) {
+    match state {
+        pw::stream::StreamState::Streaming if sample_rate > 0 => {
+            if let Some(init_tx) = init_tx.take() {
+                tracing::info!(
+                    anarlog.audio.sample_rate_hz = sample_rate,
+                    "pipewire_capture_initialized"
+                );
+                let _ = init_tx.send(Ok(()));
+            }
+        }
+        pw::stream::StreamState::Error(error) => {
+            if let Some(init_tx) = init_tx.take() {
+                // Initialization failures can recover through the PulseAudio fallback.
+                tracing::warn!(error = %error, "pipewire_stream_init_failed");
+                let _ = init_tx.send(Err(anyhow::anyhow!(
+                    "PipeWire stream entered an error state: {error}"
+                )));
+            } else {
+                tracing::error!(error = %error, "pipewire_stream_error");
+            }
+        }
+        _ => {}
+    }
+}
+
 impl SpeakerInput {
     pub fn new() -> Result<Self> {
         Ok(Self {
@@ -319,13 +349,12 @@ fn pipewire_capture_setup(
             let mainloop = mainloop.clone();
             move |_, user_data, old, new| {
                 tracing::debug!(?old, ?new, "pipewire_stream_state_changed");
-                if let pw::stream::StreamState::Error(error) = new {
-                    tracing::error!(error = %error, "pipewire_stream_error");
-                    if let Some(init_tx) = user_data.init_tx.take() {
-                        let _ = init_tx.send(Err(anyhow::anyhow!(
-                            "PipeWire stream entered an error state: {error}"
-                        )));
-                    }
+                update_pipewire_initialization(
+                    &mut user_data.init_tx,
+                    &new,
+                    user_data.format.rate(),
+                );
+                if matches!(new, pw::stream::StreamState::Error(_)) {
                     mainloop.quit();
                 }
             }
@@ -352,13 +381,6 @@ fn pipewire_capture_setup(
                 let rate = user_data.format.rate();
                 if rate > 0 {
                     user_data.current_sample_rate.store(rate, Ordering::Release);
-                    tracing::info!(
-                        anarlog.audio.sample_rate_hz = rate,
-                        "pipewire_capture_initialized"
-                    );
-                    if let Some(init_tx) = user_data.init_tx.take() {
-                        let _ = init_tx.send(Ok(()));
-                    }
                 }
             }
         })
@@ -860,7 +882,40 @@ impl PinnedDrop for SpeakerStream {
 
 #[cfg(test)]
 mod tests {
-    use super::{SinkTarget, pick_sink_in_use};
+    use super::{SinkTarget, pick_sink_in_use, update_pipewire_initialization};
+    use pipewire::stream::StreamState;
+    use std::sync::mpsc::{self, TryRecvError};
+
+    #[test]
+    fn negotiated_format_does_not_hide_a_pipewire_startup_failure() {
+        let (tx, rx) = mpsc::channel();
+        let mut init_tx = Some(tx);
+        update_pipewire_initialization(&mut init_tx, &StreamState::Paused, 48_000);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+
+        update_pipewire_initialization(
+            &mut init_tx,
+            &StreamState::Error("negotiation failed".into()),
+            48_000,
+        );
+        let error = rx.try_recv().unwrap().unwrap_err();
+        assert!(error.to_string().contains("negotiation failed"));
+    }
+
+    #[test]
+    fn pipewire_is_ready_only_when_streaming_with_a_valid_format() {
+        let (tx, rx) = mpsc::channel();
+        let mut init_tx = Some(tx);
+        update_pipewire_initialization(&mut init_tx, &StreamState::Connecting, 0);
+        update_pipewire_initialization(&mut init_tx, &StreamState::Streaming, 0);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+
+        update_pipewire_initialization(&mut init_tx, &StreamState::Streaming, 48_000);
+        assert!(rx.try_recv().unwrap().is_ok());
+        update_pipewire_initialization(&mut init_tx, &StreamState::Paused, 48_000);
+        update_pipewire_initialization(&mut init_tx, &StreamState::Streaming, 48_000);
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Disconnected)));
+    }
 
     fn sink(index: u32, name: &str) -> SinkTarget {
         SinkTarget {

--- a/scripts/repack-linux-appimage.mjs
+++ b/scripts/repack-linux-appimage.mjs
@@ -1,12 +1,33 @@
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
-import { access, readdir, rm, stat } from "node:fs/promises";
+import {
+  access,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Host Mesa and WebKitGTK must resolve against the host's matching Wayland ABI.
 const waylandLibraryPattern = /^libwayland-.*\.so(?:\..*)?$/;
+const gdkBackendDefault = 'export GDK_BACKEND="${GDK_BACKEND:-x11,wayland}"';
+
+function patchGtkHook(source) {
+  if (source.includes(gdkBackendDefault)) {
+    return source;
+  }
+
+  // Keep X11 preferred, but allow Wayland-only sessions and explicit overrides.
+  const forcedX11 = /^export GDK_BACKEND=x11(?:[ \t]+#.*)?$/m;
+  if (!forcedX11.test(source)) {
+    throw new Error("Unrecognized GDK_BACKEND setting in AppImage GTK hook");
+  }
+  return source.replace(forcedX11, gdkBackendDefault);
+}
 
 async function findSingleBundleEntry(bundleDirectory, suffix, isExpectedType) {
   const entries = await readdir(bundleDirectory, { withFileTypes: true });
@@ -94,10 +115,20 @@ export async function repackLinuxAppImage({
   const waylandLibraries = await findBundledWaylandLibraries(
     path.join(appDirectory, "usr"),
   );
+  const gtkHook = path.join(
+    appDirectory,
+    "apprun-hooks",
+    "linuxdeploy-plugin-gtk.sh",
+  );
+  const originalGtkHook = await readFile(gtkHook, "utf8");
+  const patchedGtkHook = patchGtkHook(originalGtkHook);
+  const updatedGtkHook = originalGtkHook !== patchedGtkHook;
 
-  if (waylandLibraries.length === 0) {
-    console.log(`AppImage already uses host Wayland libraries: ${appImage}`);
-    return { appDirectory, appImage, removedLibraries: [] };
+  if (waylandLibraries.length === 0 && !updatedGtkHook) {
+    console.log(
+      `AppImage already uses host Wayland libraries and GTK backends: ${appImage}`,
+    );
+    return { appDirectory, appImage, removedLibraries: [], updatedGtkHook };
   }
 
   if (!arch) {
@@ -110,6 +141,9 @@ export async function repackLinuxAppImage({
     throw new Error(`AppImage output plugin is not executable: ${pluginPath}`);
   }
 
+  if (updatedGtkHook) {
+    await writeFile(gtkHook, patchedGtkHook);
+  }
   await Promise.all(waylandLibraries.map((library) => rm(library)));
 
   const remainingLibraries = await findBundledWaylandLibraries(
@@ -154,7 +188,12 @@ export async function repackLinuxAppImage({
   }
 
   console.log(`Repacked and re-signed AppImage: ${appImage}`);
-  return { appDirectory, appImage, removedLibraries: waylandLibraries };
+  return {
+    appDirectory,
+    appImage,
+    removedLibraries: waylandLibraries,
+    updatedGtkHook,
+  };
 }
 
 async function main() {

--- a/scripts/repack-linux-appimage.test.mjs
+++ b/scripts/repack-linux-appimage.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { constants } from "node:fs";
 import {
   access,
@@ -15,7 +16,10 @@ import test from "node:test";
 
 import { repackLinuxAppImage } from "./repack-linux-appimage.mjs";
 
-async function createFixture(t, { withWaylandLibraries = true } = {}) {
+async function createFixture(
+  t,
+  { withWaylandLibraries = true, patchedGtkHook = false } = {},
+) {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "anarlog-appimage-repack-"),
   );
@@ -25,6 +29,11 @@ async function createFixture(t, { withWaylandLibraries = true } = {}) {
   const libraryDirectory = path.join(appDirectory, "usr", "lib");
   const nestedLibraryDirectory = path.join(libraryDirectory, "gtk-3.0");
   const appImage = path.join(directory, "Anarlog_1.4.5_amd64.AppImage");
+  const gtkHook = path.join(
+    appDirectory,
+    "apprun-hooks",
+    "linuxdeploy-plugin-gtk.sh",
+  );
   const plugin = path.join(
     directory,
     "tools",
@@ -33,6 +42,19 @@ async function createFixture(t, { withWaylandLibraries = true } = {}) {
 
   await mkdir(nestedLibraryDirectory, { recursive: true });
   await mkdir(path.dirname(plugin), { recursive: true });
+  await mkdir(path.dirname(gtkHook), { recursive: true });
+  await writeFile(
+    gtkHook,
+    [
+      "#!/usr/bin/env bash",
+      "export GTK_DATA_PREFIX=unchanged",
+      patchedGtkHook
+        ? 'export GDK_BACKEND="${GDK_BACKEND:-x11,wayland}"'
+        : "export GDK_BACKEND=x11 # Crash with Wayland backend on Wayland",
+      "",
+    ].join("\n"),
+  );
+  await chmod(gtkHook, 0o755);
   await writeFile(path.join(libraryDirectory, "libgtk-3.so.0"), "gtk");
   if (withWaylandLibraries) {
     await writeFile(
@@ -49,7 +71,7 @@ async function createFixture(t, { withWaylandLibraries = true } = {}) {
   await writeFile(plugin, "plugin");
   await chmod(plugin, 0o755);
 
-  return { directory, appDirectory, appImage, plugin };
+  return { directory, appDirectory, appImage, plugin, gtkHook };
 }
 
 test("removes Wayland libraries, repacks, and regenerates the signature", async (t) => {
@@ -72,6 +94,8 @@ test("removes Wayland libraries, repacks, and regenerates the signature", async 
   });
 
   assert.equal(result.removedLibraries.length, 2);
+  assert.equal(result.updatedGtkHook, true);
+  await access(fixture.gtkHook, constants.X_OK);
   await assert.rejects(
     access(
       path.join(fixture.appDirectory, "usr", "lib", "libwayland-client.so.0"),
@@ -119,7 +143,10 @@ test("removes Wayland libraries, repacks, and regenerates the signature", async 
 });
 
 test("keeps an already-clean AppImage and its signature unchanged", async (t) => {
-  const fixture = await createFixture(t, { withWaylandLibraries: false });
+  const fixture = await createFixture(t, {
+    withWaylandLibraries: false,
+    patchedGtkHook: true,
+  });
 
   const result = await repackLinuxAppImage({
     bundleDirectory: fixture.directory,
@@ -130,10 +157,77 @@ test("keeps an already-clean AppImage and its signature unchanged", async (t) =>
   });
 
   assert.deepEqual(result.removedLibraries, []);
+  assert.equal(result.updatedGtkHook, false);
   assert.equal(await readFile(fixture.appImage, "utf8"), "original-appimage");
   assert.equal(
     await readFile(`${fixture.appImage}.sig`, "utf8"),
     "stale-signature",
+  );
+});
+
+test("repacks a hook-only fix and preserves explicit GTK backend preferences", async (t) => {
+  const fixture = await createFixture(t, { withWaylandLibraries: false });
+  const commands = [];
+  const result = await repackLinuxAppImage({
+    arch: "x86_64",
+    bundleDirectory: fixture.directory,
+    pluginPath: fixture.plugin,
+    run: async (command) => {
+      commands.push(command);
+      await writeFile(
+        command === fixture.plugin
+          ? fixture.appImage
+          : `${fixture.appImage}.sig`,
+        "regenerated",
+      );
+    },
+  });
+  assert.deepEqual(result.removedLibraries, []);
+  assert.equal(result.updatedGtkHook, true);
+  assert.deepEqual(commands, [fixture.plugin, "pnpm"]);
+
+  for (const [preference, expected] of [
+    [undefined, "x11,wayland"],
+    ["", "x11,wayland"],
+    ["wayland", "wayland"],
+    ["x11", "x11"],
+    ["wayland,x11", "wayland,x11"],
+  ]) {
+    const env = { ...process.env };
+    delete env.GDK_BACKEND;
+    if (preference !== undefined) env.GDK_BACKEND = preference;
+    const backend = execFileSync(
+      "bash",
+      [
+        "-c",
+        '. "$1"; printf "%s" "$GDK_BACKEND:$GTK_DATA_PREFIX"',
+        "bash",
+        fixture.gtkHook,
+      ],
+      { env, encoding: "utf8" },
+    );
+    assert.equal(backend, `${expected}:unchanged`);
+  }
+});
+
+test("rejects an unfamiliar GTK hook before mutating the bundle", async (t) => {
+  const fixture = await createFixture(t);
+  await writeFile(fixture.gtkHook, "export GDK_BACKEND=unknown\n");
+  await assert.rejects(
+    repackLinuxAppImage({
+      arch: "x86_64",
+      bundleDirectory: fixture.directory,
+      pluginPath: fixture.plugin,
+    }),
+    /Unrecognized GDK_BACKEND/,
+  );
+  assert.equal(await readFile(fixture.appImage, "utf8"), "original-appimage");
+  assert.equal(
+    await readFile(
+      path.join(fixture.appDirectory, "usr", "lib", "libwayland-client.so.0"),
+      "utf8",
+    ),
+    "wayland-client",
   );
 });
 
@@ -156,6 +250,7 @@ test("fails before mutation when the AppImage output plugin is unavailable", asy
   );
 
   assert.equal(await readFile(waylandLibrary, "utf8"), "wayland-client");
+  assert.match(await readFile(fixture.gtkHook, "utf8"), /GDK_BACKEND=x11 #/);
   assert.equal(
     await readFile(`${fixture.appImage}.sig`, "utf8"),
     "stale-signature",


### PR DESCRIPTION
Allow AppImages to start on Wayland-only desktops while preserving explicit GTK backend preferences. Wait for a streaming PipeWire capture with a valid sample rate before accepting initialization, so negotiation errors still trigger PulseAudio fallback.

Validation: AppImage repack and backend override regression tests passed in the common CI suite. Linux compilation and CloudSync checks run in desktop CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux audio capture readiness and AppImage GTK backend selection at startup; wrong behavior could block capture or prevent the app from launching on some desktops.
> 
> **Overview**
> Fixes Linux desktop startup and speaker capture initialization so AppImages work on Wayland-only sessions and PipeWire failures still fall back to PulseAudio.
> 
> **AppImage repack** no longer forces `GDK_BACKEND=x11` in the GTK apprun hook. It replaces that with `GDK_BACKEND="${GDK_BACKEND:-x11,wayland}"`, so X11 stays preferred by default while Wayland-only desktops and explicit env overrides still work. Repack now runs when only the hook needs fixing (not just when bundled Wayland libs are removed), and tests cover hook-only repacks, unknown hook formats, and backend override behavior.
> 
> **PipeWire capture** centralizes init signaling in `update_pipewire_initialization`: success is reported only when the stream reaches **Streaming** with a **sample rate &gt; 0**, not when format params are negotiated. Init-time stream errors send `Err` on the init channel (warn log) so the existing PulseAudio fallback can run; post-init errors still error-log and quit the loop. Unit tests lock in that negotiated format alone cannot mask startup failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a61f0bd62df6e10779d5cc00c388a6e9d8dbef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->