### PR TITLE
Move Windows sidebar actions into the title bar

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -851,4 +851,27 @@ describe("ClassicMainBody", () => {
     expect(screen.queryByTestId("resize-handle")).toBeNull();
     expect(screen.getAllByTestId("panel")).toHaveLength(1);
   });
+
+  it("removes the Windows sidebar action row when actions are in the title bar", () => {
+    mocks.runtimePlatform = "windows";
+    render(<ClassicMainBody />);
+
+    expect(screen.getByTestId("classic-main-sidebar")).toBeTruthy();
+    expect(document.querySelector("[data-sidebar-timeline-header]")).toBeNull();
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+  });
+
+  it("keeps Linux note actions in the sidebar", () => {
+    mocks.runtimePlatform = "linux";
+    render(<ClassicMainBody />);
+
+    expect(
+      document.querySelector("[data-sidebar-timeline-header]"),
+    ).not.toBeNull();
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+  });
 });

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -37,6 +37,7 @@ import { useShell } from "~/contexts/shell";
 import { scrollElementByWheel } from "~/shared/dom/scroll-wheel";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
+  usesTitleBarSidebarActions,
   usesWindowsStyleTitleBar,
   useWindowControlsGutter,
 } from "~/shared/hooks/useWindowControlsGutter";
@@ -396,29 +397,30 @@ export function ClassicMainBody({
     "--left-sidebar-panel-size": `${renderedLeftSidebarPanelSize}`,
     "--left-sidebar-panel-width": `${renderedLeftSidebarPanelSize}%`,
   } as LeftSidebarSizeStyle;
-  const timelineHeader = showSidebarTimelineChrome ? (
-    <div
-      data-tauri-drag-region
-      data-sidebar-timeline-header
-      className={cn([
-        "flex h-9 shrink-0 items-start pt-[9px] pr-1",
-        showWindowControlsGutter ? "pl-[76px]" : "pl-2",
-      ])}
-      onWheelCapture={handleSidebarTimelineHeaderWheel}
-    >
-      {showSidebarTimeline ? (
-        <SidebarTimelineChromeWithUpcomingMeeting
-          currentSessionId={currentSessionId}
-          sidebarExpanded
-          showSidebarToggle={showSidebarToggleInBody}
-          showIgnoredTimelineEvents={showIgnoredTimelineEvents}
-          onNewNote={createNewNote}
-          onSearch={handleOpenNoteDialog}
-          onToggleSidebar={handleToggleLeftSidebar}
-        />
-      ) : null}
-    </div>
-  ) : null;
+  const timelineHeader =
+    showSidebarTimelineChrome && !usesTitleBarSidebarActions() ? (
+      <div
+        data-tauri-drag-region
+        data-sidebar-timeline-header
+        className={cn([
+          "flex h-9 shrink-0 items-start pt-[9px] pr-1",
+          showWindowControlsGutter ? "pl-[76px]" : "pl-2",
+        ])}
+        onWheelCapture={handleSidebarTimelineHeaderWheel}
+      >
+        {showSidebarTimeline ? (
+          <SidebarTimelineChromeWithUpcomingMeeting
+            currentSessionId={currentSessionId}
+            sidebarExpanded
+            showSidebarToggle={showSidebarToggleInBody}
+            showIgnoredTimelineEvents={showIgnoredTimelineEvents}
+            onNewNote={createNewNote}
+            onSearch={handleOpenNoteDialog}
+            onToggleSidebar={handleToggleLeftSidebar}
+          />
+        ) : null}
+      </div>
+    ) : null;
 
   return (
     <div

--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -22,7 +22,16 @@ vi.mock("./body", () => ({
 }));
 
 vi.mock("./windows-title-bar", () => ({
-  WindowsTitleBar: () => <div data-testid="windows-title-bar" />,
+  WindowsTitleBar: ({
+    showSidebarTimelineChrome,
+  }: {
+    showSidebarTimelineChrome: boolean;
+  }) => (
+    <div
+      data-testid="windows-title-bar"
+      data-show-sidebar-timeline-chrome={String(showSidebarTimelineChrome)}
+    />
+  ),
 }));
 
 vi.mock("~/shared/main", () => ({
@@ -104,6 +113,33 @@ describe("ClassicMainShellFrame", () => {
     expect(screen.queryByTestId("windows-title-bar")).toBeNull();
     expect(screen.getByTestId("main-shell-scaffold")).toBeTruthy();
   });
+
+  it.each([
+    ["empty", true],
+    ["sessions", true],
+    ["changelog", true],
+    ["onboarding", false],
+    ["settings", false],
+    ["calendar", false],
+    ["contacts", false],
+    ["templates", false],
+    ["automations", false],
+    ["folders", false],
+  ])(
+    "passes timeline chrome visibility for %s to the title bar",
+    (type, visible) => {
+      mocks.platform = "windows";
+      mocks.currentTab = { type };
+
+      render(<ClassicMainShellFrame />);
+
+      expect(
+        screen
+          .getByTestId("windows-title-bar")
+          .getAttribute("data-show-sidebar-timeline-chrome"),
+      ).toBe(String(visible));
+    },
+  );
 
   it("places the devtools status bar below the shell", () => {
     render(<ClassicMainShellFrame />);

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -48,7 +48,11 @@ export function ClassicMainShellFrame() {
 
   return (
     <div className="bg-background flex h-full min-h-0 flex-col">
-      {usesWindowsStyleTitleBar() ? <WindowsTitleBar /> : null}
+      {usesWindowsStyleTitleBar() ? (
+        <WindowsTitleBar
+          showSidebarTimelineChrome={showSidebarTimelineChrome}
+        />
+      ) : null}
       <div className="min-h-0 flex-1">{shell}</div>
       <DevtoolsStatusBar />
     </div>

--- a/apps/desktop/src/main/sidebar-timeline-chrome.tsx
+++ b/apps/desktop/src/main/sidebar-timeline-chrome.tsx
@@ -74,7 +74,7 @@ function SidebarTimelineChrome({
   return (
     <div data-tauri-drag-region className="flex w-full items-center">
       <div data-tauri-drag-region className="flex items-center gap-0">
-        {showSidebarToggle ? (
+        {showSidebarToggle && (
           <LeftSurfaceChromeButton
             ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
             badge={collapsedBadge}
@@ -86,26 +86,32 @@ function SidebarTimelineChrome({
               <Sidebar size={16} />
             )}
           </LeftSurfaceChromeButton>
-        ) : (
-          <span
-            aria-hidden="true"
-            data-tauri-drag-region
-            className="size-7 shrink-0"
-          />
         )}
         {sidebarExpanded ? (
-          <>
-            <LeftSurfaceChromeButton ariaLabel="Search" onClick={onSearch}>
-              <MagnifyingGlass size={15} />
-            </LeftSurfaceChromeButton>
-            <LeftSurfaceChromeButton ariaLabel="New note" onClick={onNewNote}>
-              <NotePencil size={15} />
-            </LeftSurfaceChromeButton>
-            <SidebarNoteFilterMenu />
-          </>
+          <SidebarNoteActions onNewNote={onNewNote} onSearch={onSearch} />
         ) : null}
       </div>
     </div>
+  );
+}
+
+export function SidebarNoteActions({
+  onNewNote,
+  onSearch,
+}: {
+  onNewNote: () => void;
+  onSearch: () => void;
+}) {
+  return (
+    <>
+      <LeftSurfaceChromeButton ariaLabel="Search" onClick={onSearch}>
+        <MagnifyingGlass size={15} />
+      </LeftSurfaceChromeButton>
+      <LeftSurfaceChromeButton ariaLabel="New note" onClick={onNewNote}>
+        <NotePencil size={15} />
+      </LeftSurfaceChromeButton>
+      <SidebarNoteFilterMenu />
+    </>
   );
 }
 

--- a/apps/desktop/src/main/windows-title-bar.test.tsx
+++ b/apps/desktop/src/main/windows-title-bar.test.tsx
@@ -7,6 +7,8 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { resetSidebarNotes, useSidebarNotes } from "~/sidebar/note-filter";
+
 const mocks = vi.hoisted(() => ({
   close: vi.fn().mockResolvedValue(undefined),
   createNewNote: vi.fn(),
@@ -15,13 +17,19 @@ const mocks = vi.hoisted(() => ({
   minimize: vi.fn().mockResolvedValue(undefined),
   onResized: vi.fn().mockResolvedValue(vi.fn()),
   openNew: vi.fn(),
+  openNoteDialog: vi.fn(),
   openUrl: vi.fn().mockResolvedValue({ status: "ok", data: null }),
   setFullscreen: vi.fn().mockResolvedValue(undefined),
   toggleExpanded: vi.fn(),
   toggleMaximize: vi.fn().mockResolvedValue(undefined),
   currentTab: { type: "empty" } as { id?: string; type: string },
   leftSidebarExpanded: true,
+  platform: "windows",
   upcomingMeetingStatus: null as null | { itemKey: string },
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.platform,
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
@@ -53,6 +61,10 @@ vi.mock("~/shared/useNewNote", () => ({
   useNewNote: () => mocks.createNewNote,
 }));
 
+vi.mock("~/shared/open-note-dialog", () => ({
+  useOpenNoteDialog: () => ({ open: mocks.openNoteDialog }),
+}));
+
 vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
   useSidebarUpcomingMeetingStatus: () => mocks.upcomingMeetingStatus,
 }));
@@ -78,17 +90,21 @@ describe("WindowsTitleBar", () => {
     mocks.minimize.mockClear();
     mocks.onResized.mockClear();
     mocks.openNew.mockClear();
+    mocks.openNoteDialog.mockClear();
     mocks.openUrl.mockClear();
     mocks.setFullscreen.mockClear();
     mocks.toggleExpanded.mockClear();
     mocks.toggleMaximize.mockClear();
     mocks.currentTab = { type: "empty" };
     mocks.leftSidebarExpanded = true;
+    mocks.platform = "windows";
     mocks.upcomingMeetingStatus = null;
+    resetSidebarNotes();
   });
 
   afterEach(() => {
     cleanup();
+    resetSidebarNotes();
   });
 
   it("renders the sidebar and application menus in the draggable title bar", async () => {
@@ -125,6 +141,59 @@ describe("WindowsTitleBar", () => {
     expect(mocks.minimize).toHaveBeenCalledOnce();
     expect(mocks.toggleMaximize).toHaveBeenCalledOnce();
     expect(mocks.close).toHaveBeenCalledOnce();
+  });
+
+  it("shows note actions beside the sidebar toggle only while expanded", () => {
+    const { rerender } = render(<WindowsTitleBar />);
+
+    expect(
+      screen
+        .getAllByRole("button")
+        .slice(0, 4)
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Hide sidebar", "Search", "New note", "Sort notes"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    fireEvent.click(screen.getByRole("button", { name: "New note" }));
+    expect(mocks.openNoteDialog).toHaveBeenCalledOnce();
+    expect(mocks.createNewNote).toHaveBeenCalledOnce();
+
+    mocks.leftSidebarExpanded = false;
+    rerender(<WindowsTitleBar />);
+
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+    expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
+
+    mocks.leftSidebarExpanded = true;
+    rerender(<WindowsTitleBar />);
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+  });
+
+  it("changes timeline grouping from the title bar", () => {
+    render(<WindowsTitleBar />);
+
+    const filter = screen.getByRole("button", { name: "Sort notes" });
+    fireEvent.pointerDown(filter);
+    fireEvent.click(filter);
+    const grouping = screen.getByRole("menuitem", { name: "Grouping, Date" });
+    fireEvent.focus(grouping);
+    fireEvent.keyDown(grouping, { key: "ArrowRight" });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Folder" }));
+
+    expect(useSidebarNotes.getState().groupBy).toBe("folder");
+  });
+
+  it("keeps Linux note actions in the sidebar", () => {
+    mocks.platform = "linux";
+    render(<WindowsTitleBar />);
+
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
   });
 
   it("preserves the collapsed-sidebar upcoming meeting badge", () => {

--- a/apps/desktop/src/main/windows-title-bar.test.tsx
+++ b/apps/desktop/src/main/windows-title-bar.test.tsx
@@ -108,7 +108,7 @@ describe("WindowsTitleBar", () => {
   });
 
   it("renders the sidebar and application menus in the draggable title bar", async () => {
-    render(<WindowsTitleBar />);
+    render(<WindowsTitleBar showSidebarTimelineChrome />);
 
     const titleBar = screen.getByTestId("windows-title-bar");
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
@@ -130,7 +130,7 @@ describe("WindowsTitleBar", () => {
   });
 
   it("connects the sidebar and native window controls", () => {
-    render(<WindowsTitleBar />);
+    render(<WindowsTitleBar showSidebarTimelineChrome />);
 
     fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
     fireEvent.click(screen.getByRole("button", { name: "Minimize" }));
@@ -144,7 +144,7 @@ describe("WindowsTitleBar", () => {
   });
 
   it("shows note actions beside the sidebar toggle only while expanded", () => {
-    const { rerender } = render(<WindowsTitleBar />);
+    const { rerender } = render(<WindowsTitleBar showSidebarTimelineChrome />);
 
     expect(
       screen
@@ -159,7 +159,7 @@ describe("WindowsTitleBar", () => {
     expect(mocks.createNewNote).toHaveBeenCalledOnce();
 
     mocks.leftSidebarExpanded = false;
-    rerender(<WindowsTitleBar />);
+    rerender(<WindowsTitleBar showSidebarTimelineChrome />);
 
     for (const name of ["Search", "New note", "Sort notes"]) {
       expect(screen.queryByRole("button", { name })).toBeNull();
@@ -167,14 +167,38 @@ describe("WindowsTitleBar", () => {
     expect(screen.getByRole("button", { name: "Show sidebar" })).toBeTruthy();
 
     mocks.leftSidebarExpanded = true;
-    rerender(<WindowsTitleBar />);
+    rerender(<WindowsTitleBar showSidebarTimelineChrome />);
     for (const name of ["Search", "New note", "Sort notes"]) {
       expect(screen.getByRole("button", { name })).toBeTruthy();
     }
   });
 
+  it("hides note actions outside timeline screens and restores them on return", () => {
+    const { rerender } = render(
+      <WindowsTitleBar showSidebarTimelineChrome={false} />,
+    );
+
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "File" })).toBeTruthy();
+
+    rerender(<WindowsTitleBar showSidebarTimelineChrome />);
+
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+
+    rerender(<WindowsTitleBar showSidebarTimelineChrome={false} />);
+
+    for (const name of ["Search", "New note", "Sort notes"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+  });
+
   it("changes timeline grouping from the title bar", () => {
-    render(<WindowsTitleBar />);
+    render(<WindowsTitleBar showSidebarTimelineChrome />);
 
     const filter = screen.getByRole("button", { name: "Sort notes" });
     fireEvent.pointerDown(filter);
@@ -189,7 +213,7 @@ describe("WindowsTitleBar", () => {
 
   it("keeps Linux note actions in the sidebar", () => {
     mocks.platform = "linux";
-    render(<WindowsTitleBar />);
+    render(<WindowsTitleBar showSidebarTimelineChrome />);
 
     for (const name of ["Search", "New note", "Sort notes"]) {
       expect(screen.queryByRole("button", { name })).toBeNull();
@@ -200,7 +224,7 @@ describe("WindowsTitleBar", () => {
     mocks.leftSidebarExpanded = false;
     mocks.upcomingMeetingStatus = { itemKey: "session-upcoming" };
 
-    render(<WindowsTitleBar />);
+    render(<WindowsTitleBar showSidebarTimelineChrome />);
 
     const toggle = screen.getByRole("button", { name: "Show sidebar" });
     expect(

--- a/apps/desktop/src/main/windows-title-bar.tsx
+++ b/apps/desktop/src/main/windows-title-bar.tsx
@@ -29,7 +29,11 @@ import { useTabs } from "~/store/zustand/tabs";
 
 const appWindow = getCurrentWindow();
 
-export function WindowsTitleBar() {
+export function WindowsTitleBar({
+  showSidebarTimelineChrome,
+}: {
+  showSidebarTimelineChrome: boolean;
+}) {
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const openNew = useTabs((state) => state.openNew);
@@ -126,7 +130,9 @@ export function WindowsTitleBar() {
             <Sidebar size={16} />
           )}
         </LeftSurfaceChromeButton>
-        {usesTitleBarSidebarActions() && leftsidebar.expanded ? (
+        {usesTitleBarSidebarActions() &&
+        showSidebarTimelineChrome &&
+        leftsidebar.expanded ? (
           <SidebarNoteActions
             onNewNote={createNewNote}
             onSearch={openNoteDialog.open}

--- a/apps/desktop/src/main/windows-title-bar.tsx
+++ b/apps/desktop/src/main/windows-title-bar.tsx
@@ -14,10 +14,15 @@ import {
 } from "@anlg/ui/components/ui/dropdown-menu";
 import { cn } from "@anlg/utils";
 
-import { LeftSurfaceChromeButton } from "./sidebar-timeline-chrome";
+import {
+  LeftSurfaceChromeButton,
+  SidebarNoteActions,
+} from "./sidebar-timeline-chrome";
 
 import { useShell } from "~/contexts/shell";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { usesTitleBarSidebarActions } from "~/shared/hooks/useWindowControlsGutter";
+import { useOpenNoteDialog } from "~/shared/open-note-dialog";
 import { useNewNote } from "~/shared/useNewNote";
 import { useSidebarUpcomingMeetingStatus } from "~/sidebar/timeline/upcoming-meeting";
 import { useTabs } from "~/store/zustand/tabs";
@@ -29,6 +34,7 @@ export function WindowsTitleBar() {
   const currentTab = useTabs((state) => state.currentTab);
   const openNew = useTabs((state) => state.openNew);
   const createNewNote = useNewNote();
+  const openNoteDialog = useOpenNoteDialog();
   const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus();
   const [isMaximized, setIsMaximized] = useState(false);
   const editTargetRef = useRef<HTMLElement | null>(null);
@@ -120,6 +126,12 @@ export function WindowsTitleBar() {
             <Sidebar size={16} />
           )}
         </LeftSurfaceChromeButton>
+        {usesTitleBarSidebarActions() && leftsidebar.expanded ? (
+          <SidebarNoteActions
+            onNewNote={createNewNote}
+            onSearch={openNoteDialog.open}
+          />
+        ) : null}
         <nav
           aria-label={t`Application menu`}
           className="ml-2 flex h-full items-center"

--- a/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
+++ b/apps/desktop/src/shared/hooks/useWindowControlsGutter.ts
@@ -10,6 +10,10 @@ export function usesWindowsStyleTitleBar() {
   return runtimePlatform === "windows" || runtimePlatform === "linux";
 }
 
+export function usesTitleBarSidebarActions() {
+  return getRuntimePlatform() === "windows";
+}
+
 export function useWindowControlsGutter() {
   const [visible, setVisible] = useState(() => {
     const runtimePlatform = getRuntimePlatform();

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -372,15 +372,19 @@ describe("ClassicMainBody", () => {
             "[data-left-sidebar-chrome] > div",
           );
 
-      await waitFor(() => {
-        expect(chromeFrame?.className).toContain("pl-2");
-      });
+      if (runtimePlatform === "windows" && expanded) {
+        expect(chromeFrame).toBeNull();
+      } else {
+        await waitFor(() => {
+          expect(chromeFrame?.className).toContain("pl-2");
+        });
+        expect(chromeFrame?.className).not.toContain("pl-[76px]");
+      }
       expect(
         screen.queryByRole("button", {
           name: expanded ? "Hide sidebar" : "Show sidebar",
         }),
       ).toBeNull();
-      expect(chromeFrame?.className).not.toContain("pl-[76px]");
       expect(mocks.isFullscreen).not.toHaveBeenCalled();
       expect(mocks.resizeListeners).toHaveLength(0);
     },

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -19,7 +19,9 @@ export function MainShellScaffold({
 }) {
   const currentTab = useTabs((state) => state.currentTab);
   const isCalendarMode = currentTab?.type === "calendar";
-  const isMacos = platform() === "macos";
+  const runtimePlatform = platform();
+  const isMacos = runtimePlatform === "macos";
+  const isWindows = runtimePlatform === "windows";
   const SyncWrapper = isCalendarMode ? SyncProvider : Fragment;
   const resolvedMainSurfaceChrome =
     mainSurfaceChrome ?? (edgeToEdge ? "top" : "default");
@@ -37,7 +39,7 @@ export function MainShellScaffold({
             isMacos && "[&_[data-chat-floating-anchor]]:rounded-t-xl",
             "[&_[data-chat-floating-anchor]]:rounded-b-none",
             "[&_[data-chat-floating-anchor]]:border-x-0",
-            resolvedMainSurfaceChrome === "top"
+            resolvedMainSurfaceChrome === "top" || isWindows
               ? "[&_[data-chat-floating-anchor]]:border-t"
               : "[&_[data-chat-floating-anchor]]:!border-t-0",
             "[&_[data-chat-floating-anchor]]:border-b-0",
@@ -46,7 +48,12 @@ export function MainShellScaffold({
             isMacos && "[&_[data-chat-floating-anchor]]:rounded-l-xl",
             !isMacos && "[&_[data-chat-floating-anchor]]:rounded-tl-xl",
             "[&_[data-chat-floating-anchor]]:rounded-r-none",
-            "[&_[data-chat-floating-anchor]]:border-y-0",
+            isWindows
+              ? [
+                  "[&_[data-chat-floating-anchor]]:border-t",
+                  "[&_[data-chat-floating-anchor]]:border-b-0",
+                ]
+              : "[&_[data-chat-floating-anchor]]:border-y-0",
             "[&_[data-chat-floating-anchor]]:border-r-0",
             "[&_[data-chat-floating-anchor]]:border-l",
           ],

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -3,6 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   currentTab: { type: "empty" } as { type: string } | null,
+  platform: "macos",
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => mocks.platform,
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({
@@ -72,6 +77,7 @@ import { LeftSidebar } from "./index";
 describe("LeftSidebar", () => {
   beforeEach(() => {
     mocks.currentTab = { type: "empty" };
+    mocks.platform = "macos";
   });
 
   afterEach(() => {
@@ -117,6 +123,20 @@ describe("LeftSidebar", () => {
         .getByTestId("timeline-view")
         .getAttribute("data-top-chips-overlap-header"),
     ).toBe("true");
+  });
+
+  it("does not reserve space for title bar actions in the Windows timeline", () => {
+    mocks.platform = "windows";
+    render(<LeftSidebar />);
+
+    const timeline = screen.getByTestId("timeline-view");
+    expect(timeline.getAttribute("data-top-chrome-inset")).toBe("false");
+    expect(timeline.getAttribute("data-top-chips-overlap-header")).toBe(
+      "false",
+    );
+    expect(timeline.getAttribute("data-show-open-calendar-button")).toBe(
+      "true",
+    );
   });
 
   it("shows received notes without the personal timeline", () => {

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -14,6 +14,7 @@ import { TemplatesNav } from "./templates";
 import { TimelineView } from "./timeline";
 import { hasOwnSidebarHeaderTab } from "./use-custom-sidebar";
 
+import { usesTitleBarSidebarActions } from "~/shared/hooks/useWindowControlsGutter";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function LeftSidebar({
@@ -88,7 +89,9 @@ export function LeftSidebar({
                         onShowIgnoredTimelineEventsChange
                       }
                       topChromeInset={
-                        isTimelineSidebarLayout && !timelineHeader
+                        isTimelineSidebarLayout &&
+                        !timelineHeader &&
+                        !usesTitleBarSidebarActions()
                       }
                       topChipsOverlapHeader={
                         isTimelineSidebarLayout && !!timelineHeader


### PR DESCRIPTION
Show Search, New Note, and Filter beside the sidebar toggle while expanded, and hide them when collapsed. Remove the old Windows sidebar action row and retain the main-area top border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Platform-gated desktop UI relocation with broad test coverage; no auth, sync, or data-path changes.
> 
> **Overview**
> On **Windows**, **Search**, **New note**, and **Sort notes** now live in the custom title bar next to the sidebar toggle when the sidebar is expanded and the user is on a timeline-style tab (empty, sessions, changelog). They are hidden when the sidebar is collapsed or on settings/calendar-style tabs.
> 
> The duplicate sidebar timeline header row is omitted on Windows via `usesTitleBarSidebarActions()`. **Linux** still shows those controls in the sidebar header. Note actions are shared through a new `SidebarNoteActions` component used by both the title bar and sidebar chrome.
> 
> `ClassicMainShellFrame` passes `showSidebarTimelineChrome` into `WindowsTitleBar` so title-bar actions track tab type. Timeline layout props on Windows drop the extra top inset reserved for the old sidebar action row. **Main shell** styling keeps a top border on the main/chat surface on Windows where the sidebar header row was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3358f991191828e968f20fafde2fb5fc7a3105e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->