### PR TITLE
Remove the sign-in sheet bottom safe area

### DIFF
--- a/apps/mobile/src/auth/screens.tsx
+++ b/apps/mobile/src/auth/screens.tsx
@@ -1,4 +1,5 @@
 import { BottomSheet, RNHostView } from "@expo/ui";
+import { ignoreSafeArea } from "@expo/ui/swift-ui/modifiers";
 import { Image } from "expo-image";
 import * as WebBrowser from "expo-web-browser";
 import { useState } from "react";
@@ -64,6 +65,11 @@ export function SignInScreen({
       <BottomSheet
         isPresented={showSignInMethods}
         onDismiss={() => setShowSignInMethods(false)}
+        modifiers={
+          Platform.OS === "ios"
+            ? [ignoreSafeArea({ regions: "container", edges: "bottom" })]
+            : undefined
+        }
         testID="sign-in-methods"
       >
         <RNHostView matchContents>


### PR DESCRIPTION
Ignore the iOS container bottom inset for the sign-in methods sheet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iOS-only layout tweak to the auth bottom sheet; no auth, billing, or data-path changes.
> 
> **Overview**
> On iOS, the **sign-in methods** `BottomSheet` now applies the Swift UI `ignoreSafeArea` modifier so the **container** no longer reserves the **bottom** safe-area inset.
> 
> That removes the extra gap under the sheet content (e.g. provider buttons and legal text) on devices with a home indicator, without changing Android behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c0eb5af02972b0eb5a5c8c0beadf38d33d438e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->