### PR TITLE
Use outline icons across desktop and mobile

### DIFF
--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -111,9 +111,9 @@ export function Timeline({
           ])}
         >
           {state === "playing" ? (
-            <Pause className="text-foreground h-3.5 w-3.5" weight="fill" />
+            <Pause className="text-foreground h-3.5 w-3.5" />
           ) : (
-            <Play className="text-foreground h-3.5 w-3.5" weight="fill" />
+            <Play className="text-foreground h-3.5 w-3.5" />
           )}
         </button>
       }

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -194,7 +194,7 @@ export function ChatMessageInput({
                 className="h-7 w-7 rounded-full"
                 aria-label={t`Stop response`}
               >
-                <Square size={14} weight="fill" />
+                <Square size={14} />
               </Button>
             ) : showSendControl ? (
               <SendButton disabled={isSendDisabled} onClick={handleSubmit} />
@@ -349,7 +349,7 @@ function VoiceStatus({
         {isProcessing ? (
           <CircleNotch className="size-3.5 animate-spin" />
         ) : (
-          <Square size={12} weight="fill" />
+          <Square size={12} />
         )}
       </button>
       {isStreaming ? (
@@ -360,7 +360,7 @@ function VoiceStatus({
           className="h-7 w-7 rounded-full"
           aria-label={t`Stop response`}
         >
-          <Square size={14} weight="fill" />
+          <Square size={14} />
         </Button>
       ) : (
         showSend && <SendButton disabled={isSendDisabled} onClick={onSend} />

--- a/apps/desktop/src/contacts/contact-page-header.tsx
+++ b/apps/desktop/src/contacts/contact-page-header.tsx
@@ -69,7 +69,7 @@ export function ContactPageHeader({
                 onClick={onTogglePin}
                 className="cursor-pointer"
               >
-                <PushPin weight={pinned ? "fill" : "regular"} />
+                <PushPin weight={pinned ? "bold" : "regular"} />
                 <span>
                   {pinned ? <Trans>Unpin</Trans> : <Trans>Pin</Trans>}
                 </span>

--- a/apps/desktop/src/contacts/organization-item.tsx
+++ b/apps/desktop/src/contacts/organization-item.tsx
@@ -84,7 +84,7 @@ export function OrganizationItem({
         ])}
         aria-label={isPinned ? "Unpin organization" : "Pin organization"}
       >
-        <PushPin className="size-3.5" weight={isPinned ? "fill" : "regular"} />
+        <PushPin className="size-3.5" weight={isPinned ? "bold" : "regular"} />
       </button>
     </div>
   );

--- a/apps/desktop/src/contacts/person-item.tsx
+++ b/apps/desktop/src/contacts/person-item.tsx
@@ -93,7 +93,7 @@ export function PersonItem({
         ])}
         aria-label={isPinned ? "Unpin contact" : "Pin contact"}
       >
-        <PushPin className="size-3.5" weight={isPinned ? "fill" : "regular"} />
+        <PushPin className="size-3.5" weight={isPinned ? "bold" : "regular"} />
       </button>
     </div>
   );

--- a/apps/desktop/src/lock/screen.tsx
+++ b/apps/desktop/src/lock/screen.tsx
@@ -31,7 +31,7 @@ export function LockScreen({
     >
       <div className="flex max-w-sm flex-col items-center px-6 text-center">
         <div className="bg-muted flex size-14 items-center justify-center rounded-full">
-          <Lock className="text-foreground size-6" weight="fill" />
+          <Lock className="text-foreground size-6" />
         </div>
         <h1 className="mt-5 text-lg font-semibold">{title}</h1>
         {description ? (

--- a/apps/desktop/src/meeting-float/overlay/bar.tsx
+++ b/apps/desktop/src/meeting-float/overlay/bar.tsx
@@ -283,7 +283,7 @@ function StopControl({
     >
       {hovered ? (
         <span className="flex items-center gap-1.5 text-xs font-semibold">
-          <Square size={9} weight="fill" />
+          <Square size={9} />
           Stop
         </span>
       ) : (

--- a/apps/desktop/src/session/components/note-input/header-transcript-icon.tsx
+++ b/apps/desktop/src/session/components/note-input/header-transcript-icon.tsx
@@ -1,0 +1,43 @@
+/*
+ * Lucide AudioLines, kept here to match the live transcript bars.
+ * https://lucide.dev/icons/audio-lines
+ *
+ * ISC License
+ * Copyright (c) 2026 Lucide Icons and Contributors
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+export function TranscriptAudioIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="size-4"
+      aria-hidden
+    >
+      <path d="M2 10v3" />
+      <path d="M6 6v11" />
+      <path d="M10 3v18" />
+      <path d="M14 8v7" />
+      <path d="M18 5v13" />
+      <path d="M22 10v3" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/session/components/note-input/header-transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/header-transcript.tsx
@@ -1,13 +1,14 @@
 import { useLingui } from "@lingui/react/macro";
 import { useCallback, useMemo } from "react";
 
-import { CheckCircle, PencilSimple, Waveform } from "@anlg/ui/components/icons";
+import { CheckCircle, PencilSimple } from "@anlg/ui/components/icons";
 import { DancingSticks } from "@anlg/ui/components/ui/dancing-sticks";
 import { Spinner } from "@anlg/ui/components/ui/spinner";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 import { cn, safeParseDate } from "@anlg/utils";
 
 import { IconHeaderView, copyTextToClipboard } from "./header-shared";
+import { TranscriptAudioIcon } from "./header-transcript-icon";
 
 import * as AudioPlayer from "~/audio-player";
 import { useNow } from "~/calendar/hooks";
@@ -105,7 +106,7 @@ function HeaderViewTranscriptButton({
         ) : isTranscribing ? (
           <Spinner size={16} className="shrink-0" />
         ) : (
-          <Waveform className="size-4" />
+          <TranscriptAudioIcon />
         )
       }
       suffixIcon={suffixIcon}
@@ -152,7 +153,7 @@ function HeaderViewTranscriptLiveIcon({
   return (
     <span className="relative flex size-4 items-center justify-center">
       {live.muted ? (
-        <Waveform className="size-4" />
+        <TranscriptAudioIcon />
       ) : (
         <DancingSticks
           amplitude={live.amplitude}

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -1068,6 +1068,35 @@ describe("Header", () => {
     expect(hoisted.requestMainListenerControl).not.toHaveBeenCalled();
   });
 
+  it.each(["idle", "muted"])(
+    "shows static audio lines in the %s transcript tab",
+    (state) => {
+      hoisted.sessionMode = state === "muted" ? "active" : "inactive";
+      hoisted.liveMuted = state === "muted";
+
+      render(
+        <SessionViewSwitcher
+          sessionId="session-1"
+          editorTabs={[{ type: "raw" }, { type: "transcript" }]}
+          currentTab={{ type: "raw" }}
+          handleTabChange={vi.fn()}
+        />,
+      );
+
+      const transcriptTab = screen.getByRole("button", { name: "Transcript" });
+      const svg = transcriptTab.querySelector("svg");
+      const bars = svg?.querySelectorAll("path");
+
+      expect(svg?.getAttribute("fill")).toBe("none");
+      expect(svg?.getAttribute("stroke-linecap")).toBe("round");
+      expect(bars).toHaveLength(6);
+      for (const bar of bars ?? []) {
+        expect(bar.getAttribute("d")).toMatch(/^M\d+ \d+v\d+$/);
+      }
+      expect(screen.queryByTestId("dancing-sticks")).toBeNull();
+    },
+  );
+
   it("keeps stop out of the view switcher while listening", () => {
     hoisted.sessionMode = "active";
     const handleTabChange = vi.fn();

--- a/apps/desktop/src/session/components/note-input/template-picker.tsx
+++ b/apps/desktop/src/session/components/note-input/template-picker.tsx
@@ -610,10 +610,7 @@ function TemplateResultButton({
           {title}
         </span>
         {isFavorite ? (
-          <Heart
-            aria-hidden
-            className="size-3.5 shrink-0 fill-rose-500 text-rose-500"
-          />
+          <Heart aria-hidden className="size-3.5 shrink-0 text-rose-500" />
         ) : null}
       </button>
       {regenerateLabel && onRegenerate ? (

--- a/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
@@ -86,7 +86,7 @@ export function TranscriptEmptyState({
             className="gap-2"
             onClick={onStopTranscription}
           >
-            <Square className="size-3" weight="fill" />
+            <Square className="size-3" />
             {t`Stop transcription`}
           </Button>
         )}

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -269,7 +269,7 @@ function HeaderMeetingAction({
       return {
         label: t`Stop`,
         title: t`Stop listening`,
-        icon: <Square className="size-3 text-red-500" weight="fill" />,
+        icon: <Square className="size-3 text-red-500" />,
         onClick: stopListening,
       };
     }

--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -622,7 +622,7 @@ const _PROVIDERS = [
     id: "custom",
     displayName: "Custom",
     badge: null,
-    icon: <Shuffle weight="fill" />,
+    icon: <Shuffle />,
     baseUrl: undefined,
     requirements: [
       { kind: "requires_config", fields: ["base_url", "api_key"] },

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -1006,7 +1006,7 @@ const _PROVIDERS = [
     displayName: "Custom",
     description: "Deepgram-compatible",
     badge: null,
-    icon: <Shuffle weight="fill" />,
+    icon: <Shuffle />,
     baseUrl: undefined,
     models: [],
     requirements: [

--- a/apps/desktop/src/settings/automations/index.tsx
+++ b/apps/desktop/src/settings/automations/index.tsx
@@ -323,7 +323,7 @@ function CustomWorkflowDetails({
 
   return (
     <AutomationDetailsLayout
-      icon={<Lightning className="text-violet-500" size={16} weight="fill" />}
+      icon={<Lightning className="text-violet-500" size={16} />}
       title={title}
       description={description}
       actions={
@@ -360,7 +360,7 @@ function CustomWorkflowDetails({
                   : undefined
               }
             >
-              <Lightning size={14} weight="fill" />
+              <Lightning size={14} />
               <Trans>Save &amp; enable</Trans>
             </Button>
           )}
@@ -518,7 +518,7 @@ function StarterAutomationDetails({ starterId }: { starterId: StarterId }) {
         <div className="border-border flex flex-wrap items-start justify-between gap-3 border-b px-5 py-4">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <Lightning className="text-primary" size={17} weight="fill" />
+              <Lightning className="text-primary" size={17} />
               <h3
                 id="automation-draft-title"
                 className="truncate text-sm font-semibold"
@@ -594,7 +594,7 @@ function StarterAutomationDetails({ starterId }: { starterId: StarterId }) {
                 }
                 title={billing.isPro && !isReady ? readinessHint : undefined}
               >
-                <Lightning size={14} weight="fill" />
+                <Lightning size={14} />
                 <Trans>Save &amp; enable</Trans>
               </Button>
             )}

--- a/apps/desktop/src/shared/icons.test.tsx
+++ b/apps/desktop/src/shared/icons.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import * as icons from "@anlg/ui/components/icons";
+
+describe("outline icons", () => {
+  it.each(Object.entries(icons))(
+    "renders %s without filled shapes at every supported weight",
+    (_, Icon) => {
+      for (const weight of ["thin", "light", "regular", "bold"] as const) {
+        const { container, unmount } = render(
+          <Icon size={16} weight={weight} />,
+        );
+        const svg = container.querySelector("svg");
+
+        expect(svg?.getAttribute("fill")).toBe("none");
+        expect(svg?.querySelector('[fill]:not([fill="none"])')).toBeNull();
+        expect(svg?.querySelector('[stroke="currentColor"]')).not.toBeNull();
+        unmount();
+      }
+    },
+  );
+
+  it("ignores legacy fill props forwarded through a spread", () => {
+    const { container } = render(
+      <icons.Play {...{ size: 16, fill: "currentColor" }} />,
+    );
+
+    expect(container.querySelector("svg")?.getAttribute("fill")).toBe("none");
+  });
+});

--- a/apps/desktop/src/sidebar/automations.tsx
+++ b/apps/desktop/src/sidebar/automations.tsx
@@ -354,7 +354,7 @@ function DraftListItem({
       ])}
     >
       <span className="flex items-center gap-2">
-        <Lightning className="size-4 shrink-0 text-violet-500" weight="fill" />
+        <Lightning className="size-4 shrink-0 text-violet-500" />
         <span className="min-w-0 flex-1">
           <span className="block truncate font-medium">{title}</span>
           <span className="text-muted-foreground mt-0.5 block truncate text-xs">
@@ -410,7 +410,7 @@ function WorkflowListItem({
       ])}
     >
       <span className="flex items-center gap-2">
-        <Lightning className="size-4 shrink-0 text-violet-500" weight="fill" />
+        <Lightning className="size-4 shrink-0 text-violet-500" />
         <span className="min-w-0 flex-1">
           <span className="block truncate font-medium">
             {workflow.title.trim() || t`Untitled automation`}
@@ -471,7 +471,7 @@ function ChatAutomationListItem({
       ])}
     >
       <span className="flex items-center gap-2">
-        <Lightning className="size-4 shrink-0 text-violet-500" weight="fill" />
+        <Lightning className="size-4 shrink-0 text-violet-500" />
         <span className="min-w-0 flex-1">
           <span className="block truncate font-medium">{automation.title}</span>
           {createdAt ? (

--- a/apps/desktop/src/sidebar/note-filter-menu.tsx
+++ b/apps/desktop/src/sidebar/note-filter-menu.tsx
@@ -49,7 +49,7 @@ export function SidebarNoteFilterMenu() {
             !isDefaultView && "bg-accent text-foreground",
           ])}
         >
-          <FunnelSimple size={15} weight={isDefaultView ? "regular" : "fill"} />
+          <FunnelSimple size={15} weight={isDefaultView ? "regular" : "bold"} />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="start" className="w-56">

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -311,13 +311,11 @@ const ItemBase = memo(function ItemBase({
               <LockOpen
                 aria-label={t`Unlock Note`}
                 className="text-muted-foreground size-3.5 shrink-0"
-                weight="fill"
               />
             ) : (
               <Lock
                 aria-label={t`Locked note`}
                 className="text-muted-foreground size-3.5 shrink-0"
-                weight="fill"
               />
             )
           ) : null}
@@ -382,7 +380,7 @@ const ItemBase = memo(function ItemBase({
             aria-hidden
             className="hidden items-center justify-center group-hover/sidebar-live-item:flex"
           >
-            <Square size={10} weight="fill" />
+            <Square size={10} />
           </span>
         </button>
       ) : null}

--- a/apps/desktop/src/templates/template-form.tsx
+++ b/apps/desktop/src/templates/template-form.tsx
@@ -276,7 +276,7 @@ export function TemplateForm({
           >
             <Heart
               className="size-4"
-              weight={template.pinned ? "fill" : "regular"}
+              weight={template.pinned ? "bold" : "regular"}
             />
           </Button>
           <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>

--- a/apps/mobile/src/app/action-button.tsx
+++ b/apps/mobile/src/app/action-button.tsx
@@ -99,13 +99,21 @@ export default function ActionButtonScreen() {
         </Card>
 
         <View style={styles.usage}>
-          <Ionicons name="radio-button-on" size={18} color={Colors.primary} />
+          <Ionicons
+            name="radio-button-off-outline"
+            size={18}
+            color={Colors.primary}
+          />
           <Text style={styles.usageLabel}>Long press</Text>
           <Ionicons name="arrow-forward" size={16} color={Colors.muted} />
-          <Ionicons name="mic" size={18} color={Colors.primary} />
+          <Ionicons name="mic-outline" size={18} color={Colors.primary} />
           <Text style={styles.usageLabel}>Listen</Text>
           <Ionicons name="arrow-forward" size={16} color={Colors.muted} />
-          <Ionicons name="radio-button-on" size={18} color={Colors.primary} />
+          <Ionicons
+            name="radio-button-off-outline"
+            size={18}
+            color={Colors.primary}
+          />
           <Text style={styles.usageLabel}>Long press</Text>
         </View>
       </ScrollView>

--- a/apps/mobile/src/components/audio-chip.tsx
+++ b/apps/mobile/src/components/audio-chip.tsx
@@ -87,7 +87,7 @@ export function AudioChip({
       style={({ pressed }) => [styles.chip, pressed && styles.pressed]}
     >
       <Ionicons
-        name={status.playing ? "pause" : "play"}
+        name={status.playing ? "pause-outline" : "play-outline"}
         size={14}
         color={Colors.accent}
       />

--- a/apps/mobile/src/live-activity/meeting-recording-activity.ios.tsx
+++ b/apps/mobile/src/live-activity/meeting-recording-activity.ios.tsx
@@ -85,7 +85,7 @@ const MeetingRecordingActivity = (
           padding({ all: 16 }),
         ]}
       >
-        <Image systemName="circle.fill" size={10} color={ACCENT_COLOR} />
+        <Image systemName="circle" size={10} color={ACCENT_COLOR} />
         <VStack alignment="leading" spacing={3}>
           <Text
             modifiers={[
@@ -110,7 +110,7 @@ const MeetingRecordingActivity = (
     ),
     compactLeading: (
       <HStack spacing={5} modifiers={[padding({ leading: 4 })]}>
-        <Image systemName="circle.fill" size={7} color={ACCENT_COLOR} />
+        <Image systemName="circle" size={7} color={ACCENT_COLOR} />
         <Waveform size={15} />
       </HStack>
     ),
@@ -118,7 +118,7 @@ const MeetingRecordingActivity = (
     minimal: <Waveform size={16} />,
     expandedLeading: (
       <HStack spacing={7} modifiers={[padding({ leading: 6 })]}>
-        <Image systemName="circle.fill" size={8} color={ACCENT_COLOR} />
+        <Image systemName="circle" size={8} color={ACCENT_COLOR} />
         <Text
           modifiers={[
             font({ size: 14, weight: "semibold" }),

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -219,9 +219,9 @@ export function SharedNoteAudioPlayer({
         {downloadQuery.isPending && resolve ? (
           <CircleNotch className="size-3.5 animate-spin" aria-hidden="true" />
         ) : playing ? (
-          <Pause className="size-3.5" weight="fill" aria-hidden="true" />
+          <Pause className="size-3.5" aria-hidden="true" />
         ) : (
-          <Play className="ml-0.5 size-3.5" weight="fill" aria-hidden="true" />
+          <Play className="ml-0.5 size-3.5" aria-hidden="true" />
         )}
       </button>
       <span className="flex shrink-0 gap-1 font-mono text-[10px] tabular-nums">

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -40,7 +40,6 @@ import {
   CheckmarkCircle02Icon,
   CircleIcon,
   CircleMinusIcon,
-  ClipboardListIcon,
   Clock01Icon,
   CloudAlertIcon,
   CloudIcon,
@@ -173,6 +172,7 @@ import {
   StethoscopeIcon,
   Sun01Icon,
   Target01Icon,
+  Task01Icon,
   TextAlignLeftIcon,
   TextBoldIcon,
   TextFontIcon,
@@ -215,15 +215,12 @@ import {
   type RefAttributes,
 } from "react";
 
-export type IconWeight =
-  | "thin"
-  | "light"
-  | "regular"
-  | "bold"
-  | "fill"
-  | "duotone";
+export type IconWeight = "thin" | "light" | "regular" | "bold";
 
-export type IconProps = Omit<HugeiconsIconProps, "icon" | "strokeWidth"> & {
+export type IconProps = Omit<
+  HugeiconsIconProps,
+  "icon" | "strokeWidth" | "fill"
+> & {
   mirrored?: boolean;
   strokeWidth?: number;
   weight?: IconWeight;
@@ -238,27 +235,18 @@ const strokeWidthByWeight: Record<IconWeight, number> = {
   light: 1.25,
   regular: 1.5,
   bold: 2,
-  fill: 2.25,
-  duotone: 1.5,
 };
 
 function createIcon(icon: IconSvgElement, displayName: string): Icon {
   const Component = forwardRef<SVGSVGElement, IconProps>(
     (
-      {
-        fill,
-        mirrored = false,
-        strokeWidth,
-        style,
-        weight = "regular",
-        ...props
-      },
+      { mirrored = false, strokeWidth, style, weight = "regular", ...props },
       ref,
     ) => (
       <HugeiconsIcon
         {...props}
         ref={ref}
-        fill={fill ?? (weight === "fill" ? "currentColor" : undefined)}
+        fill="none"
         icon={icon}
         strokeWidth={strokeWidth ?? strokeWidthByWeight[weight]}
         style={
@@ -417,7 +405,7 @@ export const CirclesThreePlus = /* @__PURE__ */ createIcon(
   "CirclesThreePlus",
 );
 export const ClipboardText = /* @__PURE__ */ createIcon(
-  ClipboardListIcon,
+  Task01Icon,
   "ClipboardText",
 );
 export const Clock = /* @__PURE__ */ createIcon(Clock01Icon, "Clock");

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { cn } from "@anlg/utils";
 
-import { CaretRight, Check, Circle } from "../icons";
+import { CaretRight, Check } from "../icons";
 import {
   AppFloatingPanel,
   appFloatingContentClassName,
@@ -145,7 +145,10 @@ const DropdownMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2" />
+        <span
+          aria-hidden="true"
+          className="block h-2 w-2 rounded-full bg-current"
+        />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -145,7 +145,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2" weight="fill" />
+        <Circle className="h-2 w-2" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}


### PR DESCRIPTION
## Summary

**Problem:** The shared Hugeicons wrapper dropped `fill="none"`, causing outline icons to render as black silhouettes. Explicit fill weights, a favorite-icon CSS fill, and filled mobile glyphs also made the app inconsistent.

**Fix:** Make Hugeicons stroke-only, remove filled variants and overrides across desktop and shared web UI, and use outline glyphs on mobile. Pins and filters indicate their active state with a thicker stroke. Keep the transcript tab's Lucide AudioLines SVG for idle/muted states and its existing live dancing bars, without adding a dependency.

## Verification

- Rendered all 206 shared icon exports at all four supported stroke weights; 207 regression tests passed, including forwarded legacy fill props.
- `pnpm -F @anlg/desktop test`: 4,183 tests passed. `pnpm -F @anlg/mobile test`: 319 tests passed. Web, editor, Supabase, and provider-validation test suites also passed.
- Typechecks passed for `@anlg/ui`, `@anlg/desktop`, `@anlg/mobile`, `@anlg/web`, `@anlg/editor`, `@anlg/pricing`, `@anlg/supabase`, and `@anlg/provider-validation`.
- Shared UI build, changed-file dprint checks, desktop i18n, web media checks, both license-boundary checks, and all 64 common CI Node tests passed.
- Audited icon props/classes across desktop, mobile, and shared packages. Inspected rendered desktop SVGs and mobile Ionicons glyphs; checked iOS symbol names and the installed Android outlined Material Symbols assets. Native apps were not relaunched.

Existing unrelated findings:

- `pnpm exec eslint apps/web/src/components/shared-note-audio-player.tsx` fails at line 45 because the query key omits `resolve` and `attachment`. Reproduced against the original filled-icon version; the query code is unchanged.
- Desktop Oxlint reports 202 warnings and no errors. `uvx zizmor --format sarif .` reports 411 existing workflow findings; no workflows were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and icon-wrapper changes only; broad UI surface but no auth, data, or business-logic changes, with dedicated regression tests.
> 
> **Overview**
> Standardizes on **stroke-only icons** by changing the shared Hugeicons wrapper to always render with `fill="none"`, dropping `fill`/`duotone` weights, and sweeping desktop, web, and mobile call sites to remove filled variants and CSS fill hacks.
> 
> **Active-state affordances** that used filled glyphs (pins, favorites, filters, template hearts) now use **bolder stroke** (`bold` weight) or outline-only styling instead of `weight="fill"`. Stop/play controls, automation lightning icons, lock icons, and dropdown radio indicators follow the same outline treatment (radio selection uses a small `rounded-full` dot).
> 
> The **transcript tab** idle/muted icon switches from shared `Waveform` to an inlined Lucide **AudioLines** SVG (`TranscriptAudioIcon`), with tests asserting the six-bar outline graphic; live listening still uses dancing sticks.
> 
> **Mobile** moves to outline Ionicons and unfilled SF Symbols for recording UI. **`ClipboardText`** maps to `Task01Icon`. A new **`icons.test.tsx`** regression suite renders every shared export at all four weights to ensure no filled shapes slip through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dfa050f536b79b3e7fa3d229789fe7d96f50c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->