### PR TITLE
Show only configured mobile providers in selection menus

### DIFF
--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -31,8 +31,8 @@ import { ProviderModelPicker } from "./provider-model-picker";
 import { ProviderPicker } from "./provider-picker";
 import {
   readProviderConfig,
-  readProviderKey,
   readProviderSetup,
+  readProviderStatus,
   removeProviderKey,
   saveProviderConfig,
   saveProviderConnection,
@@ -89,10 +89,7 @@ function ProviderForm({
   const setups = useQueries({
     queries: definitions.map(({ id }) => ({
       queryKey: ["provider-setup", account, kind, id],
-      queryFn: async () => ({
-        config: await readProviderSetup(account, kind, id),
-        hasKey: Boolean(await readProviderKey(account, kind, id)),
-      }),
+      queryFn: () => readProviderStatus(account, kind, id),
     })),
   });
   const [expanded, setExpanded] = useState<string | null>(null);
@@ -101,6 +98,19 @@ function ProviderForm({
   const modelDrafts = useRef<Record<string, string>>({});
   const selectedSetup =
     setups[definitions.findIndex(({ id }) => id === selectedProvider)];
+  const configuredIds = new Set(
+    setups.flatMap(({ data }) =>
+      data?.isConfigured ? [data.config.provider] : [],
+    ),
+  );
+  const providerOptions = providersFor(kind).filter(
+    ({ id }) => id === "anarlog" || configuredIds.has(id),
+  );
+  const visibleProvider = providerOptions.some(
+    ({ id }) => id === selectedProvider,
+  )
+    ? selectedProvider
+    : "";
   const select = useMutation({
     scope: { id: `provider-settings:${account}:${kind}` },
     mutationFn: async ({
@@ -145,10 +155,11 @@ function ProviderForm({
           <Text>Provider</Text>
           <Spacer />
           <ProviderPicker
-            kind={kind}
-            selectedValue={selectedProvider}
+            providers={providerOptions}
+            selectedValue={visibleProvider}
             enabled={!select.isPending}
             onValueChange={(provider) => {
+              if (!providerOptions.some(({ id }) => id === provider)) return;
               if (!modelDrafts.current[provider]?.trim())
                 delete modelDrafts.current[provider];
               selectedProviderRef.current = provider;
@@ -158,7 +169,9 @@ function ProviderForm({
             }}
           />
         </Row>
-        {selectedProvider === "anarlog" ? (
+        {!visibleProvider ? (
+          <Text>Choose a configured provider to select a model.</Text>
+        ) : selectedProvider === "anarlog" ? (
           <Row alignment="center">
             <Text>Model</Text>
             <Spacer />
@@ -203,7 +216,8 @@ function ProviderForm({
       <FieldGroup.Section title="Configure providers">
         {definitions.map((provider, index) => {
           const setup = setups[index];
-          const active = config.provider === provider.id;
+          const active =
+            config.provider === provider.id && setup.data?.isConfigured;
           const open = expanded === provider.id;
           return (
             <Column key={provider.id} spacing={16}>

--- a/apps/mobile/src/settings/provider-picker.android.tsx
+++ b/apps/mobile/src/settings/provider-picker.android.tsx
@@ -8,21 +8,20 @@ import { menuAnchor } from "@expo/ui/jetpack-compose/modifiers";
 import { useState } from "react";
 
 import { ProviderIcon } from "./provider-icon";
-import { providersFor, type ProviderKind } from "./providers-model";
 
 export function ProviderPicker({
-  kind,
+  providers,
   selectedValue,
   enabled,
   onValueChange,
 }: {
-  kind: ProviderKind;
+  providers: readonly { id: string; name: string }[];
   selectedValue: string;
   enabled: boolean;
   onValueChange: (provider: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const providers = providersFor(kind);
+  const selected = providers.find(({ id }) => id === selectedValue);
   return (
     <ExposedDropdownMenuBox
       expanded={expanded}
@@ -34,11 +33,8 @@ export function ProviderPicker({
         alignment="center"
         testID="active-provider"
       >
-        <ProviderIcon provider={selectedValue} />
-        <Text>
-          {providers.find(({ id }) => id === selectedValue)?.name ??
-            selectedValue}
-        </Text>
+        {selected && <ProviderIcon provider={selected.id} />}
+        <Text>{selected?.name ?? "Select provider"}</Text>
         <Icon
           name={Icon.select({
             ios: "chevron.down",

--- a/apps/mobile/src/settings/provider-picker.ios.tsx
+++ b/apps/mobile/src/settings/provider-picker.ios.tsx
@@ -8,27 +8,25 @@ import {
 } from "@expo/ui/swift-ui/modifiers";
 
 import { ProviderIcon } from "./provider-icon";
-import { providersFor, type ProviderKind } from "./providers-model";
 
 export function ProviderPicker({
-  kind,
+  providers,
   selectedValue,
   enabled,
   onValueChange,
 }: {
-  kind: ProviderKind;
+  providers: readonly { id: string; name: string }[];
   selectedValue: string;
   enabled: boolean;
   onValueChange: (provider: string) => void;
 }) {
+  const selected = providers.find(({ id }) => id === selectedValue);
   return (
     <Menu
       label={
         <HStack spacing={8}>
-          <ProviderIcon provider={selectedValue} size={20} />
-          <Text>
-            {providersFor(kind).find(({ id }) => id === selectedValue)?.name}
-          </Text>
+          {selected && <ProviderIcon provider={selected.id} size={20} />}
+          <Text>{selected?.name ?? "Select provider"}</Text>
           <Image systemName="chevron.up.chevron.down" size={12} />
         </HStack>
       }
@@ -37,11 +35,11 @@ export function ProviderPicker({
     >
       <Picker
         label="Provider"
-        selection={selectedValue}
+        selection={selected?.id}
         onSelectionChange={onValueChange}
         modifiers={[pickerStyle("inline"), labelsHidden()]}
       >
-        {providersFor(kind).map((provider) => (
+        {providers.map((provider) => (
           <Label
             key={provider.id}
             title={provider.name}

--- a/apps/mobile/src/settings/provider-picker.tsx
+++ b/apps/mobile/src/settings/provider-picker.tsx
@@ -1,14 +1,12 @@
 import { Picker } from "@expo/ui";
 
-import { providersFor, type ProviderKind } from "./providers-model";
-
 export function ProviderPicker({
-  kind,
+  providers,
   selectedValue,
   enabled,
   onValueChange,
 }: {
-  kind: ProviderKind;
+  providers: readonly { id: string; name: string }[];
   selectedValue: string;
   enabled: boolean;
   onValueChange: (provider: string) => void;
@@ -20,7 +18,8 @@ export function ProviderPicker({
       onValueChange={onValueChange}
       testID="active-provider"
     >
-      {providersFor(kind).map((provider) => (
+      {!selectedValue && <Picker.Item value="" label="Select provider" />}
+      {providers.map((provider) => (
         <Picker.Item
           key={provider.id}
           value={provider.id}

--- a/apps/mobile/src/settings/providers.ts
+++ b/apps/mobile/src/settings/providers.ts
@@ -72,6 +72,26 @@ export async function readProviderSetup(
   return defaultProviderConfig(kind, provider);
 }
 
+export async function readProviderStatus(
+  accountId: string | null,
+  kind: ProviderKind,
+  provider: string,
+) {
+  const [config, apiKey] = await Promise.all([
+    readProviderSetup(accountId, kind, provider),
+    readProviderKey(accountId, kind, provider),
+  ]);
+  let hasKey = false;
+  let isConfigured = provider === "anarlog";
+  try {
+    validateProviderApiKey(apiKey ?? "");
+    hasKey = true;
+    validateProviderConnection(kind, config);
+    isConfigured = true;
+  } catch {}
+  return { config, hasKey, isConfigured };
+}
+
 export async function saveProviderConfig(
   accountId: string | null,
   kind: ProviderKind,

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -110,6 +110,7 @@ const {
   saveProviderConnection,
   readProviderConfig,
   readProviderSetup,
+  readProviderStatus,
   removeProviderKey,
   resolveProvider,
 } = await import("./providers.ts");
@@ -152,6 +153,60 @@ beforeEach(() => {
     Response.json({
       choices: [{ message: { content: "## Decisions\nShip the mobile app." } }],
     });
+});
+
+test("provider availability follows saved device keys for transcription and summaries", async () => {
+  for (const kind of ["stt", "llm"]) {
+    for (const { id } of providersFor(kind)) {
+      const status = await readProviderStatus("account-a", kind, id);
+      assert.equal(status.isConfigured, id === "anarlog", `${kind}/${id}`);
+    }
+    const config = defaultProviderConfig(kind, "openai");
+    await saveProviderConnection("account-a", kind, config, "synthetic-key");
+    const configured = await readProviderStatus("account-a", kind, "openai");
+    assert.equal(configured.isConfigured, true);
+    assert.equal(configured.hasKey, true);
+    assert.equal("apiKey" in configured, false);
+    assert.equal(
+      (await readProviderStatus("account-b", kind, "openai")).isConfigured,
+      false,
+    );
+
+    await removeProviderKey("account-a", kind, "openai");
+    assert.equal(
+      (await readProviderStatus("account-a", kind, "openai")).isConfigured,
+      false,
+    );
+  }
+});
+
+test("provider availability rejects invalid saved keys and incomplete custom connections", async () => {
+  for (const kind of ["stt", "llm"]) {
+    for (const value of ["", "  ", "bad\nkey", "x".repeat(8193)]) {
+      fixture.keys.set(providerStorageKey("account-a", kind, "openai"), {
+        value,
+      });
+      assert.equal(
+        (await readProviderStatus("account-a", kind, "openai")).isConfigured,
+        false,
+      );
+    }
+    fixture.keys.set(providerStorageKey("account-a", kind, "custom"), {
+      value: "synthetic-key",
+    });
+    assert.equal(
+      (await readProviderStatus("account-a", kind, "custom")).isConfigured,
+      false,
+    );
+    await saveProviderConnection("account-a", kind, {
+      provider: "custom",
+      baseUrl: "https://custom.test/v1",
+    });
+    assert.equal(
+      (await readProviderStatus("account-a", kind, "custom")).isConfigured,
+      true,
+    );
+  }
 });
 
 test("preference writes work offline and sync only supported preferences to the bound workspace", async () => {


### PR DESCRIPTION
Filter transcription and summary options using saved keys and valid connections, keep setup accordions available, and clear stale visible selections after key removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which providers users can select and how stale selections display after key removal; logic touches local credential validation for STT/LLM settings but not runtime API calls directly.
> 
> **Overview**
> Mobile transcription and summary settings now **limit the active provider picker** to Anarlog plus providers that pass on-device validation (saved API key and complete connection), while the **Configure providers** section still lists every option for setup.
> 
> A new **`readProviderStatus`** helper drives that logic: it loads setup and key together, sets `isConfigured` from key/connection validators (Anarlog is always eligible), and never exposes the raw key. The form uses it for setup queries, builds `providerOptions` from `isConfigured`, and passes an empty **`visibleProvider`** when the saved active provider is no longer configured—showing **“Select provider”** / a prompt to pick a configured provider instead of a stale name. The **Active** label on a row only applies when that provider is both selected and configured.
> 
> **`ProviderPicker`** now takes a `providers` list instead of `kind`, with placeholder copy when nothing is selected (iOS/Android/web). Runtime tests cover configured vs invalid keys, account scoping, and incomplete custom URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae02dfdb8650dd0e50adc08e2df7a8533cc7531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->