### PR TITLE
Hide empty mobile settings details

### DIFF
--- a/apps/mobile/src/app/settings/transcription.tsx
+++ b/apps/mobile/src/app/settings/transcription.tsx
@@ -49,13 +49,17 @@ export default function TranscriptionSettings() {
             preferences.spoken_languages
               .filter((code) => code !== preferences.ai_language)
               .map(languageName)
-              .join(", ") || "None"
+              .join(", ") || undefined
           }
           onPress={() => router.push("/settings/languages")}
         />
         <SettingsRow
           title="Dictionary"
-          value={`${preferences.personalization_dictionary_terms.length} terms`}
+          value={
+            preferences.personalization_dictionary_terms.length > 0
+              ? `${preferences.personalization_dictionary_terms.length} terms`
+              : undefined
+          }
           onPress={() => router.push("/settings/dictionary")}
         />
         <FieldGroup.SectionFooter>


### PR DESCRIPTION
Omit the None and 0 terms subtitles from transcription settings while retaining populated language and dictionary summaries.

Validated with the mobile typecheck, 315 tests, formatting, and simulator review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes on the transcription settings screen with no API or preference logic changes.
> 
> **Overview**
> **Transcription settings** no longer shows placeholder detail text when there is nothing to summarize.
> 
> On **Additional spoken languages**, the row subtitle is omitted when there are no extra languages (instead of **None**). On **Dictionary**, the **N terms** subtitle appears only when the dictionary has at least one term (instead of **0 terms**). Both rows pass `undefined` to `SettingsRow` so the chevron-only layout stays clean when empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735f12c27c881070885d95eea85e0cd8724a9b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->