### PR TITLE
Present note actions in a native iOS glass sheet

### DIFF
--- a/apps/mobile/src/components/note-actions-sheet.ios.tsx
+++ b/apps/mobile/src/components/note-actions-sheet.ios.tsx
@@ -1,0 +1,150 @@
+import { Host } from "@expo/ui";
+import {
+  BottomSheet,
+  Button,
+  Divider,
+  HStack,
+  Image,
+  Text,
+  VStack,
+} from "@expo/ui/swift-ui";
+import {
+  buttonStyle,
+  contentShape,
+  font,
+  foregroundStyle,
+  frame,
+  padding,
+  presentationDragIndicator,
+  shapes,
+} from "@expo/ui/swift-ui/modifiers";
+import { useRef } from "react";
+
+import { Spacing } from "@/constants/theme";
+import { useAppColorScheme, useColors } from "@/settings/theme-provider";
+
+import type { NoteActionsSheetProps } from "./note-actions-sheet";
+
+export function NoteActionsSheet({
+  hasRecordingHistory,
+  listening,
+  onClose,
+  onDelete,
+  onExport,
+  onImportRecording,
+  onToggleListening,
+  visible,
+}: NoteActionsSheetProps) {
+  const Colors = useColors();
+  const colorScheme = useAppColorScheme();
+  const pendingAction = useRef<(() => void) | null>(null);
+  const actions = [
+    { label: "Export", icon: "square.and.arrow.up", onPress: onExport },
+    ...(!listening && !hasRecordingHistory
+      ? [
+          {
+            label: "Import recording",
+            icon: "icloud.and.arrow.up" as const,
+            onPress: onImportRecording,
+          },
+        ]
+      : []),
+    ...(listening || !hasRecordingHistory
+      ? [
+          {
+            label: listening ? "Stop listening" : "Start listening",
+            icon: listening ? ("mic.slash" as const) : ("mic" as const),
+            onPress: onToggleListening,
+          },
+        ]
+      : []),
+    { label: "Delete", icon: "trash", onPress: onDelete, destructive: true },
+  ] as const;
+
+  return (
+    <Host
+      style={{ position: "absolute" }}
+      pointerEvents="none"
+      colorScheme={colorScheme}
+    >
+      <BottomSheet
+        isPresented={visible}
+        fitToContents
+        onIsPresentedChange={(presented) => {
+          if (!presented) onClose();
+        }}
+        onDismiss={() => {
+          // Native share and document pickers need the presenting sheet fully dismissed.
+          const action = pendingAction.current;
+          pendingAction.current = null;
+          action?.();
+        }}
+      >
+        <VStack
+          spacing={0}
+          modifiers={[
+            frame({ maxWidth: Infinity }),
+            padding({
+              horizontal: Spacing.md,
+              top: Spacing.lg,
+              bottom: Spacing.sm,
+            }),
+            presentationDragIndicator("visible"),
+          ]}
+        >
+          {actions.map((action) => {
+            const destructive = "destructive" in action;
+            return (
+              <VStack key={action.label} spacing={0}>
+                {destructive && (
+                  <Divider modifiers={[padding({ vertical: Spacing.xs })]} />
+                )}
+                <Button
+                  role={destructive ? "destructive" : "default"}
+                  modifiers={[buttonStyle("plain")]}
+                  onPress={() => {
+                    if (pendingAction.current) return;
+                    pendingAction.current = action.onPress;
+                    onClose();
+                  }}
+                >
+                  <HStack
+                    spacing={Spacing.md}
+                    modifiers={[
+                      padding({ horizontal: Spacing.md, vertical: Spacing.sm }),
+                      frame({
+                        minHeight: 52,
+                        maxWidth: Infinity,
+                        alignment: "leading",
+                      }),
+                      contentShape(shapes.rectangle()),
+                      foregroundStyle(
+                        destructive ? Colors.destructive : Colors.ink,
+                      ),
+                    ]}
+                  >
+                    <Image
+                      systemName={action.icon}
+                      size={20}
+                      modifiers={[frame({ width: 24 })]}
+                    />
+                    <Text
+                      modifiers={[
+                        font({
+                          textStyle: "callout",
+                          weight: "semibold",
+                        }),
+                      ]}
+                    >
+                      {action.label}
+                    </Text>
+                  </HStack>
+                </Button>
+              </VStack>
+            );
+          })}
+        </VStack>
+      </BottomSheet>
+    </Host>
+  );
+}

--- a/apps/mobile/src/components/note-actions-sheet.tsx
+++ b/apps/mobile/src/components/note-actions-sheet.tsx
@@ -5,6 +5,17 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CornerCurve, Radius, Spacing, Typography } from "@/constants/theme";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
 
+export type NoteActionsSheetProps = {
+  hasRecordingHistory: boolean;
+  listening: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  onExport: () => void;
+  onImportRecording: () => void;
+  onToggleListening: () => void;
+  visible: boolean;
+};
+
 export function NoteActionsSheet({
   hasRecordingHistory,
   listening,
@@ -14,16 +25,7 @@ export function NoteActionsSheet({
   onImportRecording,
   onToggleListening,
   visible,
-}: {
-  hasRecordingHistory: boolean;
-  listening: boolean;
-  onClose: () => void;
-  onDelete: () => void;
-  onExport: () => void;
-  onImportRecording: () => void;
-  onToggleListening: () => void;
-  visible: boolean;
-}) {
+}: NoteActionsSheetProps) {
   const styles = useStyles();
   const Colors = useColors();
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
Replace the custom iOS modal with a SwiftUI sheet and native action rows. Wait for dismissal before opening sharing, file import, or delete confirmation.

Validated with the mobile typecheck, 315 mobile tests, formatting, and simulator checks for outside-tap dismissal, Export, Import, and canceled deletion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only platform split for note actions on iOS; behavior is intentionally aligned with dismissal timing for native pickers.
> 
> **Overview**
> On **iOS**, note actions (Export, Import, listening toggle, Delete) now use an **Expo UI SwiftUI `BottomSheet`** with system SF Symbol rows and theme-aware styling, instead of the React Native `Modal` bottom sheet.
> 
> Action taps **close the sheet first** and run the handler in **`onDismiss`**, so share sheets, document import, and delete confirmation only open after the presenting sheet is fully gone. The shared **`NoteActionsSheetProps`** type is exported from the default module for the `.ios` implementation; **Android and other platforms** keep the existing modal UI and `requestAnimationFrame` deferral.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d31f37aa166c10e7333527e86be42e414c138f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->