### PR TITLE
Match mobile provider icons to the Soniox size

### DIFF
--- a/apps/mobile/src/settings/provider-icon-assets.ts
+++ b/apps/mobile/src/settings/provider-icon-assets.ts
@@ -152,3 +152,7 @@ const PROVIDER_ICONS: Record<string, { light: number; dark: number }> = {
 export function providerIconSource(provider: string, scheme: "light" | "dark") {
   return PROVIDER_ICONS[provider]?.[scheme];
 }
+
+export function providerIconArtworkSize(provider: string, size: number) {
+  return provider === "soniox" ? size : size * 0.6;
+}

--- a/apps/mobile/src/settings/provider-icon.android.tsx
+++ b/apps/mobile/src/settings/provider-icon.android.tsx
@@ -1,8 +1,11 @@
-import { Icon } from "@expo/ui";
+import { Column, Icon } from "@expo/ui";
 import { Image } from "@expo/ui/jetpack-compose";
 import { size as iconSize } from "@expo/ui/jetpack-compose/modifiers";
 
-import { providerIconSource } from "./provider-icon-assets";
+import {
+  providerIconArtworkSize,
+  providerIconSource,
+} from "./provider-icon-assets";
 import { useAppColorScheme, useColors } from "./theme-provider";
 
 export function ProviderIcon({
@@ -15,20 +18,31 @@ export function ProviderIcon({
   const scheme = useAppColorScheme();
   const Colors = useColors();
   const source = providerIconSource(provider, scheme);
-  return source ? (
-    <Image
-      source={source}
-      contentDescription={null}
-      modifiers={[iconSize(size, size)]}
-    />
-  ) : (
-    <Icon
-      name={Icon.select({
-        ios: "shuffle",
-        android: import("@expo/material-symbols/shuffle.xml"),
-      })}
-      size={size}
-      color={Colors.muted}
-    />
+  const artworkSize = providerIconArtworkSize(provider, size);
+  return (
+    <Column
+      alignment="center"
+      style={{
+        width: size,
+        paddingVertical: (size - artworkSize) / 2,
+      }}
+    >
+      {source ? (
+        <Image
+          source={source}
+          contentDescription={null}
+          modifiers={[iconSize(artworkSize, artworkSize)]}
+        />
+      ) : (
+        <Icon
+          name={Icon.select({
+            ios: "shuffle",
+            android: import("@expo/material-symbols/shuffle.xml"),
+          })}
+          size={artworkSize}
+          color={Colors.muted}
+        />
+      )}
+    </Column>
   );
 }

--- a/apps/mobile/src/settings/provider-icon.tsx
+++ b/apps/mobile/src/settings/provider-icon.tsx
@@ -1,7 +1,10 @@
-import { Icon, RNHostView } from "@expo/ui";
+import { Column, Icon, RNHostView } from "@expo/ui";
 import { Image } from "react-native";
 
-import { providerIconSource } from "./provider-icon-assets";
+import {
+  providerIconArtworkSize,
+  providerIconSource,
+} from "./provider-icon-assets";
 import { useAppColorScheme } from "./theme-provider";
 
 export function ProviderIcon({
@@ -12,15 +15,26 @@ export function ProviderIcon({
   size?: number;
 }) {
   const source = providerIconSource(provider, useAppColorScheme());
-  return source ? (
-    <RNHostView matchContents>
-      <Image
-        source={source}
-        style={{ width: size, height: size }}
-        accessible={false}
-      />
-    </RNHostView>
-  ) : (
-    <Icon name="shuffle" size={size} />
+  const artworkSize = providerIconArtworkSize(provider, size);
+  return (
+    <Column
+      alignment="center"
+      style={{
+        width: size,
+        paddingVertical: (size - artworkSize) / 2,
+      }}
+    >
+      {source ? (
+        <RNHostView matchContents>
+          <Image
+            source={source}
+            style={{ width: artworkSize, height: artworkSize }}
+            accessible={false}
+          />
+        </RNHostView>
+      ) : (
+        <Icon name="shuffle" size={artworkSize} />
+      )}
+    </Column>
   );
 }


### PR DESCRIPTION
Use compact artwork in fixed icon slots across iOS, Android, and fallback settings components while preserving Soniox sizing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only sizing in settings provider icons; no auth, data, or API behavior changes.
> 
> **Overview**
> **Provider icons in mobile settings** now render at **60% of the slot size** (with vertical centering), while **Soniox stays at full size** so all providers look consistent in the same fixed-width row.
> 
> A shared `providerIconArtworkSize` helper drives this rule. **iOS** (`provider-icon.tsx`) and **Android** (`provider-icon.android.tsx`) both wrap the image or shuffle fallback in a `Column` with width `size` and `paddingVertical` so the outer footprint is unchanged; only the artwork and fallback icon dimensions shrink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e413b7479a8daef23e43b0af61dd37a1963360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->