### PR TITLE
Move mobile model controls above provider credentials

### DIFF
--- a/apps/mobile/src/settings/provider-autosave.ts
+++ b/apps/mobile/src/settings/provider-autosave.ts
@@ -1,6 +1,7 @@
 import {
   validateProviderApiKey,
   validateProviderConfig,
+  validateProviderConnection,
   type ProviderConfig,
   type ProviderKind,
 } from "./providers-model";
@@ -8,6 +9,7 @@ import {
 export function createProviderAutosave(
   kind: ProviderKind,
   save: (draft: { config: ProviderConfig; apiKey: string }) => void,
+  options?: { connectionOnly?: boolean },
 ) {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let pending: { config: ProviderConfig; apiKey: string } | undefined;
@@ -28,7 +30,9 @@ export function createProviderAutosave(
     schedule(config: ProviderConfig, apiKey: string, hasSavedKey: boolean) {
       cancel();
       try {
-        const normalized = validateProviderConfig(kind, config);
+        const normalized = options?.connectionOnly
+          ? { ...config, ...validateProviderConnection(kind, config) }
+          : validateProviderConfig(kind, config);
         const key = apiKey.trim();
         if (key || !hasSavedKey) validateProviderApiKey(key);
         pending = { config: normalized, apiKey: key };

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -115,7 +115,10 @@ function ProviderForm({
         selectedProviderRef.current === provider
           ? saveProviderConfig
           : saveProviderSetup;
-      await save(account, kind, { ...setup, model: model ?? setup.model });
+      await save(account, kind, {
+        ...setup,
+        model: model?.trim() || setup.model,
+      });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -126,7 +129,11 @@ function ProviderForm({
       });
     },
     onError: (error) => {
-      if (error instanceof ProRequiredError) router.push("/settings/pro");
+      if (error instanceof ProRequiredError) {
+        selectedProviderRef.current = config.provider;
+        setSelectedProvider(config.provider);
+        router.push("/settings/pro");
+      }
     },
   });
   return (
@@ -139,6 +146,8 @@ function ProviderForm({
             selectedValue={selectedProvider}
             enabled={!select.isPending}
             onValueChange={(provider) => {
+              if (!modelDrafts.current[provider]?.trim())
+                delete modelDrafts.current[provider];
               selectedProviderRef.current = provider;
               setSelectedProvider(provider);
               setExpanded(provider === "anarlog" ? null : provider);

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -33,6 +33,7 @@ import {
   readProviderSetup,
   removeProviderKey,
   saveProviderConfig,
+  saveProviderConnection,
   saveProviderSetup,
 } from "./providers";
 import {
@@ -93,16 +94,37 @@ function ProviderForm({
     })),
   });
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [selectedProvider, setSelectedProvider] = useState(config.provider);
+  const selectedProviderRef = useRef(config.provider);
+  const modelDrafts = useRef<Record<string, string>>({});
+  const selectedSetup =
+    setups[definitions.findIndex(({ id }) => id === selectedProvider)];
   const select = useMutation({
     scope: { id: `provider-settings:${account}:${kind}` },
-    mutationFn: async (provider: string) => {
+    mutationFn: async ({
+      provider,
+      model,
+    }: {
+      provider: string;
+      model?: string;
+    }) => {
       if (provider === "anarlog" && !auth.billing.isPro && !auth.bypass)
         throw new ProRequiredError();
       const setup = await readProviderSetup(account, kind, provider);
-      await saveProviderConfig(account, kind, setup);
+      const save =
+        selectedProviderRef.current === provider
+          ? saveProviderConfig
+          : saveProviderSetup;
+      await save(account, kind, { ...setup, model: model ?? setup.model });
     },
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["provider", account, kind] }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["provider", account, kind],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["provider-setup", account, kind],
+      });
+    },
     onError: (error) => {
       if (error instanceof ProRequiredError) router.push("/settings/pro");
     },
@@ -114,12 +136,13 @@ function ProviderForm({
           <Text>Provider</Text>
           <Spacer />
           <Picker
-            key={`${config.provider}:${select.status}`}
-            selectedValue={config.provider}
+            selectedValue={selectedProvider}
             enabled={!select.isPending}
             onValueChange={(provider) => {
+              selectedProviderRef.current = provider;
+              setSelectedProvider(provider);
               setExpanded(provider === "anarlog" ? null : provider);
-              select.mutate(provider);
+              select.mutate({ provider, model: modelDrafts.current[provider] });
             }}
             testID="active-provider"
           >
@@ -132,20 +155,44 @@ function ProviderForm({
             ))}
           </Picker>
         </Row>
-        <Row alignment="center">
-          <Text>Model</Text>
-          <Spacer />
-          <Text>
-            {config.provider === "anarlog" ? "Automatic" : config.model}
-          </Text>
-        </Row>
+        {selectedProvider === "anarlog" ? (
+          <Row alignment="center">
+            <Text>Model</Text>
+            <Spacer />
+            <Text>Automatic</Text>
+          </Row>
+        ) : selectedSetup?.data ? (
+          <ModelField
+            key={selectedProvider}
+            kind={kind}
+            config={selectedSetup.data.config}
+            model={
+              modelDrafts.current[selectedProvider] ??
+              selectedSetup.data.config.model
+            }
+            hasKey={selectedSetup.data.hasKey}
+            onChange={(model) => {
+              modelDrafts.current[selectedProvider] = model;
+            }}
+            onSave={(model) =>
+              select.mutate({ provider: selectedProvider, model })
+            }
+          />
+        ) : selectedSetup?.error ? (
+          <Button
+            label="Try again"
+            onPress={() => void selectedSetup.refetch()}
+          />
+        ) : (
+          <Text>Loading…</Text>
+        )}
         <FieldGroup.SectionFooter>
           <Text>
             {select.error instanceof Error
               ? select.error.message
-              : config.provider === "anarlog"
+              : selectedProvider === "anarlog"
                 ? "Included with your Pro trial or subscription. No API key needed."
-                : "Using your saved provider settings below."}
+                : "Choose your model here. Configure API keys and connections below."}
           </Text>
         </FieldGroup.SectionFooter>
       </FieldGroup.Section>
@@ -196,7 +243,14 @@ function ProviderForm({
                   config={setup.data.config}
                   hasKey={setup.data.hasKey}
                   open={open}
-                  onSaved={() => select.reset()}
+                  onSaved={() => {
+                    if (selectedProviderRef.current === provider.id) {
+                      select.mutate({
+                        provider: provider.id,
+                        model: modelDrafts.current[provider.id],
+                      });
+                    }
+                  }}
                 />
               )}
             </Column>
@@ -209,6 +263,59 @@ function ProviderForm({
         </FieldGroup.SectionFooter>
       </FieldGroup.Section>
     </>
+  );
+}
+
+function ModelField({
+  kind,
+  config,
+  model: initialModel,
+  hasKey,
+  onChange,
+  onSave,
+}: {
+  kind: ProviderKind;
+  config: ProviderConfig;
+  model: string;
+  hasKey: boolean;
+  onChange: (model: string) => void;
+  onSave: (model: string) => void;
+}) {
+  const Colors = useColors();
+  const model = useNativeState(initialModel);
+  const form = useForm({ defaultValues: { model: initialModel } });
+  const [autosave] = useState(() =>
+    createProviderAutosave(kind, ({ config }) => onSave(config.model)),
+  );
+  useFocusEffect(useCallback(() => () => autosave.flush(), [autosave]));
+  return (
+    <Row alignment="center" spacing={8}>
+      <Icon
+        name={Icon.select({
+          ios: "cpu",
+          android: import("@expo/material-symbols/memory.xml"),
+        })}
+        size={18}
+        color={Colors.muted}
+        style={{ width: 20 }}
+      />
+      <Text>Model</Text>
+      <TextInput
+        value={model}
+        placeholder="Model ID"
+        textAlign="right"
+        autoCapitalize="none"
+        autoCorrect={false}
+        onBlur={autosave.flush}
+        onSubmitEditing={autosave.flush}
+        onChangeText={(value) => {
+          model.value = value;
+          form.setFieldValue("model", value);
+          onChange(value);
+          autosave.schedule({ ...config, ...form.state.values }, "", hasKey);
+        }}
+      />
+    </Row>
   );
 }
 
@@ -231,7 +338,6 @@ function ProviderFields({
   const queryClient = useQueryClient();
   const key = useNativeState("");
   const apiKey = useRef("");
-  const model = useNativeState(config.model);
   const baseUrl = useNativeState(config.baseUrl);
   const invalidate = async () => {
     await queryClient.invalidateQueries({
@@ -245,13 +351,15 @@ function ProviderFields({
     gcTime: 0,
     scope: { id: `provider-settings:${account}:${kind}` },
     mutationFn: (draft: { config: ProviderConfig; apiKey: string }) =>
-      saveProviderSetup(account, kind, draft.config, draft.apiKey),
+      saveProviderConnection(account, kind, draft.config, draft.apiKey),
     onSuccess: async () => {
       await invalidate();
       onSaved();
     },
   });
-  const [autosave] = useState(() => createProviderAutosave(kind, save.mutate));
+  const [autosave] = useState(() =>
+    createProviderAutosave(kind, save.mutate, { connectionOnly: true }),
+  );
   useFocusEffect(useCallback(() => () => autosave.flush(), [autosave]));
   const remove = useMutation({
     scope: { id: `provider-settings:${account}:${kind}` },
@@ -262,7 +370,7 @@ function ProviderFields({
     },
   });
   const form = useForm({
-    defaultValues: { model: config.model, baseUrl: config.baseUrl },
+    defaultValues: { baseUrl: config.baseUrl },
   });
   const scheduleSave = () => {
     if (remove.isPending) return;
@@ -303,31 +411,6 @@ function ProviderFields({
           onChangeText={(value) => {
             key.value = value;
             apiKey.current = value;
-            scheduleSave();
-          }}
-        />
-      </Row>
-      <Row alignment="center" spacing={8}>
-        <Icon
-          name={Icon.select({
-            ios: "cpu",
-            android: import("@expo/material-symbols/memory.xml"),
-          })}
-          size={18}
-          color={Colors.muted}
-          style={{ width: 20 }}
-        />
-        <TextInput
-          value={model}
-          placeholder="Model ID"
-          autoCapitalize="none"
-          autoCorrect={false}
-          editable={!remove.isPending}
-          onBlur={autosave.flush}
-          onSubmitEditing={autosave.flush}
-          onChangeText={(value) => {
-            model.value = value;
-            form.setFieldValue("model", value);
             scheduleSave();
           }}
         />

--- a/apps/mobile/src/settings/providers-model.ts
+++ b/apps/mobile/src/settings/providers-model.ts
@@ -329,6 +329,18 @@ export function validateProviderConfig(
   kind: ProviderKind,
   config: ProviderConfig,
 ): ProviderConfig {
+  const connection = validateProviderConnection(kind, config);
+  if (config.provider === "anarlog") return defaultProviderConfig(kind);
+  const model = config.model.trim();
+  if (!model || model.length > 200 || /[\r\n]/.test(model))
+    throw new Error("Enter a model ID.");
+  return { ...connection, model };
+}
+
+export function validateProviderConnection(
+  kind: ProviderKind,
+  config: { provider: string; baseUrl: string },
+) {
   const definition = defaultProviderConfig(kind, config.provider);
   if (config.provider === "anarlog") return definition;
   let url: URL;
@@ -350,12 +362,8 @@ export function validateProviderConfig(
       "Enter an HTTPS base URL without credentials or query parameters.",
     );
   }
-  const model = config.model.trim();
-  if (!model || model.length > 200 || /[\r\n]/.test(model))
-    throw new Error("Enter a model ID.");
   return {
     provider: config.provider,
-    model,
     baseUrl: url.toString().replace(/\/+$/, ""),
   };
 }

--- a/apps/mobile/src/settings/providers.ts
+++ b/apps/mobile/src/settings/providers.ts
@@ -13,6 +13,7 @@ import {
   providerStorageKey,
   validateProviderApiKey,
   validateProviderConfig,
+  validateProviderConnection,
   type ProviderConfig,
   type ProviderKind,
 } from "./providers-model";
@@ -64,7 +65,9 @@ export async function readProviderSetup(
   for (const row of rows) {
     const config = JSON.parse(row.value_json) as ProviderConfig;
     if (config.provider === provider)
-      return validateProviderConfig(kind, config);
+      return config.model
+        ? validateProviderConfig(kind, config)
+        : { ...validateProviderConnection(kind, config), model: "" };
   }
   return defaultProviderConfig(kind, provider);
 }
@@ -87,14 +90,35 @@ export async function saveProviderSetup(
   return persistProviderConfig(accountId, kind, config, apiKey, false);
 }
 
+export async function saveProviderConnection(
+  accountId: string | null,
+  kind: ProviderKind,
+  connection: { provider: string; baseUrl: string },
+  apiKey?: string,
+): Promise<void> {
+  const normalized = validateProviderConnection(kind, connection);
+  const saved = await readProviderSetup(accountId, kind, connection.provider);
+  return persistProviderConfig(
+    accountId,
+    kind,
+    { ...saved, ...normalized },
+    apiKey,
+    false,
+    true,
+  );
+}
+
 async function persistProviderConfig(
   accountId: string | null,
   kind: ProviderKind,
   config: ProviderConfig,
   apiKey: string | undefined,
   activate: boolean,
+  connectionOnly = false,
 ): Promise<void> {
-  const normalized = validateProviderConfig(kind, config);
+  const normalized = connectionOnly
+    ? { ...config, ...validateProviderConnection(kind, config) }
+    : validateProviderConfig(kind, config);
   if (normalized.provider !== "anarlog") {
     const key = validateProviderApiKey(
       apiKey?.trim() ||

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -107,6 +107,7 @@ const { createProviderAutosave } = await import("./provider-autosave.ts");
 const {
   saveProviderConfig,
   saveProviderSetup,
+  saveProviderConnection,
   readProviderConfig,
   readProviderSetup,
   removeProviderKey,
@@ -325,6 +326,110 @@ test("saving provider credentials leaves the active selection unchanged", async 
     "anarlog",
   );
   assert.equal(fixture.requests.length, 0);
+});
+
+test("credentials can be saved before choosing a summary model", async () => {
+  const connection = defaultProviderConfig("llm", "openai");
+  await saveProviderConnection("account-a", "llm", connection, "synthetic-key");
+  assert.equal(
+    (await readProviderSetup("account-a", "llm", "openai")).model,
+    "",
+  );
+  assert.equal(
+    (await readProviderConfig("account-a", "llm")).provider,
+    "anarlog",
+  );
+  assert.equal(
+    fixture.keys.get(providerStorageKey("account-a", "llm", "openai")).value,
+    "synthetic-key",
+  );
+  await assert.rejects(
+    saveProviderConfig("account-a", "llm", connection),
+    /model ID/,
+  );
+
+  await saveProviderConfig("account-a", "llm", {
+    ...connection,
+    model: "chosen-model",
+  });
+  signedInWith({});
+  assert.equal((await resolveProvider("llm")).model, "chosen-model");
+  assert.equal(fixture.requests.length, 0);
+});
+
+test("credential edits preserve the latest model instead of restoring a stale form value", async () => {
+  const earlier = {
+    ...defaultProviderConfig("llm", "custom"),
+    baseUrl: "https://old.test/v1",
+    model: "first-model",
+  };
+  await saveProviderConfig("account-a", "llm", earlier, "synthetic-old-key");
+  await saveProviderConfig("account-a", "llm", {
+    ...earlier,
+    model: "new-model",
+  });
+  await saveProviderConnection(
+    "account-a",
+    "llm",
+    { ...earlier, baseUrl: "https://new.test/v1" },
+    "synthetic-new-key",
+  );
+  const active = await readProviderConfig("account-a", "llm");
+  assert.equal(active.model, "new-model");
+  assert.equal(active.baseUrl, "https://new.test/v1");
+});
+
+test("saving another provider's connection cannot change the active model", async () => {
+  const active = {
+    ...defaultProviderConfig("llm", "openai"),
+    model: "active-model",
+  };
+  await saveProviderConfig("account-a", "llm", active, "synthetic-openai-key");
+  await saveProviderConnection(
+    "account-a",
+    "llm",
+    defaultProviderConfig("llm", "anthropic"),
+    "synthetic-anthropic-key",
+  );
+  assert.deepEqual(await readProviderConfig("account-a", "llm"), active);
+  assert.equal(
+    (await readProviderSetup("account-a", "llm", "anthropic")).model,
+    "",
+  );
+});
+
+test("connection autosave accepts credentials without a model and rejects incomplete connections", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const writes = [];
+  const autosave = createProviderAutosave(
+    "llm",
+    (draft) =>
+      writes.push(
+        saveProviderConnection("account-a", "llm", draft.config, draft.apiKey),
+      ),
+    { connectionOnly: true },
+  );
+  const config = {
+    ...defaultProviderConfig("llm", "custom"),
+    baseUrl: "https://custom.test/v1",
+  };
+  autosave.schedule(config, "synthetic-key", false);
+  t.mock.timers.tick(500);
+  await Promise.all(writes);
+  assert.equal(writes.length, 1);
+  assert.equal(
+    (await readProviderSetup("account-a", "llm", "custom")).model,
+    "",
+  );
+  for (const baseUrl of [
+    "",
+    "http://custom.test",
+    "https://user:secret@custom.test",
+  ]) {
+    autosave.schedule({ ...config, baseUrl }, "synthetic-key", true);
+    autosave.flush();
+  }
+  assert.equal(writes.length, 1);
 });
 
 test("switching providers restores each saved model and endpoint without re-entering keys", async () => {


### PR DESCRIPTION
Edit models beside the provider selection and keep accordions for keys and endpoints. Save credentials independently while preserving each provider model and the active configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how provider settings are validated, autosaved, and persisted on device, which could affect which model/endpoint is used at runtime if merge or activation logic regresses.
> 
> **Overview**
> Moves **model ID editing** next to the provider picker and leaves accordions for **API keys and base URLs only**.
> 
> Persistence is split: **`saveProviderConnection`** and **`connectionOnly` autosave** validate URLs/keys via `validateProviderConnection` without requiring a model, while merging with stored per-provider setup so the active model is not overwritten when editing another provider’s credentials. **`ModelField`** autosaves model changes through the provider-select flow (`saveProviderConfig` / `saveProviderSetup` with optional model drafts).
> 
> Provider picker UX now tracks a **local selected provider** (with Pro-error rollback), refreshes setup queries on success, and re-syncs the active config when credentials save for the currently selected provider. Runtime tests cover credentials-before-model, stale-model preservation, and inactive-provider isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f3a4a68bb23938740274313246ed819a2cfd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->