### PR TITLE
Measure mobile recording time from saved audio

### DIFF
--- a/apps/mobile/src/audio/session-wav-writer.test.mjs
+++ b/apps/mobile/src/audio/session-wav-writer.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import { test } from "node:test";
+
+const files = (globalThis.wavWriterFiles = new Map());
+registerHooks({
+  resolve(specifier, context, next) {
+    if (specifier === "@/audio/pcm-wav")
+      return {
+        url: new URL("./pcm-wav.ts", import.meta.url).href,
+        shortCircuit: true,
+      };
+    if (specifier === "expo-file-system")
+      return { url: "test:wav-files", shortCircuit: true };
+    return next(specifier, context);
+  },
+  load(url, context, next) {
+    if (url !== "test:wav-files") return next(url, context);
+    return {
+      format: "module",
+      shortCircuit: true,
+      source: `
+      export const Paths = { document: "/test" };
+      export const FileMode = { ReadWrite: "rw" };
+      export class Directory { constructor(...parts) { this.path = parts.join("/"); } create() {} }
+      export class File {
+        exists = false;
+        bytes = new Uint8Array(0);
+        constructor(directory, filename) { this.path = directory.path + "/" + filename; globalThis.wavWriterFiles.set(this.path, this); }
+        get size() { return this.bytes.length; }
+        create() { this.exists = true; }
+        delete() { this.exists = false; }
+        open() {
+          const file = this;
+          return { offset: 0, writeBytes(bytes) {
+            if (file.failWrite) throw Error("Disk write failed");
+            const result = new Uint8Array(Math.max(file.bytes.length, this.offset + bytes.length));
+            result.set(file.bytes); result.set(bytes, this.offset); file.bytes = result; this.offset += bytes.length;
+          }, close() {} };
+        }
+      }
+    `,
+    };
+  },
+});
+const { SessionWavWriter } = await import("./session-wav-writer.ts");
+
+test("elapsed recording time comes from captured PCM and matches the finalized WAV", () => {
+  for (const [sampleRate, channels] of [
+    [16000, 1],
+    [48000, 2],
+  ]) {
+    const writer = new SessionWavWriter(`duration-${channels}`);
+    assert.equal(writer.durationMs, 0);
+    const bytesPerFrame = (sampleRate * channels * 2) / 10;
+    for (let i = 0; i < 400; i++)
+      writer.append(new ArrayBuffer(bytesPerFrame), sampleRate, channels);
+    assert.equal(writer.durationMs, 40000);
+    const file = writer.finalize();
+    const header = new DataView(file.bytes.buffer);
+    assert.equal(
+      (header.getUint32(40, true) / header.getUint32(28, true)) * 1000,
+      writer.durationMs,
+    );
+    assert.equal(file.size, 44 + bytesPerFrame * 400);
+  }
+});
+
+test("failed audio writes do not advance the recording duration", () => {
+  const writer = new SessionWavWriter("failed-write");
+  writer.append(new ArrayBuffer(3200), 16000, 1);
+  writer.file.failWrite = true;
+  assert.throws(
+    () => writer.append(new ArrayBuffer(3200), 16000, 1),
+    /Disk write failed/,
+  );
+  assert.equal(writer.durationMs, 100);
+  assert.equal(files.get("/test/sessions/failed-write/audio.wav").size, 3244);
+});

--- a/apps/mobile/src/audio/session-wav-writer.ts
+++ b/apps/mobile/src/audio/session-wav-writer.ts
@@ -53,6 +53,10 @@ export class SessionWavWriter {
     }
   }
 
+  get durationMs(): number {
+    return (this.dataBytes * 1_000) / (this.sampleRate * this.channels * 2);
+  }
+
   finalize(): File {
     if (this.finalized) return this.file;
     if (!this.handle) throw new Error("Recording file is unavailable");

--- a/apps/mobile/src/audio/use-session-recorder.ts
+++ b/apps/mobile/src/audio/use-session-recorder.ts
@@ -124,12 +124,10 @@ export function useSessionRecorder(
       if (phaseRef.current !== "starting" && phaseRef.current !== "recording") {
         return;
       }
+      const writer = writerRef.current;
+      if (!writer) return;
       try {
-        writerRef.current?.append(
-          buffer.data,
-          buffer.sampleRate,
-          buffer.channels,
-        );
+        writer.append(buffer.data, buffer.sampleRate, buffer.channels);
       } catch (error) {
         reportFailure("save_failed", error, "recording_stream_write");
         setPhase("save_error");
@@ -157,15 +155,7 @@ export function useSessionRecorder(
         },
       );
       liveRef.current?.sendAudio(buffer.data);
-      const frameDuration =
-        buffer.data.byteLength /
-        2 /
-        Math.max(1, buffer.channels) /
-        Math.max(1, buffer.sampleRate);
-      durationRef.current = Math.max(
-        durationRef.current,
-        Math.round((buffer.timestamp + frameDuration) * 1_000),
-      );
+      durationRef.current = Math.round(writer.durationMs);
       if (activeRef.current) {
         setAmplitude(pcmAmplitude(buffer.data));
         setDurationMs(durationRef.current);


### PR DESCRIPTION
The recording timer uses native host timestamps and can remain near 0:00 while audio continues to accumulate. Derive elapsed time from the WAV writer's captured PCM bytes so the displayed duration matches the saved recording, including when timestamps are missing or incorrectly scaled.

Mobile typecheck and the full mobile test suite pass in the combined workspace (337 tests, including #7404). New tests compare elapsed time with finalized mono/stereo WAV headers and verify that failed writes do not advance the timer. iOS Simulator and Android Release builds pass with both fixes applied. Physical-device verification remains pending while the Mac is locked.
