### PR TITLE
Honor explicit sign-in choices across account switches

### DIFF
--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -12,7 +12,10 @@ import {
   type NewAccountAuthMethod,
   shouldOfferNewAccountTrialCheckoutFallback,
 } from "@/functions/new-account-trial-policy";
-import { oauthProviderScopes } from "@/functions/oauth-provider";
+import {
+  oauthProviderQueryParams,
+  oauthProviderScopes,
+} from "@/functions/oauth-provider";
 import { claimPendingReferral } from "@/functions/referrals";
 import {
   mapSsoAuthError,
@@ -286,8 +289,7 @@ export const doAuth = createServerFn({ method: "POST" })
       provider: data.provider,
       options: {
         redirectTo: buildAuthCallbackUrl(params),
-        queryParams:
-          data.provider === "azure" ? { prompt: "select_account" } : undefined,
+        queryParams: oauthProviderQueryParams(data.provider),
         scopes: oauthProviderScopes(data.provider),
       },
     });

--- a/apps/web/src/functions/oauth-provider.test.ts
+++ b/apps/web/src/functions/oauth-provider.test.ts
@@ -1,7 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { oauthProviderScopes } from "./oauth-provider.ts";
+import {
+  oauthProviderQueryParams,
+  oauthProviderScopes,
+} from "./oauth-provider.ts";
+
+test("Google and Microsoft sign-in let the user choose an account", () => {
+  for (const provider of ["google", "azure"] as const) {
+    assert.deepEqual(oauthProviderQueryParams(provider), {
+      prompt: "select_account",
+    });
+  }
+});
+
+test("other providers do not receive unsupported account chooser parameters", () => {
+  for (const provider of ["apple", "github"] as const) {
+    assert.equal(oauthProviderQueryParams(provider), undefined);
+  }
+});
 
 test("Microsoft login requests OIDC identity scopes", () => {
   assert.equal(oauthProviderScopes("azure"), "openid email profile");

--- a/apps/web/src/functions/oauth-provider.ts
+++ b/apps/web/src/functions/oauth-provider.ts
@@ -1,5 +1,12 @@
 export type OAuthProvider = "apple" | "azure" | "google" | "github";
 
+export function oauthProviderQueryParams(provider: OAuthProvider) {
+  if (provider === "google" || provider === "azure") {
+    return { prompt: "select_account" };
+  }
+  return undefined;
+}
+
 export function oauthProviderScopes(provider: OAuthProvider) {
   if (provider === "azure") {
     return "openid email profile";

--- a/apps/web/src/lib/auth-flow-context.test.ts
+++ b/apps/web/src/lib/auth-flow-context.test.ts
@@ -3,8 +3,25 @@ import test from "node:test";
 
 import {
   resolveAuthFlowContext,
+  shouldReuseBrowserSession,
   toAuthFlowSearch,
 } from "./auth-flow-context.ts";
+
+test("explicit provider choices bypass the previous browser account", () => {
+  for (const provider of ["apple", "google", "azure", "github"]) {
+    assert.equal(shouldReuseBrowserSession({ provider }), false);
+  }
+});
+
+test("email and SSO choices also bypass the previous browser account", () => {
+  for (const view of ["email", "sso"]) {
+    assert.equal(shouldReuseBrowserSession({ view }), false);
+  }
+});
+
+test("generic sign-in links can still reuse an authenticated browser session", () => {
+  assert.equal(shouldReuseBrowserSession({}), true);
+});
 
 test("restores desktop recovery context from the encoded Supabase redirect", () => {
   const context = resolveAuthFlowContext({

--- a/apps/web/src/lib/auth-flow-context.ts
+++ b/apps/web/src/lib/auth-flow-context.ts
@@ -11,6 +11,13 @@ export type AuthFlowContext = {
   redirect?: string;
 };
 
+export function shouldReuseBrowserSession(search: {
+  provider?: string;
+  view?: string;
+}) {
+  return search.provider === undefined && search.view === undefined;
+}
+
 export function resolveAuthFlowContext({
   flow,
   scheme,

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -29,7 +29,10 @@ import {
   flowSearchSchema,
 } from "@/functions/desktop-flow";
 import { useMountEffect } from "@/hooks/useMountEffect";
-import { toAuthFlowSearch } from "@/lib/auth-flow-context";
+import {
+  shouldReuseBrowserSession,
+  toAuthFlowSearch,
+} from "@/lib/auth-flow-context";
 import type { AuthSignInMethod } from "@/lib/auth-last-sign-in-method";
 import {
   buildPostAuthDestination,
@@ -60,7 +63,7 @@ export const Route = createFileRoute("/auth")({
   }),
   beforeLoad: async ({ search }) => {
     const [user, lastSignInMethod] = await Promise.all([
-      fetchUser(),
+      shouldReuseBrowserSession(search) ? fetchUser() : null,
       fetchLastSignInMethod(),
     ]);
 


### PR DESCRIPTION
After signing out of mobile and choosing Google, an existing Apple browser session could be handed back to the app before Google authentication started. Explicit provider, email, and SSO choices now bypass browser-session reuse. Google also requests its account chooser, so users can select a different Google account. Generic sign-in links retain the existing session handoff.

Validated with 310 web tests, 22 Supabase tests, both package typechecks, the production web build, targeted formatting and ESLint, media checks, license-boundary checks, and 64 common CI tests. Real account switching will be verified against the deployed callback with the mobile QA builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when authenticated users are auto-redirected on `/auth` and OAuth provider parameters; wrong gating could break desktop handoff or leave stale sessions, but scope is narrow and well-tested.
> 
> **Overview**
> Fixes account-switch bugs where an existing browser session (e.g. Apple) could short-circuit a newly chosen provider (e.g. Google) before OAuth started.
> 
> The `/auth` route **only** calls `fetchUser()` for generic sign-in links (no `provider` or `view` search params). Links that name a provider or open the email/SSO views skip session reuse, so users always get the flow they picked. Generic desktop/web handoff behavior is unchanged.
> 
> OAuth start now uses shared **`oauthProviderQueryParams`**: Google and Microsoft both send `prompt: select_account`; Apple and GitHub get no extra query params (replacing Azure-only inline logic in `doAuth`).
> 
> Unit tests cover the new helpers and session-reuse rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6ac410f7b959495b3522343fa37d0d2d256192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->