### PR TITLE
Separate sync test startup and interruption deadlines

### DIFF
--- a/crates/db-core/src/cloudsync/runtime/tests/orchestration.rs
+++ b/crates/db-core/src/cloudsync/runtime/tests/orchestration.rs
@@ -370,17 +370,18 @@ async fn activity_pause_during_pending_preflight_defers_and_drains_before_local_
             "pending payload generation completed before interrupt registration was observable"
         );
         assert!(
-            started_at.elapsed() < Duration::from_secs(2),
+            started_at.elapsed() < Duration::from_secs(10),
             "pending payload generation never registered for interruption"
         );
         tokio::task::yield_now().await;
     }
 
     recording_hook.activity_paused.store(true, Ordering::SeqCst);
+    let interrupted_at = std::time::Instant::now();
     while !request.is_finished() {
         db.cloudsync_interrupt_sync();
         assert!(
-            started_at.elapsed() < Duration::from_secs(2),
+            interrupted_at.elapsed() < Duration::from_secs(2),
             "pending payload generation did not honor sqlite3_interrupt"
         );
         tokio::task::yield_now().await;


### PR DESCRIPTION
Separate sync test startup and interruption deadlines

The iOS native CI run failed before the large-payload preflight registered its interrupt handle. Give that startup phase its own bounded wait, then start the existing two-second interruption deadline when the pause is requested. The 250 ms drain and local-write checks remain unchanged.

Validation: all 79 db-core CloudSync tests passed with `cargo test --locked -p db-core 'cloudsync::' -- --test-threads=1`; formatting passed. This changes only the test's timing and does not change runtime behavior. The previous failure is in mobile CI run 34055834908; native CI still needs to pass on the updated candidate.

The exact native iOS script `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer crates/cloudsync/scripts/test-ios.sh` also passed: 23 native CloudSync tests and all 79 db-core CloudSync tests, including the previously failing interruption test.
