### PR TITLE
Choose mobile models from provider pickers

### DIFF
--- a/apps/mobile/src/settings/provider-catalog.test.mjs
+++ b/apps/mobile/src/settings/provider-catalog.test.mjs
@@ -3,6 +3,10 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import ts from "typescript";
 
+import {
+  modelOptions,
+  presetProviderModels,
+} from "./provider-model-catalog.ts";
 import { providersFor } from "./providers-model.ts";
 
 function desktopProviders(kind) {
@@ -57,6 +61,44 @@ function desktopProviders(kind) {
     );
   });
 }
+
+test("transcription choices follow desktop's catalog without its live-only models", () => {
+  const liveOnly = new Set([
+    "flux-general-multi",
+    "flux-general-en",
+    "gpt-live-transcribe",
+    "universal-3-5-pro-realtime",
+    "gemini-3.5-transcribe-live",
+    "scribe_v2_realtime",
+    "voxtral-mini-transcribe-realtime-2602",
+  ]);
+  for (const provider of desktopProviders("stt")) {
+    if (provider.id.text === "dashscope") continue;
+    const expected = provider.models.elements
+      .map((model) => model.text)
+      .filter((model) => !liveOnly.has(model))
+      .map((model) =>
+        provider.id.text === "soniox"
+          ? model.replace("stt-rt-", "stt-async-")
+          : model,
+      );
+    assert.deepEqual(
+      presetProviderModels("stt", provider.id.text),
+      expected,
+      provider.id.text,
+    );
+  }
+});
+
+test("model options retain a saved or manually entered ID without duplicates or empty options", () => {
+  assert.deepEqual(modelOptions(["known", "known"], "custom-model"), [
+    "known",
+    "custom-model",
+  ]);
+  assert.deepEqual(modelOptions(["known"], "known"), ["known"]);
+  assert.deepEqual(modelOptions([], ""), []);
+  assert.deepEqual(modelOptions([], "manual"), ["manual"]);
+});
 
 for (const kind of ["stt", "llm"]) {
   test(`${kind} includes the desktop's remote API-key providers supported by mobile recording`, () => {

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -27,6 +27,7 @@ import { useAuth } from "@/auth/context";
 
 import { SettingsPage } from "./components";
 import { createProviderAutosave } from "./provider-autosave";
+import { ProviderModelPicker } from "./provider-model-picker";
 import {
   readProviderConfig,
   readProviderKey,
@@ -171,8 +172,9 @@ function ProviderForm({
             <Text>Automatic</Text>
           </Row>
         ) : selectedSetup?.data ? (
-          <ModelField
+          <ProviderModelPicker
             key={selectedProvider}
+            account={account}
             kind={kind}
             config={selectedSetup.data.config}
             model={
@@ -275,59 +277,6 @@ function ProviderForm({
   );
 }
 
-function ModelField({
-  kind,
-  config,
-  model: initialModel,
-  hasKey,
-  onChange,
-  onSave,
-}: {
-  kind: ProviderKind;
-  config: ProviderConfig;
-  model: string;
-  hasKey: boolean;
-  onChange: (model: string) => void;
-  onSave: (model: string) => void;
-}) {
-  const Colors = useColors();
-  const model = useNativeState(initialModel);
-  const form = useForm({ defaultValues: { model: initialModel } });
-  const [autosave] = useState(() =>
-    createProviderAutosave(kind, ({ config }) => onSave(config.model)),
-  );
-  useFocusEffect(useCallback(() => () => autosave.flush(), [autosave]));
-  return (
-    <Row alignment="center" spacing={8}>
-      <Icon
-        name={Icon.select({
-          ios: "cpu",
-          android: import("@expo/material-symbols/memory.xml"),
-        })}
-        size={18}
-        color={Colors.muted}
-        style={{ width: 20 }}
-      />
-      <Text>Model</Text>
-      <TextInput
-        value={model}
-        placeholder="Model ID"
-        textAlign="right"
-        autoCapitalize="none"
-        autoCorrect={false}
-        onBlur={autosave.flush}
-        onSubmitEditing={autosave.flush}
-        onChangeText={(value) => {
-          model.value = value;
-          form.setFieldValue("model", value);
-          onChange(value);
-          autosave.schedule({ ...config, ...form.state.values }, "", hasKey);
-        }}
-      />
-    </Row>
-  );
-}
-
 function ProviderFields({
   kind,
   account,
@@ -355,12 +304,19 @@ function ProviderFields({
     await queryClient.invalidateQueries({
       queryKey: ["provider", account, kind],
     });
+    void queryClient.resetQueries({
+      queryKey: ["provider-models", account, kind, config.provider],
+    });
   };
   const save = useMutation({
     gcTime: 0,
     scope: { id: `provider-settings:${account}:${kind}` },
-    mutationFn: (draft: { config: ProviderConfig; apiKey: string }) =>
-      saveProviderConnection(account, kind, draft.config, draft.apiKey),
+    mutationFn: async (draft: { config: ProviderConfig; apiKey: string }) => {
+      await queryClient.cancelQueries({
+        queryKey: ["provider-models", account, kind, config.provider],
+      });
+      await saveProviderConnection(account, kind, draft.config, draft.apiKey);
+    },
     onSuccess: async () => {
       await invalidate();
       onSaved();
@@ -372,7 +328,12 @@ function ProviderFields({
   useFocusEffect(useCallback(() => () => autosave.flush(), [autosave]));
   const remove = useMutation({
     scope: { id: `provider-settings:${account}:${kind}` },
-    mutationFn: () => removeProviderKey(account, kind, config.provider),
+    mutationFn: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ["provider-models", account, kind, config.provider],
+      });
+      await removeProviderKey(account, kind, config.provider);
+    },
     onSuccess: async () => {
       save.reset();
       await invalidate();

--- a/apps/mobile/src/settings/provider-model-catalog.ts
+++ b/apps/mobile/src/settings/provider-model-catalog.ts
@@ -1,0 +1,88 @@
+import type { ProviderKind } from "./providers-model";
+
+// Desktop's remote model catalog, limited to models usable after recording.
+const TRANSCRIPTION_MODELS: Record<string, readonly string[]> = {
+  deepgram: ["nova-3-general", "nova-3-medical"],
+  assemblyai: ["universal-3-5-pro"],
+  openai: ["gpt-transcribe", "gpt-4o-transcribe-diarize", "whisper-1"],
+  openrouter: [
+    "openai/gpt-transcribe",
+    "mistralai/voxtral-mini-transcribe",
+    "openai/whisper-large-v3-turbo",
+    "openai/whisper-large-v3",
+    "fish-audio/transcribe-1",
+    "x-ai/grok-stt-1.0",
+    "deepgram/nova-3",
+    "microsoft/mai-transcribe-1.5",
+    "nvidia/parakeet-tdt-0.6b-v3",
+    "qwen/qwen3-asr-flash-2026-02-10",
+    "qwen/qwen3-asr-1.7b",
+    "qwen/qwen3-asr-0.6b",
+    "nvidia/nemotron-3.5-asr-streaming-multilingual-0.6b",
+    "mistralai/voxtral-small-24b-2507-stt",
+    "mistralai/voxtral-mini-3b-2507",
+    "google/chirp-3",
+    "openai/whisper-1",
+  ],
+  zai: ["glm-asr-2512"],
+  siliconflow: ["FunAudioLLM/SenseVoiceSmall", "TeleAI/TeleSpeechASR"],
+  google_generative_ai: ["gemini-3.5-transcribe"],
+  google_cloud: ["latest_long"],
+  aws_transcribe: ["amazon-transcribe"],
+  azure_speech: ["fast-transcription"],
+  elevenlabs: ["scribe_v2"],
+  soniox: ["stt-async-v5"],
+  speechmatics: ["enhanced", "standard"],
+  groq: ["whisper-large-v3-turbo", "whisper-large-v3"],
+  mistral: ["voxtral-mini-2602"],
+  revai: ["machine"],
+  gladia: ["solaria-3", "solaria-1"],
+  cartesia: ["ink-2"],
+  cloudflare_workers_ai: ["nova-3"],
+  together: [
+    "openai/whisper-large-v3",
+    "nvidia/parakeet-tdt-0.6b-v3",
+    "nvidia/nemotron-3.5-asr-streaming-0.6b",
+    "nvidia/nemotron-3-asr-streaming-0.6b",
+  ],
+  xai: ["xai-stt"],
+  smallestai: ["pulse", "pulse-pro"],
+  pyannote: ["parakeet-tdt-0.6b-v3", "faster-whisper-large-v3-turbo"],
+  cohere: ["cohere-transcribe-03-2026", "cohere-transcribe-arabic-07-2026"],
+  aquavoice: ["avalon-v1.5"],
+  custom: [],
+};
+
+const SUMMARY_MODELS: Record<string, readonly string[]> = {
+  google_vertex_ai: [
+    "google/gemini-3.8-flash",
+    "google/gemini-3.7-flash",
+    "google/gemini-3.6-flash",
+    "google/gemini-3.5-flash-lite",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3.5-flash",
+    "google/gemini-3.1-flash-lite",
+  ],
+  cloudflare_workers_ai: [
+    "@cf/moonshotai/kimi-k2.7-code",
+    "@cf/zai-org/glm-5.2",
+    "@cf/moonshotai/kimi-k2.6",
+    "@cf/zai-org/glm-4.7-flash",
+    "@cf/openai/gpt-oss-120b",
+    "@cf/meta/llama-4-scout-17b-16e-instruct",
+    "@cf/google/gemma-4-26b-a4b-it",
+    "@cf/nvidia/nemotron-3-120b-a12b",
+    "@cf/openai/gpt-oss-20b",
+    "@cf/qwen/qwen3-30b-a3b-fp8",
+    "@cf/mistralai/mistral-small-3.1-24b-instruct",
+    "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+  ],
+};
+
+export function presetProviderModels(kind: ProviderKind, provider: string) {
+  return (kind === "stt" ? TRANSCRIPTION_MODELS : SUMMARY_MODELS)[provider];
+}
+
+export function modelOptions(models: readonly string[], selected: string) {
+  return [...new Set([...models, selected].filter(Boolean))];
+}

--- a/apps/mobile/src/settings/provider-model-picker.tsx
+++ b/apps/mobile/src/settings/provider-model-picker.tsx
@@ -1,0 +1,151 @@
+import {
+  Button,
+  Column,
+  Icon,
+  Picker,
+  Row,
+  Spacer,
+  Text,
+  TextInput,
+  useNativeState,
+} from "@expo/ui";
+import { layoutPriority } from "@expo/ui/swift-ui/modifiers";
+import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { useFocusEffect } from "expo-router";
+import { useCallback, useState } from "react";
+import { Platform } from "react-native";
+
+import { createProviderAutosave } from "./provider-autosave";
+import { modelOptions, presetProviderModels } from "./provider-model-catalog";
+import { discoverProviderModels } from "./provider-models";
+import type { ProviderConfig, ProviderKind } from "./providers-model";
+import { useColors } from "./theme-provider";
+
+export function ProviderModelPicker({
+  kind,
+  account,
+  config,
+  model: initialModel,
+  hasKey,
+  onChange,
+  onSave,
+}: {
+  kind: ProviderKind;
+  account: string | null;
+  config: ProviderConfig;
+  model: string;
+  hasKey: boolean;
+  onChange: (model: string) => void;
+  onSave: (model: string) => void;
+}) {
+  const Colors = useColors();
+  const input = useNativeState(initialModel);
+  const [manual, setManual] = useState(false);
+  const form = useForm({ defaultValues: { model: initialModel } });
+  const presets = presetProviderModels(kind, config.provider);
+  const models = useQuery({
+    queryKey: [
+      "provider-models",
+      account,
+      kind,
+      config.provider,
+      config.baseUrl,
+    ],
+    queryFn: ({ signal }) => discoverProviderModels(account, config, signal),
+    enabled: !presets && hasKey && Boolean(config.baseUrl),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 0,
+    retry: false,
+  });
+  const [autosave] = useState(() =>
+    createProviderAutosave(kind, ({ config }) => onSave(config.model)),
+  );
+  useFocusEffect(useCallback(() => () => autosave.flush(), [autosave]));
+  const changeModel = (value: string) => {
+    input.value = value;
+    form.setFieldValue("model", value);
+    onChange(value);
+    autosave.schedule({ ...config, model: value }, "", hasKey);
+  };
+  return (
+    <Column spacing={12}>
+      <Row alignment="center" spacing={8}>
+        <Icon
+          name={Icon.select({
+            ios: "cpu",
+            android: import("@expo/material-symbols/memory.xml"),
+          })}
+          size={18}
+          color={Colors.muted}
+          style={{ width: 20 }}
+        />
+        <Text>Model</Text>
+        <Spacer />
+        <Column
+          alignment="end"
+          modifiers={Platform.OS === "ios" ? [layoutPriority(1)] : undefined}
+        >
+          <form.Subscribe selector={(state) => state.values.model}>
+            {(model) => (
+              <Picker
+                selectedValue={
+                  manual ? "manual" : model ? `model:${model}` : "empty"
+                }
+                onValueChange={(value) => {
+                  if (value === "empty") return;
+                  if (value === "manual") {
+                    setManual(true);
+                    return;
+                  }
+                  setManual(false);
+                  changeModel(value.slice("model:".length));
+                  autosave.flush();
+                }}
+                testID="provider-model"
+              >
+                {!model && <Picker.Item value="empty" label="Select model" />}
+                {modelOptions(
+                  presets ?? (hasKey ? (models.data ?? []) : []),
+                  model,
+                ).map((id) => (
+                  <Picker.Item key={id} value={`model:${id}`} label={id} />
+                ))}
+                <Picker.Item value="manual" label="Enter model ID…" />
+              </Picker>
+            )}
+          </form.Subscribe>
+        </Column>
+      </Row>
+      {manual && (
+        <TextInput
+          value={input}
+          placeholder="Model ID"
+          autoCapitalize="none"
+          autoCorrect={false}
+          onBlur={autosave.flush}
+          onSubmitEditing={autosave.flush}
+          onChangeText={changeModel}
+          testID="custom-model-id"
+        />
+      )}
+      {!presets &&
+        (!hasKey || !config.baseUrl ? (
+          <Text textStyle={{ color: Colors.muted }}>
+            Configure this provider below to load models.
+          </Text>
+        ) : models.isFetching ? (
+          <Text textStyle={{ color: Colors.muted }}>Loading models…</Text>
+        ) : models.error || !models.data?.length ? (
+          <Column spacing={8}>
+            <Text textStyle={{ color: Colors.muted }}>
+              {models.error
+                ? "Couldn’t load models. You can still enter a model ID."
+                : "No models found. You can enter a model ID."}
+            </Text>
+            <Button label="Retry" onPress={() => void models.refetch()} />
+          </Column>
+        ) : null)}
+    </Column>
+  );
+}

--- a/apps/mobile/src/settings/provider-models.ts
+++ b/apps/mobile/src/settings/provider-models.ts
@@ -1,0 +1,149 @@
+import { fetch } from "expo/fetch";
+
+import { readProviderKey, readProviderSetup } from "./providers";
+import {
+  validateProviderConnection,
+  type ProviderConfig,
+} from "./providers-model";
+
+export async function discoverProviderModels(
+  account: string | null,
+  config: ProviderConfig,
+  signal: AbortSignal,
+): Promise<string[]> {
+  signal.throwIfAborted();
+  const connection = validateProviderConnection("llm", config);
+  const saved = await readProviderSetup(account, "llm", config.provider);
+  if (saved.baseUrl !== connection.baseUrl)
+    throw new Error("Provider connection changed. Reload models.");
+  const apiKey = await readProviderKey(account, "llm", config.provider);
+  if (!apiKey) throw new Error("Add an API key to load models.");
+  signal.throwIfAborted();
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  signal.addEventListener("abort", abort, { once: true });
+  const timer = setTimeout(abort, 8_000);
+  try {
+    let url = `${connection.baseUrl}/models`;
+    const headers: Record<string, string> = {};
+    switch (config.provider) {
+      case "anthropic":
+        headers["x-api-key"] = apiKey;
+        headers["anthropic-version"] = "2023-06-01";
+        break;
+      case "google_generative_ai":
+        headers["x-goog-api-key"] = apiKey;
+        break;
+      case "azure_openai": {
+        const base = connection.baseUrl.replace(/\/openai(?:\/v1)?$/, "");
+        url = `${base}/openai/models?api-version=2024-10-21`;
+        headers["api-key"] = apiKey;
+        break;
+      }
+      case "azure_ai":
+        headers["api-key"] = apiKey;
+        break;
+      default:
+        headers.Authorization = `Bearer ${apiKey}`;
+    }
+    const response = await fetch(url, {
+      headers,
+      signal: controller.signal,
+      redirect: "error",
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error("Model request failed.");
+    }
+    return parseProviderModels(
+      config.provider,
+      JSON.parse(await readModels(response)),
+    );
+  } catch {
+    throw new Error("Couldn’t load models. Retry or enter a model ID.");
+  } finally {
+    clearTimeout(timer);
+    signal.removeEventListener("abort", abort);
+  }
+}
+
+async function readModels(response: Response) {
+  const limit = 8 * 1024 * 1024;
+  if (Number(response.headers.get("content-length")) > limit) {
+    await response.body?.cancel();
+    throw new Error("Model list is too large.");
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("Empty model response.");
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return text + decoder.decode();
+      bytes += value.byteLength;
+      if (bytes > limit) {
+        await reader.cancel();
+        throw new Error("Model list is too large.");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function parseProviderModels(
+  provider: string,
+  response: unknown,
+): string[] {
+  const body = record(response);
+  const data = body.data ?? body.models;
+  if (!Array.isArray(data)) throw new Error("Invalid model list.");
+  const models = data.flatMap((entry: unknown) => {
+    const model = record(entry);
+    const raw = model.id ?? model.name;
+    if (typeof raw !== "string") return [];
+    const id =
+      provider === "google_generative_ai" ? raw.replace(/^models\//, "") : raw;
+    if (!id.trim() || id.length > 200 || /[\r\n]/.test(id)) return [];
+    const capabilities = record(model.capabilities);
+    if (
+      capabilities.completion_chat === false ||
+      (capabilities.chat_completion === false &&
+        capabilities.completion === false)
+    )
+      return [];
+    const methods = model.supportedGenerationMethods;
+    if (Array.isArray(methods) && !methods.includes("generateContent"))
+      return [];
+    const outputs = record(model.architecture).output_modalities;
+    if (Array.isArray(outputs) && !outputs.includes("text")) return [];
+    const inputs = record(model.architecture).input_modalities;
+    if (Array.isArray(inputs) && !inputs.includes("text")) return [];
+    if (Array.isArray(model.endpoints) && !model.endpoints.includes("chat"))
+      return [];
+    if (
+      typeof model.type === "string" &&
+      !["chat", "language"].includes(model.type)
+    )
+      return [];
+    if (
+      /(embed|tts|whisper|dall-e|audio|image|realtime|transcribe|moderation|rerank)/i.test(
+        id,
+      )
+    )
+      return [];
+    return [id];
+  });
+  return [...new Set(models)].sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  );
+}

--- a/apps/mobile/src/settings/provider-models.ts
+++ b/apps/mobile/src/settings/provider-models.ts
@@ -132,7 +132,7 @@ export function parseProviderModels(
       return [];
     if (
       typeof model.type === "string" &&
-      !["chat", "language"].includes(model.type)
+      ["embedding", "embed", "rerank", "image", "audio"].includes(model.type)
     )
       return [];
     if (

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -1258,3 +1258,224 @@ test("Azure resource URLs use the v1 endpoint without duplicating its path", asy
     assert.ok(!request.headers.Authorization);
   }
 });
+
+const { discoverProviderModels, parseProviderModels } =
+  await import("./provider-models.ts");
+const { presetProviderModels } = await import("./provider-model-catalog.ts");
+
+for (const definition of providersFor("llm").filter(
+  ({ id }) => id !== "anarlog" && !presetProviderModels("llm", id),
+)) {
+  test(`${definition.name} discovers selectable models with its device key and authentication headers`, async () => {
+    const config = {
+      ...defaultProviderConfig("llm", definition.id),
+      baseUrl: definition.baseUrl || "https://provider.example.test",
+    };
+    await saveProviderConnection(
+      "account-a",
+      "llm",
+      config,
+      "synthetic-discovery-key",
+    );
+    fixture.respond = () =>
+      Response.json(
+        definition.id === "google_generative_ai"
+          ? {
+              models: [
+                {
+                  name: "models/test-chat",
+                  supportedGenerationMethods: ["generateContent"],
+                },
+              ],
+            }
+          : { data: [{ id: "test-chat" }] },
+      );
+    assert.deepEqual(
+      await discoverProviderModels(
+        "account-a",
+        config,
+        new AbortController().signal,
+      ),
+      ["test-chat"],
+    );
+    const { url, options } = fixture.requests[0];
+    assert.equal(
+      url,
+      `${config.baseUrl}${definition.id === "azure_openai" ? "/openai/models?api-version=2024-10-21" : "/models"}`,
+    );
+    const header =
+      definition.id === "google_generative_ai"
+        ? "x-goog-api-key"
+        : definition.id === "anthropic"
+          ? "x-api-key"
+          : definition.id.startsWith("azure_")
+            ? "api-key"
+            : "Authorization";
+    assert.equal(
+      options.headers[header],
+      `${header === "Authorization" ? "Bearer " : ""}synthetic-discovery-key`,
+    );
+    assert.equal(options.redirect, "error");
+    assert.ok(!url.includes("synthetic-discovery-key"));
+    assert.equal(
+      (await readProviderSetup("account-a", "llm", definition.id)).model,
+      "",
+    );
+    assert.equal(
+      (await readProviderConfig("account-a", "llm")).provider,
+      "anarlog",
+    );
+  });
+}
+
+test("model discovery excludes non-text models and keeps custom IDs and Cohere model names", () => {
+  assert.deepEqual(
+    parseProviderModels("openrouter", {
+      data: [
+        { id: "chat-model" },
+        { id: "chat-model" },
+        { id: "my-custom-model" },
+        { id: "embedding-model" },
+        { id: "speech-transcribe" },
+        { id: "vision-only", architecture: { output_modalities: ["image"] } },
+        { id: "speech-only", architecture: { input_modalities: ["audio"] } },
+        { id: "no-chat", capabilities: { completion_chat: false } },
+        { id: "bad\nmodel" },
+        { id: "a".repeat(201) },
+        null,
+      ],
+    }),
+    ["chat-model", "my-custom-model"],
+  );
+  assert.deepEqual(
+    parseProviderModels("cohere", {
+      models: [
+        { name: "command-a", endpoints: ["chat"] },
+        { name: "classify", endpoints: ["classify"] },
+      ],
+    }),
+    ["command-a"],
+  );
+  assert.deepEqual(
+    parseProviderModels("google_generative_ai", {
+      models: [
+        {
+          name: "models/gemini-chat",
+          supportedGenerationMethods: ["generateContent"],
+        },
+        {
+          name: "models/embedding",
+          supportedGenerationMethods: ["embedContent"],
+        },
+      ],
+    }),
+    ["gemini-chat"],
+  );
+  assert.throws(() => parseProviderModels("openai", {}), /Invalid model list/);
+});
+
+test("model discovery preserves manual selection on empty, malformed, oversized, or failed responses", async () => {
+  const config = {
+    ...defaultProviderConfig("llm", "openai"),
+    model: "my-manual-model",
+  };
+  await saveProviderConfig("account-a", "llm", config, "synthetic-key");
+  fixture.respond = () => Response.json({ data: [] });
+  assert.deepEqual(
+    await discoverProviderModels(
+      "account-a",
+      config,
+      new AbortController().signal,
+    ),
+    [],
+  );
+  for (const response of [
+    () => new Response("private-provider-error-body", { status: 401 }),
+    () => new Response("not-json"),
+    () =>
+      Response.json(
+        { data: [] },
+        { headers: { "content-length": String(9 * 1024 * 1024) } },
+      ),
+    () => new Response("x".repeat(8 * 1024 * 1024 + 1)),
+  ]) {
+    fixture.respond = response;
+    await assert.rejects(
+      discoverProviderModels("account-a", config, new AbortController().signal),
+      { message: "Couldn’t load models. Retry or enter a model ID." },
+    );
+    assert.equal(
+      (await readProviderConfig("account-a", "llm")).model,
+      "my-manual-model",
+    );
+  }
+});
+
+test("discovery never uses another account's key or a stale custom endpoint", async () => {
+  const config = {
+    ...defaultProviderConfig("llm", "custom"),
+    baseUrl: "https://old.example.test",
+  };
+  await saveProviderConnection("account-a", "llm", config, "synthetic-key");
+  await assert.rejects(
+    discoverProviderModels(
+      "account-b",
+      { ...defaultProviderConfig("llm", "openai") },
+      new AbortController().signal,
+    ),
+    /Add an API key/,
+  );
+  await saveProviderConnection(
+    "account-a",
+    "llm",
+    { ...config, baseUrl: "https://new.example.test" },
+    "replacement-key",
+  );
+  await assert.rejects(
+    discoverProviderModels("account-a", config, new AbortController().signal),
+    /connection changed/,
+  );
+  assert.equal(fixture.requests.length, 0);
+});
+
+test("discovery aborts requests when leaving the picker", async () => {
+  const config = defaultProviderConfig("llm", "openai");
+  await saveProviderConnection("account-a", "llm", config, "synthetic-key");
+  const before = new AbortController();
+  before.abort();
+  await assert.rejects(
+    discoverProviderModels("account-a", config, before.signal),
+    { name: "AbortError" },
+  );
+  assert.equal(fixture.requests.length, 0);
+  const during = new AbortController();
+  fixture.respond = (_url, { signal }) => {
+    during.abort();
+    assert.equal(signal.aborted, true);
+    throw new Error("aborted");
+  };
+  await assert.rejects(
+    discoverProviderModels("account-a", config, during.signal),
+    /Couldn’t load models/,
+  );
+});
+
+for (const suffix of ["", "/openai", "/openai/v1"]) {
+  test(`Azure model discovery normalizes the configured endpoint ${suffix || "root"}`, async () => {
+    const config = {
+      ...defaultProviderConfig("llm", "azure_openai"),
+      baseUrl: `https://azure.example.test${suffix}`,
+    };
+    await saveProviderConnection("account-a", "llm", config, "synthetic-key");
+    fixture.respond = () => Response.json({ data: [{ id: "my-deployment" }] });
+    await discoverProviderModels(
+      "account-a",
+      config,
+      new AbortController().signal,
+    );
+    assert.equal(
+      fixture.requests[0].url,
+      "https://azure.example.test/openai/models?api-version=2024-10-21",
+    );
+  });
+}

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -1374,6 +1374,38 @@ test("model discovery excludes non-text models and keeps custom IDs and Cohere m
   assert.throws(() => parseProviderModels("openai", {}), /Invalid model list/);
 });
 
+test("model discovery accepts provider object types and still excludes non-chat capabilities", () => {
+  assert.deepEqual(
+    parseProviderModels("anthropic", {
+      data: [{ id: "claude-sonnet-4-6", type: "model" }],
+    }),
+    ["claude-sonnet-4-6"],
+  );
+  assert.deepEqual(
+    parseProviderModels("mistral", {
+      data: [
+        {
+          id: "mistral-small-latest",
+          type: "base",
+          capabilities: { completion_chat: true },
+        },
+        {
+          id: "ft:my-model",
+          type: "fine-tuned",
+          capabilities: { completion_chat: true },
+        },
+        {
+          id: "no-chat",
+          type: "base",
+          capabilities: { completion_chat: false },
+        },
+        { id: "vector-model", type: "embedding" },
+      ],
+    }),
+    ["ft:my-model", "mistral-small-latest"],
+  );
+});
+
 test("model discovery preserves manual selection on empty, malformed, oversized, or failed responses", async () => {
   const config = {
     ...defaultProviderConfig("llm", "openai"),


### PR DESCRIPTION
Show transcription presets and discover summary models using saved device credentials. Keep manual model entry optional, preserve selections, and cover discovery errors and provider catalog parity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Discovery sends device-stored API keys to provider `/models` endpoints; logic is guarded by account checks and abort handling, but misconfiguration or provider errors could still leak request failures to the UI without changing stored models.
> 
> **Overview**
> **Mobile provider settings** replace the plain model text field with a **picker** that shows preset IDs for transcription (aligned with desktop, excluding live/realtime models) and for a few summary providers, while other summary providers **fetch `/models`** using the saved on-device API key once base URL and key are configured.
> 
> The new **`ProviderModelPicker`** merges preset or discovered lists with the current selection (no duplicates), supports **“Enter model ID…”** for custom values, autosaves changes, and surfaces loading, empty, and retry states when discovery fails. **Credential edits** cancel and reset the model-list cache so lists don’t go stale across accounts or endpoint changes.
> 
> **Tests** lock catalog parity with desktop STT, `modelOptions` behavior, discovery auth/URLs (including Azure), parsing filters for chat-only models, and isolation so discovery never uses another account’s key or an outdated endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63e4fc02be32d570af662e72eb78fdc317932d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->