### PR TITLE
Provide the ready-made iPhone recording shortcut

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -132,6 +132,7 @@ jobs:
           test -n "$app"
           test -f "$app/Frameworks/CloudSync.framework/CloudSync"
           strings "$app/Frameworks/CloudSync.framework/CloudSync" | grep -F CLOUDSYNC_CURL_TIMEOUT_MS >/dev/null
+          node apps/mobile/scripts/verify-ios-shortcuts.mjs "$app"
 
   android_build:
     if: ${{ github.event_name != 'pull_request' }}

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,6 +16,7 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
+      "./modules/quick-actions/app.plugin.js",
       "expo-asset",
       "expo-dev-client",
       "expo-font",

--- a/apps/mobile/modules/quick-actions/app-target/AnarlogAppShortcuts.swift
+++ b/apps/mobile/modules/quick-actions/app-target/AnarlogAppShortcuts.swift
@@ -1,0 +1,32 @@
+internal import AnarlogQuickActions
+import AppIntents
+
+struct ToggleListeningIntent: AppIntent {
+  static var title: LocalizedStringResource = "Start or Stop Listening"
+  static var description = IntentDescription(
+    "Start a new meeting recording, or stop the recording already in progress."
+  )
+  static var openAppWhenRun: Bool = true
+
+  func perform() async throws -> some IntentResult {
+    AnarlogQuickActionsModule.toggleListening()
+    return .result()
+  }
+}
+
+struct AnarlogAppShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: ToggleListeningIntent(),
+      phrases: [
+        "Start listening with \(.applicationName)",
+        "Stop listening with \(.applicationName)",
+        "Quick capture with \(.applicationName)",
+      ],
+      shortTitle: "Start Listening",
+      systemImageName: "waveform"
+    )
+  }
+
+  static var shortcutTileColor: ShortcutTileColor = .yellow
+}

--- a/apps/mobile/modules/quick-actions/app.plugin.js
+++ b/apps/mobile/modules/quick-actions/app.plugin.js
@@ -1,0 +1,23 @@
+const { copyFileSync } = require("node:fs");
+const path = require("node:path");
+const { IOSConfig, withXcodeProject } = require("expo/config-plugins");
+
+module.exports = function withAnarlogAppShortcuts(config) {
+  return withXcodeProject(config, (config) => {
+    const projectName = config.modRequest.projectName;
+    const filename = "AnarlogAppShortcuts.swift";
+    const filepath = path.join(projectName, filename);
+
+    // AppShortcutsProvider must be compiled in the app target to be indexed by iOS.
+    copyFileSync(
+      path.join(__dirname, "app-target", filename),
+      path.join(config.modRequest.platformProjectRoot, filepath),
+    );
+    IOSConfig.XcodeUtils.addBuildSourceFileToGroup({
+      filepath,
+      groupName: projectName,
+      project: config.modResults,
+    });
+    return config;
+  });
+};

--- a/apps/mobile/modules/quick-actions/expo-module.config.json
+++ b/apps/mobile/modules/quick-actions/expo-module.config.json
@@ -1,7 +1,6 @@
 {
   "platforms": ["apple"],
   "apple": {
-    "modules": ["AnarlogQuickActionsModule"],
-    "appDelegateSubscribers": ["AnarlogQuickActionsAppDelegateSubscriber"]
+    "modules": ["AnarlogQuickActionsModule"]
   }
 }

--- a/apps/mobile/modules/quick-actions/index.ts
+++ b/apps/mobile/modules/quick-actions/index.ts
@@ -1,2 +1,3 @@
 export { default } from "./src/AnarlogQuickActionsModule";
 export * from "./src/AnarlogQuickActions.types";
+export { AnarlogShortcutsButton } from "./src/AnarlogShortcutsButton";

--- a/apps/mobile/modules/quick-actions/ios/AnarlogQuickActionsModule.swift
+++ b/apps/mobile/modules/quick-actions/ios/AnarlogQuickActionsModule.swift
@@ -5,43 +5,17 @@ import UIKit
 
 private let pendingActionKey = "quick-actions-pending-action"
 
