### PR TITLE
Keep mobile usable during and after the Pro trial

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -9,7 +9,7 @@ Expo (SDK 57) app for Anarlog. Expo has changed significantly — read the exact
 
 ## Architecture
 
-- Local-first, Pro-only client on the canonical SQLite schema. `src/db/` uses the UniFFI `crates/mobile-bridge` transport to implement the `@anlg/db-runtime` `LiveQueryClient`/`TransactionClient` contracts, consumed through `@anlg/db-react`'s `useLiveQuery`.
+- Local-first client on the canonical SQLite schema. Signed-in users can use local notes and recording on any plan. The shared three-week Pro trial and paid Pro entitlement enable cloud sync and Anarlog-hosted models; users can also configure their own provider keys. `src/db/` uses the UniFFI `crates/mobile-bridge` transport to implement the `@anlg/db-runtime` `LiveQueryClient`/`TransactionClient` contracts, consumed through `@anlg/db-react`'s `useLiveQuery`.
 - `crates/db-app` owns the canonical schema and migrations on mobile and desktop. Keep every statement semantically identical to desktop (`apps/desktop/src/session/queries.ts` is the reference for session SQL).
 - `src/data/` mirrors desktop query semantics: canonical create-session transaction, note docs as ProseMirror JSON with `id == session_id`, `session-audio:<sessionId>` attachment rows.
 - `src/auth/` is supabase-js with AsyncStorage plus the desktop browser-handoff flow (`/auth?flow=desktop&scheme=anarlog`). Pro gating uses the same JWT-claims logic as `packages/supabase/src/billing.ts` (ported, since jose does not run on Hermes). No Supabase env → bypass mode (local dev, no gate).

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,8 +14,9 @@ import {
 } from "@/audio/capture-lifecycle";
 import { recoverInterruptedRecordings } from "@/audio/recover-recordings";
 import { AuthProvider, useAuth } from "@/auth/context";
-import { PaywallScreen, SignInScreen } from "@/auth/screens";
+import { SignInScreen } from "@/auth/screens";
 import type { SignInMethod } from "@/auth/sign-in";
+import { useTrial } from "@/auth/use-trial";
 import { BrandLoadingView } from "@/components/brand-loading-view";
 import { Button } from "@/components/ui/button";
 import { Spacing, Typography } from "@/constants/theme";
