### PR TITLE
Match mobile provider settings to desktop

### DIFF
--- a/apps/mobile/src/settings/provider-autosave.ts
+++ b/apps/mobile/src/settings/provider-autosave.ts
@@ -1,0 +1,43 @@
+import {
+  validateProviderApiKey,
+  validateProviderConfig,
+  type ProviderConfig,
+  type ProviderKind,
+} from "./providers-model";
+
+export function createProviderAutosave(
+  kind: ProviderKind,
+  save: (draft: { config: ProviderConfig; apiKey: string }) => void,
+) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pending: { config: ProviderConfig; apiKey: string } | undefined;
+
+  function cancel() {
+    clearTimeout(timer);
+    timer = undefined;
+    pending = undefined;
+  }
+
+  function flush() {
+    const draft = pending;
+    cancel();
+    if (draft) save(draft);
+  }
+
+  return {
+    schedule(config: ProviderConfig, apiKey: string, hasSavedKey: boolean) {
+      cancel();
+      try {
+        const normalized = validateProviderConfig(kind, config);
+        const key = apiKey.trim();
+        if (key || !hasSavedKey) validateProviderApiKey(key);
+        pending = { config: normalized, apiKey: key };
+      } catch {
+        return;
+      }
+      timer = setTimeout(flush, 500);
+    },
+    flush,
+    cancel,
+  };
+}

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -1,6 +1,9 @@
 import {
   Button,
+  Column,
   FieldGroup,
+  Icon,
+  ListItem,
   Picker,
   Row,
   Spacer,
@@ -9,25 +12,35 @@ import {
   useNativeState,
 } from "@expo/ui";
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "expo-router";
-import { useRef, useState } from "react";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useCallback, useRef, useState } from "react";
+import { Platform } from "react-native";
 
+import { ProRequiredError } from "@/auth/billing";
 import { useAuth } from "@/auth/context";
 
 import { SettingsPage } from "./components";
+import { createProviderAutosave } from "./provider-autosave";
 import {
   readProviderConfig,
   readProviderKey,
+  readProviderSetup,
   removeProviderKey,
   saveProviderConfig,
+  saveProviderSetup,
 } from "./providers";
 import {
-  defaultProviderConfig,
   providersFor,
   type ProviderConfig,
   type ProviderKind,
 } from "./providers-model";