-@available(iOS 16.0, *)
-struct ToggleListeningIntent: AppIntent {
-  static var title: LocalizedStringResource = "Start or Stop Listening"
-  static var description = IntentDescription(
-    "Start a new meeting recording, or stop the recording already in progress."
-  )
-  static var openAppWhenRun: Bool = true
-
-  func perform() async throws -> some IntentResult {
-    QuickActionsService.shared.enqueue(action: "toggle_listening")
-    return .result()
-  }
-}
-
-@available(iOS 16.0, *)
-struct AnarlogAppShortcuts: AppShortcutsProvider {
-  static var appShortcuts: [AppShortcut] {
-    AppShortcut(
-      intent: ToggleListeningIntent(),
-      phrases: [
-        "Start listening with \(.applicationName)",
-        "Stop listening with \(.applicationName)",
-        "Quick capture with \(.applicationName)",
-      ],
-      shortTitle: "Start Listening",
-      systemImageName: "waveform"
-    )
-  }
-
-  static var shortcutTileColor: ShortcutTileColor = .yellow
-}
-
 public class AnarlogQuickActionsModule: Module {
+  public static func toggleListening() {
+    QuickActionsService.shared.enqueue(action: "toggle_listening")
+  }
+
   public func definition() -> ModuleDefinition {
     Name("AnarlogQuickActions")
 
     Events("onAction")
+
+    View(AnarlogShortcutsButtonView.self) {}
 
     OnCreate {
       QuickActionsService.shared.attach(module: self)
@@ -61,17 +35,17 @@ public class AnarlogQuickActionsModule: Module {
   }
 }
 
-public class AnarlogQuickActionsAppDelegateSubscriber:
-  ExpoAppDelegateSubscriber
-{
-  public func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  ) -> Bool {
-    if #available(iOS 16.0, *) {
-      AnarlogAppShortcuts.updateAppShortcutParameters()
-    }
-    return true
+class AnarlogShortcutsButtonView: ExpoView {
+  private let button = ShortcutsUIButton(style: .automaticOutline)
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    addSubview(button)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    button.frame = bounds
   }
 }
 

--- a/apps/mobile/modules/quick-actions/src/AnarlogShortcutsButton.ios.tsx
+++ b/apps/mobile/modules/quick-actions/src/AnarlogShortcutsButton.ios.tsx
@@ -1,0 +1,6 @@
+import { requireNativeView } from "expo";
+import type { ViewProps } from "react-native";
+
+export const AnarlogShortcutsButton = requireNativeView<ViewProps>(
+  "AnarlogQuickActions",
+);

--- a/apps/mobile/modules/quick-actions/src/AnarlogShortcutsButton.tsx
+++ b/apps/mobile/modules/quick-actions/src/AnarlogShortcutsButton.tsx
@@ -1,0 +1,5 @@
+import type { ViewProps } from "react-native";
+
+export function AnarlogShortcutsButton(_props: ViewProps) {
+  return null;
+}

--- a/apps/mobile/scripts/verify-ios-shortcuts.mjs
+++ b/apps/mobile/scripts/verify-ios-shortcuts.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function verifyAppShortcuts(metadata) {
+  assert(
+    metadata.actions?.ToggleListeningIntent?.openAppWhenRun,
+    "The recording intent must open Anarlog to start microphone capture.",
+  );
+  assert(
+    metadata.autoShortcuts?.some(
+      (shortcut) =>
+        shortcut.actionIdentifier === "ToggleListeningIntent" &&
+        shortcut.shortTitle?.key === "Start Listening",
+    ),
+    "The app must include the ready-made Start Listening shortcut, not only its intent.",
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  assert(process.argv[2], "Pass the built .app directory.");
+  const metadata = JSON.parse(
+    readFileSync(
+      path.join(process.argv[2], "Metadata.appintents", "extract.actionsdata"),
+      "utf8",
+    ),
+  );
+  verifyAppShortcuts(metadata);
+  console.log("Start Listening App Shortcut is packaged in the app.");
+}

--- a/apps/mobile/scripts/verify-ios-shortcuts.test.mjs
+++ b/apps/mobile/scripts/verify-ios-shortcuts.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { verifyAppShortcuts } from "./verify-ios-shortcuts.mjs";
+
+const actions = { ToggleListeningIntent: { openAppWhenRun: true } };
+const autoShortcuts = [
+  {
+    actionIdentifier: "ToggleListeningIntent",
+    shortTitle: { key: "Start Listening" },
+  },
+];
+
+test("rejects a build that extracts the intent but drops its App Shortcut", () => {
+  assert.throws(() => verifyAppShortcuts({ actions }), /ready-made/);
+});
+
+test("accepts an app with the ready-made recording shortcut", () => {
+  verifyAppShortcuts({ actions, autoShortcuts });
+});
+
+test("rejects a shortcut that cannot foreground microphone capture", () => {
+  assert.throws(
+    () => verifyAppShortcuts({ actions: {}, autoShortcuts }),
+    /open Anarlog/,
+  );
+});

--- a/apps/mobile/src/app/action-button.tsx
+++ b/apps/mobile/src/app/action-button.tsx
@@ -14,6 +14,8 @@ import { IconButton } from "@/components/ui/icon-button";
 import { ControlSize, Radius, Spacing, Typography } from "@/constants/theme";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
 
+import { AnarlogShortcutsButton } from "../../modules/quick-actions";
+
 const steps = [
   {
     title: "Open Action Button settings",
@@ -81,6 +83,11 @@ export default function ActionButtonScreen() {
           <Text style={styles.description}>
             Your iPhone Action Button can start a new Anarlog recording or stop
             the one already in progress.
+          </Text>
+          <AnarlogShortcutsButton style={styles.shortcutsButton} />
+          <Text style={styles.shortcutHint}>
+            Start Listening is ready to use in Shortcuts. Try it once to allow
+            microphone access, then assign it below.
           </Text>
         </View>
 
@@ -172,6 +179,17 @@ const useStyles = createStyleHook((Colors) => ({
     marginTop: Spacing.xl,
     padding: Spacing.md,
     gap: Spacing.md,
+  },
+  shortcutsButton: {
+    height: ControlSize.default,
+    alignSelf: "stretch",
+    marginTop: Spacing.lg,
+  },
+  shortcutHint: {
+    ...Typography.caption,
+    color: Colors.muted,
+    textAlign: "center",
+    marginTop: Spacing.sm,
   },
   step: {
     flexDirection: "row",


### PR DESCRIPTION
The Action Button setup directed users to a Start Listening shortcut that was missing from the app’s packaged metadata. Compile the intent and AppShortcutsProvider in the app target through an Expo config plugin, and add Apple’s native Open in Shortcuts button to the setup screen. The included shortcut toggles the existing recording flow and remains compatible with iOS 16.4.

Add an iOS build check that rejects intent-only metadata, with regression coverage for the missing-shortcut failure.

Validation: mobile typecheck and 324 tests pass; formatting, license-boundary checks and 64 common CI tests pass. iOS Release builds succeed for both simulator and arm64 iPhone, and both packaged metadata checks pass; the previous device build fails that check as expected. Zizmor reports only existing findings. Shortcuts UI discovery and recording start/stop still need device verification; macOS is currently locked.
