### PR TITLE
Align Android settings with the neutral mobile theme

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -1,4 +1,3 @@
-import { FieldGroup, Text } from "@expo/ui";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
@@ -11,6 +10,8 @@ import {
   SettingsPage,
   SettingsRow,
 } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Text } from "@/settings/fields";
 
 export default function AccountSettings() {
   const auth = useAuth();

--- a/apps/mobile/src/app/settings/appearance.tsx
+++ b/apps/mobile/src/app/settings/appearance.tsx
@@ -1,6 +1,8 @@
-import { FieldGroup, Picker, Row, Spacer, Switch, Text } from "@expo/ui";
+import { Row, Spacer } from "@expo/ui";
 
 import { SettingsError, SettingsPage } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Picker, Switch, Text } from "@/settings/fields";
 import { usePreferenceMutation, usePreferences } from "@/settings/preferences";
 
 export default function AppearanceSettings() {
@@ -13,7 +15,7 @@ export default function AppearanceSettings() {
       <FieldGroup.Section>
         <Row alignment="center">
           <Text>Theme</Text>
-          <Spacer />
+          <Spacer flexible />
           <Picker
             selectedValue={preferences.theme}
             onValueChange={(value) => theme.mutate(value)}

--- a/apps/mobile/src/app/settings/dictionary.tsx
+++ b/apps/mobile/src/app/settings/dictionary.tsx
@@ -1,15 +1,9 @@
-import {
-  Button,
-  FieldGroup,
-  Row,
-  Spacer,
-  Text,
-  TextInput,
-  useNativeState,
-} from "@expo/ui";
+import { Row, Spacer, useNativeState } from "@expo/ui";
 import { useForm } from "@tanstack/react-form";
 
 import { SettingsError, SettingsPage } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Button, Text, TextInput } from "@/settings/fields";
 import { usePreferenceMutation, usePreferences } from "@/settings/preferences";
 import { normalizeDictionary } from "@/settings/preferences-model";
 

--- a/apps/mobile/src/app/settings/help.tsx
+++ b/apps/mobile/src/app/settings/help.tsx
@@ -1,4 +1,3 @@
-import { FieldGroup } from "@expo/ui";
 import { useMutation } from "@tanstack/react-query";
 import Constants from "expo-constants";
 import * as WebBrowser from "expo-web-browser";
@@ -9,6 +8,7 @@ import {
   SettingsPage,
   SettingsRow,
 } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
 
 export default function HelpSettings() {
   const open = useMutation({

--- a/apps/mobile/src/app/settings/languages.tsx
+++ b/apps/mobile/src/app/settings/languages.tsx
@@ -1,6 +1,6 @@
-import { FieldGroup, Switch, Text } from "@expo/ui";
-
 import { SettingsError, SettingsPage } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Switch, Text } from "@/settings/fields";
 import { LANGUAGE_CODES, languageName } from "@/settings/languages";
 import { usePreferenceMutation, usePreferences } from "@/settings/preferences";
 

--- a/apps/mobile/src/app/settings/privacy.tsx
+++ b/apps/mobile/src/app/settings/privacy.tsx
@@ -1,9 +1,10 @@
-import { FieldGroup, Switch, Text } from "@expo/ui";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as LocalAuthentication from "expo-local-authentication";
 
 import { authenticateForAppLock } from "@/settings/app-lock";
 import { SettingsError, SettingsPage } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Switch, Text } from "@/settings/fields";
 import {
   setPrivacyPreference,
   usePrivacyPreferences,

--- a/apps/mobile/src/app/settings/recording.tsx
+++ b/apps/mobile/src/app/settings/recording.tsx
@@ -1,4 +1,3 @@
-import { FieldGroup, Text } from "@expo/ui";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   getRecordingPermissionsAsync,
@@ -12,6 +11,8 @@ import {
   SettingsPage,
   SettingsRow,
 } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Text } from "@/settings/fields";
 
 export default function RecordingSettings() {
   const router = useRouter();

--- a/apps/mobile/src/app/settings/recordings.tsx
+++ b/apps/mobile/src/app/settings/recordings.tsx
@@ -1,9 +1,15 @@
 import { useRouter } from "expo-router";
-import { FlatList, Pressable, Text, View } from "react-native";
+import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { IconButton } from "@/components/ui/icon-button";
-import { Spacing, Typography } from "@/constants/theme";
+import {
+  ControlSize,
+  CornerCurve,
+  Radius,
+  Spacing,
+  Typography,
+} from "@/constants/theme";
 import { useLiveQuery } from "@/db";
 import { formatStorageBytes } from "@/settings/storage";
 import { createStyleHook } from "@/settings/theme-provider";
@@ -33,6 +39,7 @@ export default function RecordingStorageScreen() {
           onPress={() => router.back()}
         />
         <Text style={styles.title}>Saved recordings</Text>
+        <View style={styles.spacer} />
       </View>
       <FlatList
         data={recordings.data ?? []}
@@ -50,7 +57,7 @@ export default function RecordingStorageScreen() {
         renderItem={({ item }) => (
           <Pressable
             accessibilityRole="button"
-            style={styles.row}
+            style={({ pressed }) => [styles.row, pressed && styles.pressed]}
             onPress={() =>
               router.push({ pathname: "/note/[id]", params: { id: item.id } })
             }
@@ -74,16 +81,23 @@ const useStyles = createStyleHook((Colors) => ({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    gap: Spacing.md,
-    padding: Spacing.lg,
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.md,
   },
   title: { ...Typography.section, color: Colors.ink },
   copy: { ...Typography.caption, color: Colors.muted },
-  list: { padding: Spacing.lg, gap: Spacing.md },
+  spacer: { width: ControlSize.default, height: ControlSize.default },
+  list: { padding: Spacing.md, gap: Spacing.md },
   row: {
     padding: Spacing.md,
     backgroundColor: Colors.surface,
-    borderRadius: 16,
+    borderRadius: Radius.card,
+    borderCurve: CornerCurve.squircle,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: Colors.border,
     gap: Spacing.sm,
   },
+  pressed: { backgroundColor: Colors.accentSurface },
 }));

--- a/apps/mobile/src/app/settings/sync.tsx
+++ b/apps/mobile/src/app/settings/sync.tsx
@@ -1,4 +1,3 @@
-import { Button, FieldGroup, Text } from "@expo/ui";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useSyncExternalStore } from "react";
@@ -9,6 +8,8 @@ import {
   SettingsPage,
   SettingsRow,
 } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Button, Text } from "@/settings/fields";
 import { formatStorageBytes, useRecordingStorage } from "@/settings/storage";
 import { requestSyncDeviceList } from "@/settings/sync-devices";
 import {

--- a/apps/mobile/src/app/settings/transcription.tsx
+++ b/apps/mobile/src/app/settings/transcription.tsx
@@ -1,4 +1,4 @@
-import { FieldGroup, Picker, Row, Spacer, Text } from "@expo/ui";
+import { Row, Spacer } from "@expo/ui";
 import { useRouter } from "expo-router";
 
 import {
@@ -6,6 +6,8 @@ import {
   SettingsPage,
   SettingsRow,
 } from "@/settings/components";
+import { FieldGroup } from "@/settings/field-group";
+import { Picker, Text } from "@/settings/fields";
 import { LANGUAGE_CODES, languageName } from "@/settings/languages";
 import { usePreferenceMutation, usePreferences } from "@/settings/preferences";
 
@@ -32,7 +34,7 @@ export default function TranscriptionSettings() {
       <FieldGroup.Section title="Language">
         <Row alignment="center">
           <Text>Main language</Text>
-          <Spacer />
+          <Spacer flexible />
           <Picker
             selectedValue={preferences.ai_language}
             onValueChange={(value) => language.mutate(value)}
@@ -72,7 +74,7 @@ export default function TranscriptionSettings() {
       <FieldGroup.Section>
         <Row alignment="center">
           <Text>Summary length</Text>
-          <Spacer />
+          <Spacer flexible />
           <Picker
             selectedValue={preferences.summary_length}
             onValueChange={(value) => length.mutate(value)}

--- a/apps/mobile/src/settings/components.tsx
+++ b/apps/mobile/src/settings/components.tsx
@@ -1,5 +1,5 @@
 import type { IconName } from "@expo/ui";
-import { FieldGroup, Host, Icon, ListItem, Text as NativeText } from "@expo/ui";
+import { Host, Icon } from "@expo/ui";
 import {
   font,
   listSectionSpacing,
@@ -12,6 +12,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { IconButton } from "@/components/ui/icon-button";
 import { ControlSize, Spacing, Typography } from "@/constants/theme";
+import { FieldGroup } from "@/settings/field-group";
+import { ListItem, Text as NativeText } from "@/settings/fields";
 import {
   createStyleHook,
   useAppColorScheme,
@@ -87,10 +89,13 @@ export function SettingsRow({
   icon?: IconName;
   onPress?: () => void;
 }) {
+  const Colors = useColors();
   return (
     <ListItem
       onPress={onPress}
-      leading={icon ? <Icon name={icon} size={20} /> : undefined}
+      leading={
+        icon ? <Icon name={icon} size={20} color={Colors.muted} /> : undefined
+      }
       supportingText={description ?? (onPress ? value : undefined)}
       trailing={
         onPress ? (
@@ -100,9 +105,10 @@ export function SettingsRow({
               android: import("@expo/material-symbols/chevron_right.xml"),
             })}
             size={14}
+            color={Colors.muted}
           />
         ) : value ? (
-          <NativeText>{value}</NativeText>
+          <NativeText textStyle={{ color: Colors.muted }}>{value}</NativeText>
         ) : undefined
       }
     >
@@ -112,10 +118,13 @@ export function SettingsRow({
 }
 
 export function SettingsError({ error }: { error: unknown }) {
+  const Colors = useColors();
   if (!error) return null;
   return (
     <FieldGroup.SectionFooter>
-      <NativeText>Could not complete this change. Please try again.</NativeText>
+      <NativeText textStyle={{ color: Colors.destructive }}>
+        Could not complete this change. Please try again.
+      </NativeText>
     </FieldGroup.SectionFooter>
   );
 }

--- a/apps/mobile/src/settings/field-group.android.tsx
+++ b/apps/mobile/src/settings/field-group.android.tsx
@@ -1,0 +1,85 @@
+import { Column, FieldGroup as NativeFieldGroup } from "@expo/ui";
+import { LazyColumn } from "@expo/ui/jetpack-compose";
+import { fillMaxWidth } from "@expo/ui/jetpack-compose/modifiers";
+import { Children, isValidElement, type ComponentProps } from "react";
+import { StyleSheet } from "react-native";
+
+import { Radius, Spacing, Typography } from "@/constants/theme";
+
+import { FieldFooter, Text } from "./fields";
+import { useColors } from "./theme-provider";
+
+function SettingsFieldGroup({
+  children,
+}: ComponentProps<typeof NativeFieldGroup>) {
+  return (
+    <LazyColumn
+      verticalArrangement={{ spacedBy: Spacing.lg }}
+      contentPadding={{
+        start: Spacing.md,
+        end: Spacing.md,
+        top: Spacing.md,
+        bottom: Spacing.lg,
+      }}
+    >
+      {children}
+    </LazyColumn>
+  );
+}
+
+function Section({
+  children,
+  title,
+}: ComponentProps<typeof NativeFieldGroup.Section>) {
+  const Colors = useColors();
+  const content = Children.toArray(children);
+  const footers = content.filter(
+    (child) => isValidElement(child) && child.type === SectionFooter,
+  );
+  const rows = content.filter(
+    (child) => !isValidElement(child) || child.type !== SectionFooter,
+  );
+  return (
+    <Column spacing={Spacing.sm} modifiers={[fillMaxWidth()]}>
+      {title && (
+        <Text
+          textStyle={{ ...Typography.section, color: Colors.muted }}
+          style={{ paddingHorizontal: Spacing.compact }}
+        >
+          {title}
+        </Text>
+      )}
+      {rows.length > 0 && (
+        <Column
+          spacing={Spacing.compact}
+          modifiers={[fillMaxWidth()]}
+          style={{
+            backgroundColor: Colors.surface,
+            borderColor: Colors.border,
+            borderWidth: StyleSheet.hairlineWidth,
+            borderRadius: Radius.card,
+            padding: Spacing.compact,
+          }}
+        >
+          {rows}
+        </Column>
+      )}
+      {footers}
+    </Column>
+  );
+}
+
+function SectionFooter({
+  children,
+}: ComponentProps<typeof NativeFieldGroup.SectionFooter>) {
+  return (
+    <Column style={{ paddingHorizontal: Spacing.compact }}>
+      <FieldFooter>{children}</FieldFooter>
+    </Column>
+  );
+}
+
+export const FieldGroup = Object.assign(SettingsFieldGroup, {
+  Section,
+  SectionFooter,
+});

--- a/apps/mobile/src/settings/field-group.tsx
+++ b/apps/mobile/src/settings/field-group.tsx
@@ -1,0 +1,1 @@
+export { FieldGroup } from "@expo/ui";

--- a/apps/mobile/src/settings/fields.android.tsx
+++ b/apps/mobile/src/settings/fields.android.tsx
@@ -1,0 +1,188 @@
+import {
+  Column,
+  Row,
+  Text as NativeText,
+  TextInput as NativeTextInput,
+  type Button as NativeButton,
+  type ListItem as NativeListItem,
+  type Switch as NativeSwitch,
+} from "@expo/ui";
+import {
+  Button as ComposeButton,
+  OutlinedButton,
+  Switch as ComposeSwitch,
+  TextButton,
+} from "@expo/ui/jetpack-compose";
+import {
+  fillMaxWidth,
+  defaultMinSize,
+  testID as testIDModifier,
+  weight,
+} from "@expo/ui/jetpack-compose/modifiers";
+import {
+  createContext,
+  useContext,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
+
+import { ControlSize, Spacing, Typography } from "@/constants/theme";
+
+import { useColors } from "./theme-provider";
+
+export { Picker } from "./picker";
+
+const FooterContext = createContext(false);
+
+export function FieldFooter({ children }: { children?: ReactNode }) {
+  return <FooterContext.Provider value>{children}</FooterContext.Provider>;
+}
+
+export function Text({
+  textStyle,
+  ...props
+}: ComponentProps<typeof NativeText>) {
+  const Colors = useColors();
+  const footer = useContext(FooterContext);
+  return (
+    <NativeText
+      {...props}
+      textStyle={{
+        ...(footer ? Typography.caption : Typography.body),
+        color: footer ? Colors.muted : Colors.ink,
+        ...textStyle,
+      }}
+    />
+  );
+}
+
+export function TextInput({
+  textStyle,
+  ...props
+}: ComponentProps<typeof NativeTextInput>) {
+  const Colors = useColors();
+  return (
+    <NativeTextInput
+      cursorColor={Colors.ink}
+      selectionColor={Colors.accentSurface}
+      selectionHandleColor={Colors.ink}
+      placeholderTextColor={Colors.muted}
+      {...props}
+      textStyle={{ ...Typography.body, color: Colors.ink, ...textStyle }}
+    />
+  );
+}
+
+export function Button({
+  label,
+  children,
+  variant = "filled",
+  onPress,
+  disabled,
+  testID,
+}: ComponentProps<typeof NativeButton>) {
+  const Colors = useColors();
+  const Component =
+    variant === "text"
+      ? TextButton
+      : variant === "outlined"
+        ? OutlinedButton
+        : ComposeButton;
+  const foreground =
+    variant === "filled" ? Colors.primaryForeground : Colors.ink;
+  return (
+    <Component
+      onClick={onPress}
+      enabled={!disabled}
+      colors={{
+        containerColor: variant === "filled" ? Colors.primary : "transparent",
+        contentColor: foreground,
+        disabledContainerColor: Colors.mutedSurface,
+        disabledContentColor: Colors.muted,
+      }}
+      modifiers={[
+        defaultMinSize({ minHeight: ControlSize.default }),
+        ...(testID ? [testIDModifier(testID)] : []),
+      ]}
+    >
+      {children ?? (
+        <Text
+          textStyle={{
+            ...Typography.label,
+            color: disabled ? Colors.muted : foreground,
+          }}
+        >
+          {label}
+        </Text>
+      )}
+    </Component>
+  );
+}
+
+export function Switch({
+  value,
+  onValueChange,
+  label,
+  disabled,
+  testID,
+}: ComponentProps<typeof NativeSwitch>) {
+  const Colors = useColors();
+  return (
+    <Row alignment="center" spacing={Spacing.sm} modifiers={[fillMaxWidth()]}>
+      {label != null && <Text modifiers={[weight(1)]}>{label}</Text>}
+      <ComposeSwitch
+        value={value}
+        onCheckedChange={onValueChange}
+        enabled={!disabled}
+        modifiers={testID ? [testIDModifier(testID)] : undefined}
+        colors={{
+          checkedTrackColor: Colors.ink,
+          checkedThumbColor: Colors.background,
+          checkedBorderColor: Colors.ink,
+          uncheckedTrackColor: Colors.mutedSurface,
+          uncheckedThumbColor: Colors.muted,
+          uncheckedBorderColor: Colors.border,
+          disabledCheckedTrackColor: Colors.mutedSurface,
+          disabledCheckedThumbColor: Colors.muted,
+          disabledCheckedBorderColor: Colors.border,
+          disabledUncheckedTrackColor: Colors.mutedSurface,
+          disabledUncheckedThumbColor: Colors.muted,
+          disabledUncheckedBorderColor: Colors.border,
+        }}
+      />
+    </Row>
+  );
+}
+
+export function ListItem({
+  children,
+  leading,
+  trailing,
+  supportingText,
+  onPress,
+}: ComponentProps<typeof NativeListItem>) {
+  const Colors = useColors();
+  return (
+    <Row
+      alignment="center"
+      spacing={Spacing.compact}
+      onPress={onPress}
+      modifiers={[
+        fillMaxWidth(),
+        defaultMinSize({ minHeight: ControlSize.default }),
+      ]}
+    >
+      {leading}
+      <Column spacing={Spacing.xs} modifiers={[weight(1)]}>
+        {children}
+        {supportingText &&
+          (typeof supportingText === "string" ? (
+            <Text textStyle={{ color: Colors.muted }}>{supportingText}</Text>
+          ) : (
+            supportingText
+          ))}
+      </Column>
+      {trailing}
+    </Row>
+  );
+}

--- a/apps/mobile/src/settings/fields.tsx
+++ b/apps/mobile/src/settings/fields.tsx
@@ -1,0 +1,5 @@
+import { FieldGroup } from "@expo/ui";
+
+export { Button, ListItem, Picker, Switch, Text, TextInput } from "@expo/ui";
+
+export const FieldFooter = FieldGroup.SectionFooter;

--- a/apps/mobile/src/settings/picker.android.tsx
+++ b/apps/mobile/src/settings/picker.android.tsx
@@ -1,0 +1,101 @@
+import { Icon, Picker as NativePicker, Row, Text } from "@expo/ui";
+import { DropdownMenuItem, DropdownMenu } from "@expo/ui/jetpack-compose";
+import {
+  defaultMinSize,
+  testID as testIDModifier,
+} from "@expo/ui/jetpack-compose/modifiers";
+import { Children, isValidElement, useState, type ReactNode } from "react";
+
+import { ControlSize, Spacing, Typography } from "@/constants/theme";
+
+import { useColors } from "./theme-provider";
+
+function SettingsPicker<T extends string | number>({
+  selectedValue,
+  onValueChange,
+  enabled = true,
+  children,
+  testID,
+}: {
+  selectedValue: T;
+  onValueChange: (value: T) => void;
+  enabled?: boolean;
+  children?: ReactNode;
+  testID?: string;
+}) {
+  const Colors = useColors();
+  const [expanded, setExpanded] = useState(false);
+  const items = Children.toArray(children).flatMap((child) =>
+    isValidElement<{ value: T; label: string }>(child) &&
+    child.type === NativePicker.Item
+      ? [child.props]
+      : [],
+  );
+  const textStyle = {
+    ...Typography.body,
+    color: enabled ? Colors.ink : Colors.muted,
+  };
+  return (
+    <DropdownMenu
+      expanded={expanded}
+      onDismissRequest={() => setExpanded(false)}
+      color={Colors.surface}
+    >
+      <DropdownMenu.Trigger>
+        <Row
+          onPress={enabled ? () => setExpanded(true) : undefined}
+          alignment="center"
+          spacing={Spacing.sm}
+          modifiers={[
+            defaultMinSize({ minHeight: ControlSize.default }),
+            ...(testID ? [testIDModifier(testID)] : []),
+          ]}
+        >
+          <Text textStyle={textStyle}>
+            {items.find((item) => item.value === selectedValue)?.label}
+          </Text>
+          <Icon
+            name={Icon.select({
+              ios: "chevron.down",
+              android: import("@expo/material-symbols/keyboard_arrow_down.xml"),
+            })}
+            color={Colors.muted}
+            size={16}
+          />
+        </Row>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Items>
+        {items.map((item) => (
+          <DropdownMenuItem
+            key={String(item.value)}
+            enabled={enabled}
+            onClick={() => {
+              onValueChange(item.value);
+              setExpanded(false);
+            }}
+          >
+            <DropdownMenuItem.Text>
+              <Text textStyle={textStyle}>{item.label}</Text>
+            </DropdownMenuItem.Text>
+            {item.value === selectedValue && (
+              <DropdownMenuItem.TrailingIcon>
+                <Icon
+                  name={Icon.select({
+                    ios: "checkmark",
+                    android: import("@expo/material-symbols/check.xml"),
+                  })}
+                  color={Colors.ink}
+                  size={18}
+                />
+              </DropdownMenuItem.TrailingIcon>
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+export const Picker = Object.assign(SettingsPicker, {
+  Item: NativePicker.Item,
+});

--- a/apps/mobile/src/settings/picker.tsx
+++ b/apps/mobile/src/settings/picker.tsx
@@ -1,0 +1,1 @@
+export { Picker } from "@expo/ui";

--- a/apps/mobile/src/settings/provider-form.tsx
+++ b/apps/mobile/src/settings/provider-form.tsx
@@ -1,15 +1,4 @@
-import {
-  Button,
-  Column,
-  FieldGroup,
-  Icon,
-  ListItem,
-  Row,
-  Spacer,
-  Text,
-  TextInput,
-  useNativeState,
-} from "@expo/ui";
+import { Column, Icon, Row, Spacer, useNativeState } from "@expo/ui";
 import { useForm } from "@tanstack/react-form";
 import {
   useMutation,
@@ -19,10 +8,11 @@ import {
 } from "@tanstack/react-query";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
-import { Platform } from "react-native";
 
 import { ProRequiredError } from "@/auth/billing";
 import { useAuth } from "@/auth/context";
+import { FieldGroup } from "@/settings/field-group";
+import { Button, ListItem, Text, TextInput } from "@/settings/fields";
 
 import { SettingsPage } from "./components";
 import { createProviderAutosave } from "./provider-autosave";
@@ -154,7 +144,7 @@ function ProviderForm({
       <FieldGroup.Section>
         <Row alignment="center">
           <Text>Provider</Text>
-          <Spacer />
+          <Spacer flexible />
           <ProviderPicker
             providers={providerOptions}
             selectedValue={visibleProvider}
@@ -175,7 +165,7 @@ function ProviderForm({
         ) : selectedProvider === "anarlog" ? (
           <Row alignment="center">
             <Text>Model</Text>
-            <Spacer />
+            <Spacer flexible />
             <Text>Automatic</Text>
           </Row>
         ) : selectedSetup?.data ? (
@@ -247,6 +237,7 @@ function ProviderForm({
                           })
                     }
                     size={14}
+                    color={Colors.muted}
                   />
                 }
               >
@@ -374,7 +365,6 @@ function ProviderFields({
       spacing={16}
       style={{
         paddingBottom: 8,
-        paddingHorizontal: Platform.OS === "android" ? 16 : 0,
       }}
     >
       <Row alignment="center" spacing={8}>

--- a/apps/mobile/src/settings/provider-model-picker.tsx
+++ b/apps/mobile/src/settings/provider-model-picker.tsx
@@ -1,20 +1,12 @@
-import {
-  Button,
-  Column,
-  Icon,
-  Picker,
-  Row,
-  Spacer,
-  Text,
-  TextInput,
-  useNativeState,
-} from "@expo/ui";
+import { Column, Icon, Row, Spacer, useNativeState } from "@expo/ui";
 import { layoutPriority } from "@expo/ui/swift-ui/modifiers";
 import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { useFocusEffect } from "expo-router";
 import { useCallback, useState } from "react";
 import { Platform } from "react-native";
+
+import { Button, Picker, Text, TextInput } from "@/settings/fields";
 
 import { createProviderAutosave } from "./provider-autosave";
 import { modelOptions, presetProviderModels } from "./provider-model-catalog";
@@ -82,7 +74,7 @@ export function ProviderModelPicker({
           style={{ width: 20 }}
         />
         <Text>Model</Text>
-        <Spacer />
+        <Spacer flexible />
         <Column
           alignment="end"
           modifiers={Platform.OS === "ios" ? [layoutPriority(1)] : undefined}

--- a/apps/mobile/src/settings/provider-picker.android.tsx
+++ b/apps/mobile/src/settings/provider-picker.android.tsx
@@ -1,13 +1,13 @@
-import { Icon, Row, Text } from "@expo/ui";
-import {
-  ExposedDropdownMenu,
-  ExposedDropdownMenuBox,
-  DropdownMenuItem,
-} from "@expo/ui/jetpack-compose";
-import { menuAnchor } from "@expo/ui/jetpack-compose/modifiers";
+import { Icon, Row } from "@expo/ui";
+import { DropdownMenu, DropdownMenuItem } from "@expo/ui/jetpack-compose";
+import { defaultMinSize } from "@expo/ui/jetpack-compose/modifiers";
 import { useState } from "react";
 
+import { ControlSize } from "@/constants/theme";
+
+import { Text } from "./fields";
 import { ProviderIcon } from "./provider-icon";
+import { useColors } from "./theme-provider";
 
 export function ProviderPicker({
   providers,
@@ -20,33 +20,36 @@ export function ProviderPicker({
   enabled: boolean;
   onValueChange: (provider: string) => void;
 }) {
+  const Colors = useColors();
   const [expanded, setExpanded] = useState(false);
   const selected = providers.find(({ id }) => id === selectedValue);
   return (
-    <ExposedDropdownMenuBox
+    <DropdownMenu
       expanded={expanded}
-      onExpandedChange={enabled ? setExpanded : undefined}
+      onDismissRequest={() => setExpanded(false)}
+      color={Colors.surface}
     >
-      <Row
-        modifiers={[menuAnchor()]}
-        spacing={8}
-        alignment="center"
-        testID="active-provider"
-      >
-        {selected && <ProviderIcon provider={selected.id} />}
-        <Text>{selected?.name ?? "Select provider"}</Text>
-        <Icon
-          name={Icon.select({
-            ios: "chevron.down",
-            android: import("@expo/material-symbols/keyboard_arrow_down.xml"),
-          })}
-          size={16}
-        />
-      </Row>
-      <ExposedDropdownMenu
-        expanded={expanded}
-        onDismissRequest={() => setExpanded(false)}
-      >
+      <DropdownMenu.Trigger>
+        <Row
+          onPress={enabled ? () => setExpanded(true) : undefined}
+          modifiers={[defaultMinSize({ minHeight: ControlSize.default })]}
+          spacing={8}
+          alignment="center"
+          testID="active-provider"
+        >
+          {selected && <ProviderIcon provider={selected.id} />}
+          <Text>{selected?.name ?? "Select provider"}</Text>
+          <Icon
+            name={Icon.select({
+              ios: "chevron.down",
+              android: import("@expo/material-symbols/keyboard_arrow_down.xml"),
+            })}
+            size={16}
+            color={Colors.muted}
+          />
+        </Row>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Items>
         {providers.map((provider) => (
           <DropdownMenuItem
             key={provider.id}
@@ -70,12 +73,13 @@ export function ProviderPicker({
                     android: import("@expo/material-symbols/check.xml"),
                   })}
                   size={18}
+                  color={Colors.ink}
                 />
               </DropdownMenuItem.TrailingIcon>
             )}
           </DropdownMenuItem>
         ))}
-      </ExposedDropdownMenu>
-    </ExposedDropdownMenuBox>
+      </DropdownMenu.Items>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
Use shared colors and compact cards for settings forms, controls, and provider menus. Remove nested row padding and empty blocks, and align saved recordings with the common layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and import-path refactor only; preference/sync/provider behavior is unchanged aside from Android presentation and dropdown components.
> 
> **Overview**
> Introduces **`@/settings/field-group`** and **`@/settings/fields`** (plus Android **`picker`**) so settings screens stop importing form primitives directly from `@expo/ui`. On **iOS**, these modules mostly re-export Expo UI; on **Android**, they apply the app **`useColors`** palette, typography, and compact **surfaced card** sections via Jetpack Compose (`LazyColumn`, bordered `Column` sections, themed switches/buttons/list rows).
> 
> Settings **rows and errors** now tint chevrons, values, and icons with **muted** colors and show errors in **destructive** color. Picker rows use **`Spacer flexible`** for trailing controls. **Provider** Android dropdowns move from **`ExposedDropdownMenu`** to the shared **`DropdownMenu`** trigger pattern with themed menu surfaces and checkmarks; provider field blocks drop extra Android-only horizontal padding.
> 
> **Saved recordings** gets the same header balance (back + title + spacer), theme **card** rows with border/press feedback, and tighter spacing to match other settings layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482e5c35120b49e1935e94bf936db1d16d6fa8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->