### PR TITLE
Simplify the custom model provider label

### DIFF
--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -165,10 +165,8 @@ describe("STT model display labels", () => {
     expect(
       "builtIn" in providers.local_file && providers.local_file.builtIn,
     ).toBe(true);
-    expect(providers.local_file.displayName).toBe("On-device file");
-    expect(
-      "description" in providers.local_file && providers.local_file.description,
-    ).toBe("whisper.cpp .bin");
+    expect(providers.local_file.displayName).toBe("BYO-model");
+    expect(providers.local_file).not.toHaveProperty("description");
     expect(providers.local_file.badge).toBe("On device");
   });
 

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -22,7 +22,7 @@ import {
 import type { ReactNode } from "react";
 
 import type { LocalModel } from "@anlg/plugin-local-stt";
-import { FolderOpen, Shuffle, Waveform } from "@anlg/ui/components/icons";
+import { Cpu, Shuffle, Waveform } from "@anlg/ui/components/icons";
 
 import { env } from "~/env";
 import {
@@ -408,12 +408,11 @@ const _PROVIDERS = [
   {
     disabled: false,
     id: "local_file",
-    displayName: "On-device file",
-    description: "whisper.cpp .bin",
+    displayName: "BYO-model",
     badge: "On device",
     baseUrl: "",
     builtIn: true,
-    icon: <FolderOpen />,
+    icon: <Cpu />,
     models: ["local-file"],
     requirements: [],
   },


### PR DESCRIPTION
Use BYO-model with a chip icon and remove the format subtitle from the provider selector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and icon-only changes in STT provider metadata; no behavior or API changes.
> 
> **Overview**
> The **local file** STT provider in the provider selector is relabeled from **On-device file** to **BYO-model**, uses the **Cpu** icon instead of **FolderOpen**, and no longer exposes a **description** (the former **whisper.cpp .bin** subtitle under the provider name).
> 
> Tests in `shared.test.ts` are updated to assert the new display name and that `local_file` has no `description` property. Model-level labeling for `local-file` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511f0090a9a66283b7b298cadacee310de851742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->