### PR TITLE
Remove Fireworks from transcription settings

### DIFF
--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -86,27 +86,25 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                         ? `Use [SiliconFlow](https://docs.siliconflow.com/en/api-reference/audio/create-audio-transcriptions) for batch transcription. The default endpoint is the international service; use \`https://api.siliconflow.cn/v1\` under Advanced for a China-region API key.`
                         : providerId === "cloudflare_workers_ai"
                           ? `Use a [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) endpoint that exposes Deepgram-compatible Nova-3 transcription.`
-                          : providerId === "fireworks"
-                            ? `Use [Fireworks AI](https://fireworks.ai) for transcriptions.`
-                            : providerId === "mistral"
-                              ? `Use [Mistral](https://mistral.ai) for transcriptions. Keep the Base URL as \`https://api.mistral.ai/v1\` (Reset under Advanced if you pasted a transcriptions endpoint). **Voxtral Mini Transcribe 2** transcribes after recording; the realtime model is for live captions.`
-                              : providerId === "cohere"
-                                ? `Use [Cohere Transcribe](https://docs.cohere.com/docs/transcribe) for batch transcription. Files must be 25 MB or smaller and use one selected language. Cohere does not return timestamps or speaker labels, so Anarlog estimates word timing.`
-                                : providerId === "google_generative_ai"
-                                  ? `Use [Gemini 3.5 Transcribe](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5-transcribe/) with a Google AI Studio API key. **3.5 Transcribe Live** captions during recording (preview sessions last up to 10 minutes). **3.5 Transcribe** runs after recording with speaker labels and word timestamps; Anarlog splits files past 15 minutes.`
-                                  : providerId === "google_cloud"
-                                    ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) synchronous recognition for recordings up to one minute and 10 MB. Paste an OAuth access token in the API key field; refresh it when it expires.`
-                                    : providerId === "azure_speech"
-                                      ? `Use [Azure AI Speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text) fast transcription. Enter the regional Speech resource endpoint as the Base URL and its subscription key as the API key.`
-                                      : providerId === "aws_transcribe"
-                                        ? `Amazon Transcribe's native file API requires SigV4 plus an S3 object. Enter an OpenAI-compatible gateway URL that performs that AWS authentication and upload, then paste the gateway token as the API key.`
-                                        : providerId === "speechmatics"
-                                          ? `Use [Speechmatics](https://docs.speechmatics.com/speech-to-text/batch/quickstart) enhanced batch transcription. The default endpoint uses the EU region and can be changed under Advanced.`
-                                          : providerId === "revai"
-                                            ? `Use [Rev AI](https://docs.rev.ai/api/asynchronous/get-started) asynchronous transcription. Anarlog uploads the recording, waits for the job, and retrieves word timestamps and speaker labels.`
-                                            : providerId === "custom"
-                                              ? `Point this at any **Deepgram-compatible** endpoint, including a server on this computer or your local network.`
-                                              : "";
+                          : providerId === "mistral"
+                            ? `Use [Mistral](https://mistral.ai) for transcriptions. Keep the Base URL as \`https://api.mistral.ai/v1\` (Reset under Advanced if you pasted a transcriptions endpoint). **Voxtral Mini Transcribe 2** transcribes after recording; the realtime model is for live captions.`
+                            : providerId === "cohere"
+                              ? `Use [Cohere Transcribe](https://docs.cohere.com/docs/transcribe) for batch transcription. Files must be 25 MB or smaller and use one selected language. Cohere does not return timestamps or speaker labels, so Anarlog estimates word timing.`
+                              : providerId === "google_generative_ai"
+                                ? `Use [Gemini 3.5 Transcribe](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5-transcribe/) with a Google AI Studio API key. **3.5 Transcribe Live** captions during recording (preview sessions last up to 10 minutes). **3.5 Transcribe** runs after recording with speaker labels and word timestamps; Anarlog splits files past 15 minutes.`
+                                : providerId === "google_cloud"
+                                  ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) synchronous recognition for recordings up to one minute and 10 MB. Paste an OAuth access token in the API key field; refresh it when it expires.`
+                                  : providerId === "azure_speech"
+                                    ? `Use [Azure AI Speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text) fast transcription. Enter the regional Speech resource endpoint as the Base URL and its subscription key as the API key.`
+                                    : providerId === "aws_transcribe"
+                                      ? `Amazon Transcribe's native file API requires SigV4 plus an S3 object. Enter an OpenAI-compatible gateway URL that performs that AWS authentication and upload, then paste the gateway token as the API key.`
+                                      : providerId === "speechmatics"
+                                        ? `Use [Speechmatics](https://docs.speechmatics.com/speech-to-text/batch/quickstart) enhanced batch transcription. The default endpoint uses the EU region and can be changed under Advanced.`
+                                        : providerId === "revai"
+                                          ? `Use [Rev AI](https://docs.rev.ai/api/asynchronous/get-started) asynchronous transcription. Anarlog uploads the recording, waits for the job, and retrieves word timestamps and speaker labels.`
+                                          : providerId === "custom"
+                                            ? `Point this at any **Deepgram-compatible** endpoint, including a server on this computer or your local network.`
+                                            : "";
 
   if (!content.trim()) {
     return null;

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -41,8 +41,6 @@ describe("STT providers", () => {
       "pyannote",
       "cohere",
       "aquavoice",
-      // Disabled providers sort after every ordered provider.
-      "fireworks",
       "custom",
     ]);
   });
@@ -122,8 +120,7 @@ describe("STT model display labels", () => {
       PROVIDERS.map((provider) => [provider.id, provider]),
     );
 
-    expect(providers.fireworks.disabled).toBe(true);
-    expect(providers.fireworks.badge).toBe("Discontinued");
+    expect(providers.fireworks).toBeUndefined();
     expect(providers.xai.badge).toBeNull();
     expect(providers.smallestai.badge).toBeNull();
     expect(providers.smallestai.models).toEqual(["pulse", "pulse-pro"]);

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -7,7 +7,6 @@ import {
   Cloudflare,
   Cohere,
   ElevenLabs,
-  Fireworks,
   Gemini,
   GoogleCloud,
   Groq,
@@ -1013,17 +1012,6 @@ const _PROVIDERS = [
       { kind: "requires_config", fields: ["base_url", "api_key"] },
     ],
   },
-  {
-    // Fireworks discontinued its audio inference API in June 2026.
-    disabled: true,
-    id: "fireworks",
-    displayName: "Fireworks",
-    badge: "Discontinued",
-    icon: <ProviderLobeIcon icon={Fireworks} />,
-    baseUrl: "https://api.fireworks.ai",
-    models: ["whisper-v3-turbo"],
-    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
-  },
 ] as const satisfies readonly Provider[];
 
 const PROVIDER_ORDER = [
@@ -1051,7 +1039,6 @@ const PROVIDER_ORDER = [
   "cartesia",
   "cloudflare_workers_ai",
   "together",
-  "fireworks",
   "xai",
   "smallestai",
   "pyannote",


### PR DESCRIPTION
Remove the discontinued provider entry and setup copy, and update provider list expectations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only removal of an already-disabled STT provider; no auth or transcription runtime paths changed in this diff.
> 
> **Overview**
> Removes **Fireworks** from desktop STT provider settings after its audio inference API was discontinued. The provider is no longer listed in `PROVIDERS`, dropped from sort order, and its setup blurb is gone from the configure UI.
> 
> Tests now expect `fireworks` to be absent (not a disabled “Discontinued” entry) and no longer include it in the ordered provider list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b836a25e918a42ab337b56c11fac8c91596a713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->