### PR TITLE
Unblock mobile device approval and sync setup

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -80,6 +80,7 @@ fn build_sync_routes(
     state: Option<anlg_api_sync::AppState>,
     replica_state: anlg_api_sync::ReplicaState,
     cloudsync_rate_limit_state: rate_limit::RateLimitState,
+    device_rate_limit_state: rate_limit::RateLimitState,
     session_share_rate_limit_state: rate_limit::RateLimitState,
     witness_rate_limit_state: rate_limit::RateLimitState,
     auth_state: AuthState,
@@ -87,6 +88,16 @@ fn build_sync_routes(
     let replica_routes = anlg_api_sync::replica_router(replica_state.clone())
         .route_layer(middleware::from_fn_with_state(
             cloudsync_rate_limit_state.clone(),
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let device_routes = anlg_api_sync::device_router(replica_state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            device_rate_limit_state,
             rate_limit::rate_limit,
         ))
         .route_layer(middleware::from_fn(auth::sentry_and_analytics))
@@ -104,7 +115,7 @@ fn build_sync_routes(
             auth_state.clone().with_required_entitlement("hyprnote_pro"),
             auth::require_auth,
         ));
-    let replica_routes = replica_routes.merge(witness_routes);
+    let replica_routes = replica_routes.merge(device_routes).merge(witness_routes);
 
     let Some(state) = state else {
         return replica_routes;
@@ -200,6 +211,11 @@ async fn app_with_session_gate(
             .build()
     };
     let cloudsync_rate_limit = build_sync_rate_limit();
+    let device_quota = rate_limit::device_management_quota();
+    let device_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(device_quota)
+        .free(device_quota)
+        .build();
     let session_share_rate_limit = build_sync_rate_limit();
     let e2ee_witness_rate_limit = rate_limit::RateLimitState::builder()
         .pro(
@@ -348,6 +364,7 @@ async fn app_with_session_gate(
         sync_state,
         replica_state,
         cloudsync_rate_limit,
+        device_rate_limit,
         session_share_rate_limit,
         e2ee_witness_rate_limit,
         auth_state.clone(),

--- a/apps/api/src/rate_limit.rs
+++ b/apps/api/src/rate_limit.rs
@@ -29,6 +29,13 @@ const IP_RATE_LIMIT_BUCKETS: u64 = 4096;
 const UNKNOWN_CLIENT_IP_BUCKET: u16 = IP_RATE_LIMIT_BUCKETS as u16;
 const MAX_RATE_LIMIT_QUEUE_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
 
+pub fn device_management_quota() -> Quota {
+    // Five devices can poll the roster every five seconds and enrollment every fifteen seconds.
+    Quota::with_period(std::time::Duration::from_millis(500))
+        .unwrap()
+        .allow_burst(std::num::NonZeroU32::new(20).unwrap())
+}
+
 #[derive(Clone)]
 pub struct IpRateLimitState {
     limiter: Arc<IpKeyedLimiter>,
@@ -232,6 +239,23 @@ fn trusted_client_ip(headers: &HeaderMap) -> Option<IpAddr> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn device_quota_sustains_five_devices_polling_without_removing_the_limit() {
+        let clock = governor::clock::FakeRelativeClock::default();
+        let limiter = RateLimiter::direct_with_clock(device_management_quota(), clock.clone());
+        for seconds in (0..120).step_by(5) {
+            let requests = if seconds % 15 == 0 { 10 } else { 5 };
+            for _ in 0..requests {
+                assert!(
+                    limiter.check().is_ok(),
+                    "normal polling throttled at {seconds}s"
+                );
+            }
+            clock.advance(std::time::Duration::from_secs(5));
+        }
+        assert!((0..21).any(|_| limiter.check().is_err()));
+    }
 
     #[test]
     fn limits_repeated_requests_per_user() {

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -480,10 +480,39 @@ async fn sync_composition_allows_non_pro_web_edits_but_keeps_other_routes_pro_on
             test_sync_rate_limit(10),
             test_sync_rate_limit(10),
             test_sync_rate_limit(10),
+            test_sync_rate_limit(10),
             AuthState::new(&server.uri()),
         ),
     );
     let token = non_pro_token();
+    for (method, path) in [
+        (Method::GET, "/sync/devices"),
+        (Method::POST, "/sync/e2ee/device-enrollments"),
+        (
+            Method::POST,
+            "/sync/e2ee/device-enrollments/11111111-1111-4111-8111-111111111111/seal",
+        ),
+        (
+            Method::POST,
+            "/sync/e2ee/device-enrollments/11111111-1111-4111-8111-111111111111/consume",
+        ),
+    ] {
+        let request = |authenticated| {
+            let mut builder = Request::builder().method(method.clone()).uri(path);
+            if authenticated {
+                builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+            }
+            builder.body(Body::empty()).unwrap()
+        };
+        assert_eq!(
+            app.clone().oneshot(request(false)).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED,
+        );
+        assert_eq!(
+            app.clone().oneshot(request(true)).await.unwrap().status(),
+            StatusCode::FORBIDDEN,
+        );
+    }
     let web_edit_response = app
         .clone()
         .oneshot(
@@ -552,7 +581,7 @@ async fn sync_composition_allows_non_pro_web_edits_but_keeps_other_routes_pro_on
 }
 
 #[tokio::test]
-async fn sync_composition_keeps_sharing_available_when_cloudsync_is_rate_limited() {
+async fn sync_composition_keeps_devices_and_sharing_available_when_credentials_are_rate_limited() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/auth/v1/.well-known/jwks.json"))
@@ -582,11 +611,23 @@ async fn sync_composition_keeps_sharing_available_when_cloudsync_is_rate_limited
 
     let sync_state = test_sync_state(&server);
     let replica_state = test_replica_state(&server);
+    for route in [
+        "/rest/v1/sync_devices",
+        "/rest/v1/e2ee_device_enrollment_requests",
+    ] {
+        Mock::given(method("GET"))
+            .and(path(route))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+    }
     let app = Router::new().nest(
         "/sync",
         build_sync_routes(
             Some(sync_state),
             replica_state,
+            test_sync_rate_limit(1),
             test_sync_rate_limit(1),
             test_sync_rate_limit(1),
             test_sync_rate_limit(1),
@@ -609,6 +650,20 @@ async fn sync_composition_keeps_sharing_available_when_cloudsync_is_rate_limited
     let second_cloudsync_response = app.clone().oneshot(cloudsync_request()).await.unwrap();
     assert_eq!(
         second_cloudsync_response.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+
+    let devices_request = || {
+        Request::get("/sync/devices")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    };
+    let devices_response = app.clone().oneshot(devices_request()).await.unwrap();
+    assert_eq!(devices_response.status(), StatusCode::OK);
+    let limited_devices_response = app.clone().oneshot(devices_request()).await.unwrap();
+    assert_eq!(
+        limited_devices_response.status(),
         StatusCode::TOO_MANY_REQUESTS
     );
 

--- a/apps/mobile/src/app/settings/sync.tsx
+++ b/apps/mobile/src/app/settings/sync.tsx
@@ -87,7 +87,14 @@ export default function SyncSettings() {
             "identity_mismatch",
             "approval_pending",
           ].includes(snapshot.phase) && (
-            <Button label="Try again" onPress={retryMobileSync} />
+            <Button
+              label={
+                snapshot.phase === "approval_pending"
+                  ? "Check approval"
+                  : "Try again"
+              }
+              onPress={retryMobileSync}
+            />
           )}
         {snapshot.phase === "reauth_required" && (
           <SettingsRow

--- a/apps/mobile/src/sync/status-presentation.test.mjs
+++ b/apps/mobile/src/sync/status-presentation.test.mjs
@@ -81,7 +81,7 @@ test("prioritizes active and pending sync detail", () => {
   );
 });
 
-test("keeps device approval in the background", () => {
+test("explains the required desktop approval instead of implying sync will finish unaided", () => {
   const presentation = syncStatusPresentation({
     ...ready,
     phase: "approval_pending",
@@ -89,7 +89,10 @@ test("keeps device approval in the background", () => {
     lastSyncAtMs: null,
   });
 
-  assert.equal(presentation.title, "Connecting this device");
-  assert.match(presentation.description, /Keep working here/);
+  assert.equal(presentation.title, "Approve this device on desktop");
+  assert.match(presentation.description, /same account/);
+  assert.match(presentation.description, /Settings → Sync → Devices/);
+  assert.match(presentation.description, /Sync will start automatically/);
   assert.equal(presentation.healthy, false);
+  assert.equal(presentation.pending, true);
 });

--- a/apps/mobile/src/sync/status-presentation.ts
+++ b/apps/mobile/src/sync/status-presentation.ts
@@ -13,9 +13,9 @@ const phaseCopy: Record<
     description: "Preparing your encrypted workspace…",
   },
   approval_pending: {
-    title: "Connecting this device",
+    title: "Approve this device on desktop",
     description:
-      "Keep working here while Anarlog finishes connecting this device.",
+      "Open Anarlog on a synced computer signed in to the same account. In Settings → Sync → Devices, approve this phone. Sync will start automatically. Your local notes are safe while you wait.",
   },
   ready: {
     title: "Cloud sync is on",

--- a/crates/api-sync/src/lib.rs
+++ b/crates/api-sync/src/lib.rs
@@ -8,8 +8,8 @@ mod state;
 pub use config::{ReplicaConfig, SharedNotesConfig, SyncConfig, SyncEnv};
 pub use error::{Result, SyncError};
 pub use routes::{
-    cloudsync_router, e2ee_witness_router, openapi, replica_router, session_share_router,
-    web_edit_router,
+    cloudsync_router, device_router, e2ee_witness_router, openapi, replica_router,
+    session_share_router, web_edit_router,
 };
 pub use shared_notes::{
     SharedNotesState, authenticated_router as authenticated_shared_notes_router,

--- a/crates/api-sync/src/routes/cloudsync_credentials/mod.rs
+++ b/crates/api-sync/src/routes/cloudsync_credentials/mod.rs
@@ -159,6 +159,18 @@ pub(super) fn replica_router() -> Router<ReplicaState> {
     Router::new()
         .route("/replica/credentials", post(create_replica_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
+        .route(
+            "/e2ee/workspaces/{workspace_id}/recipients",
+            get(get_workspace_e2ee_key_recipients),
+        )
+        .route(
+            "/e2ee/workspaces/{workspace_id}/key",
+            put(set_workspace_e2ee_key),
+        )
+}
+
+pub(super) fn device_router() -> Router<ReplicaState> {
+    Router::new()
         .route("/devices", get(get_devices))
         .route(
             "/devices/{fingerprint}",
@@ -175,14 +187,6 @@ pub(super) fn replica_router() -> Router<ReplicaState> {
         .route(
             "/e2ee/device-enrollments/{request_id}/consume",
             post(consume_e2ee_device_enrollment),
-        )
-        .route(
-            "/e2ee/workspaces/{workspace_id}/recipients",
-            get(get_workspace_e2ee_key_recipients),
-        )
-        .route(
-            "/e2ee/workspaces/{workspace_id}/key",
-            put(set_workspace_e2ee_key),
         )
 }
 

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -37,6 +37,10 @@ pub fn replica_router(state: ReplicaState) -> Router {
     cloudsync_credentials::replica_router().with_state(state)
 }
 
+pub fn device_router(state: ReplicaState) -> Router {
+    cloudsync_credentials::device_router().with_state(state)
+}
+
 pub fn session_share_router(state: AppState) -> Router {
     session_shares::router()
         .merge(shared_attachments::router())

--- a/crates/api-sync/src/routes/tests/mod.rs
+++ b/crates/api-sync/src/routes/tests/mod.rs
@@ -46,6 +46,7 @@ fn test_router_with_protocol(
     });
     cloudsync_router(state.clone())
         .merge(replica_router(state.replica.clone()))
+        .merge(device_router(state.replica.clone()))
         .merge(session_share_router(state.clone()))
         .merge(web_edit_router(state))
         .layer(Extension(AuthContext {


### PR DESCRIPTION
Unblock mobile device approval and sync setup

A signed-in phone waiting for encrypted device approval polls every 15 seconds, but its requests shared a quota that replenished only once every 30 seconds with credential issuance and the desktop device list. Normal setup could exhaust the quota and leave both devices waiting.

Give device listing and enrollment their own bounded quota sized for five devices, preserving authentication, Pro entitlement, approval, and credential limits. Mobile now explains where to approve the phone and labels its retry action “Check approval.”

Validation: 337 mobile tests, mobile typecheck, Android Release build, API check and full API/API-sync/API-auth/API-cloud/MCP/Supabase-auth/transcribe-proxy tests, deployment/E2EE tests, common CI tests, and formatting passed. Added fake-clock polling and rate-isolation/access regression coverage. OpenAPI output is unchanged. Existing zizmor findings are unchanged; no workflow files changed.

Live diagnosis confirmed the emulator's pending enrollment and HTTP 429 responses for the signed-in device list. End-to-end note sync still needs approval and verification after deployment.

Additional check: `cargo clippy --locked -p api -p api-sync --all-targets --no-deps -- -D warnings` is blocked by existing `with_invitation_email_api_base` dead code, `manual_hash_one`, and `collapsible_if` warnings in unchanged code. These are outside the API CI job and this fix.
