### PR TITLE
Keep the listening button at a consistent height

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -262,7 +262,6 @@ export default function HomeScreen() {
           }
         >
           <StartListeningButton
-            bottomSpacing={Spacing.xs}
             onPress={() => void createAndOpen("?listen=1")}
           />
         </Animated.View>

--- a/apps/mobile/src/components/start-listening-button.tsx
+++ b/apps/mobile/src/components/start-listening-button.tsx
@@ -9,23 +9,13 @@ import {
 } from "@/constants/theme";
 import { createStyleHook } from "@/settings/theme-provider";
 
-export function StartListeningButton({
-  bottomSpacing = Spacing.md,
-  onPress,
-}: {
-  bottomSpacing?: number;
-  onPress: () => void;
-}) {
+export function StartListeningButton({ onPress }: { onPress: () => void }) {
   const styles = useStyles();
   return (
     <Pressable
       accessibilityRole="button"
       onPress={onPress}
-      style={({ pressed }) => [
-        styles.button,
-        { marginBottom: bottomSpacing },
-        pressed && styles.buttonPressed,
-      ]}
+      style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
     >
       <View style={styles.dot} />
       <Text style={styles.label}>Start listening</Text>
@@ -41,6 +31,7 @@ const useStyles = createStyleHook((Colors) => ({
     justifyContent: "center",
     gap: Spacing.sm,
     marginHorizontal: Spacing.md,
+    marginBottom: Spacing.xs,
     borderRadius: LISTENING_CONTROL_RADIUS,
     borderCurve: CornerCurve.squircle,
     backgroundColor: Colors.primary,


### PR DESCRIPTION
Use the same bottom margin on the home and empty note screens so opening a note does not move the Start listening button upward.

Validated with the mobile typecheck, 315 tests, formatting, and a simulator comparison of both screens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only spacing change on a shared button component with no logic or data impact.
> 
> **Overview**
> **Start listening** no longer jumps when navigating between the home timeline and an empty note screen.
> 
> `StartListeningButton` drops the optional `bottomSpacing` prop and always applies `marginBottom: Spacing.xs` in its styles. The home screen stops overriding spacing with a prop, so it matches the note screen (which previously relied on the old default `Spacing.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4302cd5dde0a38470818ecf12c108d58a36a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->