### PR TITLE
Verify provider credentials before saving and selecting

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -19,6 +19,7 @@ on:
       - packages/mobile-bridge-rn/**
       - packages/db-react/**
       - packages/db-runtime/**
+      - packages/provider-validation/**
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
@@ -36,6 +37,7 @@ on:
       - packages/mobile-bridge-rn/**
       - packages/db-react/**
       - packages/db-runtime/**
+      - packages/provider-validation/**
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
@@ -63,6 +65,8 @@ jobs:
       - uses: ./.github/actions/pnpm_install
       - run: pnpm -F @anlg/mobile typecheck
       - run: pnpm -F @anlg/mobile test
+      - run: pnpm -F @anlg/provider-validation typecheck
+      - run: pnpm -F @anlg/provider-validation test
 
   watchos_build:
     if: ${{ github.event_name != 'pull_request' }}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@anlg/provider-validation": "workspace:*",
     "@ai-sdk/anthropic": "^3.0.69",
     "@ai-sdk/azure": "^3.0.53",
     "@ai-sdk/google": "^3.0.62",

--- a/apps/desktop/src/settings/ai/llm/select.test.ts
+++ b/apps/desktop/src/settings/ai/llm/select.test.ts
@@ -73,10 +73,11 @@ describe("getLlmProviderStatus", () => {
     expect(status.listModels).toBeUndefined();
   });
 
-  test("configures API-key providers when a key is saved", () => {
+  test("configures API-key providers only after their saved key is verified", () => {
     const status = getLlmProviderStatus({
       provider: provider("openai"),
       config: { api_key: "sk-test" },
+      isAvailable: true,
       isAuthenticated: false,
       isPaid: false,
     });
@@ -84,6 +85,21 @@ describe("getLlmProviderStatus", () => {
     expect(status.configured).toBe(true);
     expect(status.listModels).toBeTypeOf("function");
   });
+
+  test.each([undefined, false])(
+    "does not expose a saved but unverified key (%s)",
+    (isAvailable) => {
+      const status = getLlmProviderStatus({
+        provider: provider("openai"),
+        config: { api_key: "nonempty-invalid-key" },
+        isAuthenticated: false,
+        isPaid: false,
+        isAvailable,
+      });
+      expect(status.configured).toBe(false);
+      expect(status.listModels).toBeUndefined();
+    },
+  );
 
   test.each(["claude", "chatgpt", "grok", "github_copilot", "kimi_code"])(
     "treats %s as a subscription provider that needs a saved credential",
@@ -135,6 +151,7 @@ describe("getLlmProviderStatus", () => {
     const status = getLlmProviderStatus({
       provider: definition,
       config: { api_key: "test-key" },
+      isAvailable: true,
       isAuthenticated: false,
       isPaid: false,
     });
@@ -151,6 +168,7 @@ describe("getLlmProviderStatus", () => {
       const missingEndpoint = getLlmProviderStatus({
         provider: definition,
         config: { api_key: "test-key" },
+        isAvailable: true,
         isAuthenticated: false,
         isPaid: false,
       });
@@ -160,6 +178,7 @@ describe("getLlmProviderStatus", () => {
           base_url: "https://provider.example.com/v1",
           api_key: "test-key",
         },
+        isAvailable: true,
         isAuthenticated: false,
         isPaid: false,
       });
@@ -178,6 +197,7 @@ describe("getLlmProviderStatus", () => {
           "https://aiplatform.googleapis.com/v1/projects/project/locations/global/endpoints/openapi",
         api_key: "test-key",
       },
+      isAvailable: true,
       isAuthenticated: false,
       isPaid: false,
     });

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -34,6 +34,7 @@ import { useBillingAccess } from "~/auth/billing-context";
 import {
   providerRowId,
   ProviderIconSlot,
+  requiresKeyVerification,
   useProviderAvailability,
 } from "~/settings/ai/shared";
 import {
@@ -539,7 +540,7 @@ export function getLlmProviderStatus({
     return { configured: false };
   }
 
-  if (provider.checkAvailability) {
+  if (provider.checkAvailability || requiresKeyVerification(provider)) {
     if (isAvailable === undefined) {
       return { configured: false, availabilityPending: true };
     }
@@ -657,7 +658,9 @@ function useConfiguredMapping(): {
         // silently re-persist the selection to another provider.
         const isAvailable = provider.checkAvailability
           ? provider.id === current_llm_provider || availability[provider.id]
-          : undefined;
+          : requiresKeyVerification(provider)
+            ? availability[provider.id]
+            : undefined;
         return [
           provider.id,
           getLlmProviderStatus({

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -1,10 +1,15 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { type AnyFieldApi, useForm } from "@tanstack/react-form";
 import { useMutation, useQueries } from "@tanstack/react-query";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { type ComponentType, type ReactNode, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
 
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
+import {
+  providerCredentialIdentity,
+  verifyProviderCredentials,
+} from "@anlg/provider-validation";
 import type { AIProvider } from "@anlg/store";
 import { aiProviderSchema } from "@anlg/store";
 import {
@@ -191,6 +196,19 @@ export function providerRowId(providerType: ProviderType, providerId: string) {
   return `${providerType}:${providerId}`;
 }
 
+export function requiresKeyVerification(
+  provider: Pick<
+    ProviderConfig,
+    "requirements" | "authKind" | "checkAvailability"
+  >,
+) {
+  return (
+    provider.authKind !== "subscription" &&
+    !provider.checkAvailability &&
+    getRequiredConfigFields(provider.requirements).includes("api_key")
+  );
+}
+
 export function useProviderAvailability(
   providerType: ProviderType,
   providers: readonly ProviderConfig[],
@@ -199,7 +217,10 @@ export function useProviderAvailability(
   const configuredProviders = useAiProviders(providerType);
 
   const inputs = providers
-    .filter((provider) => provider.checkAvailability)
+    .filter(
+      (provider) =>
+        provider.checkAvailability || requiresKeyVerification(provider),
+    )
     .map((provider) => {
       const config =
         configuredProviders[providerRowId(providerType, provider.id)];
@@ -222,12 +243,23 @@ export function useProviderAvailability(
         providerType,
         provider.id,
         baseUrl,
-        apiKey,
+        providerCredentialIdentity({ provider: provider.id, baseUrl, apiKey }),
       ],
-      queryFn: () => provider.checkAvailability?.(baseUrl, apiKey) ?? false,
+      queryFn: async ({ signal }: { signal: AbortSignal }) => {
+        if (provider.checkAvailability)
+          return provider.checkAvailability(baseUrl, apiKey);
+        await verifyProviderCredentials(
+          { provider: provider.id, baseUrl, apiKey },
+          tauriFetch,
+          signal,
+        );
+        return true;
+      },
       enabled: isConfigured,
       retry: false,
-      refetchInterval: 5_000,
+      staleTime: provider.checkAvailability ? 0 : 5 * 60_000,
+      gcTime: 0,
+      refetchInterval: provider.checkAvailability ? 5_000 : (false as const),
     })),
   });
 
@@ -261,7 +293,10 @@ export function useIsProviderReady(
   const availability = useProviderAvailability(providerType, providers);
   const providerDef = providers.find((p) => p.id === providerId);
 
-  if (providerDef?.checkAvailability) {
+  if (
+    providerDef &&
+    (providerDef.checkAvailability || requiresKeyVerification(providerDef))
+  ) {
     return availability[providerId];
   }
 
@@ -302,7 +337,7 @@ export function NonAnarlogProviderCard({
   const billing = useBillingAccess();
   const [provider, providerMutation, providerStateReady] = useProvider(
     providerType,
-    config.id,
+    config,
   );
   const clearProvider = useClearAiProvider(providerType, config.id);
   const clearSubscription = useClearAiProvider(
@@ -373,6 +408,7 @@ export function NonAnarlogProviderCard({
         api_key: "",
       } satisfies AIProvider),
     listeners: {
+      onChangeDebounceMs: 500,
       onChange: ({ formApi }) => {
         providerMutation.reset();
         queueMicrotask(() => {
@@ -782,10 +818,14 @@ export function StyledStreamdown({
   );
 }
 
-function useProvider(providerType: ProviderType, id: string) {
+function useProvider(providerType: ProviderType, config: ProviderConfig) {
   const { providers, isReady } = useAiProvidersState(providerType);
-  const providerRow = providers[providerRowId(providerType, id)];
-  const providerMutation = useSetAiProvider(providerType, id);
+  const providerRow = providers[providerRowId(providerType, config.id)];
+  const providerMutation = useSetAiProvider(
+    providerType,
+    config.id,
+    requiresKeyVerification(config),
+  );
 
   const { data } = aiProviderSchema.safeParse(providerRow);
   return [data, providerMutation, isReady] as const;

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -7,6 +7,7 @@ import { Streamdown } from "streamdown";
 
 import { commands as analyticsCommands } from "@anlg/plugin-analytics";
 import {
+  ProviderCredentialError,
   providerCredentialIdentity,
   verifyProviderCredentials,
 } from "@anlg/provider-validation";
@@ -248,11 +249,17 @@ export function useProviderAvailability(
       queryFn: async ({ signal }: { signal: AbortSignal }) => {
         if (provider.checkAvailability)
           return provider.checkAvailability(baseUrl, apiKey);
-        await verifyProviderCredentials(
-          { provider: provider.id, baseUrl, apiKey },
-          tauriFetch,
-          signal,
-        );
+        try {
+          await verifyProviderCredentials(
+            { provider: provider.id, baseUrl, apiKey },
+            tauriFetch,
+            signal,
+          );
+        } catch (error) {
+          if (error instanceof ProviderCredentialError && !error.retryable)
+            return false;
+          throw error;
+        }
         return true;
       },
       enabled: isConfigured,
@@ -265,14 +272,7 @@ export function useProviderAvailability(
 
   const entries = inputs.map(
     ({ provider, isConfigured }, index) =>
-      [
-        provider.id,
-        !isConfigured
-          ? false
-          : queries[index]?.isPending
-            ? undefined
-            : queries[index]?.data === true,
-      ] as const,
+      [provider.id, !isConfigured ? false : queries[index]?.data] as const,
   );
 
   // Callers put this record in memo dependency lists, so its identity has to
@@ -821,11 +821,10 @@ export function StyledStreamdown({
 function useProvider(providerType: ProviderType, config: ProviderConfig) {
   const { providers, isReady } = useAiProvidersState(providerType);
   const providerRow = providers[providerRowId(providerType, config.id)];
-  const providerMutation = useSetAiProvider(
-    providerType,
-    config.id,
-    requiresKeyVerification(config),
-  );
+  const providerMutation = useSetAiProvider(providerType, config.id, {
+    verifyCredentials: requiresKeyVerification(config),
+    defaultBaseUrl: config.baseUrl,
+  });
 
   const { data } = aiProviderSchema.safeParse(providerRow);
   return [data, providerMutation, isReady] as const;

--- a/apps/desktop/src/settings/ai/shared/provider-availability.test.tsx
+++ b/apps/desktop/src/settings/ai/shared/provider-availability.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ fetch: vi.fn(), key: 0 }));
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: mocks.fetch }));
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => ({ isPaid: true }),
+}));
+vi.mock("~/settings/providers", () => ({
+  useAiProviders: (type: string) => ({
+    [`${type}:openai`]: { api_key: `saved-key-${mocks.key}`, base_url: "" },
+  }),
+}));
+
+import { useProviderAvailability } from "./index";
+
+beforeEach(() => {
+  mocks.fetch.mockReset();
+  mocks.key++;
+});
+afterEach(cleanup);
+
+function setup(type: "stt" | "llm") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const hook = renderHook(
+    () =>
+      useProviderAvailability(type, [
+        {
+          id: "openai",
+          displayName: "OpenAI",
+          icon: null,
+          baseUrl: "https://api.openai.com/v1",
+          requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+        },
+      ]),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    },
+  );
+  return { ...hook, client };
+}
+
+test.each(["stt", "llm"] as const)(
+  "keeps %s availability unknown after a network failure and recovers on retry",
+  async (type) => {
+    mocks.fetch.mockRejectedValue(new Error("offline"));
+    const { result, client, unmount } = setup(type);
+    await waitFor(() =>
+      expect(client.getQueryCache().getAll()[0]?.state.status).toBe("error"),
+    );
+    expect(result.current.openai).toBeUndefined();
+
+    mocks.fetch.mockResolvedValue(Response.json({ data: [] }));
+    await act(() => client.refetchQueries());
+    await waitFor(() => expect(result.current.openai).toBe(true));
+    unmount();
+    client.clear();
+  },
+);
+
+test.each([401, 403, 429, 500])(
+  "distinguishes rejected credentials from inconclusive HTTP %i responses",
+  async (status) => {
+    mocks.fetch.mockResolvedValue(new Response(null, { status }));
+    const { result, client, unmount } = setup("stt");
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    if (status === 401 || status === 403) {
+      await waitFor(() => expect(result.current.openai).toBe(false));
+    } else {
+      expect(result.current.openai).toBeUndefined();
+    }
+    unmount();
+    client.clear();
+  },
+);

--- a/apps/desktop/src/settings/ai/shared/provider-availability.test.tsx
+++ b/apps/desktop/src/settings/ai/shared/provider-availability.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ fetch: vi.fn(), key: 0 }));
+const mocks = vi.hoisted(() => ({ fetch: vi.fn(), key: 0, baseUrl: "" }));
 
 vi.mock("@tauri-apps/plugin-http", () => ({ fetch: mocks.fetch }));
 vi.mock("~/auth/billing-context", () => ({
@@ -11,7 +11,10 @@ vi.mock("~/auth/billing-context", () => ({
 }));
 vi.mock("~/settings/providers", () => ({
   useAiProviders: (type: string) => ({
-    [`${type}:openai`]: { api_key: `saved-key-${mocks.key}`, base_url: "" },
+    [`${type}:openai`]: {
+      api_key: `saved-key-${mocks.key}`,
+      base_url: mocks.baseUrl,
+    },
   }),
 }));
 
@@ -20,8 +23,25 @@ import { useProviderAvailability } from "./index";
 beforeEach(() => {
   mocks.fetch.mockReset();
   mocks.key++;
+  mocks.baseUrl = "";
 });
 afterEach(cleanup);
+
+test.each([
+  "http://192.168.1.10/v1",
+  "https://provider.test/v1?key=invalid",
+  "not-a-url",
+])(
+  "invalid saved endpoint %s settles availability without a request",
+  async (baseUrl) => {
+    mocks.baseUrl = baseUrl;
+    const { result, client, unmount } = setup("stt");
+    await waitFor(() => expect(result.current.openai).toBe(false));
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    unmount();
+    client.clear();
+  },
+);
 
 function setup(type: "stt" | "llm") {
   const client = new QueryClient({

--- a/apps/desktop/src/settings/ai/stt/select.test.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+
+const { useProviderAvailabilityMock } = vi.hoisted(() => ({
+  useProviderAvailabilityMock: vi.fn(),
+}));
+
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => ({ isPaid: true }),
+}));
+
+vi.mock("~/settings/ai/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/settings/ai/shared")>()),
+  useProviderAvailability: useProviderAvailabilityMock,
+}));
+
+vi.mock("~/settings/providers", () => ({
+  useAiProvidersState: () => ({
+    isReady: true,
+    providers: { "stt:deepgram": { api_key: "saved-key" } },
+  }),
+}));
+
+vi.mock("~/shared/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/shared/config")>()),
+  useConfigValues: () => ({ local_stt_model_path: "" }),
+}));
+
+import { useConfiguredMapping } from "./select";
+
+afterEach(cleanup);
+
+test.each([true, false])(
+  "waits for saved transcription credentials before enabling selection repair (%s)",
+  (verified) => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData(["device-info"], { totalMemoryBytes: 16e9 });
+    client.setQueryData(["list-supported-models"], []);
+    useProviderAvailabilityMock.mockReturnValue({ deepgram: undefined });
+
+    const { result, rerender } = renderHook(useConfiguredMapping, {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    });
+
+    expect(result.current.providers.anarlog.configured).toBe(true);
+    expect(result.current.providers.deepgram.configured).toBe(false);
+    expect(result.current.isReady).toBe(false);
+
+    useProviderAvailabilityMock.mockReturnValue({ deepgram: verified });
+    rerender();
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.providers.deepgram.configured).toBe(verified);
+  },
+);

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -61,7 +61,12 @@ import {
 
 import { useBillingAccess } from "~/auth/billing-context";
 import { useNotifications } from "~/contexts/notifications";
-import { providerRowId, ProviderIconSlot } from "~/settings/ai/shared";
+import {
+  providerRowId,
+  ProviderIconSlot,
+  requiresKeyVerification,
+  useProviderAvailability,
+} from "~/settings/ai/shared";
 import {
   getProviderSelectionBlockers,
   requiresEntitlement,
@@ -630,6 +635,7 @@ function useConfiguredMapping(): {
   isReady: boolean;
 } {
   const billing = useBillingAccess();
+  const availability = useProviderAvailability("stt", PROVIDERS);
   const { providers: configuredProviders, isReady } =
     useAiProvidersState("stt");
   const { local_stt_model_path } = useConfigValues([
@@ -686,7 +692,11 @@ function useConfiguredMapping(): {
           config: { base_url: baseUrl, api_key: apiKey },
         }).length === 0;
 
-      if (!eligible) {
+      if (
+        !eligible ||
+        (requiresKeyVerification(provider) &&
+          availability[provider.id] !== true)
+      ) {
         return [provider.id, { configured: false, models: [] }];
       }
 

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -624,7 +624,7 @@ function getModelCategoryLabel(category?: ModelCategory) {
   return null;
 }
 
-function useConfiguredMapping(): {
+export function useConfiguredMapping(): {
   providers: Record<
     ProviderId,
     {
@@ -784,7 +784,11 @@ function useConfiguredMapping(): {
 
   return {
     providers,
-    isReady: isReady && supportedModels.isFetched && deviceInfo.isFetched,
+    isReady:
+      isReady &&
+      supportedModels.isFetched &&
+      deviceInfo.isFetched &&
+      Object.values(availability).every((value) => value !== undefined),
   };
 }
 

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -84,7 +84,7 @@ describe("SQLite AI providers", () => {
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
     const { result } = renderHook(
-      () => useSetAiProvider("llm", "openai", true),
+      () => useSetAiProvider("llm", "openai", { verifyCredentials: true }),
       { wrapper },
     );
     const draft = { base_url: "https://api.openai.com/v1", api_key: "invalid" };
@@ -116,6 +116,57 @@ describe("SQLite AI providers", () => {
     expect(mocks.setSecret).toHaveBeenCalled();
     queryClient.clear();
   });
+
+  it.each([
+    { stored: "", draft: undefined, expected: "https://api.openai.com/v1" },
+    { stored: "", draft: "  ", expected: "https://api.openai.com/v1" },
+    {
+      stored: "https://custom.test/v1",
+      draft: undefined,
+      expected: "https://custom.test/v1",
+    },
+    {
+      stored: "",
+      draft: "https://new.test/v1",
+      expected: "https://new.test/v1",
+    },
+  ])(
+    "verifies and stores the resolved provider URL: $expected",
+    async ({ stored, draft, expected }) => {
+      mocks.execute.mockResolvedValue([
+        {
+          id: "ai_provider:llm:openai",
+          value_json: JSON.stringify({
+            type: "llm",
+            base_url: stored,
+            api_key: "",
+          }),
+        },
+      ]);
+      const queryClient = new QueryClient();
+      const wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children);
+      const { result } = renderHook(
+        () =>
+          useSetAiProvider("llm", "openai", {
+            verifyCredentials: true,
+            defaultBaseUrl: "https://api.openai.com/v1",
+          }),
+        { wrapper },
+      );
+      await result.current.mutateAsync({ api_key: "working", base_url: draft });
+      expect(mocks.verify).toHaveBeenCalledWith(
+        { provider: "openai", baseUrl: expected, apiKey: "working" },
+        expect.any(Function),
+      );
+      const persisted = mocks.executeTransaction.mock.calls[0][0][0].params[0];
+      expect(JSON.parse(String(persisted))).toMatchObject({
+        base_url: expected,
+        api_key: "",
+      });
+      queryClient.clear();
+    },
+  );
 
   it("waits for secure provider keys before reporting provider state as ready", async () => {
     let resolveSecret!: (value: { status: "ok"; data: string | null }) => void;

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   execute: vi.fn(),
+  verify: vi.fn(async () => {}),
   useLiveQuery: vi.fn(),
   getSecret: vi.fn(async () => ({
     status: "ok",
@@ -21,6 +22,10 @@ const mocks = vi.hoisted(() => ({
     (_statements: Array<{ sql: string; params: unknown[] }>) =>
       Promise.resolve([1]),
   ),
+}));
+
+vi.mock("@anlg/provider-validation", () => ({
+  verifyProviderCredentials: mocks.verify,
 }));
 
 vi.mock("@anlg/plugin-store2", () => ({
@@ -53,11 +58,13 @@ import {
   repairKeychainAccess,
   setAiProvider,
   useAiProvidersState,
+  useSetAiProvider,
 } from "./providers";
 
 describe("SQLite AI providers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.verify.mockResolvedValue(undefined);
     mocks.executeTransaction.mockResolvedValue([1]);
     mocks.getSecret.mockResolvedValue({ status: "ok", data: null });
     mocks.setSecret.mockResolvedValue({ status: "ok", data: null });
@@ -67,6 +74,47 @@ describe("SQLite AI providers", () => {
       data: null,
     });
     mocks.useLiveQuery.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it("verifies API credentials before writing the keychain or provider settings", async () => {
+    mocks.execute.mockResolvedValue([]);
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(
+      () => useSetAiProvider("llm", "openai", true),
+      { wrapper },
+    );
+    const draft = { base_url: "https://api.openai.com/v1", api_key: "invalid" };
+    mocks.verify.mockRejectedValueOnce(
+      Error("The provider rejected this key."),
+    );
+    await expect(result.current.mutateAsync(draft)).rejects.toThrow("rejected");
+    expect(mocks.setSecret).not.toHaveBeenCalled();
+    expect(mocks.executeTransaction).not.toHaveBeenCalled();
+    await result.current.mutateAsync({ ...draft, api_key: "working" });
+    expect(mocks.setSecret).toHaveBeenCalled();
+    expect(mocks.executeTransaction).toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it("preserves subscription credentials without an API-key probe", async () => {
+    mocks.execute.mockResolvedValue([]);
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useSetAiProvider("llm", "claude"), {
+      wrapper,
+    });
+    await result.current.mutateAsync({
+      base_url: "https://api.anthropic.com",
+      api_key: "oauth-credential",
+    });
+    expect(mocks.verify).not.toHaveBeenCalled();
+    expect(mocks.setSecret).toHaveBeenCalled();
+    queryClient.clear();
   });
 
   it("waits for secure provider keys before reporting provider state as ready", async () => {

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { useMemo } from "react";
 
 import { commands as store2Commands } from "@anlg/plugin-store2";
+import { verifyProviderCredentials } from "@anlg/provider-validation";
 
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
@@ -196,14 +198,35 @@ export function setAiProvider(
   });
 }
 
-export function useSetAiProvider(type: AiProviderType, providerId: string) {
+export function useSetAiProvider(
+  type: AiProviderType,
+  providerId: string,
+  verifyCredentials = false,
+) {
   const queryClient = useQueryClient();
 
   return useMutation({
+    gcTime: 0,
+    scope: { id: `ai-provider:${type}:${providerId}` },
     mutationKey: ["set-ai-provider", type, providerId],
-    mutationFn: (
+    mutationFn: async (
       changes: Partial<Pick<AiProviderConfig, "base_url" | "api_key">>,
-    ) => setAiProvider(type, providerId, changes),
+    ) => {
+      if (verifyCredentials) {
+        const previous = await getStoredAiProvider(type, providerId);
+        const apiKey = (changes.api_key ?? previous?.api_key ?? "").trim();
+        await verifyProviderCredentials(
+          {
+            provider: providerId,
+            baseUrl: changes.base_url ?? previous?.base_url ?? "",
+            apiKey,
+          },
+          tauriFetch,
+        );
+        changes = { ...changes, api_key: apiKey };
+      }
+      await setAiProvider(type, providerId, changes);
+    },
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -201,7 +201,10 @@ export function setAiProvider(
 export function useSetAiProvider(
   type: AiProviderType,
   providerId: string,
-  verifyCredentials = false,
+  {
+    verifyCredentials = false,
+    defaultBaseUrl = "",
+  }: { verifyCredentials?: boolean; defaultBaseUrl?: string } = {},
 ) {
   const queryClient = useQueryClient();
 
@@ -215,15 +218,18 @@ export function useSetAiProvider(
       if (verifyCredentials) {
         const previous = await getStoredAiProvider(type, providerId);
         const apiKey = (changes.api_key ?? previous?.api_key ?? "").trim();
+        const baseUrl =
+          (changes.base_url ?? previous?.base_url ?? "").trim() ||
+          defaultBaseUrl.trim();
         await verifyProviderCredentials(
           {
             provider: providerId,
-            baseUrl: changes.base_url ?? previous?.base_url ?? "",
+            baseUrl,
             apiKey,
           },
           tauriFetch,
         );
-        changes = { ...changes, api_key: apiKey };
+        changes = { ...changes, base_url: baseUrl, api_key: apiKey };
       }
       await setAiProvider(type, providerId, changes);
     },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anlg/provider-validation": "workspace:*",
     "@anlg/db-react": "workspace:*",
     "@anlg/db-runtime": "workspace:*",
     "@anlg/design-system": "workspace:^",

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -82,6 +82,7 @@ function ProviderForm({
   account: string | null;
   config: ProviderConfig;
 }) {
+  const Colors = useColors();
   const auth = useAuth();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -204,7 +205,13 @@ function ProviderForm({
           <Text>Loading…</Text>
         )}
         <FieldGroup.SectionFooter>
-          <Text>
+          <Text
+            textStyle={
+              select.error instanceof Error
+                ? { color: Colors.destructive }
+                : undefined
+            }
+          >
             {select.error instanceof Error
               ? select.error.message
               : selectedProvider === "anarlog"
@@ -261,6 +268,7 @@ function ProviderForm({
                   kind={kind}
                   config={setup.data.config}
                   hasKey={setup.data.hasKey}
+                  verificationError={setup.data.verificationError}
                   open={open}
                   onSaved={() => {
                     if (selectedProviderRef.current === provider.id) {
@@ -290,6 +298,7 @@ function ProviderFields({
   account,
   config,
   hasKey,
+  verificationError,
   open,
   onSaved,
 }: {
@@ -297,6 +306,7 @@ function ProviderFields({
   account: string | null;
   config: ProviderConfig;
   hasKey: boolean;
+  verificationError?: string;
   open: boolean;
   onSaved: () => void;
 }) {
@@ -435,8 +445,23 @@ function ProviderFields({
           />
         </Row>
       )}
+      {save.isPending && <Text>Verifying key…</Text>}
       {(save.error || remove.error) && (
-        <Text>{(save.error || remove.error)?.message}</Text>
+        <Text textStyle={{ color: Colors.destructive }}>
+          {(save.error || remove.error)?.message}
+        </Text>
+      )}
+      {!save.isPending && !save.error && verificationError && (
+        <Row>
+          <Text textStyle={{ color: Colors.destructive }}>
+            {verificationError}
+          </Text>
+          <Button
+            label="Retry"
+            variant="text"
+            onPress={() => save.mutate({ config, apiKey: apiKey.current })}
+          />
+        </Row>
       )}
     </Column>
   );

--- a/apps/mobile/src/settings/providers.ts
+++ b/apps/mobile/src/settings/providers.ts
@@ -1,4 +1,7 @@
 import * as SecureStore from "expo-secure-store";
+import { fetch } from "expo/fetch";
+
+import { verifyProviderCredentials } from "@anlg/provider-validation";
 
 import {
   decodeJwtPayload,
@@ -83,13 +86,19 @@ export async function readProviderStatus(
   ]);
   let hasKey = false;
   let isConfigured = provider === "anarlog";
+  let verificationError: string | undefined;
   try {
     validateProviderApiKey(apiKey ?? "");
     hasKey = true;
     validateProviderConnection(kind, config);
+    await verifyProviderCredentials({ ...config, apiKey: apiKey! }, fetch);
     isConfigured = true;
-  } catch {}
-  return { config, hasKey, isConfigured };
+  } catch (error) {
+    if (hasKey)
+      verificationError =
+        error instanceof Error ? error.message : "Couldn’t verify this key.";
+  }
+  return { config, hasKey, isConfigured, verificationError };
 }
 
 export async function saveProviderConfig(
@@ -145,6 +154,7 @@ async function persistProviderConfig(
         (await readProviderKey(accountId, kind, normalized.provider)) ||
         "",
     );
+    await verifyProviderCredentials({ ...normalized, apiKey: key }, fetch);
     if (apiKey?.trim())
       await SecureStore.setItemAsync(
         providerStorageKey(accountId, kind, normalized.provider),

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -34,6 +34,7 @@ const fixture = (globalThis.mobileSettingsFixture = {
     }),
 });
 const modules = {
+  "@anlg/provider-validation": `export async function verifyProviderCredentials(credential) { return globalThis.mobileSettingsFixture.verify(credential); }`,
   "@anlg/mobile-bridge": `export const ProviderTranscriptionError = Object.fromEntries(["AudioTooLarge", "AudioMissing", "ResponseTooLarge", "InvalidSettings", "TimedOut", "RequestFailed"].map(tag => [tag, {instanceOf: error => error.tag === tag}]));
   export async function transcribeProviderAudio(request, options) {
     const fixture = globalThis.mobileSettingsFixture;
@@ -149,10 +150,57 @@ beforeEach(() => {
   fixture.keys.clear();
   fixture.session = null;
   fixture.requests = [];
+  fixture.verify = async () => {};
   fixture.respond = () =>
     Response.json({
       choices: [{ message: { content: "## Decisions\nShip the mobile app." } }],
     });
+});
+
+test("rejected provider keys never replace working credentials or settings", async () => {
+  for (const kind of ["stt", "llm"]) {
+    const config = defaultProviderConfig(kind, "openai");
+    await saveProviderConnection("account-a", kind, config, "working-key");
+    const before = [...fixture.keys.entries()];
+    fixture.verify = async () => {
+      throw Error("The provider rejected this key.");
+    };
+    await assert.rejects(
+      saveProviderConnection("account-a", kind, config, "invalid-key"),
+      /rejected/,
+    );
+    assert.deepEqual([...fixture.keys.entries()], before);
+    assert.equal(
+      (await readProviderStatus("account-a", kind, "openai")).isConfigured,
+      false,
+    );
+    fixture.verify = async () => {};
+    assert.equal(
+      (await readProviderStatus("account-a", kind, "openai")).isConfigured,
+      true,
+    );
+  }
+});
+
+test("failed verification never creates a provider or exposes it in selection", async () => {
+  fixture.verify = async () => {
+    throw Error("Couldn’t verify this key. Check your connection.");
+  };
+  await assert.rejects(
+    saveProviderConnection(
+      null,
+      "stt",
+      defaultProviderConfig("stt", "deepgram"),
+      "bad-key",
+    ),
+    /Couldn’t verify/,
+  );
+  assert.equal(fixture.keys.size, 0);
+  assert.equal(
+    (await readProviderStatus(null, "stt", "deepgram")).isConfigured,
+    false,
+  );
+  assert.equal((await readProviderConfig(null, "stt")).provider, "anarlog");
 });
 
 test("provider availability follows saved device keys for transcription and summaries", async () => {

--- a/packages/provider-validation/package.json
+++ b/packages/provider-validation/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@anlg/provider-validation",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --test --experimental-strip-types",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "js-sha256": "0.10.1"
+  }
+}

--- a/packages/provider-validation/src/index.test.mjs
+++ b/packages/provider-validation/src/index.test.mjs
@@ -92,6 +92,36 @@ test("a gateway must accept the candidate key and reject the control key", async
   ]);
 });
 
+test("Vertex verifies tokens through the beta publisher catalog, separate from the project inference path", async () => {
+  const requests = [];
+  await verifyProviderCredentials(
+    {
+      ...credential,
+      provider: "google_vertex_ai",
+      baseUrl:
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi",
+    },
+    async (url, init) => {
+      requests.push({ url, authorization: init.headers.Authorization });
+      return requests.length === 1
+        ? Response.json({
+            publisherModels: [{ name: "publishers/google/models/test" }],
+          })
+        : new Response(null, { status: 401 });
+    },
+  );
+  assert.deepEqual(requests, [
+    {
+      url: "https://us-central1-aiplatform.googleapis.com/v1beta1/publishers/google/models?pageSize=1",
+      authorization: "Bearer synthetic-key",
+    },
+    {
+      url: "https://us-central1-aiplatform.googleapis.com/v1beta1/publishers/google/models?pageSize=1",
+      authorization: "Bearer anarlog-invalid-key-verification",
+    },
+  ]);
+});
+
 for (const [provider, path, header, value, payload] of [
   [
     "openrouter",

--- a/packages/provider-validation/src/index.test.mjs
+++ b/packages/provider-validation/src/index.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  ProviderCredentialError,
   verifyProviderCredentials,
   providerCredentialIdentity,
 } from "./index.ts";
@@ -47,6 +48,8 @@ for (const [status, message] of [
       (error) => {
         assert.match(error.message, message);
         assert.ok(!error.message.includes("secret-key-echo"));
+        assert.ok(error instanceof ProviderCredentialError);
+        assert.equal(error.retryable, status !== 401 && status !== 403);
         return true;
       },
     );
@@ -91,6 +94,32 @@ test("a gateway must accept the candidate key and reject the control key", async
     "Bearer anarlog-invalid-key-verification",
   ]);
 });
+
+for (const status of [429, 500, 404]) {
+  test(`an inconclusive control response (${status}) is retryable and never cached as proof`, async () => {
+    let calls = 0;
+    let controlStatus = status;
+    const fetcher = async (_url, init) => {
+      calls++;
+      return init.headers.Authorization === "Bearer synthetic-key"
+        ? Response.json({ data: [] })
+        : new Response(null, { status: controlStatus });
+    };
+    const custom = { ...credential, provider: "custom" };
+    await assert.rejects(
+      verifyProviderCredentials(custom, fetcher),
+      (error) => {
+        assert.ok(error instanceof ProviderCredentialError);
+        assert.equal(error.retryable, true);
+        assert.doesNotMatch(error.message, /doesn’t support/);
+        return true;
+      },
+    );
+    controlStatus = 401;
+    await verifyProviderCredentials(custom, fetcher);
+    assert.equal(calls, 4);
+  });
+}
 
 test("Vertex verifies tokens through the beta publisher catalog, separate from the project inference path", async () => {
   const requests = [];

--- a/packages/provider-validation/src/index.test.mjs
+++ b/packages/provider-validation/src/index.test.mjs
@@ -272,6 +272,7 @@ test("rejects malformed credentials and unsafe endpoints before a request", asyn
   for (const update of [
     { apiKey: "" },
     { apiKey: "a\nb" },
+    { baseUrl: "not-a-url" },
     { baseUrl: "http://remote.test" },
     { baseUrl: "https://u:p@remote.test" },
     { baseUrl: "https://remote.test/?token=test" },
@@ -280,6 +281,11 @@ test("rejects malformed credentials and unsafe endpoints before a request", asyn
       verifyProviderCredentials({ ...credential, ...update }, () =>
         assert.fail("Unexpected network request"),
       ),
+      (error) => {
+        assert.ok(error instanceof ProviderCredentialError);
+        assert.equal(error.retryable, false);
+        return true;
+      },
     );
   }
 });

--- a/packages/provider-validation/src/index.test.mjs
+++ b/packages/provider-validation/src/index.test.mjs
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  verifyProviderCredentials,
+  providerCredentialIdentity,
+} from "./index.ts";
+
+const credential = {
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: "synthetic-key",
+};
+
+test("accepts an authenticated model response, without sending keys in URLs", async () => {
+  const requests = [];
+  await verifyProviderCredentials(credential, async (url, init) => {
+    requests.push({ url, init });
+    return Response.json({ data: [] });
+  });
+  assert.equal(requests[0].url, "https://api.openai.com/v1/models");
+  assert.equal(requests[0].init.headers.Authorization, "Bearer synthetic-key");
+  assert.equal(requests[0].init.redirect, "error");
+  assert.equal(requests.length, 1);
+  assert.ok(
+    !providerCredentialIdentity(credential).includes(credential.apiKey),
+  );
+  assert.notEqual(
+    providerCredentialIdentity(credential),
+    providerCredentialIdentity({ ...credential, apiKey: "other" }),
+  );
+});
+
+for (const [status, message] of [
+  [401, /rejected/],
+  [403, /permissions/],
+  [429, /rate limiting/],
+  [500, /Couldn’t verify/],
+  [404, /Couldn’t verify/],
+]) {
+  test(`does not save on HTTP ${status}, or expose response secrets`, async () => {
+    await assert.rejects(
+      verifyProviderCredentials(
+        credential,
+        async () => new Response("secret-key-echo", { status }),
+      ),
+      (error) => {
+        assert.match(error.message, message);
+        assert.ok(!error.message.includes("secret-key-echo"));
+        return true;
+      },
+    );
+  });
+}
+
+for (const body of [
+  { error: "invalid key", data: [] },
+  { valid: false },
+  "<html>success</html>",
+  null,
+]) {
+  test(`does not treat an arbitrary 200 response as verification: ${JSON.stringify(body)}`, async () => {
+    await assert.rejects(
+      verifyProviderCredentials(credential, async () => Response.json(body)),
+    );
+  });
+}
+
+test("a public model catalog cannot validate a key", async () => {
+  await assert.rejects(
+    verifyProviderCredentials({ ...credential, provider: "custom" }, async () =>
+      Response.json({ data: [] }),
+    ),
+    /doesn’t support API key verification/,
+  );
+});
+
+test("a gateway must accept the candidate key and reject the control key", async () => {
+  const keys = [];
+  await verifyProviderCredentials(
+    { ...credential, provider: "custom" },
+    async (_url, init) => {
+      keys.push(init.headers.Authorization);
+      return keys.length === 1
+        ? Response.json({ data: [] })
+        : new Response(null, { status: 401 });
+    },
+  );
+  assert.deepEqual(keys, [
+    "Bearer synthetic-key",
+    "Bearer anarlog-invalid-key-verification",
+  ]);
+});
+
+for (const [provider, path, header, value, payload] of [
+  [
+    "openrouter",
+    "/v1/key",
+    "Authorization",
+    "Bearer synthetic-key",
+    { data: { label: "test key" } },
+  ],
+  [
+    "deepgram",
+    "/v1/projects",
+    "Authorization",
+    "Token synthetic-key",
+    { projects: [] },
+  ],
+  [
+    "assemblyai",
+    "/v1/v2/transcript?limit=1",
+    "Authorization",
+    "synthetic-key",
+    { transcripts: [] },
+  ],
+  ["anthropic", "/v1/models", "x-api-key", "synthetic-key", { data: [] }],
+  [
+    "google_generative_ai",
+    "/v1/models",
+    "x-goog-api-key",
+    "synthetic-key",
+    { models: [] },
+  ],
+  [
+    "siliconflow",
+    "/v1/user/info",
+    "Authorization",
+    "Bearer synthetic-key",
+    { status: true },
+  ],
+  [
+    "cohere",
+    "/v1/check-api-key",
+    "Authorization",
+    "Bearer synthetic-key",
+    { valid: true },
+  ],
+  [
+    "gladia",
+    "/v1/v2/live?limit=1",
+    "x-gladia-key",
+    "synthetic-key",
+    { items: [] },
+  ],
+  [
+    "elevenlabs",
+    "/v1/v1/user",
+    "xi-api-key",
+    "synthetic-key",
+    { user_id: "test" },
+  ],
+  [
+    "azure_openai",
+    "/v1/openai/models?api-version=2024-10-21",
+    "api-key",
+    "synthetic-key",
+    { data: [] },
+  ],
+]) {
+  test(`uses ${provider}'s authentication protocol`, async () => {
+    const host =
+      provider === "anthropic"
+        ? "api.anthropic.com"
+        : provider === "google_generative_ai"
+          ? "generativelanguage.googleapis.com"
+          : "api.openai.com";
+    await verifyProviderCredentials(
+      { ...credential, provider, baseUrl: `https://${host}/v1` },
+      async (url, init) => {
+        assert.equal(url, `https://${host}${path}`);
+        assert.equal(init.headers[header], value);
+        return Response.json(payload);
+      },
+    );
+  });
+}
+
+test("a negative Cohere validity result is rejected despite HTTP 200", async () => {
+  await assert.rejects(
+    verifyProviderCredentials({ ...credential, provider: "cohere" }, async () =>
+      Response.json({ valid: false }),
+    ),
+    /did not confirm/,
+  );
+});
+
+test("cancellation does not validate a key", async () => {
+  const controller = new AbortController();
+  await assert.rejects(
+    verifyProviderCredentials(
+      credential,
+      async () => {
+        controller.abort();
+        return Response.json({ data: [] });
+      },
+      controller.signal,
+    ),
+    /Couldn’t verify/,
+  );
+});
+
+test("network failures are not mislabeled as invalid credentials", async () => {
+  await assert.rejects(
+    verifyProviderCredentials(credential, async () => {
+      throw Error("secret-key");
+    }),
+    /Couldn’t verify this key. Check your connection/,
+  );
+});
+
+test("rejects malformed credentials and unsafe endpoints before a request", async () => {
+  for (const update of [
+    { apiKey: "" },
+    { apiKey: "a\nb" },
+    { baseUrl: "http://remote.test" },
+    { baseUrl: "https://u:p@remote.test" },
+    { baseUrl: "https://remote.test/?token=test" },
+  ]) {
+    await assert.rejects(
+      verifyProviderCredentials({ ...credential, ...update }, () =>
+        assert.fail("Unexpected network request"),
+      ),
+    );
+  }
+});
+
+test("public catalogs at overridden OpenAI endpoints are not trusted", async () => {
+  await assert.rejects(
+    verifyProviderCredentials(
+      { ...credential, baseUrl: "https://public.example/v1" },
+      async () => Response.json({ data: [] }),
+    ),
+    /doesn’t support API key verification/,
+  );
+});
+
+test("reuses recent proof only for the same credential and endpoint", async () => {
+  let requests = 0;
+  const fetcher = async () => {
+    requests++;
+    return Response.json({ data: [] });
+  };
+  await verifyProviderCredentials(credential, fetcher);
+  await verifyProviderCredentials(credential, fetcher);
+  assert.equal(requests, 1);
+  await verifyProviderCredentials(
+    { ...credential, apiKey: "replacement" },
+    fetcher,
+  );
+  assert.equal(requests, 2);
+  await verifyProviderCredentials(
+    { ...credential, baseUrl: credential.baseUrl + "/new" },
+    fetcher,
+  );
+  assert.equal(requests, 3);
+});
+
+test("never caches a failed verification as accepted", async () => {
+  let rejected = true;
+  let calls = 0;
+  const fetcher = async () => {
+    calls++;
+    return rejected
+      ? new Response(null, { status: 401 })
+      : Response.json({ data: [] });
+  };
+  await assert.rejects(
+    verifyProviderCredentials(credential, fetcher),
+    /rejected/,
+  );
+  rejected = false;
+  await verifyProviderCredentials(credential, fetcher);
+  assert.equal(calls, 2);
+});

--- a/packages/provider-validation/src/index.ts
+++ b/packages/provider-validation/src/index.ts
@@ -9,6 +9,15 @@ export type ProviderCredential = {
 type CredentialFetch = (url: string, init: RequestInit) => Promise<Response>;
 const verified = new WeakMap<CredentialFetch, Map<string, number>>();
 
+export class ProviderCredentialError extends Error {
+  readonly retryable: boolean;
+
+  constructor(message: string, retryable = false) {
+    super(message);
+    this.retryable = retryable;
+  }
+}
+
 export function providerCredentialIdentity(credential: ProviderCredential) {
   return sha256(JSON.stringify(credential));
 }
@@ -55,21 +64,22 @@ export async function verifyProviderCredentials(
     });
     if (response.status === 401 || response.status === 403) {
       await response.body?.cancel();
-      throw new CredentialError(
+      throw new ProviderCredentialError(
         "The provider rejected this key or its permissions. Check the key and try again.",
       );
     }
     if (!response.ok) {
       await response.body?.cancel();
-      throw new CredentialError(
+      throw new ProviderCredentialError(
         response.status === 429
           ? "The provider is rate limiting verification. Try again shortly."
           : "Couldn’t verify this key with the provider. Check the connection and try again.",
+        true,
       );
     }
     const body = await readResponse(response, request.plainText);
     if (!request.accept(body))
-      throw new CredentialError(
+      throw new ProviderCredentialError(
         "The provider did not confirm this key. Check the key and connection.",
       );
 
@@ -86,10 +96,18 @@ export async function verifyProviderCredentials(
         redirect: "error",
       });
       await rejected.body?.cancel();
-      if (rejected.status !== 401 && rejected.status !== 403)
-        throw new CredentialError(
+      if (rejected.status !== 401 && rejected.status !== 403) {
+        if (!rejected.ok)
+          throw new ProviderCredentialError(
+            rejected.status === 429
+              ? "The provider is rate limiting verification. Try again shortly."
+              : "Couldn’t verify this key with the provider. Check the connection and try again.",
+            true,
+          );
+        throw new ProviderCredentialError(
           "This endpoint doesn’t support API key verification. Use an authenticated model-list endpoint.",
         );
+      }
     }
     controller.signal.throwIfAborted();
     // Saving and refreshing availability use the same proof, without retaining
@@ -97,17 +115,16 @@ export async function verifyProviderCredentials(
     recent.set(identity, Date.now() + 60_000);
     if (recent.size > 128) recent.delete(recent.keys().next().value!);
   } catch (error) {
-    if (error instanceof CredentialError) throw error;
-    throw new Error(
+    if (error instanceof ProviderCredentialError) throw error;
+    throw new ProviderCredentialError(
       "Couldn’t verify this key. Check your connection and try again.",
+      true,
     );
   } finally {
     clearTimeout(timer);
     signal?.removeEventListener("abort", abort);
   }
 }
-
-class CredentialError extends Error {}
 
 function credentialRequest({ provider, baseUrl, apiKey }: ProviderCredential) {
   const base = baseUrl.replace(/\/+$/, "");

--- a/packages/provider-validation/src/index.ts
+++ b/packages/provider-validation/src/index.ts
@@ -29,10 +29,15 @@ export async function verifyProviderCredentials(
 ): Promise<void> {
   const apiKey = credential.apiKey.trim();
   if (!apiKey || apiKey.length > 8192 || /[\r\n]/.test(apiKey))
-    throw new Error("Enter a valid API key.");
-  const base = new URL(credential.baseUrl);
+    throw new ProviderCredentialError("Enter a valid API key.");
+  let base: URL;
+  try {
+    base = new URL(credential.baseUrl);
+  } catch {
+    throw new ProviderCredentialError("Enter a valid base URL.");
+  }
   if (base.username || base.password || base.search || base.hash)
-    throw new Error(
+    throw new ProviderCredentialError(
       "Enter a base URL without credentials or query parameters.",
     );
   if (
@@ -42,7 +47,7 @@ export async function verifyProviderCredentials(
       ["localhost", "127.0.0.1", "[::1]"].includes(base.hostname)
     )
   )
-    throw new Error("Use HTTPS for provider credentials.");
+    throw new ProviderCredentialError("Use HTTPS for provider credentials.");
 
   signal?.throwIfAborted();
   const identity = providerCredentialIdentity({ ...credential, apiKey });

--- a/packages/provider-validation/src/index.ts
+++ b/packages/provider-validation/src/index.ts
@@ -1,0 +1,308 @@
+import { sha256 } from "js-sha256";
+
+export type ProviderCredential = {
+  provider: string;
+  baseUrl: string;
+  apiKey: string;
+};
+
+type CredentialFetch = (url: string, init: RequestInit) => Promise<Response>;
+const verified = new WeakMap<CredentialFetch, Map<string, number>>();
+
+export function providerCredentialIdentity(credential: ProviderCredential) {
+  return sha256(JSON.stringify(credential));
+}
+
+export async function verifyProviderCredentials(
+  credential: ProviderCredential,
+  fetcher: CredentialFetch,
+  signal?: AbortSignal,
+): Promise<void> {
+  const apiKey = credential.apiKey.trim();
+  if (!apiKey || apiKey.length > 8192 || /[\r\n]/.test(apiKey))
+    throw new Error("Enter a valid API key.");
+  const base = new URL(credential.baseUrl);
+  if (base.username || base.password || base.search || base.hash)
+    throw new Error(
+      "Enter a base URL without credentials or query parameters.",
+    );
+  if (
+    base.protocol !== "https:" &&
+    !(
+      base.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "[::1]"].includes(base.hostname)
+    )
+  )
+    throw new Error("Use HTTPS for provider credentials.");
+
+  signal?.throwIfAborted();
+  const identity = providerCredentialIdentity({ ...credential, apiKey });
+  const recent = verified.get(fetcher) ?? new Map<string, number>();
+  verified.set(fetcher, recent);
+  if ((recent.get(identity) ?? 0) > Date.now()) return;
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  signal?.throwIfAborted();
+  signal?.addEventListener("abort", abort, { once: true });
+  const timer = setTimeout(abort, 8_000);
+  try {
+    const request = credentialRequest({ ...credential, apiKey });
+    const response = await fetcher(request.url, {
+      ...request.init,
+      signal: controller.signal,
+      redirect: "error",
+    });
+    if (response.status === 401 || response.status === 403) {
+      await response.body?.cancel();
+      throw new CredentialError(
+        "The provider rejected this key or its permissions. Check the key and try again.",
+      );
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new CredentialError(
+        response.status === 429
+          ? "The provider is rate limiting verification. Try again shortly."
+          : "Couldn’t verify this key with the provider. Check the connection and try again.",
+      );
+    }
+    const body = await readResponse(response, request.plainText);
+    if (!request.accept(body))
+      throw new CredentialError(
+        "The provider did not confirm this key. Check the key and connection.",
+      );
+
+    // A public model catalog cannot prove that credentials work. Gateways must
+    // also reject an invalid credential before their model response is trusted.
+    if (request.checkAuthentication) {
+      const control = credentialRequest({
+        ...credential,
+        apiKey: "anarlog-invalid-key-verification",
+      });
+      const rejected = await fetcher(control.url, {
+        ...control.init,
+        signal: controller.signal,
+        redirect: "error",
+      });
+      await rejected.body?.cancel();
+      if (rejected.status !== 401 && rejected.status !== 403)
+        throw new CredentialError(
+          "This endpoint doesn’t support API key verification. Use an authenticated model-list endpoint.",
+        );
+    }
+    controller.signal.throwIfAborted();
+    // Saving and refreshing availability use the same proof, without retaining
+    // raw credentials or turning a temporary network failure into a lost setup.
+    recent.set(identity, Date.now() + 60_000);
+    if (recent.size > 128) recent.delete(recent.keys().next().value!);
+  } catch (error) {
+    if (error instanceof CredentialError) throw error;
+    throw new Error(
+      "Couldn’t verify this key. Check your connection and try again.",
+    );
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", abort);
+  }
+}
+
+class CredentialError extends Error {}
+
+function credentialRequest({ provider, baseUrl, apiKey }: ProviderCredential) {
+  const base = baseUrl.replace(/\/+$/, "");
+  const origin = new URL(base).origin;
+  let url = `${base}/models`;
+  let headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+  let method = "GET";
+  let body: string | undefined;
+  let checkAuthentication = false;
+  let plainText = false;
+  let accept = (value: unknown) => {
+    const data = record(value);
+    return (
+      !data.error && (Array.isArray(data.data) || Array.isArray(data.models))
+    );
+  };
+  switch (provider) {
+    case "anthropic":
+      checkAuthentication = new URL(base).hostname !== "api.anthropic.com";
+      headers = { "x-api-key": apiKey, "anthropic-version": "2023-06-01" };
+      break;
+    case "google_generative_ai":
+      checkAuthentication =
+        new URL(base).hostname !== "generativelanguage.googleapis.com";
+      headers = { "x-goog-api-key": apiKey };
+      break;
+    case "azure_openai":
+      url = `${base.replace(/\/openai(?:\/v1)?$/, "")}/openai/models?api-version=2024-10-21`;
+      headers = { "api-key": apiKey };
+      break;
+    case "azure_ai":
+      headers = { "api-key": apiKey };
+      break;
+    case "azure_speech":
+      url = `${origin}/sts/v1.0/issueToken`;
+      method = "POST";
+      headers = { "Ocp-Apim-Subscription-Key": apiKey };
+      plainText = true;
+      accept = (value) =>
+        typeof value === "string" && value.split(".").length === 3;
+      break;
+    case "google_cloud":
+      url = `${base}/operations?pageSize=1`;
+      checkAuthentication = new URL(base).hostname !== "speech.googleapis.com";
+      accept = (value) =>
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        !record(value).error &&
+        (record(value).operations === undefined ||
+          Array.isArray(record(value).operations));
+      break;
+    case "google_vertex_ai":
+      url = `${origin}/v1/publishers/google/models?pageSize=1`;
+      accept = (value) => Array.isArray(record(value).publisherModels);
+      checkAuthentication = true;
+      break;
+    case "openrouter":
+      url = `${base}/key`;
+      accept = (value) => typeof record(record(value).data).label === "string";
+      break;
+    case "deepgram":
+      url = `${base}/projects`;
+      headers = { Authorization: `Token ${apiKey}` };
+      accept = (value) => Array.isArray(record(value).projects);
+      break;
+    case "assemblyai":
+      url = `${base}/v2/transcript?limit=1`;
+      headers = { Authorization: apiKey };
+      accept = (value) => Array.isArray(record(value).transcripts);
+      break;
+    case "siliconflow":
+      url = `${base}/user/info`;
+      accept = (value) => record(value).status === true;
+      break;
+    case "xai":
+      url = `${base}/api-key`;
+      accept = (value) =>
+        record(value).api_key_blocked === false &&
+        record(value).api_key_disabled === false;
+      break;
+    case "cloudflare_workers_ai":
+      url = `${origin}/client/v4/user/tokens/verify`;
+      accept = (value) =>
+        record(value).success === true &&
+        record(record(value).result).status === "active";
+      break;
+    case "cartesia":
+      url = `${base}/voices?limit=1`;
+      headers["Cartesia-Version"] = "2025-04-16";
+      checkAuthentication = true;
+      accept = (value) =>
+        Array.isArray(value) || Array.isArray(record(value).data);
+      break;
+    case "smallestai":
+      url = `${base}/waves/v1/voice-cloning`;
+      checkAuthentication = true;
+      accept = (value) => Array.isArray(record(value).data);
+      break;
+    case "fireworks":
+      url = `${origin}/inference/v1/models`;
+      checkAuthentication = true;
+      break;
+    case "deepseek":
+      url = `${base}/user/balance`;
+      accept = (value) => typeof record(value).is_available === "boolean";
+      break;
+    case "cohere":
+      url = `${origin}/v1/check-api-key`;
+      method = "POST";
+      headers["Content-Type"] = "application/json";
+      body = "{}";
+      accept = (value) => record(value).valid === true;
+      break;
+    case "soniox":
+      url = `${base}/v1/transcriptions?limit=1`;
+      accept = (value) => Array.isArray(record(value).transcriptions);
+      break;
+    case "speechmatics":
+      url = `${base}/jobs`;
+      accept = (value) => Array.isArray(record(value).jobs);
+      break;
+    case "revai":
+      url = `${base}/account`;
+      accept = (value) => typeof record(value).id === "string";
+      break;
+    case "elevenlabs":
+      url = `${base}/v1/user`;
+      headers = { "xi-api-key": apiKey };
+      accept = (value) => typeof record(value).user_id === "string";
+      break;
+    case "gladia":
+      url = `${base}/v2/live?limit=1`;
+      headers = { "x-gladia-key": apiKey };
+      accept = (value) => Array.isArray(record(value).items);
+      break;
+    case "pyannote":
+      url = `${base}/v1/test`;
+      accept = (value) => record(value).status === "OK";
+      break;
+    case "dashscope":
+      url = `${base}/compatible-mode/v1/models`;
+      checkAuthentication = true;
+      break;
+    case "openai":
+      checkAuthentication = new URL(base).hostname !== "api.openai.com";
+      break;
+    case "groq":
+      checkAuthentication = new URL(base).hostname !== "api.groq.com";
+      break;
+    case "mistral":
+      checkAuthentication = new URL(base).hostname !== "api.mistral.ai";
+      break;
+    default:
+      checkAuthentication = true;
+  }
+  return {
+    url,
+    init: { method, headers, body },
+    accept,
+    checkAuthentication,
+    plainText,
+  };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+async function readResponse(
+  response: Response,
+  plainText: boolean,
+): Promise<unknown> {
+  const limit = 8 * 1024 * 1024;
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("Empty verification response");
+  let text = "";
+  let size = 0;
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > limit) {
+        await reader.cancel();
+        throw new Error("Verification response too large");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return plainText ? text : JSON.parse(text);
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/provider-validation/src/index.ts
+++ b/packages/provider-validation/src/index.ts
@@ -161,7 +161,7 @@ function credentialRequest({ provider, baseUrl, apiKey }: ProviderCredential) {
           Array.isArray(record(value).operations));
       break;
     case "google_vertex_ai":
-      url = `${origin}/v1/publishers/google/models?pageSize=1`;
+      url = `${origin}/v1beta1/publishers/google/models?pageSize=1`;
       accept = (value) => Array.isArray(record(value).publisherModels);
       checkAuthentication = true;
       break;

--- a/packages/provider-validation/tsconfig.json
+++ b/packages/provider-validation/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@anlg/pricing':
         specifier: workspace:^
         version: link:../../packages/pricing
+      '@anlg/provider-validation':
+        specifier: workspace:*
+        version: link:../../packages/provider-validation
       '@anlg/store':
         specifier: workspace:*
         version: link:../../packages/store
@@ -447,6 +450,9 @@ importers:
       '@anlg/mobile-bridge':
         specifier: workspace:*
         version: link:../../packages/mobile-bridge-rn
+      '@anlg/provider-validation':
+        specifier: workspace:*
+        version: link:../../packages/provider-validation
       '@anlg/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
@@ -1166,6 +1172,12 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+
+  packages/provider-validation:
+    dependencies:
+      js-sha256:
+        specifier: 0.10.1
+        version: 0.10.1
 
   packages/store:
     dependencies:


### PR DESCRIPTION
Validate credentials with each provider before saving keys or offering a provider in desktop and mobile selectors. Failed checks preserve existing credentials and show an inline error. Desktop selectors wait for pending or inconclusive verification before repairing saved selections; network failures and rate limits do not erase provider choices. Key saves use the catalog URL when a stored endpoint is empty, while preserving custom endpoints.

Shared checks reject public catalogs that do not authenticate keys; Custom gateways need an authenticated model-list endpoint. Inconclusive control responses remain retryable and cannot authorize a new save. Vertex verification uses the documented v1beta1 publisher catalog.

Validated with 33 shared verification tests, 315 mobile tests, 3954 desktop tests, affected typechecks, formatting, desktop lint, and an invalid-key simulator check. Desktop tests used NODE_OPTIONS=--no-experimental-webstorage for the local Node 26 runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when API keys are persisted and how LLM/STT provider readiness is computed, with outbound credential checks across desktop and mobile.
> 
> **Overview**
> Adds shared **`@anlg/provider-validation`** with provider-specific probe requests, gateway **control-key** checks so public model lists cannot pass verification, short-lived proof caching, and **`ProviderCredentialError`** semantics (401/403 vs retryable outages).
> 
> **Desktop and mobile** call **`verifyProviderCredentials`** before writing keys or treating a provider as configured. Failed saves leave existing keychain/secure-store data unchanged; selectors only expose API-key providers after verification succeeds, and inconclusive network/rate-limit responses stay **unknown** instead of clearing a working setup. Desktop resolves an empty stored base URL to the provider default when verifying; mobile surfaces verification errors with retry styling.
> 
> Mobile CI now typechecks and tests the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9712cc45263bfebc73ecab891573d4760edfd5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->