### PR TITLE
Separate mobile memos from transcripts and generate summaries automatically

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/react-native";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { useFonts } from "expo-font";
 import { type ErrorBoundaryProps, Stack, usePathname } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
@@ -26,6 +26,7 @@ import {
   captureOperationalError,
   initializeErrorReporting,
 } from "@/lib/error-reporting";
+import { queryClient } from "@/lib/query-client";
 import { useMountEffect } from "@/lib/use-mount-effect";
 import { QuickActionLifecycle } from "@/quick-actions/quick-action-lifecycle";
 import { AppLock } from "@/settings/app-lock";
@@ -35,9 +36,6 @@ import { MobileSyncLifecycle } from "@/sync/mobile-sync-lifecycle";
 import { initializeWatchConnectivity } from "@/watch-connectivity";
 
 void initializeErrorReporting().catch(() => {});
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: 1, staleTime: 10_000 } },
-});
 initializeWatchConnectivity();
 SplashScreen.setOptions({ duration: 300, fade: true });
 

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -1,6 +1,5 @@
 import SegmentedControl from "@expo/ui/community/segmented-control";
 import { Ionicons } from "@expo/vector-icons";
-import { useMutation } from "@tanstack/react-query";
 import { File, Paths } from "expo-file-system";
 import * as Linking from "expo-linking";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -259,12 +258,6 @@ export default function NoteScreen() {
   const audio = useSessionAudio(id);
   const noteAttachments = useNoteAttachments(id);
   const transcripts = useSessionTranscripts(id);
-  const summarize = useMutation({
-    mutationFn: async () => {
-      await flush(true);
-      await summarizeSession(id);
-    },
-  });
   const summaryState = useSessionSummaryState(id);
   const [selectedTab, setSelectedTab] = useState(0);
   const transcription = useTranscriptionState(id);
@@ -297,8 +290,8 @@ export default function NoteScreen() {
   const active = listening && recorder.phase !== "saved";
   const showTabs = !active && (hasRecordingHistory || Boolean(data?.summary));
   const showMemos = !showTabs || selectedTab === 1;
-  const summaryPending = summarize.isPending || summaryState?.status === "pending";
-  const summaryError = summarize.error ?? summaryState?.error;
+  const summaryPending = summaryState?.status === "pending";
+  const summaryError = summaryState?.error;
   const localNoteAttachments = noteAttachments.map((attachment) => {
     const file = attachment.localRelativePath
       ? new File(Paths.document, "sessions", id, attachment.localRelativePath)
@@ -737,85 +730,129 @@ export default function NoteScreen() {
             onChangeText={(title) => onEdit({ title })}
             onFocus={() => setEditorFocused(true)}
           />
-          {showTabs && <View style={styles.tabs}>
-            <SegmentedControl values={["Summary", "Memos"]} selectedIndex={selectedTab}
-              onChange={(event) => {
-                void flush();
-                Keyboard.dismiss();
-                setEditorFocused(false);
-                setSelectedTab(event.nativeEvent.selectedSegmentIndex);
-              }} />
-          </View>}
-          {showTabs && !showMemos && <ScrollView style={styles.summaryScroll} contentContainerStyle={styles.summary}>
-            {data.summary && <View>
-              {data.summary.title !== "Summary" && <Text style={styles.summaryTitle}>{data.summary.title}</Text>}
-              <Text selectable style={styles.summaryText}>{data.summary.text}</Text>
-            </View>}
-            {!data.summary && <Text style={styles.summaryText}>
-              {summaryPending ? "Generating summary…" : transcription === "running" ? "Your summary will be generated when transcription finishes." : "Your meeting summary will appear here. Your memos are in the Memos tab."}
-            </Text>}
-            {summaryError && <Text accessibilityRole="alert" style={styles.summaryError}>{summaryError.message}</Text>}
-            <Button
-              label={!canSummarize ? "Choose summary provider" : summaryError ? "Retry summary" : data.summary ? "Regenerate summary" : "Generate summary"}
-              loading={summaryPending}
-              disabled={transcription === "running"}
-              variant="ghost" size="small"
-              onPress={() => canSummarize ? summarize.mutate() : router.push("/settings/summary-provider")}
-            />
-          </ScrollView>}
-          <View style={[styles.editor, !showMemos && styles.hidden]}>
-          {localNoteAttachments.length > 0 && (
-            <View style={styles.attachments}>
-              <Text style={styles.attachmentLabel}>Files</Text>
-              {localNoteAttachments.map(({ attachment, file }) => (
-                <NoteAttachmentCard
-                  key={attachment.attachmentId}
-                  availableLocally={file !== null}
-                  cloudAvailable={Boolean(
-                    attachment.cloudObjectKey &&
-                    auth.billing.isPro &&
-                    auth.session?.access_token &&
-                    env.supabaseUrl,
-                  )}
-                  errorMessage={
-                    attachmentActionError?.attachmentId ===
-                    attachment.attachmentId
-                      ? attachmentActionError.message
-                      : null
-                  }
-                  filename={attachment.filename}
-                  loading={attachmentActionId === attachment.attachmentId}
-                  onDownload={() => void handleDownloadAttachment(attachment)}
-                  onShare={() => {
-                    if (file) void handleShareAttachment(attachment, file.uri);
-                  }}
-                  sizeBytes={attachment.sizeBytes}
-                />
-              ))}
-            </View>
-          )}
-          {!data.plainEditable && (
-            <View style={styles.readOnlyChip}>
-              <Ionicons
-                name="lock-closed-outline"
-                size={12}
-                color={Colors.muted}
+          {showTabs && (
+            <View style={styles.tabs}>
+              <SegmentedControl
+                values={["Summary", "Memos"]}
+                selectedIndex={selectedTab}
+                onChange={(event) => {
+                  void flush();
+                  Keyboard.dismiss();
+                  setEditorFocused(false);
+                  setSelectedTab(event.nativeEvent.selectedSegmentIndex);
+                }}
               />
-              <Text style={styles.readOnlyLabel}>
-                Formatted note — edit the body on desktop
-              </Text>
             </View>
           )}
-          <BodyEditor
-            accessoryId={`note-editor-controls-${data.id}`}
-            defaultBodyFormat={data.bodyFormat}
-            defaultValue={data.noteText}
-            editable={data.plainEditable}
-            onAttach={handleAttachFile}
-            onChangeText={(body, bodyFormat) => onEdit({ body, bodyFormat })}
-            onCommit={flush}
-            onFocusChange={setEditorFocused}
-          />
+          {showTabs && !showMemos && (
+            <ScrollView
+              style={styles.summaryScroll}
+              contentContainerStyle={styles.summary}
+            >
+              {data.summary && (
+                <View>
+                  {data.summary.title !== "Summary" && (
+                    <Text style={styles.summaryTitle}>
+                      {data.summary.title}
+                    </Text>
+                  )}
+                  <Text selectable style={styles.summaryText}>
+                    {data.summary.text}
+                  </Text>
+                </View>
+              )}
+              {!data.summary && (
+                <Text style={styles.summaryText}>
+                  {summaryPending
+                    ? "Generating summary…"
+                    : transcription === "running"
+                      ? "Your summary will be generated when transcription finishes."
+                      : "Your meeting summary will appear here. Your memos are in the Memos tab."}
+                </Text>
+              )}
+              {summaryError && (
+                <Text accessibilityRole="alert" style={styles.summaryError}>
+                  {summaryError.message}
+                </Text>
+              )}
+              <Button
+                label={
+                  !canSummarize
+                    ? "Choose summary provider"
+                    : summaryError
+                      ? "Retry summary"
+                      : data.summary
+                        ? "Regenerate summary"
+                        : "Generate summary"
+                }
+                loading={summaryPending}
+                disabled={transcription === "running"}
+                variant="ghost"
+                size="small"
+                onPress={() =>
+                  canSummarize
+                    ? void summarizeSession(id, {
+                        beforeGenerate: () => flush(true),
+                      }).catch(() => {})
+                    : router.push("/settings/summary-provider")
+                }
+              />
+            </ScrollView>
+          )}
+          <View style={[styles.editor, !showMemos && styles.hidden]}>
+            {localNoteAttachments.length > 0 && (
+              <View style={styles.attachments}>
+                <Text style={styles.attachmentLabel}>Files</Text>
+                {localNoteAttachments.map(({ attachment, file }) => (
+                  <NoteAttachmentCard
+                    key={attachment.attachmentId}
+                    availableLocally={file !== null}
+                    cloudAvailable={Boolean(
+                      attachment.cloudObjectKey &&
+                      auth.billing.isPro &&
+                      auth.session?.access_token &&
+                      env.supabaseUrl,
+                    )}
+                    errorMessage={
+                      attachmentActionError?.attachmentId ===
+                      attachment.attachmentId
+                        ? attachmentActionError.message
+                        : null
+                    }
+                    filename={attachment.filename}
+                    loading={attachmentActionId === attachment.attachmentId}
+                    onDownload={() => void handleDownloadAttachment(attachment)}
+                    onShare={() => {
+                      if (file)
+                        void handleShareAttachment(attachment, file.uri);
+                    }}
+                    sizeBytes={attachment.sizeBytes}
+                  />
+                ))}
+              </View>
+            )}
+            {!data.plainEditable && (
+              <View style={styles.readOnlyChip}>
+                <Ionicons
+                  name="lock-closed-outline"
+                  size={12}
+                  color={Colors.muted}
+                />
+                <Text style={styles.readOnlyLabel}>
+                  Formatted note — edit the body on desktop
+                </Text>
+              </View>
+            )}
+            <BodyEditor
+              accessoryId={`note-editor-controls-${data.id}`}
+              defaultBodyFormat={data.bodyFormat}
+              defaultValue={data.noteText}
+              editable={data.plainEditable}
+              onAttach={handleAttachFile}
+              onChangeText={(body, bodyFormat) => onEdit({ body, bodyFormat })}
+              onCommit={flush}
+              onFocusChange={setEditorFocused}
+            />
           </View>
         </View>
       )}
@@ -839,57 +876,59 @@ export default function NoteScreen() {
         <ListeningSheet
           active={active}
           transcripts={transcripts}
-          recordingDetails={<>
-          {audio.data && localAudioAvailable && localAudioFile && (
-            <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
-              <AudioChip
-                uri={localAudioFile.uri}
-                filename={audio.data.filename}
-                sizeBytes={audio.data.sizeBytes}
-              />
-              <RecordingSyncCard audio={audio.data} />
-            </View>
-          )}
-          {audio.data && !localAudioAvailable && (
-            <RemoteAudioCard
-              cloudAvailable={Boolean(
-                audio.data.cloudObjectKey &&
-                auth.billing.isPro &&
-                auth.session?.access_token &&
-                env.supabaseUrl,
+          recordingDetails={
+            <>
+              {audio.data && localAudioAvailable && localAudioFile && (
+                <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
+                  <AudioChip
+                    uri={localAudioFile.uri}
+                    filename={audio.data.filename}
+                    sizeBytes={audio.data.sizeBytes}
+                  />
+                  <RecordingSyncCard audio={audio.data} />
+                </View>
               )}
-              errorMessage={audioRestoreError}
-              loading={restoringAudio}
-              onDownloadRecording={() => void handleDownloadRecording()}
-              onChooseRecording={() => void handleChooseRecording()}
-            />
-          )}
-          {audio.data &&
-            localAudioAvailable &&
-            audio.data.transcriptStatus !== "complete" &&
-            transcripts.length === 0 &&
-            (transcription === "running" ? (
-              <Text style={styles.transcribeStatus}>Transcribing…</Text>
-            ) : (
-              <Pressable
-                hitSlop={4}
-                onPress={() =>
-                  canTranscribe
-                    ? void transcribeSession(id)
-                    : router.push("/settings/transcription-provider")
-                }
-                style={({ pressed }) => pressed && styles.transcribePressed}
-              >
-                <Text style={styles.transcribeAction}>
-                  {!canTranscribe
-                    ? "Choose transcription provider"
-                    : transcription === "failed"
-                      ? "Transcription failed — tap to retry"
-                      : "Tap to transcribe"}
-                </Text>
-              </Pressable>
-            ))}
-          </>}
+              {audio.data && !localAudioAvailable && (
+                <RemoteAudioCard
+                  cloudAvailable={Boolean(
+                    audio.data.cloudObjectKey &&
+                    auth.billing.isPro &&
+                    auth.session?.access_token &&
+                    env.supabaseUrl,
+                  )}
+                  errorMessage={audioRestoreError}
+                  loading={restoringAudio}
+                  onDownloadRecording={() => void handleDownloadRecording()}
+                  onChooseRecording={() => void handleChooseRecording()}
+                />
+              )}
+              {audio.data &&
+                localAudioAvailable &&
+                audio.data.transcriptStatus !== "complete" &&
+                transcripts.length === 0 &&
+                (transcription === "running" ? (
+                  <Text style={styles.transcribeStatus}>Transcribing…</Text>
+                ) : (
+                  <Pressable
+                    hitSlop={4}
+                    onPress={() =>
+                      canTranscribe
+                        ? void transcribeSession(id)
+                        : router.push("/settings/transcription-provider")
+                    }
+                    style={({ pressed }) => pressed && styles.transcribePressed}
+                  >
+                    <Text style={styles.transcribeAction}>
+                      {!canTranscribe
+                        ? "Choose transcription provider"
+                        : transcription === "failed"
+                          ? "Transcription failed — tap to retry"
+                          : "Tap to transcribe"}
+                    </Text>
+                  </Pressable>
+                ))}
+            </>
+          }
           phase={recorder.phase}
           failure={recorder.failure}
           amplitude={recorder.amplitude}
@@ -927,11 +966,19 @@ const useStyles = createStyleHook((Colors) => ({
   },
   tabs: { marginHorizontal: Spacing.md, marginVertical: Spacing.md },
   hidden: { display: "none" },
-  summary: { paddingHorizontal: Spacing.md, paddingBottom: Spacing.lg, gap: Spacing.md },
+  summary: {
+    paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.lg,
+    gap: Spacing.md,
+  },
   summaryTitle: { ...Typography.section, color: Colors.ink },
   summaryScroll: { flex: 1 },
   summaryText: { ...Typography.body, color: Colors.ink },
-  summaryError: { ...Typography.caption, color: Colors.accent, marginTop: Spacing.sm },
+  summaryError: {
+    ...Typography.caption,
+    color: Colors.accent,
+    marginTop: Spacing.sm,
+  },
   transcribeStatus: {
     marginHorizontal: Spacing.md,
     marginTop: Spacing.xs,

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -1,3 +1,4 @@
+import SegmentedControl from "@expo/ui/community/segmented-control";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation } from "@tanstack/react-query";
 import { File, Paths } from "expo-file-system";
@@ -29,7 +30,6 @@ import { RecordingSyncCard } from "@/components/recording-sync-card";
 import { RemoteAudioCard } from "@/components/remote-audio-card";
 import { StartListeningButton } from "@/components/start-listening-button";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { IconButton } from "@/components/ui/icon-button";
 import { Spacing, Typography } from "@/constants/theme";
 import { useSessionAudio } from "@/data/audio-catalog";
@@ -54,7 +54,7 @@ import {
   saveSessionTitle,
   useSessionDetail,
 } from "@/data/session";
-import { summarizeSession } from "@/data/summarize";
+import { summarizeSession, useSessionSummaryState } from "@/data/summarize";
 import { transcribeSession, useTranscriptionState } from "@/data/transcribe";
 import { useSessionTranscripts } from "@/data/transcripts";
 import { captureAnalytics } from "@/lib/analytics";
@@ -265,6 +265,8 @@ export default function NoteScreen() {
       await summarizeSession(id);
     },
   });
+  const summaryState = useSessionSummaryState(id);
+  const [selectedTab, setSelectedTab] = useState(0);
   const transcription = useTranscriptionState(id);
   const [listening, setListening] = useState(listen === "1");
   const [editorFocused, setEditorFocused] = useState(false);
@@ -292,6 +294,11 @@ export default function NoteScreen() {
   const localAudioAvailable =
     audio.data?.availableLocally === true && localAudioFile?.exists === true;
   const hasRecordingHistory = audio.data !== null || transcripts.length > 0;
+  const active = listening && recorder.phase !== "saved";
+  const showTabs = !active && (hasRecordingHistory || Boolean(data?.summary));
+  const showMemos = !showTabs || selectedTab === 1;
+  const summaryPending = summarize.isPending || summaryState?.status === "pending";
+  const summaryError = summarize.error ?? summaryState?.error;
   const localNoteAttachments = noteAttachments.map((attachment) => {
     const file = attachment.localRelativePath
       ? new File(Paths.document, "sessions", id, attachment.localRelativePath)
@@ -311,7 +318,7 @@ export default function NoteScreen() {
   }>({});
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showEmptyNoteCta =
-    !listening &&
+    !active &&
     !editorFocused &&
     !audio.isLoading &&
     data !== null &&
@@ -398,13 +405,14 @@ export default function NoteScreen() {
   };
 
   const handleBack = async () => {
+    await flush();
     await recorder.stop();
-    flush();
     if (router.canGoBack()) router.back();
     else router.replace("/");
   };
 
   const handleStop = async () => {
+    await flush();
     const result = await recorder.stop();
     if (result !== "failed") setListening(false);
   };
@@ -659,7 +667,7 @@ export default function NoteScreen() {
     const title = (draft.title ?? current.title).trim() || "Untitled";
     const note = (draft.body ?? current.noteText).trim();
     const transcript = transcripts
-      .map((segment) => segment.text)
+      .map((segment) => `${segment.speaker}: ${segment.text}`)
       .join("\n\n")
       .trim();
     const sections = [`# ${title}`];
@@ -685,7 +693,7 @@ export default function NoteScreen() {
   };
 
   const handleListeningAction = () => {
-    if (listening) void handleStop();
+    if (active) void handleStop();
     else if (!audio.isLoading && !hasRecordingHistory) {
       setListening(true);
       void recorder.start();
@@ -729,107 +737,33 @@ export default function NoteScreen() {
             onChangeText={(title) => onEdit({ title })}
             onFocus={() => setEditorFocused(true)}
           />
-          {data.summary && (
-            <Card style={styles.summary} tone="muted">
-              <Text style={styles.summaryLabel}>Summary</Text>
-              {data.summary.title !== "Summary" && (
-                <Text style={styles.summaryTitle}>{data.summary.title}</Text>
-              )}
-              {data.summary.text !== "" && (
-                <ScrollView style={styles.summaryScroll} nestedScrollEnabled>
-                  <Text style={styles.summaryText}>{data.summary.text}</Text>
-                </ScrollView>
-              )}
-            </Card>
-          )}
-          {!listening &&
-            (transcripts.length > 0 || data.noteText.trim() !== "") && (
-              <View>
-                <Button
-                  label={
-                    !canSummarize
-                      ? "Choose summary provider"
-                      : data.summary
-                        ? "Regenerate summary"
-                        : "Generate summary"
-                  }
-                  loading={summarize.isPending}
-                  variant="ghost"
-                  size="small"
-                  onPress={() =>
-                    canSummarize
-                      ? summarize.mutate()
-                      : router.push("/settings/summary-provider")
-                  }
-                />
-                {summarize.error && (
-                  <Text style={styles.summaryText}>
-                    {summarize.error.message}
-                  </Text>
-                )}
-              </View>
-            )}
-          {audio.data && localAudioAvailable && localAudioFile && (
-            <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
-              <AudioChip
-                uri={localAudioFile.uri}
-                filename={audio.data.filename}
-                sizeBytes={audio.data.sizeBytes}
-              />
-              <RecordingSyncCard audio={audio.data} />
-            </View>
-          )}
-          {audio.data && !localAudioAvailable && (
-            <RemoteAudioCard
-              cloudAvailable={Boolean(
-                audio.data.cloudObjectKey &&
-                auth.billing.isPro &&
-                auth.session?.access_token &&
-                env.supabaseUrl,
-              )}
-              errorMessage={audioRestoreError}
-              loading={restoringAudio}
-              onDownloadRecording={() => void handleDownloadRecording()}
-              onChooseRecording={() => void handleChooseRecording()}
+          {showTabs && <View style={styles.tabs}>
+            <SegmentedControl values={["Summary", "Memos"]} selectedIndex={selectedTab}
+              onChange={(event) => {
+                void flush();
+                Keyboard.dismiss();
+                setEditorFocused(false);
+                setSelectedTab(event.nativeEvent.selectedSegmentIndex);
+              }} />
+          </View>}
+          {showTabs && !showMemos && <ScrollView style={styles.summaryScroll} contentContainerStyle={styles.summary}>
+            {data.summary && <View>
+              {data.summary.title !== "Summary" && <Text style={styles.summaryTitle}>{data.summary.title}</Text>}
+              <Text selectable style={styles.summaryText}>{data.summary.text}</Text>
+            </View>}
+            {!data.summary && <Text style={styles.summaryText}>
+              {summaryPending ? "Generating summary…" : transcription === "running" ? "Your summary will be generated when transcription finishes." : "Your meeting summary will appear here. Your memos are in the Memos tab."}
+            </Text>}
+            {summaryError && <Text accessibilityRole="alert" style={styles.summaryError}>{summaryError.message}</Text>}
+            <Button
+              label={!canSummarize ? "Choose summary provider" : summaryError ? "Retry summary" : data.summary ? "Regenerate summary" : "Generate summary"}
+              loading={summaryPending}
+              disabled={transcription === "running"}
+              variant="ghost" size="small"
+              onPress={() => canSummarize ? summarize.mutate() : router.push("/settings/summary-provider")}
             />
-          )}
-          {audio.data &&
-            localAudioAvailable &&
-            audio.data.transcriptStatus !== "complete" &&
-            transcripts.length === 0 &&
-            (transcription === "running" ? (
-              <Text style={styles.transcribeStatus}>Transcribing…</Text>
-            ) : (
-              <Pressable
-                hitSlop={4}
-                onPress={() =>
-                  canTranscribe
-                    ? void transcribeSession(id)
-                    : router.push("/settings/transcription-provider")
-                }
-                style={({ pressed }) => pressed && styles.transcribePressed}
-              >
-                <Text style={styles.transcribeAction}>
-                  {!canTranscribe
-                    ? "Choose transcription provider"
-                    : transcription === "failed"
-                      ? "Transcription failed — tap to retry"
-                      : "Tap to transcribe"}
-                </Text>
-              </Pressable>
-            ))}
-          {transcripts.length > 0 && (
-            <Card style={styles.transcript} tone="muted">
-              <Text style={styles.transcriptTitle}>Transcript</Text>
-              <ScrollView style={styles.transcriptScroll} nestedScrollEnabled>
-                {transcripts.map((segment) => (
-                  <Text key={segment.id} style={styles.transcriptText}>
-                    {segment.text}
-                  </Text>
-                ))}
-              </ScrollView>
-            </Card>
-          )}
+          </ScrollView>}
+          <View style={[styles.editor, !showMemos && styles.hidden]}>
           {localNoteAttachments.length > 0 && (
             <View style={styles.attachments}>
               <Text style={styles.attachmentLabel}>Files</Text>
@@ -882,6 +816,7 @@ export default function NoteScreen() {
             onCommit={flush}
             onFocusChange={setEditorFocused}
           />
+          </View>
         </View>
       )}
 
@@ -891,7 +826,7 @@ export default function NoteScreen() {
 
       <NoteActionsSheet
         hasRecordingHistory={hasRecordingHistory}
-        listening={listening}
+        listening={active}
         onClose={() => setActionsOpen(false)}
         onDelete={() => void handleDelete()}
         onExport={() => void handleExport()}
@@ -900,8 +835,61 @@ export default function NoteScreen() {
         visible={actionsOpen}
       />
 
-      {listening && (
+      {(active || hasRecordingHistory) && (
         <ListeningSheet
+          active={active}
+          transcripts={transcripts}
+          recordingDetails={<>
+          {audio.data && localAudioAvailable && localAudioFile && (
+            <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
+              <AudioChip
+                uri={localAudioFile.uri}
+                filename={audio.data.filename}
+                sizeBytes={audio.data.sizeBytes}
+              />
+              <RecordingSyncCard audio={audio.data} />
+            </View>
+          )}
+          {audio.data && !localAudioAvailable && (
+            <RemoteAudioCard
+              cloudAvailable={Boolean(
+                audio.data.cloudObjectKey &&
+                auth.billing.isPro &&
+                auth.session?.access_token &&
+                env.supabaseUrl,
+              )}
+              errorMessage={audioRestoreError}
+              loading={restoringAudio}
+              onDownloadRecording={() => void handleDownloadRecording()}
+              onChooseRecording={() => void handleChooseRecording()}
+            />
+          )}
+          {audio.data &&
+            localAudioAvailable &&
+            audio.data.transcriptStatus !== "complete" &&
+            transcripts.length === 0 &&
+            (transcription === "running" ? (
+              <Text style={styles.transcribeStatus}>Transcribing…</Text>
+            ) : (
+              <Pressable
+                hitSlop={4}
+                onPress={() =>
+                  canTranscribe
+                    ? void transcribeSession(id)
+                    : router.push("/settings/transcription-provider")
+                }
+                style={({ pressed }) => pressed && styles.transcribePressed}
+              >
+                <Text style={styles.transcribeAction}>
+                  {!canTranscribe
+                    ? "Choose transcription provider"
+                    : transcription === "failed"
+                      ? "Transcription failed — tap to retry"
+                      : "Tap to transcribe"}
+                </Text>
+              </Pressable>
+            ))}
+          </>}
           phase={recorder.phase}
           failure={recorder.failure}
           amplitude={recorder.amplitude}
@@ -937,28 +925,13 @@ const useStyles = createStyleHook((Colors) => ({
     ...Typography.title,
     color: Colors.ink,
   },
-  summary: {
-    marginHorizontal: Spacing.md,
-    marginTop: Spacing.md,
-    padding: Spacing.md,
-  },
-  summaryLabel: {
-    ...Typography.captionStrong,
-    color: Colors.muted,
-  },
-  summaryTitle: {
-    marginTop: Spacing.xs,
-    ...Typography.section,
-    color: Colors.ink,
-  },
-  summaryScroll: {
-    maxHeight: 220,
-    marginTop: Spacing.sm,
-  },
-  summaryText: {
-    ...Typography.body,
-    color: Colors.ink,
-  },
+  tabs: { marginHorizontal: Spacing.md, marginVertical: Spacing.md },
+  hidden: { display: "none" },
+  summary: { paddingHorizontal: Spacing.md, paddingBottom: Spacing.lg, gap: Spacing.md },
+  summaryTitle: { ...Typography.section, color: Colors.ink },
+  summaryScroll: { flex: 1 },
+  summaryText: { ...Typography.body, color: Colors.ink },
+  summaryError: { ...Typography.caption, color: Colors.accent, marginTop: Spacing.sm },
   transcribeStatus: {
     marginHorizontal: Spacing.md,
     marginTop: Spacing.xs,
@@ -973,26 +946,6 @@ const useStyles = createStyleHook((Colors) => ({
   },
   transcribePressed: {
     opacity: 0.6,
-  },
-  transcript: {
-    marginHorizontal: Spacing.md,
-    marginTop: Spacing.sm,
-    paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.sm,
-    paddingBottom: Spacing.xs,
-  },
-  transcriptTitle: {
-    ...Typography.captionStrong,
-    color: Colors.muted,
-    marginBottom: Spacing.xs,
-  },
-  transcriptScroll: {
-    maxHeight: 160,
-  },
-  transcriptText: {
-    ...Typography.body,
-    color: Colors.ink,
-    marginBottom: Spacing.sm,
   },
   attachments: {
     gap: Spacing.sm,

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -24,6 +24,7 @@ import {
   markSessionAudioTranscribed,
   type LiveTranscriptionStatus,
 } from "@/data/live-transcription";
+import { generateSummaryAfterTranscription } from "@/data/summarize";
 import { transcribeSession } from "@/data/transcribe";
 import { captureAnalytics } from "@/lib/analytics";
 import { captureOperationalError } from "@/lib/error-reporting";
@@ -153,7 +154,7 @@ export function useSessionRecorder(
             return;
           }
           setLiveStatus(status);
-          if (text !== "") setLiveTranscript(text);
+          setLiveTranscript(text);
         },
       );
       liveRef.current?.sendAudio(buffer.data);
@@ -399,14 +400,18 @@ export function useSessionRecorder(
       const liveComplete = await (live?.stop() ?? Promise.resolve(false));
       let transcriptionMode = liveComplete ? "live" : "batch_fallback";
       if (liveComplete) {
-        await markSessionAudioTranscribed(sessionId).catch((error) => {
-          transcriptionMode = "batch_fallback";
-          captureOperationalError(error, {
-            operation: "transcription_live_mark_complete",
-            tags: { mode: "live" },
+        await markSessionAudioTranscribed(sessionId)
+          .then(() => {
+            generateSummaryAfterTranscription(sessionId);
+          })
+          .catch((error) => {
+            transcriptionMode = "batch_fallback";
+            captureOperationalError(error, {
+              operation: "transcription_live_mark_complete",
+              tags: { mode: "live" },
+            });
+            void transcribeSession(sessionId);
           });
-          void transcribeSession(sessionId);
-        });
       } else {
         void transcribeSession(sessionId);
       }

--- a/apps/mobile/src/components/listening-sheet.tsx
+++ b/apps/mobile/src/components/listening-sheet.tsx
@@ -1,17 +1,15 @@
+import { BottomSheet, RNHostView } from "@expo/ui";
 import { Ionicons } from "@expo/vector-icons";
-import { useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import {
   ActivityIndicator,
+  FlatList,
+  Keyboard,
   Pressable,
   StyleSheet,
   Text,
   View,
 } from "react-native";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated";
 
 import type {
   RecorderFailure,
@@ -22,13 +20,11 @@ import {
   CornerCurve,
   LISTENING_CONTROL_HEIGHT,
   LISTENING_CONTROL_RADIUS,
-  Radius,
   Spacing,
   Typography,
 } from "@/constants/theme";
+import type { TranscriptSegment } from "@/data/transcripts";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
-
-const DETAIL_HEIGHT = 124;
 
 function formatDuration(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
@@ -70,22 +66,28 @@ function transcriptionLabel(status: "connecting" | "live" | "fallback") {
 }
 
 export function ListeningSheet({
+  active,
   phase,
   failure,
   amplitude,
   durationMs,
   liveStatus,
   liveTranscript,
+  transcripts,
+  recordingDetails,
   onStop,
   onRetry,
   onOpenSettings,
 }: {
+  active: boolean;
   phase: RecorderPhase;
   failure: RecorderFailure | null;
   amplitude: number;
   durationMs: number;
   liveStatus: "connecting" | "live" | "fallback";
   liveTranscript: string;
+  transcripts: TranscriptSegment[];
+  recordingDetails: ReactNode;
   onStop: () => void;
   onRetry: () => void;
   onOpenSettings: () => void;
@@ -93,19 +95,8 @@ export function ListeningSheet({
   const styles = useStyles();
   const Colors = useColors();
   const [expanded, setExpanded] = useState(false);
-  const detailHeight = useSharedValue(0);
-
-  const toggle = () => {
-    const next = !expanded;
-    setExpanded(next);
-    detailHeight.value = withTiming(next ? DETAIL_HEIGHT : 0, {
-      duration: 240,
-    });
-  };
-
-  const detailStyle = useAnimatedStyle(() => ({
-    height: detailHeight.value,
-  }));
+  const listRef = useRef<FlatList<TranscriptSegment>>(null);
+  const following = useRef(active);
   const permissionDenied =
     phase === "unavailable" &&
     (failure === "permission_denied" ||
@@ -116,132 +107,195 @@ export function ListeningSheet({
     : recoverable
       ? onRetry
       : onStop;
-
-  return (
-    <View style={styles.sheet}>
-      <Pressable hitSlop={12} onPress={toggle} style={styles.chevron}>
-        <Ionicons
-          name={expanded ? "chevron-down" : "chevron-up"}
-          size={22}
-          color={Colors.muted}
-        />
-      </Pressable>
-
-      <Animated.View style={[styles.detail, detailStyle]}>
-        <View style={styles.detailRow}>
-          <View style={styles.recordingDot} />
-          <Text style={styles.detailStatus}>
-            {statusLabel(phase, durationMs)}
+  const control = (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={
+        permissionDenied
+          ? "Open recording settings"
+          : recoverable
+            ? "Recover recording"
+            : "Stop listening"
+      }
+      onPress={handlePanelPress}
+      disabled={phase === "saving"}
+      style={({ pressed }) => [styles.panel, pressed && styles.panelPressed]}
+    >
+      {phase === "saving" ? (
+        <View style={styles.panelCenter}>
+          <ActivityIndicator color={Colors.inkInverse} />
+        </View>
+      ) : permissionDenied ? (
+        <View style={styles.panelCenter}>
+          <Text style={styles.panelMessage}>
+            {failure === "notification_permission_denied"
+              ? "Allow recording notifications in Settings"
+              : "Microphone access is off — open Settings"}
           </Text>
         </View>
-        <Text style={styles.transcriptionStatus}>
-          {transcriptionLabel(liveStatus)}
-        </Text>
-        <Text numberOfLines={2} style={styles.detailHint}>
-          {liveTranscript ||
-            "Leave your phone on the table and talk. Audio stays locally durable while Anarlog listens."}
-        </Text>
-      </Animated.View>
+      ) : phase === "interrupted" ? (
+        <View style={styles.panelCenter}>
+          <Text style={styles.panelMessage}>
+            Interrupted — tap to save or retry
+          </Text>
+        </View>
+      ) : phase === "save_error" ? (
+        <View style={styles.panelCenter}>
+          <Text style={styles.panelMessage}>Couldn't save — tap to retry</Text>
+        </View>
+      ) : phase === "error" ? (
+        <View style={styles.panelCenter}>
+          <Text style={styles.panelMessage}>Tap to recover recording</Text>
+        </View>
+      ) : (
+        <DancingSticks
+          amplitude={amplitude}
+          color={Colors.inkInverse}
+          height={36}
+          width={80}
+          stickWidth={3}
+          gap={3}
+        />
+      )}
+    </Pressable>
+  );
+  const label = active ? statusLabel(phase, durationMs) : "Transcript";
 
-      <Pressable
-        onPress={handlePanelPress}
-        disabled={phase === "saving"}
-        style={({ pressed }) => [styles.panel, pressed && styles.panelPressed]}
+  return (
+    <>
+      <View style={styles.dock}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Open full transcript"
+          onPress={() => {
+            Keyboard.dismiss();
+            following.current = active;
+            setExpanded(true);
+          }}
+          style={styles.heading}
+        >
+          {active && <View style={styles.recordingDot} />}
+          <Text style={styles.headingText}>{label}</Text>
+          <Ionicons name="chevron-up" size={20} color={Colors.muted} />
+        </Pressable>
+        {active && control}
+      </View>
+      <BottomSheet
+        isPresented={expanded}
+        onDismiss={() => setExpanded(false)}
+        snapPoints={["half", "full"]}
+        contentPadding={0}
       >
-        {phase === "saving" ? (
-          <View style={styles.panelCenter}>
-            <ActivityIndicator color={Colors.inkInverse} />
+        <RNHostView>
+          <View style={styles.content}>
+            <View style={styles.heading}>
+              {active && <View style={styles.recordingDot} />}
+              <Text style={styles.headingText}>{label}</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Close transcript"
+                hitSlop={12}
+                onPress={() => setExpanded(false)}
+              >
+                <Ionicons name="chevron-down" size={22} color={Colors.muted} />
+              </Pressable>
+            </View>
+            <FlatList
+              ref={listRef}
+              style={styles.list}
+              contentContainerStyle={styles.transcriptContent}
+              data={transcripts}
+              keyExtractor={(item) => item.id}
+              onScroll={({
+                nativeEvent: { contentOffset, contentSize, layoutMeasurement },
+              }) => {
+                following.current =
+                  contentSize.height -
+                    layoutMeasurement.height -
+                    contentOffset.y <
+                  80;
+              }}
+              scrollEventThrottle={100}
+              onContentSizeChange={() => {
+                if (active && following.current)
+                  listRef.current?.scrollToEnd({ animated: true });
+              }}
+              renderItem={({ item }) => (
+                <View style={styles.turn}>
+                  <Text style={styles.speaker}>{item.speaker}</Text>
+                  <Text selectable style={styles.transcriptText}>
+                    {item.text}
+                  </Text>
+                </View>
+              )}
+              ListEmptyComponent={
+                !liveTranscript ? (
+                  <Text style={styles.hint}>
+                    {active
+                      ? liveStatus === "fallback"
+                        ? "Your recording will be transcribed after you stop listening."
+                        : "Your transcript will appear here as you speak."
+                      : "No transcript yet."}
+                  </Text>
+                ) : null
+              }
+              ListFooterComponent={
+                <View>
+                  {active && liveTranscript !== "" && (
+                    <View style={styles.turn}>
+                      <Text style={styles.speaker}>Speaking…</Text>
+                      <Text style={styles.hint}>{liveTranscript}</Text>
+                    </View>
+                  )}
+                  {!active && recordingDetails}
+                </View>
+              }
+            />
+            {active && (
+              <View style={styles.controls}>
+                <Text style={styles.hint}>
+                  {transcriptionLabel(liveStatus)}
+                </Text>
+                {control}
+              </View>
+            )}
           </View>
-        ) : permissionDenied ? (
-          <View style={styles.panelCenter}>
-            <Text style={styles.panelMessage}>
-              {failure === "notification_permission_denied"
-                ? "Allow recording notifications in Settings"
-                : "Microphone access is off — open Settings"}
-            </Text>
-          </View>
-        ) : phase === "interrupted" ? (
-          <View style={styles.panelCenter}>
-            <Text style={styles.panelMessage}>
-              Interrupted — tap to save or retry
-            </Text>
-          </View>
-        ) : phase === "save_error" ? (
-          <View style={styles.panelCenter}>
-            <Text style={styles.panelMessage}>
-              Couldn't save — tap to retry
-            </Text>
-          </View>
-        ) : phase === "error" ? (
-          <View style={styles.panelCenter}>
-            <Text style={styles.panelMessage}>Tap to recover recording</Text>
-          </View>
-        ) : (
-          <DancingSticks
-            amplitude={amplitude}
-            color={Colors.inkInverse}
-            height={36}
-            width={80}
-            stickWidth={3}
-            gap={3}
-          />
-        )}
-      </Pressable>
-    </View>
+        </RNHostView>
+      </BottomSheet>
+    </>
   );
 }
 
 const useStyles = createStyleHook((Colors) => ({
-  sheet: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderBottomWidth: 0,
+  dock: {
+    paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.sm,
+    borderTopWidth: StyleSheet.hairlineWidth,
     borderColor: Colors.border,
-    borderTopLeftRadius: Radius.sheet,
-    borderTopRightRadius: Radius.sheet,
-    backgroundColor: Colors.background,
-    paddingHorizontal: Spacing.lg,
-    paddingBottom: Spacing.md,
-    shadowColor: Colors.ink,
-    shadowOffset: { width: 0, height: -4 },
-    shadowOpacity: 0.06,
-    shadowRadius: 12,
-    elevation: 4,
   },
-  chevron: {
-    alignSelf: "center",
-    paddingVertical: Spacing.sm,
-  },
-  detail: {
-    overflow: "hidden",
-  },
-  detailRow: {
+  content: { flex: 1 },
+  heading: {
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.sm,
-    paddingHorizontal: Spacing.sm,
+    padding: Spacing.md,
   },
+  headingText: { flex: 1, ...Typography.bodyStrong, color: Colors.ink },
+  list: { flex: 1 },
+  transcriptContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.lg,
+  },
+  turn: { paddingVertical: Spacing.sm, gap: Spacing.xs },
+  speaker: { ...Typography.captionStrong, color: Colors.muted },
+  transcriptText: { ...Typography.body, color: Colors.ink },
+  hint: { ...Typography.caption, color: Colors.muted },
+  controls: { padding: Spacing.md, gap: Spacing.sm },
   recordingDot: {
     width: 10,
     height: 10,
     borderRadius: 5,
-    borderCurve: CornerCurve.squircle,
     backgroundColor: Colors.accent,
-  },
-  detailStatus: {
-    ...Typography.bodyStrong,
-    color: Colors.ink,
-  },
-  detailHint: {
-    paddingHorizontal: Spacing.sm,
-    paddingTop: Spacing.sm,
-    ...Typography.caption,
-    color: Colors.muted,
-  },
-  transcriptionStatus: {
-    paddingHorizontal: Spacing.sm,
-    paddingTop: Spacing.xs,
-    ...Typography.captionStrong,
-    color: Colors.ink,
   },
   panel: {
     height: LISTENING_CONTROL_HEIGHT,
@@ -251,16 +305,7 @@ const useStyles = createStyleHook((Colors) => ({
     borderCurve: CornerCurve.squircle,
     backgroundColor: Colors.accent,
   },
-  panelPressed: {
-    opacity: 0.9,
-  },
-  panelCenter: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  panelMessage: {
-    ...Typography.label,
-    color: Colors.inkInverse,
-  },
+  panelPressed: { opacity: 0.9 },
+  panelCenter: { flex: 1, alignItems: "center", justifyContent: "center" },
+  panelMessage: { ...Typography.label, color: Colors.inkInverse },
 }));

--- a/apps/mobile/src/data/live-transcription-access.test.mjs
+++ b/apps/mobile/src/data/live-transcription-access.test.mjs
@@ -238,6 +238,11 @@ test("own-key live recording works after trial expiry and persists the selected 
   assert.equal(fixture.transactions.length, 0);
   native.listener.onMessage(transcript("Hello"));
   await settle();
+  assert.equal(
+    updates.at(-1).text,
+    "",
+    "Committed words are read from SQLite, not repeated as a partial",
+  );
   fixture.finalize = (listener) => listener.onMessage(transcript("Hello!"));
   assert.equal(await live.stop(), true);
   assert.equal(native.cancelled, true);

--- a/apps/mobile/src/data/live-transcription.ts
+++ b/apps/mobile/src/data/live-transcription.ts
@@ -388,7 +388,7 @@ export class SessionLiveTranscription {
       );
       for (const word of event.words) this.wordsById.set(word.id, word);
       for (const hint of event.hints) this.hintsById.set(hint.id, hint);
-      this.onUpdate({ status: this.status, text: event.text });
+      this.onUpdate({ status: this.status, text: "" });
       this.persistDelta(event.words, replacedIds);
     }
   }

--- a/apps/mobile/src/data/summarize.ts
+++ b/apps/mobile/src/data/summarize.ts
@@ -1,8 +1,11 @@
+import { useMutationState } from "@tanstack/react-query";
 import { fetch } from "expo/fetch";
 
 import { execute, executeTransaction } from "@/db";
 import { env } from "@/lib/env";
+import { captureOperationalError } from "@/lib/error-reporting";
 import { id, nowIso } from "@/lib/ids";
+import { queryClient } from "@/lib/query-client";
 import { readPreferences } from "@/settings/preferences";
 import { resolveProvider } from "@/settings/providers";
 
@@ -11,24 +14,27 @@ import { summaryRequest } from "./provider-summary";
 import { buildSummaryPrompt, readSummaryText } from "./summary-model";
 import { readBoundedTranscriptionResponse } from "./transcription-response";
 
-export async function summarizeSession(sessionId: string): Promise<void> {
-  const [notes, transcripts, existing, preferences, provider] =
-    await Promise.all([
-      execute<{ body: string; body_format: string }>(
-        "SELECT body, body_format FROM session_documents WHERE session_id = ? AND kind = 'note' AND deleted_at IS NULL ORDER BY CASE WHEN id = session_id THEN 0 ELSE 1 END, sort_order, id LIMIT 1",
-        [sessionId],
-      ),
-      execute<{ words_json: string }>(
-        "SELECT words_json FROM transcripts WHERE session_id = ? AND deleted_at IS NULL ORDER BY started_at_ms, id",
-        [sessionId],
-      ),
-      execute<{ id: string; updated_at: string }>(
-        "SELECT id, updated_at FROM session_documents WHERE session_id = ? AND kind = 'summary' AND deleted_at IS NULL ORDER BY sort_order, created_at, id LIMIT 1",
-        [sessionId],
-      ),
-      readPreferences(),
-      resolveProvider("llm"),
-    ]);
+async function runSummary(
+  sessionId: string,
+  automatic: boolean,
+): Promise<void> {
+  const existing = await execute<{ id: string; updated_at: string }>(
+    "SELECT id, updated_at FROM session_documents WHERE session_id = ? AND kind = 'summary' AND deleted_at IS NULL ORDER BY sort_order, created_at, id LIMIT 1",
+    [sessionId],
+  );
+  if (automatic && existing.length > 0) return;
+  const [notes, transcripts, preferences, provider] = await Promise.all([
+    execute<{ body: string; body_format: string }>(
+      "SELECT body, body_format FROM session_documents WHERE session_id = ? AND kind = 'note' AND deleted_at IS NULL ORDER BY CASE WHEN id = session_id THEN 0 ELSE 1 END, sort_order, id LIMIT 1",
+      [sessionId],
+    ),
+    execute<{ words_json: string }>(
+      "SELECT words_json FROM transcripts WHERE session_id = ? AND deleted_at IS NULL ORDER BY started_at_ms, id",
+      [sessionId],
+    ),
+    readPreferences(),
+    resolveProvider("llm"),
+  ]);
   const note = notes[0];
   const text = note
     ? (note.body_format === "markdown"
@@ -118,4 +124,42 @@ export async function summarizeSession(sessionId: string): Promise<void> {
     throw new Error(
       "This note changed while generating its summary. Please try again.",
     );
+}
+
+const inflight = new Map<string, Promise<void>>();
+
+export function summarizeSession(
+  sessionId: string,
+  automatic = false,
+): Promise<void> {
+  const pending = inflight.get(sessionId);
+  if (pending) return pending;
+  const mutation = queryClient.getMutationCache().build(queryClient, {
+    mutationKey: ["session-summary", sessionId],
+    mutationFn: () => runSummary(sessionId, automatic),
+    retry: false,
+    onError: (error) =>
+      captureOperationalError(error, { operation: "session_summary" }),
+  });
+  const promise = mutation
+    .execute(undefined)
+    .finally(() => inflight.delete(sessionId));
+  inflight.set(sessionId, promise);
+  return promise;
+}
+
+export function generateSummaryAfterTranscription(sessionId: string): void {
+  // Summary failures are visible in the note; they must never fail audio persistence.
+  void summarizeSession(sessionId, true).catch(() => {});
+}
+
+export function useSessionSummaryState(sessionId: string) {
+  const states = useMutationState({
+    filters: { mutationKey: ["session-summary", sessionId], exact: true },
+    select: (mutation) => ({
+      status: mutation.state.status,
+      error: mutation.state.error,
+    }),
+  });
+  return states.at(-1);
 }

--- a/apps/mobile/src/data/summarize.ts
+++ b/apps/mobile/src/data/summarize.ts
@@ -12,6 +12,12 @@ import { resolveProvider } from "@/settings/providers";
 import { docToPlainText, stripMarkdownTitle } from "./note-doc";
 import { summaryRequest } from "./provider-summary";
 import { buildSummaryPrompt, readSummaryText } from "./summary-model";
+import {
+  SESSION_TRANSCRIPTS_SQL,
+  SESSION_SPEAKERS_SQL,
+  transcriptSegments,
+  type TranscriptRow,
+} from "./transcript-model";
 import { readBoundedTranscriptionResponse } from "./transcription-response";
 
 async function runSummary(
@@ -23,18 +29,18 @@ async function runSummary(
     [sessionId],
   );
   if (automatic && existing.length > 0) return;
-  const [notes, transcripts, preferences, provider] = await Promise.all([
-    execute<{ body: string; body_format: string }>(
-      "SELECT body, body_format FROM session_documents WHERE session_id = ? AND kind = 'note' AND deleted_at IS NULL ORDER BY CASE WHEN id = session_id THEN 0 ELSE 1 END, sort_order, id LIMIT 1",
-      [sessionId],
-    ),
-    execute<{ words_json: string }>(
-      "SELECT words_json FROM transcripts WHERE session_id = ? AND deleted_at IS NULL ORDER BY started_at_ms, id",
-      [sessionId],
-    ),
-    readPreferences(),
-    resolveProvider("llm"),
-  ]);
+  const [notes, transcripts, humans, preferences, provider] = await Promise.all(
+    [
+      execute<{ body: string; body_format: string }>(
+        "SELECT body, body_format FROM session_documents WHERE session_id = ? AND kind = 'note' AND deleted_at IS NULL ORDER BY CASE WHEN id = session_id THEN 0 ELSE 1 END, sort_order, id LIMIT 1",
+        [sessionId],
+      ),
+      execute<TranscriptRow>(SESSION_TRANSCRIPTS_SQL, [sessionId]),
+      execute<{ id: string; name: string }>(SESSION_SPEAKERS_SQL, [sessionId]),
+      readPreferences(),
+      resolveProvider("llm"),
+    ],
+  );
   const note = notes[0];
   const text = note
     ? (note.body_format === "markdown"
@@ -42,15 +48,10 @@ async function runSummary(
         : docToPlainText(note.body)
       ).text
     : "";
+  const names = new Map(humans.map((human) => [human.id, human.name]));
   const transcript = transcripts
-    .map((row) => {
-      const words: unknown = JSON.parse(row.words_json);
-      if (!Array.isArray(words))
-        throw new Error("This transcript could not be read.");
-      return words
-        .map((word) => (typeof word?.text === "string" ? word.text : ""))
-        .join(" ");
-    })
+    .flatMap((row) => transcriptSegments(row, names))
+    .map((segment) => `${segment.speaker}: ${segment.text}`)
     .join("\n");
   const source = `Notes:\n${text}\n\nTranscript:\n${transcript}`;
   if (!text.trim() && !transcript.trim())
@@ -130,13 +131,22 @@ const inflight = new Map<string, Promise<void>>();
 
 export function summarizeSession(
   sessionId: string,
-  automatic = false,
+  {
+    automatic = false,
+    beforeGenerate,
+  }: {
+    automatic?: boolean;
+    beforeGenerate?: () => void | Promise<void>;
+  } = {},
 ): Promise<void> {
   const pending = inflight.get(sessionId);
   if (pending) return pending;
   const mutation = queryClient.getMutationCache().build(queryClient, {
     mutationKey: ["session-summary", sessionId],
-    mutationFn: () => runSummary(sessionId, automatic),
+    mutationFn: async () => {
+      await beforeGenerate?.();
+      await runSummary(sessionId, automatic);
+    },
     retry: false,
     onError: (error) =>
       captureOperationalError(error, { operation: "session_summary" }),
@@ -150,7 +160,7 @@ export function summarizeSession(
 
 export function generateSummaryAfterTranscription(sessionId: string): void {
   // Summary failures are visible in the note; they must never fail audio persistence.
-  void summarizeSession(sessionId, true).catch(() => {});
+  void summarizeSession(sessionId, { automatic: true }).catch(() => {});
 }
 
 export function useSessionSummaryState(sessionId: string) {

--- a/apps/mobile/src/data/transcribe.ts
+++ b/apps/mobile/src/data/transcribe.ts
@@ -22,6 +22,7 @@ import {
 import { batchTranscriptionModel } from "@/settings/transcription-mode";
 
 import { requestProviderTranscription } from "./provider-transcription";
+import { generateSummaryAfterTranscription } from "./summarize";
 import { TranscriptionAdmission } from "./transcription-admission";
 import {
   assertBoundedTranscriptionResponse,
@@ -526,6 +527,7 @@ async function runTranscription(sessionId: string): Promise<void> {
   ]).catch((error) => {
     throw withTranscriptionStage(error, "persist");
   });
+  generateSummaryAfterTranscription(sessionId);
 }
 
 export function transcribeSession(sessionId: string): Promise<void> {

--- a/apps/mobile/src/data/transcript-model.test.mjs
+++ b/apps/mobile/src/data/transcript-model.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { transcriptSegments } from "./transcript-model.ts";
+
+const word = (id, text, speaker = 0, start = 0) => ({
+  id,
+  text,
+  start_ms: start,
+  end_ms: start + 100,
+  channel: 0,
+  speaker_index: speaker,
+});
+const row = (words, deltas = [], hints = []) => ({
+  id: "transcript",
+  started_at_ms: 1000,
+  words_json: JSON.stringify(words),
+  pending_deltas_json: JSON.stringify(deltas),
+  speaker_hints_json: JSON.stringify(hints),
+});
+
+test("live deltas append the full conversation and group consecutive speaker turns", () => {
+  const segments = transcriptSegments(
+    row(
+      [word("a", "Hello")],
+      [
+        { new_words: [word("b", "there", 0, 100)], replaced_ids: [] },
+        { new_words: [word("c", "Hi!", 1, 200)], replaced_ids: [] },
+        { new_words: [word("d", "Welcome", 0, 300)], replaced_ids: [] },
+      ],
+    ),
+  );
+  assert.deepEqual(
+    segments.map(({ text, speaker }) => ({ text, speaker })),
+    [
+      { text: "Hello there", speaker: "Speaker 1" },
+      { text: "Hi!", speaker: "Speaker 2" },
+      { text: "Welcome", speaker: "Speaker 1" },
+    ],
+  );
+  assert.equal(segments[0].startMs, 1000);
+});
+
+test("revisions replace prior words without duplicating repeated final events", () => {
+  const replacement = {
+    new_words: [word("b", "Corrected")],
+    replaced_ids: ["a"],
+  };
+  const segments = transcriptSegments(
+    row([word("a", "Wrong")], [replacement, replacement]),
+  );
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0].text, "Corrected");
+});
+
+test("compacting the saved transcript preserves the exact displayed history", () => {
+  const a = word("a", "First");
+  const b = word("b", "Second", 1, 100);
+  assert.deepEqual(
+    transcriptSegments(row([a], [{ new_words: [b], replaced_ids: [] }])),
+    transcriptSegments(row([a, b])),
+  );
+});
+
+test("desktop provider hints and user speaker assignments preserve names and turns", () => {
+  const hints = [
+    {
+      word_id: "a",
+      type: "provider_speaker_index",
+      value: { speaker_index: 2, channel: 1 },
+    },
+    {
+      word_id: "a",
+      type: "automatic_speaker_assignment",
+      value: { human_id: "auto" },
+    },
+    {
+      word_id: "a",
+      type: "user_speaker_assignment",
+      value: JSON.stringify({
+        scope: "speaker",
+        channel: 1,
+        speaker_index: 2,
+        human_id: "john",
+      }),
+    },
+    {
+      word_id: "b",
+      type: "user_speaker_assignment",
+      value: { scope: "segment", word_ids: ["b"], human_id: "guest" },
+    },
+  ];
+  const segments = transcriptSegments(
+    row([word("a", "One"), word("b", "Two", 0, 100)], [], hints),
+    new Map([
+      ["auto", "Automatic match"],
+      ["john", "John"],
+      ["guest", "Guest"],
+    ]),
+  );
+  assert.deepEqual(
+    segments.map((s) => s.speaker),
+    ["John", "Guest"],
+  );
+});
+
+test("words without diarization remain readable without inventing an identity", () => {
+  assert.equal(
+    transcriptSegments(row([{ id: "legacy", text: "Hello" }]))[0].speaker,
+    "Speaker",
+  );
+  assert.deepEqual(transcriptSegments(row([{ id: "empty", text: " " }])), []);
+  assert.throws(
+    () => transcriptSegments({ ...row([]), words_json: "{}" }),
+    /Invalid transcript/,
+  );
+});

--- a/apps/mobile/src/data/transcript-model.test.mjs
+++ b/apps/mobile/src/data/transcript-model.test.mjs
@@ -115,3 +115,29 @@ test("words without diarization remain readable without inventing an identity", 
     /Invalid transcript/,
   );
 });
+
+test("a live speaker correction wins over the initial persisted provider hint", () => {
+  const initial = word("a", "Hello", 0);
+  const revised = word("a", "Hello!", 1);
+  const originalHint = {
+    word_id: "a",
+    type: "provider_speaker_index",
+    value: { speaker_index: 0, channel: 0 },
+  };
+  const live = transcriptSegments(
+    row(
+      [initial],
+      [{ new_words: [revised], replaced_ids: ["a"] }],
+      [originalHint],
+    ),
+  );
+  const saved = transcriptSegments(
+    row(
+      [revised],
+      [],
+      [{ ...originalHint, value: { speaker_index: 1, channel: 0 } }],
+    ),
+  );
+  assert.deepEqual(live, saved);
+  assert.equal(live[0].speaker, "Speaker 2");
+});

--- a/apps/mobile/src/data/transcript-model.ts
+++ b/apps/mobile/src/data/transcript-model.ts
@@ -50,13 +50,25 @@ export function transcriptSegments(
     }
   };
   addWords(parseArray(row.words_json));
+  const updatedWordIds = new Set<string>();
   for (const value of parseArray(row.pending_deltas_json)) {
     if (!value || typeof value !== "object") continue;
     const delta = value as { replaced_ids?: string[]; new_words?: unknown[] };
     if (Array.isArray(delta.replaced_ids)) {
       for (const id of delta.replaced_ids) wordsById.delete(id);
     }
-    if (Array.isArray(delta.new_words)) addWords(delta.new_words);
+    if (Array.isArray(delta.new_words)) {
+      addWords(delta.new_words);
+      for (const word of delta.new_words) {
+        if (
+          word &&
+          typeof word === "object" &&
+          "id" in word &&
+          typeof word.id === "string"
+        )
+          updatedWordIds.add(word.id);
+      }
+    }
   }
   const words = [...wordsById.values()].sort(
     (a, b) => a.start_ms - b.start_ms || a.end_ms - b.end_ms,
@@ -72,6 +84,9 @@ export function transcriptSegments(
     if (hint.type !== "provider_speaker_index" || !hint.word_id) continue;
     const word = wordsById.get(hint.word_id);
     const value = hint.value as { channel?: number; speaker_index?: number };
+    // A live revision can reuse word IDs while correcting the initial speaker hint.
+    if (word && updatedWordIds.has(word.id) && word.speaker_index != null)
+      continue;
     if (word && typeof value.speaker_index === "number") {
       word.speaker_index = value.speaker_index;
       if (typeof value.channel === "number") word.channel = value.channel;

--- a/apps/mobile/src/data/transcript-model.ts
+++ b/apps/mobile/src/data/transcript-model.ts
@@ -1,0 +1,142 @@
+export type TranscriptRow = {
+  id: string;
+  started_at_ms: number;
+  words_json: string;
+  speaker_hints_json: string;
+  pending_deltas_json: string;
+};
+
+export type TranscriptSegment = {
+  id: string;
+  text: string;
+  speaker: string;
+  startMs: number;
+};
+
+type Word = {
+  id: string;
+  text: string;
+  start_ms: number;
+  end_ms: number;
+  channel: number;
+  speaker_index?: number | null;
+};
+
+function parseArray(json: string): unknown[] {
+  const value: unknown = JSON.parse(json);
+  if (!Array.isArray(value)) throw new Error("Invalid transcript data");
+  return value;
+}
+
+export function transcriptSegments(
+  row: TranscriptRow,
+  names: ReadonlyMap<string, string> = new Map(),
+): TranscriptSegment[] {
+  const wordsById = new Map<string, Word>();
+  const addWords = (values: unknown[]) => {
+    for (const [index, value] of values.entries()) {
+      if (!value || typeof value !== "object") continue;
+      const word = value as Partial<Word>;
+      if (typeof word.text !== "string") continue;
+      const id = typeof word.id === "string" ? word.id : `${row.id}:${index}`;
+      wordsById.set(id, {
+        id,
+        text: word.text,
+        start_ms: typeof word.start_ms === "number" ? word.start_ms : 0,
+        end_ms: typeof word.end_ms === "number" ? word.end_ms : 0,
+        channel: typeof word.channel === "number" ? word.channel : 0,
+        speaker_index: word.speaker_index,
+      });
+    }
+  };
+  addWords(parseArray(row.words_json));
+  for (const value of parseArray(row.pending_deltas_json)) {
+    if (!value || typeof value !== "object") continue;
+    const delta = value as { replaced_ids?: string[]; new_words?: unknown[] };
+    if (Array.isArray(delta.replaced_ids)) {
+      for (const id of delta.replaced_ids) wordsById.delete(id);
+    }
+    if (Array.isArray(delta.new_words)) addWords(delta.new_words);
+  }
+  const words = [...wordsById.values()].sort(
+    (a, b) => a.start_ms - b.start_ms || a.end_ms - b.end_ms,
+  );
+  const hints = parseArray(row.speaker_hints_json).flatMap((hint) => {
+    if (!hint || typeof hint !== "object") return [];
+    const item = hint as { type?: string; word_id?: string; value?: unknown };
+    const value =
+      typeof item.value === "string" ? JSON.parse(item.value) : item.value;
+    return value && typeof value === "object" ? [{ ...item, value }] : [];
+  });
+  for (const hint of hints) {
+    if (hint.type !== "provider_speaker_index" || !hint.word_id) continue;
+    const word = wordsById.get(hint.word_id);
+    const value = hint.value as { channel?: number; speaker_index?: number };
+    if (word && typeof value.speaker_index === "number") {
+      word.speaker_index = value.speaker_index;
+      if (typeof value.channel === "number") word.channel = value.channel;
+    }
+  }
+  const identities = new Map<string, string>();
+  // Desktop applies explicit user assignments after automatic speaker matching.
+  for (const type of [
+    "automatic_speaker_assignment",
+    "user_speaker_assignment",
+  ]) {
+    for (const hint of hints) {
+      if (hint.type !== type) continue;
+      const value = hint.value as {
+        human_id?: string;
+        scope?: string;
+        channel?: number;
+        speaker_index?: number;
+        word_ids?: string[];
+      };
+      if (!value.human_id) continue;
+      const anchor = hint.word_id ? wordsById.get(hint.word_id) : undefined;
+      for (const word of words) {
+        const matches =
+          value.scope === "segment"
+            ? value.word_ids?.includes(word.id)
+            : value.scope === "speaker"
+              ? word.channel === value.channel &&
+                (value.speaker_index == null ||
+                  word.speaker_index === value.speaker_index)
+              : anchor &&
+                word.channel === anchor.channel &&
+                (anchor.speaker_index == null ||
+                  word.speaker_index === anchor.speaker_index);
+        if (matches) identities.set(word.id, value.human_id);
+      }
+    }
+  }
+  const result: (Omit<TranscriptSegment, "text"> & { parts: string[] })[] = [];
+  let previousIdentity: string | undefined;
+  for (const word of words) {
+    if (!word.text.trim()) continue;
+    const humanId = identities.get(word.id);
+    const identity =
+      humanId ?? `${word.channel}:${word.speaker_index ?? "unknown"}`;
+    const speaker =
+      (humanId ? names.get(humanId) : undefined) ||
+      (typeof word.speaker_index === "number"
+        ? `Speaker ${word.speaker_index + 1}`
+        : "Speaker");
+    const last = result.at(-1);
+    if (last && previousIdentity === identity) {
+      last.parts.push(word.text);
+    } else {
+      result.push({
+        id: `${row.id}:${word.id}`,
+        parts: [word.text],
+        speaker,
+        startMs: row.started_at_ms + word.start_ms,
+      });
+    }
+    previousIdentity = identity;
+  }
+  return result.map(({ parts, ...segment }) => ({
+    ...segment,
+    text: parts.join(" ").replace(/\s+/g, " ").trim(),
+  }));
+}

--- a/apps/mobile/src/data/transcript-model.ts
+++ b/apps/mobile/src/data/transcript-model.ts
@@ -1,3 +1,13 @@
+export const SESSION_TRANSCRIPTS_SQL = `SELECT transcript.id, transcript.started_at_ms, transcript.words_json, transcript.speaker_hints_json,
+      COALESCE((SELECT json_group_array(json(ordered_delta.delta_json)) FROM (
+        SELECT delta.delta_json FROM transcript_live_deltas AS delta
+        WHERE delta.transcript_id = transcript.id ORDER BY delta.sequence
+      ) AS ordered_delta), '[]') AS pending_deltas_json
+      FROM transcripts AS transcript WHERE transcript.session_id = ? AND transcript.deleted_at IS NULL
+      ORDER BY transcript.started_at_ms, transcript.created_at, transcript.id`;
+
+export const SESSION_SPEAKERS_SQL = `SELECT id, name FROM humans WHERE workspace_id = (SELECT workspace_id FROM sessions WHERE id = ?) AND deleted_at IS NULL`;
+
 export type TranscriptRow = {
   id: string;
   started_at_ms: number;

--- a/apps/mobile/src/data/transcription-retry.test.mjs
+++ b/apps/mobile/src/data/transcription-retry.test.mjs
@@ -16,9 +16,11 @@ const fixture = (globalThis.transcriptionRetryFixture = {
   requests: 0,
   transactions: [],
   failures: [],
+  summaries: [],
   requestError: null,
 });
 const mocks = {
+  "./summarize": `export function generateSummaryAfterTranscription(sessionId) { globalThis.transcriptionRetryFixture.summaries.push(sessionId); }`,
   "expo-file-system": `export const Paths = {document: '/synthetic'}; export class File { exists = true; size = 1024; }`,
   "expo/fetch": `export function fetch() { throw new Error('Unexpected hosted request'); }`,
   "react-native": `export const Platform = {OS: 'ios'};`,
@@ -71,6 +73,7 @@ test("live-only recordings stop automatic retries but can be recovered manually 
   assert.equal(fixture.failures.at(-1).code, "stt_live_only");
   assert.equal(fixture.pending, true);
   assert.equal(fixture.requests, 0);
+  assert.deepEqual(fixture.summaries, []);
   assert.equal(fixture.resolutions, 1);
 
   await retryPendingTranscriptions();
@@ -87,6 +90,7 @@ test("live-only recordings stop automatic retries but can be recovered manually 
   assert.equal(fixture.requests, 1);
   assert.equal(fixture.transactions.length, 1);
   assert.equal(fixture.pending, false);
+  assert.ok(fixture.summaries.includes(fixture.sessionId));
 });
 
 test("temporary request failures remain eligible for automatic retry", async () => {
@@ -107,4 +111,5 @@ test("temporary request failures remain eligible for automatic retry", async () 
   await retryPendingTranscriptions();
   assert.equal(fixture.requests, requests + 2);
   assert.equal(fixture.pending, false);
+  assert.ok(fixture.summaries.includes(fixture.sessionId));
 });

--- a/apps/mobile/src/data/transcripts.ts
+++ b/apps/mobile/src/data/transcripts.ts
@@ -5,6 +5,8 @@ import { captureOperationalError } from "@/lib/error-reporting";
 
 import {
   transcriptSegments,
+  SESSION_TRANSCRIPTS_SQL,
+  SESSION_SPEAKERS_SQL,
   type TranscriptRow,
   type TranscriptSegment,
 } from "./transcript-model";
@@ -26,13 +28,7 @@ function rememberInvalidRow(rowId: string) {
 
 export function useSessionTranscripts(sessionId: string): TranscriptSegment[] {
   const { data: rows } = useLiveQuery<TranscriptRow, TranscriptRow[]>({
-    sql: `SELECT transcript.id, transcript.started_at_ms, transcript.words_json, transcript.speaker_hints_json,
-      COALESCE((SELECT json_group_array(json(ordered_delta.delta_json)) FROM (
-        SELECT delta.delta_json FROM transcript_live_deltas AS delta
-        WHERE delta.transcript_id = transcript.id ORDER BY delta.sequence
-      ) AS ordered_delta), '[]') AS pending_deltas_json
-      FROM transcripts AS transcript WHERE transcript.session_id = ? AND transcript.deleted_at IS NULL
-      ORDER BY transcript.started_at_ms, transcript.created_at, transcript.id`,
+    sql: SESSION_TRANSCRIPTS_SQL,
     params: [sessionId],
     mapRows: (rows) => rows,
   });
@@ -40,7 +36,7 @@ export function useSessionTranscripts(sessionId: string): TranscriptSegment[] {
     { id: string; name: string },
     { id: string; name: string }[]
   >({
-    sql: `SELECT id, name FROM humans WHERE workspace_id = (SELECT workspace_id FROM sessions WHERE id = ?) AND deleted_at IS NULL`,
+    sql: SESSION_SPEAKERS_SQL,
     params: [sessionId],
     mapRows: (rows) => rows,
   });

--- a/apps/mobile/src/data/transcripts.ts
+++ b/apps/mobile/src/data/transcripts.ts
@@ -1,15 +1,14 @@
+import { useMemo } from "react";
+
 import { useLiveQuery } from "@/db";
 import { captureOperationalError } from "@/lib/error-reporting";
 
-type TranscriptRow = {
-  id: string;
-  words_json: string;
-};
-
-export type TranscriptSegment = {
-  id: string;
-  text: string;
-};
+import {
+  transcriptSegments,
+  type TranscriptRow,
+  type TranscriptSegment,
+} from "./transcript-model";
+export type { TranscriptSegment } from "./transcript-model";
 
 const MAX_REPORTED_INVALID_ROWS = 1_000;
 const reportedInvalidRows = new Set<string>();
@@ -25,17 +24,33 @@ function rememberInvalidRow(rowId: string) {
   }
 }
 
-function mapTranscriptRows(rows: TranscriptRow[]): TranscriptSegment[] {
-  return rows
-    .map((row) => {
-      let text = "";
+export function useSessionTranscripts(sessionId: string): TranscriptSegment[] {
+  const { data: rows } = useLiveQuery<TranscriptRow, TranscriptRow[]>({
+    sql: `SELECT transcript.id, transcript.started_at_ms, transcript.words_json, transcript.speaker_hints_json,
+      COALESCE((SELECT json_group_array(json(ordered_delta.delta_json)) FROM (
+        SELECT delta.delta_json FROM transcript_live_deltas AS delta
+        WHERE delta.transcript_id = transcript.id ORDER BY delta.sequence
+      ) AS ordered_delta), '[]') AS pending_deltas_json
+      FROM transcripts AS transcript WHERE transcript.session_id = ? AND transcript.deleted_at IS NULL
+      ORDER BY transcript.started_at_ms, transcript.created_at, transcript.id`,
+    params: [sessionId],
+    mapRows: (rows) => rows,
+  });
+  const { data: humans } = useLiveQuery<
+    { id: string; name: string },
+    { id: string; name: string }[]
+  >({
+    sql: `SELECT id, name FROM humans WHERE workspace_id = (SELECT workspace_id FROM sessions WHERE id = ?) AND deleted_at IS NULL`,
+    params: [sessionId],
+    mapRows: (rows) => rows,
+  });
+  return useMemo(() => {
+    const names = new Map(
+      (humans ?? []).map((human) => [human.id, human.name]),
+    );
+    return (rows ?? []).flatMap((row) => {
       try {
-        const words = JSON.parse(row.words_json) as { text?: string }[];
-        text = words
-          .map((word) => word.text ?? "")
-          .join(" ")
-          .replace(/\s+/g, " ")
-          .trim();
+        return transcriptSegments(row, names);
       } catch (error) {
         if (!reportedInvalidRows.has(row.id)) {
           rememberInvalidRow(row.id);
@@ -44,17 +59,8 @@ function mapTranscriptRows(rows: TranscriptRow[]): TranscriptSegment[] {
             level: "warning",
           });
         }
+        return [];
       }
-      return { id: row.id, text };
-    })
-    .filter((segment) => segment.text !== "");
-}
-
-export function useSessionTranscripts(sessionId: string): TranscriptSegment[] {
-  const { data } = useLiveQuery<TranscriptRow, TranscriptSegment[]>({
-    sql: "SELECT id, words_json FROM transcripts WHERE session_id = ? AND deleted_at IS NULL ORDER BY started_at_ms, id",
-    params: [sessionId],
-    mapRows: mapTranscriptRows,
-  });
-  return data ?? [];
+    });
+  }, [rows, humans]);
 }

--- a/apps/mobile/src/lib/query-client.ts
+++ b/apps/mobile/src/lib/query-client.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: 1, staleTime: 10_000 } },
+});

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -75,6 +75,8 @@ const modules = {
   "@sentry/react-native": `const state = globalThis.mobileSettingsFixture.sentry;
     export function init(options) { state.starts++; state.nativeEnabled = true; state.client = { getOptions: () => options }; }
     export function getClient() { return state.client; }
+    export function withScope(callback) { callback({setTag() {}, setContext() {}, setLevel() {}}); }
+    export function captureException() {}
     export async function close() { state.closes++; state.nativeEnabled = false; }
   `,
 };
@@ -1614,3 +1616,100 @@ for (const suffix of ["", "/openai", "/openai/v1"]) {
     );
   });
 }
+
+test("automatic summaries preserve memos and never overwrite an existing summary", async () => {
+  createNote();
+  signedInWith({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
+  const memo = fixture.db
+    .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
+    .get().body;
+  await summarizeSession("note-1", true);
+  assert.equal(fixture.requests.length, 1);
+  assert.equal(
+    fixture.db
+      .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
+      .get().body,
+    memo,
+  );
+  fixture.db
+    .prepare(
+      "UPDATE session_documents SET body = 'My edited summary' WHERE kind = 'summary'",
+    )
+    .run();
+  await summarizeSession("note-1", true);
+  assert.equal(fixture.requests.length, 1);
+  assert.equal(
+    fixture.db
+      .prepare("SELECT body FROM session_documents WHERE kind = 'summary'")
+      .get().body,
+    "My edited summary",
+  );
+});
+
+test("automatic and manual summary requests share an in-flight generation", async () => {
+  createNote();
+  signedInWith({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
+  let release;
+  fixture.respond = () =>
+    new Promise((resolve) => {
+      release = resolve;
+    });
+  const automatic = summarizeSession("note-1", true);
+  const manual = summarizeSession("note-1");
+  assert.equal(automatic, manual);
+  while (!release) await new Promise((resolve) => setImmediate(resolve));
+  release(
+    Response.json({ choices: [{ message: { content: "Finished summary" } }] }),
+  );
+  await Promise.all([automatic, manual]);
+  assert.equal(fixture.requests.length, 1);
+  assert.equal(
+    fixture.db
+      .prepare(
+        "SELECT COUNT(*) AS count FROM session_documents WHERE kind = 'summary'",
+      )
+      .get().count,
+    1,
+  );
+});
+
+test("automatic summary failure is observable and can be retried without changing memos", async () => {
+  const { queryClient } = await import("../lib/query-client.ts");
+  createNote();
+  signedInWith({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
+  const memo = fixture.db
+    .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
+    .get().body;
+  fixture.respond = () => new Response("Rejected", { status: 401 });
+  await assert.rejects(summarizeSession("note-1", true), /API key or sign in/);
+  const mutation = queryClient
+    .getMutationCache()
+    .findAll({ mutationKey: ["session-summary", "note-1"] })
+    .at(-1);
+  assert.equal(mutation.state.status, "error");
+  assert.match(mutation.state.error.message, /API key or sign in/);
+  assert.equal(
+    fixture.db
+      .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
+      .get().body,
+    memo,
+  );
+  fixture.respond = () =>
+    Response.json({ choices: [{ message: { content: "Recovered summary" } }] });
+  await summarizeSession("note-1");
+  assert.equal(
+    fixture.db
+      .prepare("SELECT body FROM session_documents WHERE kind = 'summary'")
+      .get().body,
+    "Recovered summary",
+  );
+});

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -138,6 +138,8 @@ beforeEach(() => {
   for (const migration of [
     "20260710223922_canonical_data_model.sql",
     "20260810120000_synced_preferences.sql",
+    "20260815100000_transcript_content_revision.sql",
+    "20260815100100_transcript_live_deltas.sql",
   ]) {
     fixture.db.exec(
       readFileSync(
@@ -1626,7 +1628,7 @@ test("automatic summaries preserve memos and never overwrite an existing summary
   const memo = fixture.db
     .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
     .get().body;
-  await summarizeSession("note-1", true);
+  await summarizeSession("note-1", { automatic: true });
   assert.equal(fixture.requests.length, 1);
   assert.equal(
     fixture.db
@@ -1639,7 +1641,7 @@ test("automatic summaries preserve memos and never overwrite an existing summary
       "UPDATE session_documents SET body = 'My edited summary' WHERE kind = 'summary'",
     )
     .run();
-  await summarizeSession("note-1", true);
+  await summarizeSession("note-1", { automatic: true });
   assert.equal(fixture.requests.length, 1);
   assert.equal(
     fixture.db
@@ -1660,7 +1662,7 @@ test("automatic and manual summary requests share an in-flight generation", asyn
     new Promise((resolve) => {
       release = resolve;
     });
-  const automatic = summarizeSession("note-1", true);
+  const automatic = summarizeSession("note-1", { automatic: true });
   const manual = summarizeSession("note-1");
   assert.equal(automatic, manual);
   while (!release) await new Promise((resolve) => setImmediate(resolve));
@@ -1690,7 +1692,10 @@ test("automatic summary failure is observable and can be retried without changin
     .prepare("SELECT body FROM session_documents WHERE id = 'note-1'")
     .get().body;
   fixture.respond = () => new Response("Rejected", { status: 401 });
-  await assert.rejects(summarizeSession("note-1", true), /API key or sign in/);
+  await assert.rejects(
+    summarizeSession("note-1", { automatic: true }),
+    /API key or sign in/,
+  );
   const mutation = queryClient
     .getMutationCache()
     .findAll({ mutationKey: ["session-summary", "note-1"] })
@@ -1712,4 +1717,100 @@ test("automatic summary failure is observable and can be retried without changin
       .get().body,
     "Recovered summary",
   );
+});
+
+test("summaries read the full visible transcript, including uncompact live revisions and speaker names", async () => {
+  createNote();
+  signedInWith({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
+  fixture.db
+    .prepare(
+      "INSERT INTO humans (id, workspace_id, name) VALUES ('speaker-a', 'workspace-a', 'John')",
+    )
+    .run();
+  const word = (id, text, start_ms) => ({
+    id,
+    text,
+    start_ms,
+    end_ms: start_ms + 100,
+    channel: 0,
+    speaker_index: 0,
+  });
+  fixture.db
+    .prepare(
+      "INSERT INTO transcripts (id, workspace_id, session_id, words_json, speaker_hints_json) VALUES (?, 'workspace-a', 'note-1', ?, ?)",
+    )
+    .run(
+      "live-transcript",
+      JSON.stringify([word("first", "First snapshot", 0)]),
+      JSON.stringify([
+        {
+          word_id: "first",
+          type: "user_speaker_assignment",
+          value: {
+            scope: "speaker",
+            channel: 0,
+            speaker_index: 0,
+            human_id: "speaker-a",
+          },
+        },
+      ]),
+    );
+  fixture.db
+    .prepare(
+      "INSERT INTO transcript_live_state (transcript_id) VALUES ('live-transcript')",
+    )
+    .run();
+  const addDelta = fixture.db.prepare(
+    "INSERT INTO transcript_live_deltas (id, transcript_id, sequence, delta_json) VALUES (?, 'live-transcript', ?, ?)",
+  );
+  addDelta.run(
+    "later",
+    2,
+    JSON.stringify({
+      replaced_ids: ["second"],
+      new_words: [word("second", "Corrected ending", 100)],
+    }),
+  );
+  addDelta.run(
+    "earlier",
+    1,
+    JSON.stringify({
+      replaced_ids: [],
+      new_words: [word("second", "Wrong ending", 100)],
+    }),
+  );
+  await summarizeSession("note-1");
+  const request = JSON.stringify(JSON.parse(fixture.requests[0].options.body));
+  assert.match(request, /John: First snapshot Corrected ending/);
+  assert.doesNotMatch(request, /Wrong ending/);
+});
+
+test("a preparation error is replaced by the next successful automatic summary state", async () => {
+  const { queryClient } = await import("../lib/query-client.ts");
+  createNote();
+  signedInWith({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
+  const latestState = () =>
+    queryClient
+      .getMutationCache()
+      .findAll({ mutationKey: ["session-summary", "note-1"] })
+      .at(-1).state;
+  await assert.rejects(
+    summarizeSession("note-1", {
+      beforeGenerate: () => {
+        throw Error("Memo save failed");
+      },
+    }),
+    /Memo save failed/,
+  );
+  assert.equal(fixture.requests.length, 0);
+  assert.equal(latestState().status, "error");
+  await summarizeSession("note-1", { automatic: true });
+  assert.equal(latestState().status, "success");
+  assert.equal(latestState().error, null);
 });


### PR DESCRIPTION
Mobile currently repeats a partial transcript inside the memo editor, limits the listening sheet to two lines, and requires a manual summary request. Keep memos in the main area during recording, show Summary/Memos tabs afterward with Summary selected, and keep the full speaker-grouped transcript accessible in a native bottom sheet.

Read live transcript deltas and desktop speaker assignments, keep partial text separate from saved words, and generate a summary after successful live or batch transcription. Share generation state and retries across navigation, deduplicate requests, and preserve existing summaries and memos. Audio playback, backup status, and transcription recovery stay with the transcript.

Validation: mobile typecheck and 335 tests pass on Node 22; 64 common CI tests, license boundaries, and formatting pass. iOS Simulator Release passes; Android Release passes after retrying an incremental packaging failure on commit f1d366a488d22cbcaec90a11aff312499b34ed31. Zizmor reports the same 410 existing findings; no workflow changes. Visual and physical-device verification remain pending because the Mac is locked. This is not release sign-off.
