### PR TITLE
Distinguish transcription and intelligence settings icons

### DIFF
--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -6,6 +6,7 @@ import {
   ArrowsClockwise,
   Bell,
   BookOpen,
+  Brain,
   CalendarDots,
   ChartBar,
   Code,
@@ -18,12 +19,12 @@ import {
   Lock,
   MagnifyingGlass,
   ShieldCheck,
-  Sparkle,
   Sun,
   User,
   Users,
   UsersThree,
   VideoCamera,
+  Waveform,
   X,
 } from "@anlg/ui/components/icons";
 import { useSquircleRef } from "@anlg/ui/hooks/use-squircle";
@@ -99,8 +100,8 @@ export function SettingsNav() {
     {
       label: "AI",
       items: [
-        { id: "transcription", label: t`Transcription`, icon: Sparkle },
-        { id: "intelligence", label: t`Intelligence`, icon: Sparkle },
+        { id: "transcription", label: t`Transcription`, icon: Waveform },
+        { id: "intelligence", label: t`Intelligence`, icon: Brain },
         {
           id: "dictionary",
           label: t`Dictionary`,


### PR DESCRIPTION
Use a waveform for Transcription and a brain for Intelligence in the settings sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only sidebar icon updates with no routing, settings logic, or data changes.
> 
> **Overview**
> The settings sidebar **AI** section no longer uses the same **Sparkle** icon for both entries.
> 
> **Transcription** now uses **Waveform** and **Intelligence** uses **Brain**, with matching icon imports in `settings.tsx`. Nav behavior and labels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03500fe494e4d711e840f0544ace20a585bd1ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->