@@ -99,6 +100,7 @@ function Screens({ accountUserId }: { accountUserId: string | null }) {
 
 function Gate() {
   const auth = useAuth();
+  useTrial();
   const captureActive = useSyncExternalStore(
     subscribeMobileCapture,
     getMobileCaptureActive,
@@ -119,30 +121,15 @@ function Gate() {
 
   if (auth.bypass) return <Screens accountUserId={null} />;
 
-  if (captureActive) {
-    const activeSession = auth.session;
-    return (
-      <>
-        {activeSession && (
-          <MobileSyncLifecycle
-            key={`${activeSession.user.id}:${activeSession.access_token}`}
-            accessToken={activeSession.access_token}
-            accountUserId={activeSession.user.id}
-          />
-        )}
-        <Screens accountUserId={activeSession?.user.id ?? null} />
-      </>
-    );
-  }
-
   if (
-    auth.status === "loading" ||
-    (auth.status === "signed_in" && !auth.billingReady)
+    !captureActive &&
+    (auth.status === "loading" ||
+      (auth.status === "signed_in" && !auth.billingReady))
   ) {
     return <BrandLoadingView />;
   }
 
-  if (auth.status === "signed_out") {
+  if (!captureActive && auth.status === "signed_out") {
     return (
       <SignInScreen
         busy={signingIn}
@@ -152,28 +139,18 @@ function Gate() {
     );
   }
 
-  if (!auth.billing.isPro) {
-    return (
-      <PaywallScreen
-        billing={auth.billing}
-        email={auth.session?.user.email ?? ""}
-        onRefreshBilling={auth.refreshBilling}
-        onSignOut={auth.signOut}
-      />
-    );
-  }
-
   const session = auth.session;
-  if (!session) return null;
 
   return (
     <>
-      <MobileSyncLifecycle
-        key={`${session.user.id}:${session.access_token}`}
-        accessToken={session.access_token}
-        accountUserId={session.user.id}
-      />
-      <Screens accountUserId={session.user.id} />
+      {session && auth.billing.isPro && (
+        <MobileSyncLifecycle
+          key={`${session.user.id}:${session.access_token}`}
+          accessToken={session.access_token}
+          accountUserId={session.user.id}
+        />
+      )}
+      <Screens accountUserId={session?.user.id ?? null} />
     </>
   );
 }

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -64,6 +64,7 @@ import { env } from "@/lib/env";
 import { captureOperationalError } from "@/lib/error-reporting";
 import { useMountEffect } from "@/lib/use-mount-effect";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
+import { useProviderAccess } from "@/settings/use-provider-access";
 
 function BodyEditor({
   accessoryId,
@@ -248,6 +249,8 @@ export default function NoteScreen() {
   const Colors = useColors();
   const router = useRouter();
   const auth = useAuth();
+  const canTranscribe = useProviderAccess("stt");
+  const canSummarize = useProviderAccess("llm");
   const { id, listen } = useLocalSearchParams<{
     id: string;
     listen?: string;
@@ -744,12 +747,20 @@ export default function NoteScreen() {
               <View>
                 <Button
                   label={
-                    data.summary ? "Regenerate summary" : "Generate summary"
+                    !canSummarize
+                      ? "Choose summary provider"
+                      : data.summary
+                        ? "Regenerate summary"
+                        : "Generate summary"
                   }
                   loading={summarize.isPending}
                   variant="ghost"
                   size="small"
-                  onPress={() => summarize.mutate()}
+                  onPress={() =>
+                    canSummarize
+                      ? summarize.mutate()
+                      : router.push("/settings/summary-provider")
+                  }
                 />
                 {summarize.error && (
                   <Text style={styles.summaryText}>
@@ -772,6 +783,7 @@ export default function NoteScreen() {
             <RemoteAudioCard
               cloudAvailable={Boolean(
                 audio.data.cloudObjectKey &&
+                auth.billing.isPro &&
                 auth.session?.access_token &&
                 env.supabaseUrl,
               )}
@@ -790,13 +802,19 @@ export default function NoteScreen() {
             ) : (
               <Pressable
                 hitSlop={4}
-                onPress={() => void transcribeSession(id)}
+                onPress={() =>
+                  canTranscribe
+                    ? void transcribeSession(id)
+                    : router.push("/settings/transcription-provider")
+                }
                 style={({ pressed }) => pressed && styles.transcribePressed}
               >
                 <Text style={styles.transcribeAction}>
-                  {transcription === "failed"
-                    ? "Transcription failed — tap to retry"
-                    : "Tap to transcribe"}
+                  {!canTranscribe
+                    ? "Choose transcription provider"
+                    : transcription === "failed"
+                      ? "Transcription failed — tap to retry"
+                      : "Tap to transcribe"}
                 </Text>
               </Pressable>
             ))}
@@ -821,6 +839,7 @@ export default function NoteScreen() {
                   availableLocally={file !== null}
                   cloudAvailable={Boolean(
                     attachment.cloudObjectKey &&
+                    auth.billing.isPro &&
                     auth.session?.access_token &&
                     env.supabaseUrl,
                   )}

--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -1,8 +1,10 @@
 import { FieldGroup, Text } from "@expo/ui";
 import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 
 import { useAuth } from "@/auth/context";
+import { useTrial } from "@/auth/use-trial";
 import { env } from "@/lib/env";
 import {
   SettingsError,
@@ -12,6 +14,8 @@ import {
 
 export default function AccountSettings() {
   const auth = useAuth();
+  const trial = useTrial();
+  const router = useRouter();
   const refresh = useMutation({ mutationFn: auth.refreshBilling });
   const signOut = useMutation({ mutationFn: auth.signOut });
   const manage = useMutation({
@@ -42,6 +46,30 @@ export default function AccountSettings() {
       </FieldGroup.Section>
       {!auth.bypass && (
         <FieldGroup.Section>
+          {(!auth.billing.isPro || auth.billing.isTrialing) && (
+            <SettingsRow
+              title="Explore Anarlog Pro"
+              onPress={() => router.push("/settings/pro")}
+            />
+          )}
+          <FieldGroup.SectionFooter>
+            <Text>
+              {auth.billing.isTrialing
+                ? "Your three-week Pro trial includes cloud sync and Anarlog models. After it ends, you can keep using your notes, recording, and your own API keys."
+                : auth.billing.isPro
+                  ? "Cloud sync and Anarlog models are included in your subscription."
+                  : trial.isFetching
+                    ? "Checking your free three-week Pro trial. You can start taking notes and recording now."
+                    : "Notes and recording are free. Cloud sync and Anarlog models require an active Pro trial or subscription. You can also use your own API keys."}
+            </Text>
+          </FieldGroup.SectionFooter>
+          {!auth.billing.isPro && trial.error && (
+            <SettingsRow
+              title="Retry trial activation"
+              onPress={() => void trial.refetch()}
+            />
+          )}
+          <SettingsError error={!auth.billing.isPro ? trial.error : null} />
           <SettingsRow
             title="Manage account & subscription"
             onPress={() => manage.mutate()}

--- a/apps/mobile/src/app/settings/pro.tsx
+++ b/apps/mobile/src/app/settings/pro.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from "expo-router";
+
+import { useAuth } from "@/auth/context";
+import { ProScreen } from "@/auth/screens";
+
+export default function ProSettings() {
+  const auth = useAuth();
+  const router = useRouter();
+  return (
+    <ProScreen
+      billing={auth.billing}
+      email={auth.session?.user.email ?? ""}
+      onRefreshBilling={auth.refreshBilling}
+      onClose={() => router.back()}
+    />
+  );
+}

--- a/apps/mobile/src/app/settings/sync.tsx
+++ b/apps/mobile/src/app/settings/sync.tsx
@@ -36,17 +36,35 @@ export default function SyncSettings() {
     queryKey: ["sync-devices", auth.session?.user.id],
     queryFn: ({ signal }) =>
       requestSyncDeviceList(auth.session!.access_token, signal),
-    enabled: Boolean(auth.session) && !auth.bypass,
+    enabled: Boolean(auth.session) && !auth.bypass && auth.billing.isPro,
   });
   return (
     <SettingsPage title="Sync & storage">
       <FieldGroup.Section>
         <SettingsRow
-          title={presentation.healthy ? "Up to date" : presentation.title}
-          description={presentation.description}
+          title={
+            !auth.billing.isPro
+              ? "Saved on this device"
+              : presentation.healthy
+                ? "Up to date"
+                : presentation.title
+          }
+          description={
+            !auth.billing.isPro
+              ? "Cloud sync is available during your Pro trial and with a Pro subscription. Your local notes and recordings are still available."
+              : presentation.description
+          }
         />
-        {presentation.detail && <Text>{presentation.detail}</Text>}
-        {snapshot.phase === "ready" && (
+        {!auth.bypass && !auth.billing.isPro && (
+          <SettingsRow
+            title="Explore Anarlog Pro"
+            onPress={() => router.push("/settings/pro")}
+          />
+        )}
+        {auth.billing.isPro && presentation.detail && (
+          <Text>{presentation.detail}</Text>
+        )}
+        {auth.billing.isPro && snapshot.phase === "ready" && (
           <Button
             label={
               sync.isPending || snapshot.syncingNow ? "Syncing…" : "Sync now"
@@ -62,14 +80,15 @@ export default function SyncSettings() {
             onPress={() => refresh.mutate()}
           />
         )}
-        {[
-          "error",
-          "device_limit",
-          "identity_mismatch",
-          "approval_pending",
-        ].includes(snapshot.phase) && (
-          <Button label="Try again" onPress={retryMobileSync} />
-        )}
+        {auth.billing.isPro &&
+          [
+            "error",
+            "device_limit",
+            "identity_mismatch",
+            "approval_pending",
+          ].includes(snapshot.phase) && (
+            <Button label="Try again" onPress={retryMobileSync} />
+          )}
         {snapshot.phase === "reauth_required" && (
           <SettingsRow
             title="Sign in again"
@@ -88,7 +107,7 @@ export default function SyncSettings() {
           }
         />
         <SettingsRow
-          title="Waiting to back up"
+          title={auth.billing.isPro ? "Waiting to back up" : "Not backed up"}
           value={data ? String(data.pending_count) : "Loading…"}
         />
         <SettingsRow
@@ -103,7 +122,7 @@ export default function SyncSettings() {
         </FieldGroup.SectionFooter>
         <SettingsError error={storage.error} />
       </FieldGroup.Section>
-      {!auth.bypass && (
+      {!auth.bypass && auth.billing.isPro && (
         <FieldGroup.Section title="Connected devices">
           {devices.isPending ? (
             <Text>Loading devices…</Text>

--- a/apps/mobile/src/auth/billing.test.mjs
+++ b/apps/mobile/src/auth/billing.test.mjs
@@ -3,6 +3,37 @@ import test from "node:test";
 
 import { deriveBillingInfo } from "./billing.ts";
 
+test("the shared 21-day trial ends at its exact server deadline, even with stale Pro claims", () => {
+  const start = Date.UTC(2026, 8, 6);
+  const end = start + 21 * 24 * 60 * 60 * 1000;
+  const payload = {
+    subscription_status: "trialing",
+    trial_end: end / 1000,
+    entitlements: ["hyprnote_pro"],
+  };
+  assert.equal(deriveBillingInfo(payload, start).trialDaysRemaining, 21);
+  assert.equal(deriveBillingInfo(payload, end - 1).isPro, true);
+  const expired = deriveBillingInfo(payload, end);
+  assert.equal(expired.isPro, false);
+  assert.equal(expired.plan, "free");
+  assert.equal(expired.trialDaysRemaining, 0);
+  assert.equal(
+    deriveBillingInfo({ ...payload, subscription_status: "active" }, end).isPro,
+    true,
+  );
+});
+
+test("an incomplete or missing trial claim cannot grant Pro access", () => {
+  assert.equal(deriveBillingInfo(null).isPro, false);
+  assert.equal(
+    deriveBillingInfo({
+      subscription_status: "trialing",
+      entitlements: ["hyprnote_pro"],
+    }).isPro,
+    false,
+  );
+});
+
 test("paused subscriptions fail closed when a Pro entitlement lingers", () => {
   const billing = deriveBillingInfo({
     entitlements: ["hyprnote_pro"],

--- a/apps/mobile/src/auth/billing.ts
+++ b/apps/mobile/src/auth/billing.ts
@@ -24,6 +24,14 @@ export type SupabaseJwtPayload = {
 
 export type Plan = "free" | "trial" | "pro";
 
+export class ProRequiredError extends Error {
+  constructor() {
+    super(
+      "Anarlog models require an active Pro trial or subscription. Choose a provider with your own API key in Settings to continue.",
+    );
+  }
+}
+
 export type BillingInfo = {
   entitlements: string[];
   subscriptionStatus: SubscriptionStatus | null;
@@ -75,6 +83,7 @@ export function decodeJwtPayload(
 
 export function deriveBillingInfo(
   payload: SupabaseJwtPayload | null,
+  now = Date.now(),
 ): BillingInfo {
   const entitlements = payload?.entitlements ?? [];
   const subscriptionStatus = payload?.subscription_status ?? null;
@@ -85,7 +94,7 @@ export function deriveBillingInfo(
 
   let trialDaysRemaining: number | null = null;
   if (trialEnd) {
-    const secondsRemaining = (trialEnd.getTime() - Date.now()) / 1000;
+    const secondsRemaining = (trialEnd.getTime() - now) / 1000;
     trialDaysRemaining =
       secondsRemaining <= 0 ? 0 : Math.ceil(secondsRemaining / (24 * 60 * 60));
   }

--- a/apps/mobile/src/auth/context.tsx
+++ b/apps/mobile/src/auth/context.tsx
@@ -32,6 +32,7 @@ import {
   parseLastSignInMethod,
   type SignInMethod,
 } from "@/auth/sign-in";
+import { useBillingInfo } from "@/auth/use-billing-info";
 import {
   captureAnalytics,
   identifyAnalytics,
@@ -230,6 +231,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const initStartedRef = useRef(false);
 
   const setSession = useCallback((next: Session | null) => {
+    if (sessionRef.current?.user.id !== next?.user.id)
+      billingRefreshRef.current = null;
     sessionRef.current = next;
     setSessionState(next);
     const userId = next?.user.id ?? null;
@@ -441,10 +444,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const client = supabase;
     if (!client) return Promise.resolve(true);
     if (billingRefreshRef.current) return billingRefreshRef.current;
+    const accountId = sessionRef.current?.user.id;
+    if (!accountId) return Promise.resolve(false);
 
     let lastError: unknown;
     const task = retryBillingEntitlement({
       refresh: async () => {
+        if (sessionRef.current?.user.id !== accountId) return false;
         const { data, error } = await client.auth.refreshSession();
         if (error) {
           lastError = error;
@@ -452,7 +458,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
 
         const nextSession = data.session;
-        if (!nextSession) return false;
+        if (
+          nextSession?.user.id !== accountId ||
+          sessionRef.current?.user.id !== accountId
+        )
+          return false;
         setSession(nextSession);
         return deriveBillingInfo(decodeJwtPayload(nextSession.access_token))
           .isPro;
@@ -468,7 +478,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return unlocked;
       })
       .finally(() => {
-        billingRefreshRef.current = null;
+        if (billingRefreshRef.current === task)
+          billingRefreshRef.current = null;
       });
     billingRefreshRef.current = task;
     return task;
@@ -509,7 +520,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     () => (accessToken ? decodeJwtPayload(accessToken) : null),
     [accessToken],
   );
-  const billing = useMemo(() => deriveBillingInfo(payload), [payload]);
+  const billing = useBillingInfo(payload);
 
   const status: AuthState["status"] = bypass
     ? "signed_in"

--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -2,13 +2,7 @@ import { BottomSheet, RNHostView } from "@expo/ui";
 import { Image } from "expo-image";
 import * as WebBrowser from "expo-web-browser";
 import { useState } from "react";
-import {
-  Platform,
-  Pressable,
-  Text,
-  useWindowDimensions,
-  View,
-} from "react-native";
+import { Platform, Text, useWindowDimensions, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import type { BillingInfo } from "@/auth/billing";
@@ -18,6 +12,7 @@ import {
 } from "@/auth/billing-handoff";
 import { isAppleSignInAvailable, type SignInMethod } from "@/auth/sign-in";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import {
   CornerCurve,
   Gradients,
@@ -206,16 +201,16 @@ function ProviderIcon({ source }: { source: number }) {
   );
 }
 
-export function PaywallScreen({
+export function ProScreen({
   billing,
   email,
   onRefreshBilling,
-  onSignOut,
+  onClose,
 }: {
   billing: BillingInfo;
   email: string;
   onRefreshBilling: () => Promise<boolean>;
-  onSignOut: () => void;
+  onClose: () => void;
 }) {
   const styles = useStyles();
   const [busy, setBusy] = useState(false);
@@ -223,14 +218,15 @@ export function PaywallScreen({
 
   useMountEffect(() => {
     captureAnalytics("paywall_viewed", {
-      entry_point: "mobile_gate",
-      feature: "mobile_access",
+      entry_point: "mobile_settings",
+      feature: "cloud_and_models",
     });
   });
 
   const refreshAccess = async (checkoutType: "trial" | "paid" | "unknown") => {
     const unlocked = await onRefreshBilling();
     if (unlocked) {
+      setAccessPending(false);
       captureAnalytics("mobile_access_unlocked", {
         entry_point: "mobile_checkout",
         checkout_type: checkoutType,
@@ -285,7 +281,7 @@ export function PaywallScreen({
     } catch (error) {
       captureOperationalError(error, {
         operation: "billing_checkout_open",
-        tags: { entry_point: "mobile_gate" },
+        tags: { entry_point: "mobile_settings" },
       });
     } finally {
       setBusy(false);
@@ -294,18 +290,23 @@ export function PaywallScreen({
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <IconButton accessibilityLabel="Back" icon="back" onPress={onClose} />
       <View style={styles.body}>
         <View style={styles.titleRow}>
-          <Text style={styles.paywallTitle}>Anarlog Mobile is for Pro</Text>
+          <Text style={styles.paywallTitle}>More with Anarlog Pro</Text>
           <View style={styles.accentDot} />
         </View>
         <Text style={styles.copy}>
-          Record in-person meetings and voice notes from your phone, then keep
-          notes and transcripts in sync with Anarlog on your other devices.
+          Sync across your devices and use Anarlog models for transcription and
+          summaries. New users get a free three-week trial, shared with desktop.
+        </Text>
+        <Text style={styles.trialLine}>
+          After your trial, your notes and recordings stay on this device.
+          Subscribe to keep sync and Anarlog models, or use your own API keys.
         </Text>
         {accessPending && (
           <Text style={styles.pendingCopy}>
-            Your plan changed, but mobile access is still updating.
+            Your plan changed. Sync and model access are still updating.
           </Text>
         )}
         {billing.plan === "trial" && billing.trialDaysRemaining !== null && (
@@ -328,9 +329,6 @@ export function PaywallScreen({
         <Text style={styles.footerEmail} numberOfLines={1}>
           {email}
         </Text>
-        <Pressable onPress={onSignOut} hitSlop={8}>
-          <Text style={styles.signOutLabel}>Sign out</Text>
-        </Pressable>
       </View>
     </SafeAreaView>
   );
@@ -461,9 +459,5 @@ const useStyles = createStyleHook((Colors) => ({
     flexShrink: 1,
     ...Typography.caption,
     color: Colors.muted,
-  },
-  signOutLabel: {
-    ...Typography.captionStrong,
-    color: Colors.ink,
   },
 }));

--- a/apps/mobile/src/auth/trial.test.mjs
+++ b/apps/mobile/src/auth/trial.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { enrollInTrial } from "./trial.ts";
+
+function fixture(responses) {
+  const requests = [];
+  return {
+    requests,
+    options: {
+      apiUrl: "https://api.anarlog.test/",
+      accessToken: "synthetic-token",
+      signal: new AbortController().signal,
+      request: async (url, options) => {
+        requests.push({ url, ...options });
+        const response = responses.shift();
+        if (response instanceof Error) throw response;
+        return response;
+      },
+    },
+  };
+}
+
+test("eligible mobile accounts start the shared server trial without supplying a new deadline", async () => {
+  const { options, requests } = fixture([
+    Response.json({ canStartTrial: true, reason: "eligible" }),
+    Response.json({ started: true, reason: "started" }),
+  ]);
+  assert.equal(await enrollInTrial(options), true);
+  assert.deepEqual(
+    requests.map(({ url, method }) => [url, method ?? "GET"]),
+    [
+      ["https://api.anarlog.test/subscription/can-start-trial", "GET"],
+      [
+        "https://api.anarlog.test/subscription/start-trial?interval=monthly",
+        "POST",
+      ],
+    ],
+  );
+  for (const request of requests) {
+    assert.equal(request.headers.Authorization, "Bearer synthetic-token");
+    assert.equal(request.signal, options.signal);
+    assert.equal(request.body, undefined);
+  }
+});
+
+test("previously used trials never send a start request", async () => {
+  const { options, requests } = fixture([
+    Response.json({ canStartTrial: false, reason: "not_eligible" }),
+  ]);
+  assert.equal(await enrollInTrial(options), false);
+  assert.equal(requests.length, 1);
+});
+
+test("optional eligibility reasons are compatible with the subscription API", async () => {
+  const { options } = fixture([
+    Response.json({ canStartTrial: true }),
+    Response.json({ started: true }),
+  ]);
+  assert.equal(await enrollInTrial(options), true);
+});
+
+test("a concurrent desktop activation is handled as an existing trial", async () => {
+  const { options } = fixture([
+    Response.json({ canStartTrial: true, reason: "eligible" }),
+    Response.json({ started: false, reason: "not_eligible" }),
+  ]);
+  assert.equal(await enrollInTrial(options), false);
+});
+
+test("eligibility outages and malformed responses remain retryable", async () => {
+  for (const response of [
+    new Response(null, { status: 503 }),
+    Response.json({ canStartTrial: false, reason: "error" }),
+    Response.json({}),
+  ]) {
+    const { options, requests } = fixture([response]);
+    await assert.rejects(enrollInTrial(options), /Could not check/);
+    assert.equal(requests.length, 1);
+  }
+});
+
+test("failed or ambiguous enrollment is not reported as a trial", async () => {
+  for (const response of [
+    new Response(null, { status: 500 }),
+    Response.json({ started: false, reason: "error" }),
+  ]) {
+    const { options } = fixture([
+      Response.json({ canStartTrial: true, reason: "eligible" }),
+      response,
+    ]);
+    await assert.rejects(enrollInTrial(options), /Could not start/);
+  }
+});
+
+test("account cancellation aborts enrollment", async () => {
+  const controller = new AbortController();
+  const { options } = fixture([]);
+  options.signal = controller.signal;
+  options.request = async (_url, { signal }) =>
+    new Promise((_resolve, reject) => {
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    });
+  const enrollment = enrollInTrial(options);
+  controller.abort();
+  await assert.rejects(enrollment, { name: "AbortError" });
+});

--- a/apps/mobile/src/auth/trial.ts
+++ b/apps/mobile/src/auth/trial.ts
@@ -1,0 +1,42 @@
+export async function enrollInTrial({
+  apiUrl,
+  accessToken,
+  signal,
+  request = fetch,
+}: {
+  apiUrl: string;
+  accessToken: string;
+  signal: AbortSignal;
+  request?: typeof fetch;
+}): Promise<boolean> {
+  const headers = { Authorization: `Bearer ${accessToken}` };
+  const base = apiUrl.replace(/\/+$/, "");
+  const eligibility = await request(`${base}/subscription/can-start-trial`, {
+    headers,
+    signal,
+    redirect: "error",
+  });
+  if (!eligibility.ok) throw new Error("Could not check your Pro trial.");
+  const status = await eligibility.json();
+  if (
+    status.canStartTrial === false &&
+    (status.reason === "not_eligible" || status.reason == null)
+  )
+    return false;
+  if (
+    status.canStartTrial !== true ||
+    (status.reason != null && status.reason !== "eligible")
+  )
+    throw new Error("Could not check your Pro trial.");
+
+  const response = await request(
+    `${base}/subscription/start-trial?interval=monthly`,
+    { method: "POST", headers, signal, redirect: "error" },
+  );
+  if (!response.ok) throw new Error("Could not start your Pro trial.");
+  const result = await response.json();
+  if (result.started === true) return true;
+  if (result.started === false && result.reason === "not_eligible")
+    return false;
+  throw new Error("Could not start your Pro trial.");
+}

--- a/apps/mobile/src/auth/use-billing-info.ts
+++ b/apps/mobile/src/auth/use-billing-info.ts
@@ -1,0 +1,30 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { AppState } from "react-native";
+
+import { deriveBillingInfo, type SupabaseJwtPayload } from "./billing";
+
+export function useBillingInfo(payload: SupabaseJwtPayload | null) {
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      const remaining = (payload?.trial_end ?? 0) * 1000 - Date.now();
+      if (payload?.subscription_status !== "trialing" || remaining <= 0)
+        return () => {};
+      const interval = setInterval(notify, 60_000);
+      const expiry = setTimeout(notify, Math.min(remaining, 2_147_483_647));
+      const foreground = AppState.addEventListener("change", (state) => {
+        if (state === "active") notify();
+      });
+      return () => {
+        clearInterval(interval);
+        clearTimeout(expiry);
+        foreground.remove();
+      };
+    },
+    [payload],
+  );
+  const days = useSyncExternalStore(
+    subscribe,
+    () => deriveBillingInfo(payload).trialDaysRemaining,
+  );
+  return useMemo(() => deriveBillingInfo(payload), [payload, days]);
+}

--- a/apps/mobile/src/auth/use-trial.ts
+++ b/apps/mobile/src/auth/use-trial.ts
@@ -1,0 +1,50 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetch } from "expo/fetch";
+
+import { supabase } from "@/auth/client";
+import { useAuth } from "@/auth/context";
+import { enrollInTrial } from "@/auth/trial";
+import { env } from "@/lib/env";
+
+export function useTrial() {
+  const auth = useAuth();
+  const accountId = auth.session?.user.id;
+  return useQuery({
+    queryKey: ["mobile-pro-trial", accountId],
+    enabled: Boolean(accountId) && !auth.bypass && !auth.billing.isPaid,
+    staleTime: Infinity,
+    retry: 1,
+    queryFn: async ({ signal }) => {
+      const current = await supabase!.auth.getSession();
+      const session = current.data.session;
+      if (current.error || !session || session.user.id !== accountId)
+        throw new Error("Sign in again to start your Pro trial.");
+      const timeout = new AbortController();
+      const abort = () => timeout.abort();
+      signal.addEventListener("abort", abort);
+      const timer = setTimeout(abort, 20_000);
+      try {
+        if (signal.aborted) timeout.abort();
+        const started = await enrollInTrial({
+          apiUrl: env.apiUrl,
+          accessToken: session.access_token,
+          signal: timeout.signal,
+          request: fetch,
+        });
+        const latest = await supabase!.auth.getSession();
+        if (signal.aborted || latest.data.session?.user.id !== accountId)
+          return started;
+        // A previous attempt or desktop may have already started this trial.
+        const unlocked = await auth.refreshBilling();
+        if (started && !unlocked && !signal.aborted)
+          throw new Error(
+            "Your trial has started. Refresh your plan to finish activating sync and Anarlog models.",
+          );
+        return started;
+      } finally {
+        clearTimeout(timer);
+        signal.removeEventListener("abort", abort);
+      }
+    },
+  });
+}

--- a/apps/mobile/src/components/listening-sheet.tsx
+++ b/apps/mobile/src/components/listening-sheet.tsx
@@ -63,7 +63,7 @@ function transcriptionLabel(status: "connecting" | "live" | "fallback") {
     case "live":
       return "Live transcription";
     case "fallback":
-      return "Recording locally · transcript after stop";
+      return "Recording on this device";
     default:
       return "Connecting live transcript…";
   }

--- a/apps/mobile/src/components/recording-sync-card.tsx
+++ b/apps/mobile/src/components/recording-sync-card.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useState } from "react";
 import { Text, View } from "react-native";
 
+import { useAuth } from "@/auth/context";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Spacing, Typography } from "@/constants/theme";
@@ -33,12 +34,20 @@ const presentation = {
 
 export function RecordingSyncCard({ audio }: { audio: SessionAudio }) {
   const styles = useStyles();
+  const { billing } = useAuth();
   const Colors = useColors();
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState(false);
-  const status = presentation[audio.deliveryState];
-  const waitingToRetry = audio.uploadPhase === "retry_wait";
-  const canRetry = audio.deliveryState === "failed" || waitingToRetry;
+  const status =
+    !billing.isPro && audio.deliveryState !== "synced"
+      ? {
+          icon: "phone-portrait-outline" as const,
+          text: "Saved on this device",
+        }
+      : presentation[audio.deliveryState];
+  const waitingToRetry = billing.isPro && audio.uploadPhase === "retry_wait";
+  const canRetry =
+    billing.isPro && (audio.deliveryState === "failed" || waitingToRetry);
 
   const handleRetry = async () => {
     if (retrying) return;
@@ -59,7 +68,9 @@ export function RecordingSyncCard({ audio }: { audio: SessionAudio }) {
   return (
     <Card
       style={styles.card}
-      tone={audio.deliveryState === "failed" ? "alert" : "muted"}
+      tone={
+        billing.isPro && audio.deliveryState === "failed" ? "alert" : "muted"
+      }
     >
       <View style={styles.statusRow}>
         <Ionicons name={status.icon} size={17} color={Colors.muted} />

--- a/apps/mobile/src/data/live-transcription-access.test.mjs
+++ b/apps/mobile/src/data/live-transcription-access.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { beforeEach, test } from "node:test";
+
+const root = new URL("../", import.meta.url);
+const fixture = (globalThis.liveAccessFixture = {
+  session: null,
+  listeners: new Set(),
+  sockets: [],
+  failures: [],
+});
+const mocks = {
+  "@/auth/client": `const f = globalThis.liveAccessFixture; export const supabase = { auth: {
+    getSession: async () => ({ data: { session: f.session } }),
+    onAuthStateChange: listener => { f.listeners.add(listener); return { data: { subscription: { unsubscribe: () => f.listeners.delete(listener) } } }; }
+  } };`,
+  "@/db": `export async function execute() { return []; } export async function executeTransaction() { return []; }`,
+  "@/settings/providers": `export async function readProviderConfig() { return { provider: 'anarlog' }; }`,
+  "@/settings/preferences": `export async function readPreferences() { return {}; }`,
+  "@/settings/preferences-model": `export const applyTranscriptionPreferences = url => url;`,
+  "@/lib/ids": `export const id = () => 'transcript-test'; export const nowIso = () => new Date().toISOString();`,
+  "@/lib/env": `export const env = { apiUrl: 'https://api.anarlog.test' };`,
+  "@/lib/analytics": `export function captureAnalytics() {}`,
+  "@/lib/error-reporting": `export function captureOperationalError(error) { globalThis.liveAccessFixture.failures.push(error); }`,
+};
+registerHooks({
+  resolve(specifier, context, next) {
+    if (mocks[specifier])
+      return {
+        url: `data:text/javascript,${encodeURIComponent(mocks[specifier])}`,
+        shortCircuit: true,
+      };
+    if (specifier.startsWith("@/"))
+      return {
+        url: new URL(`${specifier.slice(2)}.ts`, root).href,
+        shortCircuit: true,
+      };
+    if (specifier.startsWith(".") && context.parentURL?.startsWith(root.href)) {
+      const url = new URL(`${specifier}.ts`, context.parentURL);
+      if (existsSync(url)) return { url: url.href, shortCircuit: true };
+    }
+    return next(specifier, context);
+  },
+});
+
+const { HostedLiveTranscription } = await import("./live-transcription.ts");
+
+function session(claims) {
+  return {
+    user: { id: "account-a" },
+    access_token: `test.${Buffer.from(JSON.stringify(claims)).toString("base64url")}.signature`,
+  };
+}
+function emitAuth(next) {
+  fixture.session = next;
+  for (const listener of fixture.listeners) listener("TOKEN_REFRESHED", next);
+}
+const settle = () => new Promise(setImmediate);
+
+beforeEach(() => {
+  fixture.session = null;
+  fixture.listeners.clear();
+  fixture.sockets = [];
+  fixture.failures = [];
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    readyState = 0;
+    bufferedAmount = 0;
+    sent = [];
+    constructor() {
+      fixture.sockets.push(this);
+    }
+    open() {
+      this.readyState = 1;
+      this.onopen?.();
+    }
+    send(data) {
+      this.sent.push(data);
+    }
+    close() {
+      this.readyState = 3;
+      this.onclose?.();
+    }
+  };
+});
+
+test("free and expired accounts record locally without opening a hosted socket or reporting a failure", async () => {
+  for (const claims of [
+    {},
+    {
+      subscription_status: "trialing",
+      trial_end: Date.now() / 1000 - 1,
+      entitlements: ["hyprnote_pro"],
+    },
+  ]) {
+    fixture.session = session(claims);
+    const updates = [];
+    const live = new HostedLiveTranscription("note-a", 16000, 1, (update) =>
+      updates.push(update),
+    );
+    await settle();
+    live.sendAudio(new ArrayBuffer(16));
+    assert.equal(updates.at(-1).status, "fallback");
+    assert.equal(await live.stop(), false);
+  }
+  assert.equal(fixture.sockets.length, 0);
+  assert.equal(fixture.failures.length, 0);
+});
+
+test("trial expiry closes an active socket and stops sending audio while preserving local recording", async (t) => {
+  const now = Date.UTC(2026, 8, 6);
+  t.mock.timers.enable({ apis: ["Date", "setTimeout", "setInterval"], now });
+  fixture.session = session({
+    subscription_status: "trialing",
+    trial_end: (now + 2000) / 1000,
+  });
+  const updates = [];
+  const live = new HostedLiveTranscription("note-a", 16000, 1, (update) =>
+    updates.push(update),
+  );
+  await settle();
+  const socket = fixture.sockets[0];
+  socket.open();
+  live.sendAudio(new ArrayBuffer(16));
+  assert.equal(updates.at(-1).status, "live");
+  t.mock.timers.tick(2000);
+  live.sendAudio(new ArrayBuffer(16));
+  assert.equal(socket.readyState, 3);
+  assert.equal(socket.sent.length, 1);
+  assert.equal(updates.at(-1).status, "fallback");
+  assert.equal(fixture.listeners.size, 0);
+  assert.equal(fixture.failures.length, 0);
+  assert.equal(await live.stop(), false);
+});
+
+test("renewal during recording clears the trial deadline; sign-out still closes the connection", async (t) => {
+  const now = Date.UTC(2026, 8, 6);
+  t.mock.timers.enable({ apis: ["Date", "setTimeout", "setInterval"], now });
+  fixture.session = session({
+    subscription_status: "trialing",
+    trial_end: (now + 2000) / 1000,
+  });
+  const live = new HostedLiveTranscription("note-a", 16000, 1, () => {});
+  await settle();
+  const socket = fixture.sockets[0];
+  socket.open();
+  emitAuth(
+    session({ subscription_status: "active", entitlements: ["hyprnote_pro"] }),
+  );
+  t.mock.timers.tick(2000);
+  live.sendAudio(new ArrayBuffer(16));
+  assert.equal(socket.readyState, 1);
+  assert.equal(socket.sent.length, 1);
+  emitAuth(null);
+  assert.equal(socket.readyState, 3);
+  await live.stop();
+  assert.equal(fixture.listeners.size, 0);
+});

--- a/apps/mobile/src/data/live-transcription.ts
+++ b/apps/mobile/src/data/live-transcription.ts
@@ -1,3 +1,4 @@
+import { decodeJwtPayload, deriveBillingInfo } from "@/auth/billing";
 import { supabase } from "@/auth/client";
 import { execute, executeTransaction } from "@/db";
 import { captureAnalytics } from "@/lib/analytics";
@@ -117,6 +118,11 @@ function liveUrl(
 
 export class HostedLiveTranscription {
   readonly transcriptId = id();
+  private readonly sessionId: string;
+  private readonly onUpdate: (update: {
+    status: LiveTranscriptionStatus;
+    text: string;
+  }) => void;
 
   private socket: WebSocket | null = null;
   private status: LiveTranscriptionStatus = "connecting";
@@ -132,20 +138,22 @@ export class HostedLiveTranscription {
   private stopPromise: Promise<boolean> | null = null;
   private connectPromise: Promise<void>;
   private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+  private trialEnd: number | null = null;
+  private trialTimer: ReturnType<typeof setTimeout> | null = null;
+  private unsubscribeAuth: (() => void) | null = null;
   private terminalResolve: (() => void) | null = null;
   private terminalPromise = new Promise<void>((resolve) => {
     this.terminalResolve = resolve;
   });
 
   constructor(
-    private readonly sessionId: string,
+    sessionId: string,
     sampleRate: number,
     channels: number,
-    private readonly onUpdate: (update: {
-      status: LiveTranscriptionStatus;
-      text: string;
-    }) => void,
+    onUpdate: HostedLiveTranscription["onUpdate"],
   ) {
+    this.sessionId = sessionId;
+    this.onUpdate = onUpdate;
     this.connectPromise = this.connect(sampleRate, channels);
   }
 
@@ -172,7 +180,17 @@ export class HostedLiveTranscription {
       const token = auth?.data.session?.access_token;
       if (!token)
         throw new Error("Live transcription requires a signed-in session");
+      this.updateBilling(token);
       if (this.stopping || this.status === "fallback") return;
+      const accountId = auth?.data.session?.user.id;
+      const subscription = supabase?.auth.onAuthStateChange(
+        (_event, session) => {
+          if (session?.user.id !== accountId) this.fallBack();
+          else this.updateBilling(session!.access_token);
+        },
+      );
+      this.unsubscribeAuth = () =>
+        subscription?.data.subscription.unsubscribe();
 
       const Socket = WebSocket as unknown as NativeWebSocketConstructor;
       const socket = new Socket(
@@ -184,7 +202,7 @@ export class HostedLiveTranscription {
       );
       socket.binaryType = "arraybuffer";
       socket.onopen = () => {
-        if (this.stopping || this.status === "fallback") {
+        if (!this.checkTrial() || this.stopping || this.status === "fallback") {
           socket.close();
           return;
         }
@@ -193,7 +211,7 @@ export class HostedLiveTranscription {
         this.queuedAudio = [];
         this.queuedAudioBytes = 0;
         this.keepAliveTimer = setInterval(() => {
-          if (socket.readyState === WebSocket.OPEN) {
+          if (this.checkTrial() && socket.readyState === WebSocket.OPEN) {
             socket.send(JSON.stringify({ type: "KeepAlive" }));
           }
         }, KEEP_ALIVE_INTERVAL_MS);
@@ -222,7 +240,8 @@ export class HostedLiveTranscription {
   }
 
   sendAudio(buffer: ArrayBuffer) {
-    if (this.status === "fallback" || this.stopping) return;
+    if (!this.checkTrial() || this.status === "fallback" || this.stopping)
+      return;
     const socket = this.socket;
     if (socket?.readyState === WebSocket.OPEN) {
       if (socket.bufferedAmount > MAX_SOCKET_BUFFERED_BYTES) {
@@ -345,13 +364,41 @@ export class HostedLiveTranscription {
       .catch((error) => this.fail(error, "persist"));
   }
 
-  private fail(error: unknown, stage: string) {
+  private checkTrial() {
+    if (this.trialEnd === null || Date.now() < this.trialEnd) return true;
+    this.fallBack();
+    return false;
+  }
+
+  private updateBilling(token: string) {
+    const billing = deriveBillingInfo(decodeJwtPayload(token));
+    if (!billing.isPro) {
+      this.fallBack();
+      return;
+    }
+    if (this.trialTimer) clearTimeout(this.trialTimer);
+    this.trialEnd = billing.isTrialing ? billing.trialEnd!.getTime() : null;
+    this.trialTimer =
+      this.trialEnd === null
+        ? null
+        : setTimeout(
+            () => this.checkTrial(),
+            Math.min(Math.max(0, this.trialEnd - Date.now()), 2_147_483_647),
+          );
+  }
+
+  private fallBack() {
     if (this.status === "fallback") return;
     this.setStatus("fallback");
     this.clearKeepAlive();
     this.queuedAudio = [];
     this.queuedAudioBytes = 0;
     this.socket?.close();
+  }
+
+  private fail(error: unknown, stage: string) {
+    if (this.status === "fallback") return;
+    this.fallBack();
     captureOperationalError(error, {
       operation: "transcription_live",
       tags: { mode: "live", stage },
@@ -444,6 +491,10 @@ export class HostedLiveTranscription {
   private clearKeepAlive() {
     if (this.keepAliveTimer) clearInterval(this.keepAliveTimer);
     this.keepAliveTimer = null;
+    if (this.trialTimer) clearTimeout(this.trialTimer);
+    this.trialTimer = null;
+    this.unsubscribeAuth?.();
+    this.unsubscribeAuth = null;
   }
 }
 

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -3,6 +3,7 @@ import { fetch } from "expo/fetch";
 import { useSyncExternalStore } from "react";
 import { Platform } from "react-native";
 
+import { ProRequiredError } from "@/auth/billing";
 import { execute, executeTransaction } from "@/db";
 import { captureAnalytics } from "@/lib/analytics";
 import { env } from "@/lib/env";
@@ -532,6 +533,10 @@ export function transcribeSession(sessionId: string): Promise<void> {
         clearStateSilently(sessionId);
       })
       .catch((error: unknown) => {
+        if (error instanceof ProRequiredError) {
+          setState(sessionId, "idle");
+          return;
+        }
         captureOperationalError(error, {
           operation: "transcription_batch",
           tags: {

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -10,6 +10,7 @@ import {
 } from "@expo/ui";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
 import { useRef, useState } from "react";
 
 import { useAuth } from "@/auth/context";
@@ -106,6 +107,10 @@ function ProviderFields({
   config: ProviderConfig;
 }) {
   const queryClient = useQueryClient();
+  const auth = useAuth();
+  const router = useRouter();
+  const needsPro =
+    config.provider === "anarlog" && !auth.billing.isPro && !auth.bypass;
   const key = useNativeState("");
   const apiKey = useRef("");
   const model = useNativeState(config.model);
@@ -194,14 +199,17 @@ function ProviderFields({
       <FieldGroup.Section>
         <Button
           label={
-            save.isPending
-              ? "Saving…"
-              : save.isSuccess
-                ? "Saved"
-                : "Use this provider"
+            needsPro
+              ? "Explore Anarlog Pro"
+              : save.isPending
+                ? "Saving…"
+                : save.isSuccess
+                  ? "Saved"
+                  : "Use this provider"
           }
           disabled={save.isPending}
           onPress={() => {
+            if (needsPro) return router.push("/settings/pro");
             void form.handleSubmit().catch(() => {});
           }}
         />
@@ -220,7 +228,7 @@ function ProviderFields({
               : remove.error || savedKey.error
                 ? "Could not update this provider. Try again."
                 : config.provider === "anarlog"
-                  ? "Included with your Anarlog Pro plan. No API key needed."
+                  ? "Included during your free three-week trial and with Anarlog Pro. No API key needed. After your trial, subscribe or choose a provider with your own API key."
                   : kind === "stt"
                     ? `Transcription starts after you stop recording.${config.provider === "deepgram" ? "" : " Recordings must be under 25 MB."}`
                     : ""}

--- a/apps/mobile/src/settings/providers.ts
+++ b/apps/mobile/src/settings/providers.ts
@@ -1,5 +1,10 @@
 import * as SecureStore from "expo-secure-store";
 
+import {
+  decodeJwtPayload,
+  deriveBillingInfo,
+  ProRequiredError,
+} from "@/auth/billing";
 import { supabase } from "@/auth/client";
 import { execute, executeTransaction } from "@/db";
 
@@ -92,8 +97,11 @@ export async function resolveProvider(kind: ProviderKind) {
   const session = auth?.data.session;
   const config = await readProviderConfig(session?.user.id ?? null, kind);
   if (config.provider === "anarlog") {
-    if (session?.access_token)
+    if (session?.access_token) {
+      if (!deriveBillingInfo(decodeJwtPayload(session.access_token)).isPro)
+        throw new ProRequiredError();
       return { ...config, apiKey: session.access_token };
+    }
     if (!supabase) return { ...config, apiKey: "" };
     throw new Error("Sign in to use Anarlog Pro.");
   }

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -104,6 +104,13 @@ const { requestProviderTranscription } =
   await import("../data/provider-transcription.ts");
 const { summarizeSession } = await import("../data/summarize.ts");
 
+function signedInWith(claims) {
+  fixture.session = {
+    user: { id: "account-a" },
+    access_token: `synthetic.${Buffer.from(JSON.stringify(claims)).toString("base64url")}.signature`,
+  };
+}
+
 beforeEach(() => {
   fixture.db?.close();
   fixture.db = new DatabaseSync(":memory:");
@@ -293,13 +300,87 @@ test("missing keys cannot activate a provider and selecting Pro uses only the ac
     /Enter an API key/,
   );
   assert.equal((await readProviderConfig(null, "stt")).provider, "anarlog");
-  fixture.session = {
-    user: { id: "account-a" },
-    access_token: "synthetic-session-token",
-  };
+  signedInWith({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
   assert.equal(
     (await resolveProvider("stt")).apiKey,
-    "synthetic-session-token",
+    fixture.session.access_token,
+  );
+});
+
+test("active trials use hosted models; expired trials cannot send STT or summary requests", async () => {
+  createNote();
+  const trial = {
+    subscription_status: "trialing",
+    trial_end: Date.now() / 1000 + 21 * 86400,
+    entitlements: ["hyprnote_pro"],
+  };
+  signedInWith(trial);
+  assert.equal(
+    (await resolveProvider("stt")).apiKey,
+    fixture.session.access_token,
+  );
+  await summarizeSession("note-1");
+  assert.equal(
+    fixture.requests[0].url,
+    "https://hosted.anarlog.test/llm/chat/completions",
+  );
+  fixture.requests = [];
+  signedInWith({ ...trial, trial_end: Date.now() / 1000 - 1 });
+  await assert.rejects(
+    resolveProvider("stt"),
+    /active Pro trial or subscription/,
+  );
+  await assert.rejects(
+    summarizeSession("note-1"),
+    /active Pro trial or subscription/,
+  );
+  assert.equal(fixture.requests.length, 0);
+  assert.match(
+    fixture.db
+      .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
+      .get().body,
+    /Ship the app/,
+  );
+  assert.equal(
+    fixture.db
+      .prepare(
+        "SELECT count(*) AS count FROM session_documents WHERE kind = 'summary'",
+      )
+      .get().count,
+    1,
+  );
+});
+
+test("expired trial users can keep using their own transcription and summary keys", async () => {
+  createNote();
+  signedInWith({
+    subscription_status: "paused",
+    entitlements: ["hyprnote_pro"],
+  });
+  await saveProviderConfig(
+    "account-a",
+    "stt",
+    { ...defaultProviderConfig("stt", "openai"), model: "whisper-1" },
+    "synthetic-stt-key",
+  );
+  await saveProviderConfig(
+    "account-a",
+    "llm",
+    { ...defaultProviderConfig("llm", "openai"), model: "test-model" },
+    "synthetic-llm-key",
+  );
+  assert.equal((await resolveProvider("stt")).apiKey, "synthetic-stt-key");
+  await summarizeSession("note-1");
+  assert.equal(
+    fixture.requests[0].url,
+    "https://api.openai.com/v1/chat/completions",
+  );
+  assert.equal(
+    fixture.requests[0].options.headers.Authorization,
+    "Bearer synthetic-llm-key",
   );
 });
 

--- a/apps/mobile/src/settings/use-provider-access.ts
+++ b/apps/mobile/src/settings/use-provider-access.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useAuth } from "@/auth/context";
+
+import { readProviderConfig } from "./providers";
+import type { ProviderKind } from "./providers-model";
+
+export function useProviderAccess(kind: ProviderKind) {
+  const auth = useAuth();
+  const account = auth.session?.user.id ?? null;
+  const config = useQuery({
+    queryKey: ["provider", account, kind],
+    queryFn: () => readProviderConfig(account, kind),
+  });
+  return (
+    auth.bypass ||
+    auth.billing.isPro ||
+    Boolean(config.data && config.data.provider !== "anarlog")
+  );
+}


### PR DESCRIPTION
Start eligible accounts through the shared trial API. Keep local notes, recording, and personal provider keys available; limit cloud sync and Anarlog models to active trials and Pro, with expiry and renewal coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entitlement gating across auth, sync, billing refresh, and transcription paths; incorrect trial/expiry handling could block sync or leak hosted model access.
> 
> **Overview**
> **Mobile is no longer Pro-only at the door.** Signed-in users can take notes and record locally on any plan; the startup **paywall gate is removed** and **`MobileSyncLifecycle` only runs when `billing.isPro`**.
> 
> **Trial and billing:** Eligible non-paid accounts auto-enroll via the shared **`/subscription/can-start-trial` / `start-trial`** flow (`useTrial` + `enrollInTrial`), with retry UX in Account settings. **`deriveBillingInfo`** fails closed on missing `trial_end` and exact trial expiry; **`useBillingInfo`** refreshes trial countdown in the UI. **`ProScreen`** (formerly paywall) lives under **Settings → Explore Anarlog Pro**.
> 
> **What stays behind Pro (or your own keys):** Cloud sync UI/actions, cloud audio/attachment restore, and **Anarlog-hosted** STT/LLM (`ProRequiredError` in `resolveProvider`). The note screen and provider settings steer users to pick API keys when hosted models aren’t available. **Live transcription** falls back to on-device recording when not entitled and drops the hosted socket on trial expiry or sign-out mid-session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e3928872ebb93bf42fb698383768139c6b97de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->