+import { useColors } from "./theme-provider";
 
 export function ProviderSettings({ kind }: { kind: ProviderKind }) {
   const auth = useAuth();
@@ -46,7 +59,7 @@ export function ProviderSettings({ kind }: { kind: ProviderKind }) {
         <Button label="Try again" onPress={() => void config.refetch()} />
       ) : (
         <ProviderForm
-          key={`${account}:${kind}:${JSON.stringify(config.data)}`}
+          key={`${account}:${kind}`}
           kind={kind}
           account={account}
           config={config.data}
@@ -65,14 +78,50 @@ function ProviderForm({
   account: string | null;
   config: ProviderConfig;
 }) {
-  const [selected, setSelected] = useState(config.provider);
+  const auth = useAuth();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const definitions = providersFor(kind).filter(({ id }) => id !== "anarlog");
+  const setups = useQueries({
+    queries: definitions.map(({ id }) => ({
+      queryKey: ["provider-setup", account, kind, id],
+      queryFn: async () => ({
+        config: await readProviderSetup(account, kind, id),
+        hasKey: Boolean(await readProviderKey(account, kind, id)),
+      }),
+    })),
+  });
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const select = useMutation({
+    scope: { id: `provider-settings:${account}:${kind}` },
+    mutationFn: async (provider: string) => {
+      if (provider === "anarlog" && !auth.billing.isPro && !auth.bypass)
+        throw new ProRequiredError();
+      const setup = await readProviderSetup(account, kind, provider);
+      await saveProviderConfig(account, kind, setup);
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["provider", account, kind] }),
+    onError: (error) => {
+      if (error instanceof ProRequiredError) router.push("/settings/pro");
+    },
+  });
   return (
     <>
       <FieldGroup.Section>
         <Row alignment="center">
           <Text>Provider</Text>
           <Spacer />
-          <Picker selectedValue={selected} onValueChange={setSelected}>
+          <Picker
+            key={`${config.provider}:${select.status}`}
+            selectedValue={config.provider}
+            enabled={!select.isPending}
+            onValueChange={(provider) => {
+              setExpanded(provider === "anarlog" ? null : provider);
+              select.mutate(provider);
+            }}
+            testID="active-provider"
+          >
             {providersFor(kind).map((provider) => (
               <Picker.Item
                 key={provider.id}
@@ -82,17 +131,82 @@ function ProviderForm({
             ))}
           </Picker>
         </Row>
+        <Row alignment="center">
+          <Text>Model</Text>
+          <Spacer />
+          <Text>
+            {config.provider === "anarlog" ? "Automatic" : config.model}
+          </Text>
+        </Row>
+        <FieldGroup.SectionFooter>
+          <Text>
+            {select.error instanceof Error
+              ? select.error.message
+              : config.provider === "anarlog"
+                ? "Included with your Pro trial or subscription. No API key needed."
+                : "Using your saved provider settings below."}
+          </Text>
+        </FieldGroup.SectionFooter>
       </FieldGroup.Section>
-      <ProviderFields
-        key={selected}
-        kind={kind}
-        account={account}
-        config={
-          selected === config.provider
-            ? config
-            : defaultProviderConfig(kind, selected)
-        }
-      />
+      <FieldGroup.Section title="Configure providers">
+        {definitions.map((provider, index) => {
+          const setup = setups[index];
+          const active = config.provider === provider.id;
+          const open = expanded === provider.id;
+          return (
+            <Column key={provider.id} spacing={16}>
+              <ListItem
+                onPress={() => setExpanded(open ? null : provider.id)}
+                trailing={
+                  <Icon
+                    name={
+                      open
+                        ? Icon.select({
+                            ios: "chevron.down",
+                            android:
+                              import("@expo/material-symbols/keyboard_arrow_down.xml"),
+                          })
+                        : Icon.select({
+                            ios: "chevron.right",
+                            android:
+                              import("@expo/material-symbols/chevron_right.xml"),
+                          })
+                    }
+                    size={14}
+                  />
+                }
+              >
+                <Text>{`${provider.name}${active ? " · Active" : setup.data?.hasKey ? " · Key saved" : ""}`}</Text>
+              </ListItem>
+              {setup.isPending ? (
+                open && <Text>Loading…</Text>
+              ) : setup.error ? (
+                open && (
+                  <Button
+                    label="Try again"
+                    onPress={() => void setup.refetch()}
+                  />
+                )
+              ) : (
+                <ProviderFields
+                  key={provider.id}
+                  account={account}
+                  kind={kind}
+                  config={setup.data.config}
+                  hasKey={setup.data.hasKey}
+                  open={open}
+                  onSaved={() => select.reset()}
+                />
+              )}
+            </Column>
+          );
+        })}
+        <FieldGroup.SectionFooter>
+          <Text>
+            Valid settings save automatically. API keys stay on this device.
+          </Text>
+        </FieldGroup.SectionFooter>
+      </FieldGroup.Section>
     </>
   );
 }
@@ -101,140 +215,170 @@ function ProviderFields({
   kind,
   account,
   config,
+  hasKey,
+  open,
+  onSaved,
 }: {
   kind: ProviderKind;
   account: string | null;
   config: ProviderConfig;
+  hasKey: boolean;
+  open: boolean;
+  onSaved: () => void;
 }) {
+  const Colors = useColors();
   const queryClient = useQueryClient();
-  const auth = useAuth();
-  const router = useRouter();
-  const needsPro =
-    config.provider === "anarlog" && !auth.billing.isPro && !auth.bypass;
   const key = useNativeState("");
   const apiKey = useRef("");
   const model = useNativeState(config.model);
   const baseUrl = useNativeState(config.baseUrl);
-  const savedKey = useQuery({
-    queryKey: ["provider-key-present", account, kind, config.provider],
-    queryFn: async () =>
-      Boolean(await readProviderKey(account, kind, config.provider)),
-  });
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ["provider-setup", account, kind, config.provider],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: ["provider", account, kind],
+    });
+  };
   const save = useMutation({
-    mutationFn: (value: { model: string; baseUrl: string }) =>
-      saveProviderConfig(
-        account,
-        kind,
-        { ...config, model: value.model, baseUrl: value.baseUrl },
-        apiKey.current,
-      ),
+    gcTime: 0,
+    scope: { id: `provider-settings:${account}:${kind}` },
+    mutationFn: (draft: { config: ProviderConfig; apiKey: string }) =>
+      saveProviderSetup(account, kind, draft.config, draft.apiKey),
     onSuccess: async () => {
-      key.value = "";
-      apiKey.current = "";
-      await queryClient.invalidateQueries({
-        queryKey: ["provider", account, kind],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ["provider-key-present", account, kind],
-      });
+      await invalidate();
+      onSaved();
     },
   });
+  const [autosave] = useState(() => createProviderAutosave(kind, save.mutate));
+  useFocusEffect(useCallback(() => () => autosave.flush(), [autosave]));
   const remove = useMutation({
+    scope: { id: `provider-settings:${account}:${kind}` },
     mutationFn: () => removeProviderKey(account, kind, config.provider),
-    onSuccess: () => savedKey.refetch(),
+    onSuccess: async () => {
+      save.reset();
+      await invalidate();
+    },
   });
   const form = useForm({
     defaultValues: { model: config.model, baseUrl: config.baseUrl },
-    onSubmit: async ({ value }) => {
-      await save.mutateAsync(value);
-    },
   });
+  const scheduleSave = () => {
+    if (remove.isPending) return;
+    autosave.schedule(
+      { ...config, ...form.state.values },
+      apiKey.current,
+      hasKey,
+    );
+  };
+  if (!open) return null;
   return (
-    <>
-      {config.provider !== "anarlog" && (
-        <FieldGroup.Section>
-          {config.provider === "custom" && (
-            <TextInput
-              value={baseUrl}
-              placeholder="HTTPS base URL"
-              autoCapitalize="none"
-              autoCorrect={false}
-              onChangeText={(value) => {
-                baseUrl.value = value;
-                form.setFieldValue("baseUrl", value);
-              }}
-            />
-          )}
-          <TextInput
-            value={model}
-            placeholder="Model ID"
-            autoCapitalize="none"
-            autoCorrect={false}
-            onChangeText={(value) => {
-              model.value = value;
-              form.setFieldValue("model", value);
-            }}
-          />
-          <TextInput
-            value={key}
-            placeholder={
-              savedKey.data ? "API key saved · enter to replace" : "API key"
-            }
-            secureTextEntry
-            autoCapitalize="none"
-            autoCorrect={false}
-            onChangeText={(value) => {
-              key.value = value;
-              apiKey.current = value;
-            }}
-          />
-          <FieldGroup.SectionFooter>
-            <Text>
-              Keys are stored securely on this device. Requests go directly to
-              the selected provider.
-            </Text>
-          </FieldGroup.SectionFooter>
-        </FieldGroup.Section>
-      )}
-      <FieldGroup.Section>
-        <Button
-          label={
-            needsPro
-              ? "Explore Anarlog Pro"
-              : save.isPending
-                ? "Saving…"
-                : save.isSuccess
-                  ? "Saved"
-                  : "Use this provider"
-          }
-          disabled={save.isPending}
-          onPress={() => {
-            if (needsPro) return router.push("/settings/pro");
-            void form.handleSubmit().catch(() => {});
+    <Column
+      spacing={16}
+      style={{
+        paddingBottom: 8,
+        paddingHorizontal: Platform.OS === "android" ? 16 : 0,
+      }}
+    >
+      <Row alignment="center" spacing={8}>
+        <Icon
+          name={Icon.select({
+            ios: "key",
+            android: import("@expo/material-symbols/key.xml"),
+          })}
+          size={18}
+          color={Colors.muted}
+          style={{ width: 20 }}
+        />
+        <TextInput
+          value={key}
+          placeholder={hasKey ? "API key saved · enter to replace" : "API key"}
+          secureTextEntry
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!remove.isPending}
+          onBlur={autosave.flush}
+          onSubmitEditing={autosave.flush}
+          onChangeText={(value) => {
+            key.value = value;
+            apiKey.current = value;
+            scheduleSave();
           }}
         />
-        {savedKey.data && (
+      </Row>
+      <Row alignment="center" spacing={8}>
+        <Icon
+          name={Icon.select({
+            ios: "cpu",
+            android: import("@expo/material-symbols/memory.xml"),
+          })}
+          size={18}
+          color={Colors.muted}
+          style={{ width: 20 }}
+        />
+        <TextInput
+          value={model}
+          placeholder="Model ID"
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!remove.isPending}
+          onBlur={autosave.flush}
+          onSubmitEditing={autosave.flush}
+          onChangeText={(value) => {
+            model.value = value;
+            form.setFieldValue("model", value);
+            scheduleSave();
+          }}
+        />
+      </Row>
+      {config.provider === "custom" && (
+        <Row alignment="center" spacing={8}>
+          <Icon
+            name={Icon.select({
+              ios: "link",
+              android: import("@expo/material-symbols/link.xml"),
+            })}
+            size={18}
+            color={Colors.muted}
+            style={{ width: 20 }}
+          />
+          <TextInput
+            value={baseUrl}
+            placeholder="HTTPS base URL"
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={!remove.isPending}
+            onBlur={autosave.flush}
+            onSubmitEditing={autosave.flush}
+            onChangeText={(value) => {
+              baseUrl.value = value;
+              form.setFieldValue("baseUrl", value);
+              scheduleSave();
+            }}
+          />
+        </Row>
+      )}
+      {hasKey && (
+        <Row>
           <Button
-            label="Remove saved key"
+            label="Remove key"
             variant="text"
             disabled={remove.isPending}
-            onPress={() => remove.mutate()}
+            onPress={() => {
+              autosave.cancel();
+              key.value = "";
+              apiKey.current = "";
+              remove.mutate();
+            }}
           />
-        )}
-        <FieldGroup.SectionFooter>
-          <Text>
-            {save.error instanceof Error
-              ? save.error.message
-              : remove.error || savedKey.error
-                ? "Could not update this provider. Try again."
-                : config.provider === "anarlog"
-                  ? "Included during your free three-week trial and with Anarlog Pro. No API key needed. After your trial, subscribe or choose a provider with your own API key."
-                  : kind === "stt"
-                    ? `Transcription starts after you stop recording.${config.provider === "deepgram" ? "" : " Recordings must be under 25 MB."}`
-                    : ""}
-          </Text>
-        </FieldGroup.SectionFooter>
-      </FieldGroup.Section>
-    </>
+        </Row>
+      )}
+      {(save.error || remove.error) && (
+        <Text>{(save.error || remove.error)?.message}</Text>
+      )}
+      {kind === "stt" && (
+        <Text>{`Transcription starts after recording.${config.provider === "deepgram" ? "" : " Recordings must be under 25 MB."}`}</Text>
+      )}
+    </Column>
   );
 }

