### PR TITLE
Prepare desktop 1.4.21 release notes

### DIFF
--- a/packages/changelog/content/1.4.21.md
+++ b/packages/changelog/content/1.4.21.md
@@ -1,0 +1,29 @@
+---
+date: "2026-09-06"
+summary: "Anarlog 1.4.21 adds personal activity stats, restores storage-location controls, and improves provider setup and recording reliability."
+---
+
+## Your activity and settings
+
+- See your conversation count, hours transcribed, active days, and weekly streak
+  in **Your stats**, with an activity calendar and conversation milestones
+- Choose where your notes and recordings are stored from Settings, or open
+  their current folder directly
+- Find your way around with a consistent set of refreshed icons
+
+## Providers and recording
+
+- Verify API keys before saving them, and choose only providers with valid
+  credentials; temporary connection failures preserve your saved setup
+- Apply a speaker name across a conversation, including recordings made after
+  pausing and resuming capture
+- Launch the Linux AppImage in Wayland-only sessions and recover more reliably
+  when system-audio capture cannot start
+- Place the macOS menu-bar icon to the left of Wi-Fi by default
+
+## Privacy and sync
+
+- Remove account emails and additional personal details from analytics and
+  error reports, and respect both analytics and error-reporting preferences
+  before recording diagnostic session replays
+- Avoid repeated sync repairs when newer encrypted changes are already present


### PR DESCRIPTION
Add the desktop changelog for 1.4.21, covering activity stats, storage controls, verified provider credentials, recording fixes, and privacy and sync improvements since 1.4.20.

Validated the changelog against the shipped diffs. Formatting, changelog typecheck, license-boundary checks, and all 64 common script tests pass. Native release checks and artifact verification will run against the merged candidate before publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or build behavior changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.21.md`**, the shipped desktop changelog for **1.4.21** (dated 2026-09-06), using the same frontmatter + section layout as prior releases like 1.4.20.
> 
> The entry documents user-facing changes since 1.4.20: **Your stats** (counts, calendar, milestones), **Settings** storage location and folder shortcuts, refreshed icons, provider API key verification and credential filtering, speaker-name behavior across pause/resume, Linux AppImage/Wayland and system-audio recovery, default macOS menu-bar placement, reduced PII in analytics/errors and gated session replays, and fewer redundant sync repairs when newer encrypted data already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a0b3d76f5e49003e6b9cce3407905938f47c6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->