### PR TITLE
Align mobile home headings with the profile icon

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -233,6 +233,7 @@ const useStyles = createStyleHook((Colors) => ({
   sectionLabel: {
     ...Typography.section,
     color: Colors.muted,
+    paddingHorizontal: Spacing.compact,
     marginTop: Spacing.md,
     marginBottom: Spacing.sm,
   },


### PR DESCRIPTION
Inset date headings to match the profile glyph and note text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single style tweak on the mobile home screen with no logic, data, or auth changes.
> 
> **Overview**
> Adds **`paddingHorizontal: Spacing.compact`** to the home screen **`sectionLabel`** style so date group headings (e.g. “Today”) sit on the same horizontal inset as note rows and the header profile control, instead of flush with the scroll view’s outer padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016076b1d2d24bb6d1f6226387157c3f0201755e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->