### PR TITLE
Fix custom STT routing and batch support

### DIFF
--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -224,6 +224,10 @@ describe("getBatchProvider", () => {
     );
   });
 
+  test("maps custom endpoints to the Deepgram-compatible batch provider", () => {
+    expect(getBatchProvider("custom", "nova-3")).toBe("deepgram");
+  });
+
   test("maps local soniqo models to soniqo batch provider", () => {
     expect(getBatchProvider("anarlog", "soniqo-parakeet-batch")).toBe("soniqo");
     expect(getBatchProvider("soniqo", "soniqo-parakeet-batch")).toBe("soniqo");
@@ -1028,7 +1032,7 @@ describe("useRunBatch", () => {
     expect(sonnerToastWarningMock).not.toHaveBeenCalled();
   });
 
-  test("falls back to local Soniqo when the selected provider is not batch-capable", async () => {
+  test("uses custom Deepgram-compatible endpoints for batch transcription", async () => {
     useSTTConnectionMock.mockReturnValue({
       conn: {
         provider: "custom",
@@ -1047,20 +1051,14 @@ describe("useRunBatch", () => {
 
     expect(startTranscriptionMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "soniqo",
-        model: "soniqo-parakeet-batch",
-        base_url: "soniqo://local",
-        api_key: "",
+        provider: "deepgram",
+        model: "realtime-only",
+        base_url: "https://custom.test",
+        api_key: "custom-key",
       }),
       expect.any(Object),
     );
-    expect(sonnerToastWarningMock).toHaveBeenCalledWith(
-      "Using a batch transcription provider",
-      expect.objectContaining({
-        description:
-          "realtime-only is not available for batch transcription. Using Soniqo batch transcription instead.",
-      }),
-    );
+    expect(sonnerToastWarningMock).not.toHaveBeenCalled();
   });
 
   test.each(["windows", "linux"] as const)(
@@ -1093,7 +1091,7 @@ describe("useRunBatch", () => {
   );
 
   test.each(["windows", "linux"] as const)(
-    "does not invoke Soniqo as a batch fallback on %s",
+    "uses custom Deepgram-compatible batch endpoints on %s",
     async (currentPlatform) => {
       platformMock.mockReturnValue(currentPlatform);
       useSTTConnectionMock.mockReturnValue({
@@ -1107,15 +1105,19 @@ describe("useRunBatch", () => {
 
       const { result } = renderHook(() => useRunBatch("session-1"));
 
-      await expect(
-        act(async () => {
-          await result.current("/tmp/session.wav");
-        }),
-      ).rejects.toThrow(
-        "realtime-only is not available for batch transcription on this platform",
-      );
+      await act(async () => {
+        await result.current("/tmp/session.wav");
+      });
 
-      expect(startTranscriptionMock).not.toHaveBeenCalled();
+      expect(startTranscriptionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "deepgram",
+          model: "realtime-only",
+          base_url: "https://custom.test",
+          api_key: "custom-key",
+        }),
+        expect.any(Object),
+      );
       expect(sonnerToastWarningMock).not.toHaveBeenCalled();
     },
   );

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -113,7 +113,7 @@ export function getBatchProvider(
   provider: string,
   model: string,
 ): TranscriptionParams["provider"] | null {
-  if (provider === "cloudflare_workers_ai") {
+  if (provider === "custom" || provider === "cloudflare_workers_ai") {
     return "deepgram";
   }
 

--- a/crates/owhisper-client/src/adapter/deepgram/live.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/live.rs
@@ -60,7 +60,19 @@ impl RealtimeSttAdapter for DeepgramAdapter {
     }
 
     fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
-        serde_json::from_str(raw).into_iter().collect()
+        let event = match serde_json::from_str(raw) {
+            Ok(event) => event,
+            Err(_error) => {
+                tracing::warn!(
+                    error.type = "invalid_provider_payload",
+                    anarlog.payload.size_bytes = raw.len() as u64,
+                    "deepgram_json_parse_failed"
+                );
+                return vec![];
+            }
+        };
+
+        vec![event]
     }
 }
 

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -360,7 +360,14 @@ pub fn normalize_languages(languages: &[anlg_language::Language]) -> Vec<anlg_la
 }
 
 fn is_local_argmax(base_url: &str) -> bool {
-    host_matches(base_url, is_local_host) && !is_anarlog_local_proxy(base_url)
+    url::Url::parse(base_url)
+        .ok()
+        .map(|url| {
+            is_local_host(url.host_str().unwrap_or(""))
+                && url.port() == Some(50060)
+                && !is_anarlog_local_proxy(base_url)
+        })
+        .unwrap_or(false)
 }
 
 pub(crate) fn build_ws_url_from_base_with(

--- a/crates/owhisper-client/src/adapter/tests.rs
+++ b/crates/owhisper-client/src/adapter/tests.rs
@@ -101,6 +101,8 @@ fn test_is_local_argmax() {
 
     assert!(!is_local_argmax("https://api.anarlog.so/stt"));
     assert!(!is_local_argmax("http://localhost:3001/stt"));
+    assert!(!is_local_argmax("http://localhost:8080/v1"));
+    assert!(!is_local_argmax("http://127.0.0.1:8080/listen"));
     assert!(!is_local_argmax("https://api.deepgram.com"));
 }
 
@@ -196,6 +198,13 @@ fn test_adapter_kind_from_url_and_languages() {
             &[En],
             None,
             AdapterKind::Argmax,
+        ),
+        // Other local endpoints are custom Deepgram-compatible providers.
+        (
+            "http://localhost:8080/v1",
+            &[En],
+            None,
+            AdapterKind::Deepgram,
         ),
         (
             "https://openrouter.ai/api/v1",


### PR DESCRIPTION
## Summary

Fix custom speech-to-text routing and batch transcription without changing the configured endpoint, API key, or model.

- Route custom batch requests through the Deepgram-compatible adapter instead of falling back to Soniqo or failing on Windows and Linux.
- Restrict the legacy Argmax localhost heuristic to port `50060`, so other local endpoints such as `http://localhost:8080/v1` use the Deepgram-compatible adapter.
- Log malformed Deepgram-compatible streaming responses using only the error category and payload size, without exposing response contents.
- Add regression coverage for localhost adapter selection and custom batch routing, including Windows and Linux.

## Scope

Argmax and Cactus are no longer used. The Argmax references in this diff are leftover adapter plumbing, not a new integration. This PR fixes the routing collision but does not remove that obsolete code. Cactus is not changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b8807c8447bf87b0eef5f674a80ad32521eb9179. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
