### PR TITLE
Fix premature title fading for CJK text

### DIFF
--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -304,8 +304,11 @@ describe("TitleInput", () => {
     renderTitleInput();
 
     const input = screen.getByPlaceholderText("Untitled");
-    expect(input.className).toContain("w-full");
-    expect(input.parentElement?.style.width).toBe("calc(10ch + 2px)");
+    expect(input.className).toContain("min-w-full");
+    expect(input.parentElement?.style.width).toBe("");
+    expect(input.parentElement?.querySelector("span")?.textContent).toBe(
+      hoisted.storeTitle,
+    );
     expect(
       screen.queryByRole("button", { name: "Regenerate title" }),
     ).toBeNull();
@@ -329,7 +332,9 @@ describe("TitleInput", () => {
 
     fireEvent.change(input, { target: { value: title } });
 
-    const hoverTitle = screen.getByText(title);
+    const hoverTitle = screen.getByText(title, {
+      selector: "span:not([aria-hidden])",
+    });
     const overlay = hoverTitle.parentElement;
     expect(input.className).toContain("text-transparent");
     expect(input.parentElement?.style.maskImage).toBe(

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -241,14 +241,6 @@ const TitleInputInner = memo(
             ).toFixed(2)}s`,
           } as CSSProperties)
         : undefined;
-      const visibleTitleLength = Math.max(
-        title.length || untitled.length,
-        untitled.length,
-      );
-      const titleShellStyle = {
-        ...titleFadeStyle,
-        width: `calc(${visibleTitleLength}ch + 2px)`,
-      };
 
       useImperativeHandle(
         ref,
@@ -399,14 +391,26 @@ const TitleInputInner = memo(
       return (
         <div
           data-tauri-drag-region="false"
-          style={titleShellStyle}
+          style={titleFadeStyle}
           className={cn([
-            "group/title-input relative flex max-w-full items-center overflow-hidden",
+            "group/title-input relative grid w-fit max-w-full grid-cols-[minmax(0,1fr)] items-center overflow-hidden",
             variant === "breadcrumb"
               ? "h-5 text-sm leading-5"
               : "h-8 text-xl font-semibold",
           ])}
         >
+          <span
+            aria-hidden="true"
+            className="invisible col-start-1 row-start-1 min-w-0 overflow-hidden px-px whitespace-pre"
+          >
+            {title}
+          </span>
+          <span
+            aria-hidden="true"
+            className="invisible col-start-1 row-start-1 min-w-0 overflow-hidden px-px whitespace-pre"
+          >
+            {untitled}
+          </span>
           <input
             data-tauri-drag-region="false"
             data-session-title-input
@@ -439,9 +443,8 @@ const TitleInputInner = memo(
             onScroll={(e) => updateOverflowState(e.currentTarget)}
             onSelect={(e) => updateOverflowState(e.currentTarget)}
             value={title}
-            size={visibleTitleLength}
             className={cn([
-              "w-full min-w-0 transition-opacity duration-200",
+              "col-start-1 row-start-1 w-0 min-w-full transition-opacity duration-200",
               "border-none bg-transparent focus:outline-hidden",
               "placeholder:text-muted-foreground text-left",
               variant === "breadcrumb"


### PR DESCRIPTION
Short Korean titles could fade even when the header had room because the input width was estimated from character count in `ch` units. Size the field from the rendered title and placeholder instead, preserving the width cap and overflow fade/scroll behavior.

Verified the original 71px-versus-75px overflow in macOS WebKit and the corrected layout in WebKit and Chrome, including mixed scripts, emoji, long titles, focus, scrolling, and resizing. All 3,988 desktop tests, desktop typecheck, formatting, i18n, license-boundary checks, and 64 CI script tests passed. Lint completed with existing warnings; the workflow scan reported 411 existing findings in unchanged files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in the session title field; overflow/fade logic is unchanged aside from more accurate width measurement.
> 
> **Overview**
> Fixes **premature end-fade on short CJK (and other wide-script) titles** by dropping `calc(Nch + 2px)` shell width and the input `size` attribute, which treated every character as one `ch`.
> 
> The title shell is now a **CSS grid** with invisible measurement spans for the current title and **Untitled** placeholder; the input overlays them with **`w-0 min-w-full`** so width follows **actual rendered text** while **`max-w-full`** and existing overflow detection, mask fades, and hover-scroll behavior stay the same.
> 
> Tests were updated for whitespace-only titles (no fixed `ch` width) and to target the **non–`aria-hidden`** hover overlay span when duplicate title text exists in the DOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725a36ce3d2ed87c6fd2bcad37dae987aac1f9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->