--- a/apps/mobile/src/settings/providers-model.ts
+++ b/apps/mobile/src/settings/providers-model.ts
@@ -20,7 +20,7 @@ export const TRANSCRIPTION_PROVIDERS = [
     baseUrl: "https://api.groq.com/openai/v1",
     model: "whisper-large-v3-turbo",
   },
-  { id: "custom", name: "OpenAI-compatible", baseUrl: "", model: "whisper-1" },
+  { id: "custom", name: "Custom", baseUrl: "", model: "whisper-1" },
 ] as const;
 
 export const SUMMARY_PROVIDERS = [
@@ -49,7 +49,7 @@ export const SUMMARY_PROVIDERS = [
     baseUrl: "https://api.groq.com/openai/v1",
     model: "",
   },
-  { id: "custom", name: "OpenAI-compatible", baseUrl: "", model: "" },
+  { id: "custom", name: "Custom", baseUrl: "", model: "" },
 ] as const;
 
 export type ProviderConfig = {
@@ -112,6 +112,14 @@ export function providerStorageKey(
   if (provider && !providersFor(kind).some((entry) => entry.id === provider))
     throw new Error("Unsupported provider");
   return `anarlog.provider.${account}.${kind}${provider ? `.${provider}` : ""}`;
+}
+
+export function validateProviderApiKey(value: string): string {
+  const key = value.trim();
+  if (!key) throw new Error("Enter an API key for this provider.");
+  if (key.length > 8192 || /[\r\n]/.test(key))
+    throw new Error("Enter a valid API key.");
+  return key;
 }
 
 export function normalizeTranscriptionResponse(

--- a/apps/mobile/src/settings/providers.ts
+++ b/apps/mobile/src/settings/providers.ts
@@ -11,6 +11,7 @@ import { execute, executeTransaction } from "@/db";
 import {
   defaultProviderConfig,
   providerStorageKey,
+  validateProviderApiKey,
   validateProviderConfig,
   type ProviderConfig,
   type ProviderKind,
@@ -46,20 +47,60 @@ export async function readProviderKey(
   );
 }
 
+export async function readProviderSetup(
+  accountId: string | null,
+  kind: ProviderKind,
+  provider: string,
+): Promise<ProviderConfig> {
+  const savedId = providerStorageKey(accountId, kind, provider);
+  const rows = await execute<{ value_json: string }>(
+    "SELECT value_json FROM app_settings WHERE id IN (?, ?) ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END",
+    [
+      savedId,
+      providerStorageKey(accountId, kind),
+      providerStorageKey(accountId, kind),
+    ],
+  );
+  for (const row of rows) {
+    const config = JSON.parse(row.value_json) as ProviderConfig;
+    if (config.provider === provider)
+      return validateProviderConfig(kind, config);
+  }
+  return defaultProviderConfig(kind, provider);
+}
+
 export async function saveProviderConfig(
   accountId: string | null,
   kind: ProviderKind,
   config: ProviderConfig,
   apiKey?: string,
 ): Promise<void> {
+  return persistProviderConfig(accountId, kind, config, apiKey, true);
+}
+
+export async function saveProviderSetup(
+  accountId: string | null,
+  kind: ProviderKind,
+  config: ProviderConfig,
+  apiKey?: string,
+): Promise<void> {
+  return persistProviderConfig(accountId, kind, config, apiKey, false);
+}
+
+async function persistProviderConfig(
+  accountId: string | null,
+  kind: ProviderKind,
+  config: ProviderConfig,
+  apiKey: string | undefined,
+  activate: boolean,
+): Promise<void> {
   const normalized = validateProviderConfig(kind, config);
   if (normalized.provider !== "anarlog") {
-    const key =
+    const key = validateProviderApiKey(
       apiKey?.trim() ||
-      (await readProviderKey(accountId, kind, normalized.provider));
-    if (!key) throw new Error("Enter an API key for this provider.");
-    if (key.length > 8192 || /[\r\n]/.test(key))
-      throw new Error("Enter a valid API key.");
+        (await readProviderKey(accountId, kind, normalized.provider)) ||
+        "",
+    );
     if (apiKey?.trim())
       await SecureStore.setItemAsync(
         providerStorageKey(accountId, kind, normalized.provider),
@@ -67,16 +108,38 @@ export async function saveProviderConfig(
         secureOptions,
       );
   }
+  const activeId = providerStorageKey(accountId, kind);
+  const value = JSON.stringify(normalized);
+  const updatedAt = new Date().toISOString();
   await executeTransaction([
+    {
+      // Preserve settings from builds that stored only the active provider.
+      sql: `INSERT INTO app_settings (id, value_json, updated_at)
+      SELECT id || '.' || json_extract(value_json, '$.provider'), value_json, updated_at
+      FROM app_settings WHERE id = ?
+      ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, updated_at = excluded.updated_at`,
+      params: [activeId],
+    },
     {
       sql: `INSERT INTO app_settings (id, value_json, updated_at) VALUES (?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, updated_at = excluded.updated_at`,
       params: [
-        providerStorageKey(accountId, kind),
-        JSON.stringify(normalized),
-        new Date().toISOString(),
+        providerStorageKey(accountId, kind, normalized.provider),
+        value,
+        updatedAt,
       ],
     },
+    activate
+      ? {
+          sql: `INSERT INTO app_settings (id, value_json, updated_at) VALUES (?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, updated_at = excluded.updated_at`,
+          params: [activeId, value, updatedAt],
+        }
+      : {
+          sql: `UPDATE app_settings SET value_json = ?, updated_at = ?
+      WHERE id = ? AND json_extract(value_json, '$.provider') = ?`,
+          params: [value, updatedAt, activeId, normalized.provider],
+        },
   ]);
 }
 

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -94,9 +94,12 @@ registerHooks({
 });
 
 const { setPreference, readPreferences } = await import("./preferences.ts");
+const { createProviderAutosave } = await import("./provider-autosave.ts");
 const {
   saveProviderConfig,
+  saveProviderSetup,
   readProviderConfig,
+  readProviderSetup,
   removeProviderKey,
   resolveProvider,
 } = await import("./providers.ts");
@@ -280,6 +283,273 @@ test("provider keys stay in device-only secure storage, separated by account and
 test("hosted Anarlog Pro requires a session token", async () => {
   fixture.session = null;
   await assert.rejects(resolveProvider("stt"), /Sign in to use Anarlog Pro/);
+});
+
+test("saving provider credentials leaves the active selection unchanged", async () => {
+  const config = {
+    ...defaultProviderConfig("llm", "openai"),
+    model: "saved-openai-model",
+  };
+  await saveProviderSetup("account-a", "llm", config, "synthetic-key");
+  assert.equal(
+    (await readProviderConfig("account-a", "llm")).provider,
+    "anarlog",
+  );
+  assert.deepEqual(
+    await readProviderSetup("account-a", "llm", "openai"),
+    config,
+  );
+  assert.equal(
+    fixture.keys.get(providerStorageKey("account-a", "llm", "openai")).value,
+    "synthetic-key",
+  );
+  assert.equal(
+    (await readProviderSetup("account-b", "llm", "openai")).model,
+    "",
+  );
+  assert.equal(
+    (await readProviderConfig("account-a", "stt")).provider,
+    "anarlog",
+  );
+  assert.equal(fixture.requests.length, 0);
+});
+
+test("switching providers restores each saved model and endpoint without re-entering keys", async () => {
+  const openai = {
+    ...defaultProviderConfig("llm", "openai"),
+    model: "openai-model",
+  };
+  const custom = {
+    provider: "custom",
+    baseUrl: "https://private-provider.test/v1",
+    model: "custom-model",
+  };
+  await saveProviderSetup("account-a", "llm", openai, "synthetic-openai-key");
+  await saveProviderSetup("account-a", "llm", custom, "synthetic-custom-key");
+  for (const config of [openai, custom, openai]) {
+    await saveProviderConfig(
+      "account-a",
+      "llm",
+      await readProviderSetup("account-a", "llm", config.provider),
+    );
+    assert.deepEqual(await readProviderConfig("account-a", "llm"), config);
+  }
+  assert.equal(fixture.keys.size, 2);
+});
+
+test("editing an active provider updates its runtime config while editing another does not", async () => {
+  const active = {
+    ...defaultProviderConfig("llm", "openai"),
+    model: "first-model",
+  };
+  await saveProviderConfig("account-a", "llm", active, "synthetic-openai-key");
+  const updated = { ...active, model: "updated-model" };
+  await saveProviderSetup("account-a", "llm", updated);
+  await saveProviderSetup(
+    "account-a",
+    "llm",
+    { ...defaultProviderConfig("llm", "anthropic"), model: "anthropic-model" },
+    "synthetic-anthropic-key",
+  );
+  assert.deepEqual(await readProviderConfig("account-a", "llm"), updated);
+  signedInWith({});
+  assert.equal((await resolveProvider("llm")).model, "updated-model");
+});
+
+test("legacy active settings survive the first provider switch, including edits made by older builds", async () => {
+  const legacy = {
+    ...defaultProviderConfig("stt", "deepgram"),
+    model: "legacy-model",
+  };
+  const activeId = providerStorageKey("account-a", "stt");
+  fixture.db
+    .prepare("INSERT INTO app_settings (id, value_json) VALUES (?, ?)")
+    .run(activeId, JSON.stringify(legacy));
+  fixture.db
+    .prepare("INSERT INTO app_settings (id, value_json) VALUES (?, ?)")
+    .run(
+      providerStorageKey("account-a", "stt", "deepgram"),
+      JSON.stringify({ ...legacy, model: "outdated-model" }),
+    );
+  fixture.keys.set(providerStorageKey("account-a", "stt", "deepgram"), {
+    value: "synthetic-existing-key",
+  });
+  assert.deepEqual(
+    await readProviderSetup("account-a", "stt", "deepgram"),
+    legacy,
+  );
+  await saveProviderConfig("account-a", "stt", defaultProviderConfig("stt"));
+  const restored = await readProviderSetup("account-a", "stt", "deepgram");
+  assert.deepEqual(restored, legacy);
+  await saveProviderConfig("account-a", "stt", restored);
+  assert.deepEqual(await readProviderConfig("account-a", "stt"), legacy);
+});
+
+test("invalid setup or a removed key cannot replace the current provider", async () => {
+  const config = defaultProviderConfig("stt", "deepgram");
+  await assert.rejects(
+    saveProviderSetup("account-a", "stt", config),
+    /Enter an API key/,
+  );
+  assert.equal(
+    fixture.db
+      .prepare(
+        "SELECT count(*) AS count FROM app_settings WHERE id LIKE 'anarlog.provider.%'",
+      )
+      .get().count,
+    0,
+  );
+  await saveProviderSetup("account-a", "stt", config, "synthetic-key");
+  await removeProviderKey("account-a", "stt", "deepgram");
+  await assert.rejects(
+    saveProviderConfig("account-a", "stt", config),
+    /Enter an API key/,
+  );
+  assert.equal(
+    (await readProviderConfig("account-a", "stt")).provider,
+    "anarlog",
+  );
+  assert.deepEqual(
+    await readProviderSetup("account-a", "stt", "deepgram"),
+    config,
+  );
+});
+
+test("provider autosave waits for typing to stop and persists only the latest valid draft", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const writes = [];
+  const autosave = createProviderAutosave("llm", (draft) => {
+    writes.push(
+      saveProviderSetup("account-a", "llm", draft.config, draft.apiKey),
+    );
+  });
+  const config = {
+    ...defaultProviderConfig("llm", "openai"),
+    model: "first-model",
+  };
+  autosave.schedule(config, "synthetic-first-key", false);
+  t.mock.timers.tick(300);
+  const latest = { ...config, model: "latest-model" };
+  autosave.schedule(latest, "synthetic-latest-key", false);
+  t.mock.timers.tick(499);
+  assert.equal(writes.length, 0);
+  t.mock.timers.tick(1);
+  await Promise.all(writes);
+  assert.equal(writes.length, 1);
+  assert.deepEqual(
+    await readProviderSetup("account-a", "llm", "openai"),
+    latest,
+  );
+  assert.equal(
+    fixture.keys.get(providerStorageKey("account-a", "llm", "openai")).value,
+    "synthetic-latest-key",
+  );
+  assert.equal(
+    (await readProviderConfig("account-a", "llm")).provider,
+    "anarlog",
+  );
+});
+
+test("an incomplete or invalid edit cancels the pending provider autosave", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const writes = [];
+  const autosave = createProviderAutosave("llm", (draft) => writes.push(draft));
+  const config = {
+    provider: "custom",
+    baseUrl: "https://provider.test/v1",
+    model: "custom-model",
+  };
+  for (const [draft, key] of [
+    [{ ...config, model: "" }, "synthetic-key"],
+    [{ ...config, model: "line\nbreak" }, "synthetic-key"],
+    [{ ...config, baseUrl: "http://provider.test/v1" }, "synthetic-key"],
+    [
+      { ...config, baseUrl: "https://user:password@provider.test" },
+      "synthetic-key",
+    ],
+    [config, ""],
+    [config, "line\nbreak"],
+    [config, "a".repeat(8193)],
+  ]) {
+    autosave.schedule(config, "synthetic-valid-key", false);
+    autosave.schedule(draft, key, false);
+    autosave.flush();
+    t.mock.timers.tick(500);
+    assert.equal(writes.length, 0);
+  }
+});
+
+test("autosave flushes on leaving a field exactly once and reuses a saved key", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const config = defaultProviderConfig("stt", "deepgram");
+  await saveProviderConfig(
+    "account-a",
+    "stt",
+    config,
+    "synthetic-existing-key",
+  );
+  const writes = [];
+  const autosave = createProviderAutosave("stt", (draft) => {
+    writes.push(
+      saveProviderSetup("account-a", "stt", draft.config, draft.apiKey),
+    );
+  });
+  const edited = { ...config, model: "  edited-model  " };
+  autosave.schedule(edited, "", true);
+  autosave.flush();
+  autosave.flush();
+  t.mock.timers.tick(500);
+  await Promise.all(writes);
+  assert.equal(writes.length, 1);
+  assert.equal(
+    (await readProviderConfig("account-a", "stt")).model,
+    "edited-model",
+  );
+  assert.equal(
+    fixture.keys.get(providerStorageKey("account-a", "stt", "deepgram")).value,
+    "synthetic-existing-key",
+  );
+});
+
+test("canceling a pending autosave does not restore a removed provider key", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const config = defaultProviderConfig("stt", "deepgram");
+  await saveProviderSetup("account-a", "stt", config, "synthetic-existing-key");
+  const writes = [];
+  const autosave = createProviderAutosave("stt", (draft) => writes.push(draft));
+  autosave.schedule(config, "synthetic-replacement-key", true);
+  autosave.cancel();
+  await removeProviderKey("account-a", "stt", "deepgram");
+  autosave.flush();
+  t.mock.timers.tick(500);
+  assert.equal(writes.length, 0);
+  assert.equal(fixture.keys.size, 0);
+  assert.deepEqual(
+    await readProviderSetup("account-a", "stt", "deepgram"),
+    config,
+  );
+});
+
+test("invalid autosaved edits preserve the last working provider configuration", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const config = defaultProviderConfig("stt", "deepgram");
+  await saveProviderConfig(
+    "account-a",
+    "stt",
+    config,
+    "synthetic-existing-key",
+  );
+  const writes = [];
+  const autosave = createProviderAutosave("stt", (draft) => {
+    writes.push(
+      saveProviderSetup("account-a", "stt", draft.config, draft.apiKey),
+    );
+  });
+  autosave.schedule({ ...config, model: "" }, "", true);
+  t.mock.timers.tick(500);
+  assert.equal(writes.length, 0);
+  assert.deepEqual(await readProviderConfig("account-a", "stt"), config);
+  assert.equal(fixture.requests.length, 0);
 });
 
 test("corrupt privacy JSON does not enable app lock", async () => {


### PR DESCRIPTION
Separate active provider selection from API key setup and retain each provider’s saved model and endpoint. Cover switching, legacy settings, and key removal with runtime tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how API keys and active STT/LLM providers are persisted and selected, but validation and broad runtime tests limit bad activations and data loss.
> 
> **Overview**
> **Aligns mobile transcription/summary provider settings with desktop** by splitting **which provider is active** from **each provider’s saved model, endpoint, and API key**.
> 
> The settings screen now uses a top **Provider** picker (with Pro gating for Anarlog) plus an expandable **Configure providers** list. Credentials and models **autosave** after validation via a new debounced `createProviderAutosave` helper (flush on blur/leave), replacing the manual save/“Use this provider” flow.
> 
> Persistence adds `readProviderSetup` / `saveProviderSetup` vs `saveProviderConfig`: setups are stored per provider id in `app_settings`, while activation only updates the active record when switching. A one-time SQL step migrates legacy single-key storage; `validateProviderApiKey` is shared for saves and autosave. Custom providers are labeled **Custom** instead of OpenAI-compatible.
> 
> Runtime tests cover switching without re-entering keys, legacy migration, invalid setup not changing the active provider, and autosave debounce/cancel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f321513ac199de97bea6af4af1544d96270b922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->