### PR TITLE
Complete OAuth after the browser returns to Anarlog

### DIFF
--- a/apps/web/src/routes/_view/callback/auth.tsx
+++ b/apps/web/src/routes/_view/callback/auth.tsx
@@ -62,8 +62,17 @@ const validateSearch = z.object({
 });
 
 export const Route = createFileRoute("/_view/callback/auth")({
+  // Exchange from a same-origin request after Safari's cross-site return.
+  ssr: false,
   validateSearch,
   component: Component,
+  pendingComponent: () => (
+    <AuthShell
+      title="Finishing sign-in"
+      description="Please wait while we connect your account."
+      children={null}
+    />
+  ),
   head: () => ({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),


### PR DESCRIPTION
The mobile Apple sign-in callback failed because its server-side exchange could not find the PKCE verifier cookie. Load the callback page before exchanging the code, so the exchange uses a same-origin browser POST. Keep server-side PKCE validation and show a pending sign-in screen during the handoff.

Validation: web typecheck and 305 tests, Supabase typecheck and 22 tests, Vite production build/prerender, media checks, formatting, and license boundary check passed. Local HTTP verification returns the pending page without attempting the exchange; an invalid code still fails in the browser. A successful Apple retry on iOS is still required to confirm the reported failure is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and where OAuth completes for all providers hitting this callback; wrong behavior could block sign-in, but scope is limited to one route and PKCE validation stays server-side.
> 
> **Overview**
> Fixes Apple/mobile OAuth failures where the PKCE verifier cookie was missing during a **server-rendered** code exchange after the cross-site redirect.
> 
> The `/callback/auth` route now sets **`ssr: false`** so `beforeLoad` runs in the browser and `exchangeOAuthCode` is invoked as a same-origin POST with cookies intact. A **`pendingComponent`** shows an “Finishing sign-in” **AuthShell** while that handoff runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146c455d8c8a47ea0bcf4c4ac0668bd1bf50f236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->