### PR TITLE
Clarify when batch transcription runs

### DIFF
--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -728,12 +728,12 @@ export function NonAnarlogProviderCard({
 }
 
 function ProviderBadge({ badge }: { badge: string }) {
-  const isBatchOnly = badge === "Batch only";
+  const isAfterRecording = badge === "After recording";
   const badgeNode = (
     <span
       className={cn([
         "text-muted-foreground normal-case",
-        isBatchOnly
+        isAfterRecording
           ? "bg-background/40 cursor-help rounded-md px-1.5 py-0.5 text-[11px] font-medium"
           : "border-border rounded-full border px-2 text-xs font-light",
       ])}
@@ -742,7 +742,7 @@ function ProviderBadge({ badge }: { badge: string }) {
     </span>
   );
 
-  if (!isBatchOnly) {
+  if (!isAfterRecording) {
     return badgeNode;
   }
 

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -142,7 +142,7 @@ describe("STT model display labels", () => {
       "azure_speech",
       "revai",
     ]) {
-      expect(providers[provider]?.badge).toBe("Batch only");
+      expect(providers[provider]?.badge).toBe("After recording");
     }
     expect(providers.aquavoice.baseUrl).toBe("https://api.aquavoice.com/v1");
     expect(providers.aquavoice.models).toEqual(["avalon-v1.5"]);

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -491,7 +491,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "openrouter",
     displayName: "OpenRouter",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={OpenRouter} />,
     baseUrl: "https://openrouter.ai/api/v1",
     models: [
@@ -549,7 +549,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "zai",
     displayName: "Z.AI",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={ZAI} />,
     baseUrl: "https://api.z.ai/api/paas/v4",
     models: ["glm-asr-2512"],
@@ -569,7 +569,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "siliconflow",
     displayName: "SiliconFlow",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={SiliconCloud} />,
     baseUrl: "https://api.siliconflow.com/v1",
     models: ["FunAudioLLM/SenseVoiceSmall", "TeleAI/TeleSpeechASR"],
@@ -589,7 +589,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "groq",
     displayName: "Groq",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={Groq} />,
     baseUrl: "https://api.groq.com/openai/v1",
     models: ["whisper-large-v3-turbo", "whisper-large-v3"],
@@ -651,7 +651,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "together",
     displayName: "Together AI",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={Together} />,
     baseUrl: "https://api.together.xyz/v1",
     models: [
@@ -676,7 +676,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "speechmatics",
     displayName: "Speechmatics",
-    badge: "Batch only",
+    badge: "After recording",
     icon: (
       <ProviderBrandImage
         src="/assets/speechmatics-mark.svg"
@@ -701,7 +701,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "azure_speech",
     displayName: "Azure AI Speech",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={Azure} />,
     baseUrl: undefined,
     models: ["fast-transcription"],
@@ -785,7 +785,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "revai",
     displayName: "Rev AI",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderBrandImage src="/assets/revai-mark.svg" alt="Rev AI" />,
     baseUrl: "https://api.rev.ai/speechtotext/v1",
     models: ["machine"],
@@ -933,7 +933,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "pyannote",
     displayName: "pyannoteAI",
-    badge: "Batch only",
+    badge: "After recording",
     icon: (
       <ProviderBrandImage
         src="/assets/pyannote-logo-black.png"
@@ -958,7 +958,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "aquavoice",
     displayName: "AquaVoice",
-    badge: "Batch only",
+    badge: "After recording",
     icon: (
       <ProviderBrandImage
         src="/assets/aquavoice-black.png"
@@ -984,7 +984,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "cohere",
     displayName: "Cohere",
-    badge: "Batch only",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={Cohere} />,
     baseUrl: "https://api.cohere.com/v2",
     models: ["cohere-transcribe-03-2026", "cohere-transcribe-arabic-07-2026"],


### PR DESCRIPTION
Rename Batch only badges to After recording and retain their tooltip behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and test updates only; no transcription or provider behavior changes.
> 
> **Overview**
> Renames the STT provider capability label from **"Batch only"** to **"After recording"** across the desktop AI settings so users understand when transcription runs, without changing which providers get the badge.
> 
> `ProviderBadge` in `shared/index.tsx` now keys off `"After recording"` for the help-style badge and tooltip (*Runs after the recording finishes, not during the meeting.*). The same string is set on all previously batch-only STT entries in `stt/shared.tsx` (e.g. OpenRouter, Groq, Speechmatics, Azure, Rev AI, pyannote, AquaVoice, Cohere). Tests in `shared.test.ts` expect the new label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e3fd43ecbf6c5473ce656fcd2662bf899609c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->