### PR TITLE
Hide the home listening button while scrolling down

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -57,6 +57,8 @@ export default function HomeScreen() {
   );
   const [buttonHidden, setButtonHidden] = useState(false);
   const scrollState = useSharedValue({ anchor: 0, hidden: false });
+  const contentHeight = useSharedValue(0);
+  const viewportHeight = useSharedValue(0);
   const buttonProgress = useSharedValue(0);
   const onScroll = useAnimatedScrollHandler((event) => {
     const previous = scrollState.get();
@@ -66,8 +68,19 @@ export default function HomeScreen() {
       event.contentSize.height - event.layoutMeasurement.height,
     );
     scrollState.set(next);
-    if (next.hidden !== previous.hidden) {
-      const target = next.hidden ? 1 : 0;
+  });
+  useAnimatedReaction(
+    () => contentHeight.get() - viewportHeight.get(),
+    (maxOffset) => {
+      if (maxOffset <= 0) scrollState.set({ anchor: 0, hidden: false });
+    },
+  );
+  useAnimatedReaction(
+    () => scrollState.get().hidden,
+    (hidden, previous) => {
+      if (hidden === previous) return;
+      scheduleOnRN(setButtonHidden, hidden);
+      const target = hidden ? 1 : 0;
       buttonProgress.set(
         reducedMotion
           ? withTiming(target, {
@@ -81,12 +94,6 @@ export default function HomeScreen() {
               overshootClamping: true,
             }),
       );
-    }
-  });
-  useAnimatedReaction(
-    () => scrollState.get().hidden,
-    (hidden, previous) => {
-      if (hidden !== previous) scheduleOnRN(setButtonHidden, hidden);
     },
   );
   const buttonStyle = useAnimatedStyle(() => ({
@@ -203,6 +210,10 @@ export default function HomeScreen() {
             { paddingBottom: buttonHeight + Spacing.lg },
           ]}
           keyboardShouldPersistTaps="handled"
+          onContentSizeChange={(_width, height) => contentHeight.set(height)}
+          onLayout={(event) =>
+            viewportHeight.set(event.nativeEvent.layout.height)
+          }
           onScroll={onScroll}
           scrollEventThrottle={16}
         >

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,8 +1,23 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useRouter } from "expo-router";
 import { useRef, useState } from "react";
-import { Platform, ScrollView, Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Platform, Text, View } from "react-native";
+import Animated, {
+  Easing,
+  ReduceMotion,
+  useAnimatedReaction,
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+import { scheduleOnRN } from "react-native-worklets";
 
 import { useAuth } from "@/auth/context";
 import { ActionButtonCard } from "@/components/action-button-card";
@@ -11,12 +26,17 @@ import { SessionCard } from "@/components/session-card";
 import { StartListeningButton } from "@/components/start-listening-button";
 import { IconButton } from "@/components/ui/icon-button";
 import { UserAvatarButton } from "@/components/user-avatar";
-import { Spacing, Typography } from "@/constants/theme";
+import {
+  LISTENING_CONTROL_HEIGHT,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
 import { createSession, deleteSession } from "@/data/session";
 import { useSidebarItemPreferences } from "@/data/sidebar-preferences";
 import { useTimelineSessions, type TimelineSession } from "@/data/timeline";
 import { confirmDestructive } from "@/lib/confirm";
 import { captureOperationalError } from "@/lib/error-reporting";
+import { scrollVisibility } from "@/lib/scroll-visibility";
 import { useMountEffect } from "@/lib/use-mount-effect";
 import { createStyleHook } from "@/settings/theme-provider";
 
@@ -28,8 +48,57 @@ export default function HomeScreen() {
   const auth = useAuth();
   const { items, isLoading } = useTimelineSessions();
   const sidebarPreferences = useSidebarItemPreferences();
+  const insets = useSafeAreaInsets();
+  const reducedMotion = useReducedMotion();
   const [searching, setSearching] = useState(false);
   const [showActionButtonCard, setShowActionButtonCard] = useState(false);
+  const [buttonHeight, setButtonHeight] = useState(
+    LISTENING_CONTROL_HEIGHT + Spacing.xs,
+  );
+  const [buttonHidden, setButtonHidden] = useState(false);
+  const scrollState = useSharedValue({ anchor: 0, hidden: false });
+  const buttonProgress = useSharedValue(0);
+  const onScroll = useAnimatedScrollHandler((event) => {
+    const previous = scrollState.get();
+    const next = scrollVisibility(
+      previous,
+      event.contentOffset.y,
+      event.contentSize.height - event.layoutMeasurement.height,
+    );
+    scrollState.set(next);
+    if (next.hidden !== previous.hidden) {
+      const target = next.hidden ? 1 : 0;
+      buttonProgress.set(
+        reducedMotion
+          ? withTiming(target, {
+              duration: 150,
+              easing: Easing.bezier(0.23, 1, 0.32, 1),
+              reduceMotion: ReduceMotion.Never,
+            })
+          : withSpring(target, {
+              duration: 400,
+              dampingRatio: 1,
+              overshootClamping: true,
+            }),
+      );
+    }
+  });
+  useAnimatedReaction(
+    () => scrollState.get().hidden,
+    (hidden, previous) => {
+      if (hidden !== previous) scheduleOnRN(setButtonHidden, hidden);
+    },
+  );
+  const buttonStyle = useAnimatedStyle(() => ({
+    opacity: 1 - buttonProgress.get(),
+    transform: [
+      {
+        translateY: reducedMotion
+          ? 0
+          : buttonProgress.get() * (buttonHeight + insets.bottom),
+      },
+    ],
+  }));
   // Ref, not state: two taps in the same frame both pass a state check.
   const busyRef = useRef(false);
 
@@ -126,50 +195,67 @@ export default function HomeScreen() {
         </View>
       </View>
 
-      <ScrollView
-        style={styles.list}
-        contentContainerStyle={styles.listContent}
-        keyboardShouldPersistTaps="handled"
-      >
-        {showActionButtonCard && (
-          <ActionButtonCard
-            onConfigure={() => router.push("/action-button")}
-            onDismiss={dismissActionButtonCard}
-          />
-        )}
-        {!isLoading && items.length === 0 && (
-          <View style={styles.empty}>
-            <Text style={styles.emptyTitle}>No meetings yet</Text>
-            <Text style={styles.emptyBody}>
-              Start listening or create a new note.
-            </Text>
-          </View>
-        )}
-        {items.map((item) => {
-          if (item.type === "header") {
-            return (
-              <Text key={item.key} style={styles.sectionLabel}>
-                {item.label}
-              </Text>
-            );
-          }
-          return (
-            <SessionCard
-              key={item.key}
-              session={item.session}
-              showFolder={sidebarPreferences.showFolder}
-              showTags={sidebarPreferences.showTags}
-              onPress={() => router.push(`/note/${item.session.id}`)}
-              onDelete={() => void handleDelete(item.session)}
+      <View style={styles.timeline}>
+        <Animated.ScrollView
+          style={styles.list}
+          contentContainerStyle={[
+            styles.listContent,
+            { paddingBottom: buttonHeight + Spacing.lg },
+          ]}
+          keyboardShouldPersistTaps="handled"
+          onScroll={onScroll}
+          scrollEventThrottle={16}
+        >
+          {showActionButtonCard && (
+            <ActionButtonCard
+              onConfigure={() => router.push("/action-button")}
+              onDismiss={dismissActionButtonCard}
             />
-          );
-        })}
-      </ScrollView>
+          )}
+          {!isLoading && items.length === 0 && (
+            <View style={styles.empty}>
+              <Text style={styles.emptyTitle}>No meetings yet</Text>
+              <Text style={styles.emptyBody}>
+                Start listening or create a new note.
+              </Text>
+            </View>
+          )}
+          {items.map((item) => {
+            if (item.type === "header") {
+              return (
+                <Text key={item.key} style={styles.sectionLabel}>
+                  {item.label}
+                </Text>
+              );
+            }
+            return (
+              <SessionCard
+                key={item.key}
+                session={item.session}
+                showFolder={sidebarPreferences.showFolder}
+                showTags={sidebarPreferences.showTags}
+                onPress={() => router.push(`/note/${item.session.id}`)}
+                onDelete={() => void handleDelete(item.session)}
+              />
+            );
+          })}
+        </Animated.ScrollView>
 
-      <StartListeningButton
-        bottomSpacing={Spacing.xs}
-        onPress={() => void createAndOpen("?listen=1")}
-      />
+        <Animated.View
+          style={[styles.listeningButton, buttonStyle]}
+          onLayout={(event) => setButtonHeight(event.nativeEvent.layout.height)}
+          pointerEvents={buttonHidden ? "none" : "box-none"}
+          accessibilityElementsHidden={buttonHidden}
+          importantForAccessibility={
+            buttonHidden ? "no-hide-descendants" : "auto"
+          }
+        >
+          <StartListeningButton
+            bottomSpacing={Spacing.xs}
+            onPress={() => void createAndOpen("?listen=1")}
+          />
+        </Animated.View>
+      </View>
       {searching && (
         <SearchPalette
           onClose={() => setSearching(false)}
@@ -209,10 +295,18 @@ const useStyles = createStyleHook((Colors) => ({
   list: {
     flex: 1,
   },
+  timeline: {
+    flex: 1,
+  },
+  listeningButton: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
   listContent: {
     flexGrow: 1,
     paddingHorizontal: Spacing.md,
-    paddingBottom: Spacing.lg,
   },
   empty: {
     flex: 1,

--- a/apps/mobile/src/lib/scroll-visibility.test.mjs
+++ b/apps/mobile/src/lib/scroll-visibility.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { scrollVisibility } from "./scroll-visibility.ts";
+
+const visible = { anchor: 0, hidden: false };
+
+test("hides after scrolling down and reveals after reversing direction", () => {
+  let state = scrollVisibility(visible, 8, 500);
+  assert.equal(state.hidden, false);
+  state = scrollVisibility(state, 12, 500);
+  assert.equal(state.hidden, true);
+  state = scrollVisibility(state, 250, 500);
+  state = scrollVisibility(state, 240, 500);
+  assert.equal(state.hidden, true);
+  state = scrollVisibility(state, 238, 500);
+  assert.equal(state.hidden, false);
+  state = scrollVisibility(state, 250, 500);
+  assert.equal(state.hidden, true);
+});
+
+test("small scroll jitter does not flicker the button", () => {
+  let state = scrollVisibility(visible, 100, 500);
+  for (const offset of [98, 102, 99, 103, 101, 97]) {
+    state = scrollVisibility(state, offset, 500);
+    assert.equal(state.hidden, true);
+  }
+  state = scrollVisibility(state, 90, 500);
+  assert.equal(state.hidden, false);
+  for (const offset of [92, 87, 90, 89, 96]) {
+    state = scrollVisibility(state, offset, 500);
+    assert.equal(state.hidden, false);
+  }
+});
+
+test("top bounce keeps the button visible", () => {
+  let state = scrollVisibility(visible, 100, 500);
+  for (const offset of [0, -40, -10, 0]) {
+    state = scrollVisibility(state, offset, 500);
+    assert.equal(state.hidden, false);
+  }
+});
+
+test("bottom bounce does not count as scrolling back up", () => {
+  let state = visible;
+  for (const offset of [500, 540, 520, 500]) {
+    state = scrollVisibility(state, offset, 500);
+    assert.equal(state.hidden, true);
+  }
+  state = scrollVisibility(state, 488, 500);
+  assert.equal(state.hidden, false);
+});
+
+test("short or emptied lists always keep the button available", () => {
+  let state = scrollVisibility(visible, 100, 500);
+  for (const maxOffset of [0, -200]) {
+    for (const offset of [100, -50, 0]) {
+      state = scrollVisibility(state, offset, maxOffset);
+      assert.equal(state.hidden, false);
+    }
+  }
+});

--- a/apps/mobile/src/lib/scroll-visibility.ts
+++ b/apps/mobile/src/lib/scroll-visibility.ts
@@ -1,0 +1,20 @@
+export function scrollVisibility(
+  previous: { anchor: number; hidden: boolean },
+  offset: number,
+  maxOffset: number,
+) {
+  "worklet";
+  const position = Math.max(0, Math.min(offset, Math.max(0, maxOffset)));
+  if (position <= 0) return { anchor: 0, hidden: false };
+
+  const anchor = previous.hidden
+    ? Math.max(previous.anchor, position)
+    : Math.min(previous.anchor, position);
+  const distance = position - anchor;
+  const hidden = previous.hidden ? distance > -12 : distance >= 12;
+
+  return {
+    anchor: hidden === previous.hidden ? anchor : position,
+    hidden,
+  };
+}


### PR DESCRIPTION
Animate hide and reveal from scroll direction, preserve list position, and support reduced motion. Cover thresholds, jitter, and edge bounce.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only home screen behavior with tested scroll logic; no auth, data, or API changes.
> 
> **Overview**
> The mobile home timeline **hides the floating Start Listening control when the user scrolls down** and brings it back when they scroll up, so more of the meeting list stays visible without losing quick access at rest.
> 
> Home swaps a plain `ScrollView` for **Reanimated-driven scroll tracking**: a new `scrollVisibility` worklet (with unit tests) applies distance thresholds, ignores small jitter, and handles top/bottom bounce and non-scrollable lists. Visibility drives an animated overlay (slide + fade) with **reduced-motion** timing, extra list bottom padding sized to the button, and **accessibility/pointer blocking** while hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23920cf97ca197fa56d3cec5ffeadd02e82197ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->