### PR TITLE
Remove maturity tags from intelligence providers

### DIFF
--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -152,7 +152,7 @@ const _PROVIDERS = [
   {
     id: "apple_foundation",
     displayName: "Apple Intelligence",
-    badge: "Experimental",
+    badge: null,
     icon: <ProviderLobeIcon icon={Apple} />,
     baseUrl: undefined,
     requirements: [],
@@ -467,7 +467,7 @@ const _PROVIDERS = [
   {
     id: "amazon_bedrock",
     displayName: "Amazon Bedrock",
-    badge: "Beta",
+    badge: null,
     icon: <ProviderLobeIcon icon={Aws} />,
     baseUrl: undefined,
     requirements: [
@@ -487,7 +487,7 @@ const _PROVIDERS = [
   {
     id: "google_vertex_ai",
     displayName: "Google Vertex AI",
-    badge: "Beta",
+    badge: null,
     icon: <ProviderLobeIcon icon={GoogleCloud} />,
     baseUrl: undefined,
     requirements: [
@@ -563,7 +563,7 @@ const _PROVIDERS = [
   {
     id: "azure_openai",
     displayName: "Azure OpenAI",
-    badge: "Beta",
+    badge: null,
     icon: <ProviderLobeIcon icon={Azure} />,
     baseUrl: undefined,
     requirements: [
@@ -583,7 +583,7 @@ const _PROVIDERS = [
   {
     id: "azure_ai",
     displayName: "Azure AI Foundry",
-    badge: "Beta",
+    badge: null,
     icon: <ProviderLobeIcon icon={AzureAI} />,
     baseUrl: undefined,
     requirements: [


### PR DESCRIPTION
Remove Beta and Experimental badges from five provider entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only metadata in provider definitions; no auth, routing, or provider behavior changes.
> 
> **Overview**
> Removes maturity labels from five LLM providers in the desktop AI settings provider list so they no longer show **Beta** or **Experimental** chips in the picker UI.
> 
> **Apple Intelligence** drops the Experimental badge; **Amazon Bedrock**, **Google Vertex AI**, **Azure OpenAI**, and **Azure AI Foundry** drop Beta. Each entry’s `badge` is set to `null`, so only badges like Recommended and Subscription remain visible elsewhere in the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5fbb1abefc6e1edc98d6789aa0cfa08c674a33e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->