### PR TITLE
Support long Google Cloud recordings

### DIFF
--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -93,7 +93,7 @@ function ProviderContext({ providerId }: { providerId: ProviderId }) {
                               : providerId === "google_generative_ai"
                                 ? `Use [Gemini 3.5 Transcribe](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5-transcribe/) with a Google AI Studio API key. **3.5 Transcribe Live** captions during recording (preview sessions last up to 10 minutes). **3.5 Transcribe** runs after recording with speaker labels and word timestamps; Anarlog splits files past 15 minutes.`
                                 : providerId === "google_cloud"
-                                  ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) synchronous recognition for recordings up to one minute and 10 MB. Paste an OAuth access token in the API key field; refresh it when it expires.`
+                                  ? `Use [Google Cloud Speech-to-Text](https://cloud.google.com/speech-to-text) to transcribe after recording. Long recordings are split automatically and combined into one transcript. Paste an OAuth access token in the API key field; refresh it when it expires.`
                                   : providerId === "azure_speech"
                                     ? `Use [Azure AI Speech](https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text) fast transcription. Enter the regional Speech resource endpoint as the Base URL and its subscription key as the API key.`
                                     : providerId === "aws_transcribe"

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -150,7 +150,7 @@ describe("STT model display labels", () => {
     expect(providers.speechmatics.models).toEqual(["enhanced", "standard"]);
     expect(providers.together.models).toContain("nvidia/parakeet-tdt-0.6b-v3");
     expect(providers.openrouter.models).toContain("qwen/qwen3-asr-1.7b");
-    expect(providers.google_cloud.badge).toBe("Short batch");
+    expect(providers.google_cloud.badge).toBe("After recording");
     expect(providers.aws_transcribe.badge).toBe("Gateway");
     expect(providers.dashscope.badge).toBeNull();
     expect("builtIn" in providers.soniqo && providers.soniqo.builtIn).toBe(

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -721,7 +721,7 @@ const _PROVIDERS = [
     disabled: false,
     id: "google_cloud",
     displayName: "Google Cloud Speech-to-Text",
-    badge: "Short batch",
+    badge: "After recording",
     icon: <ProviderLobeIcon icon={GoogleCloud} />,
     baseUrl: "https://speech.googleapis.com/v1",
     models: ["latest_long"],

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -1,4 +1,5 @@
 mod direct;
+mod google_cloud;
 mod local;
 
 pub(super) use direct::run_direct_batch_for_adapter_kind;

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -72,6 +72,9 @@ pub(in crate::batch) async fn run_direct_batch_for_adapter_kind(
     if adapter_kind == AdapterKind::Anarlog {
         return run_anarlog_batch(params, listen_params).await;
     }
+    if adapter_kind == AdapterKind::GoogleCloud {
+        return super::google_cloud::run(params, listen_params).await;
+    }
 
     let limit = adapter_kind.batch_upload_limit(listen_params.model.as_deref());
 

--- a/crates/listener2-core/src/batch/simple/google_cloud.rs
+++ b/crates/listener2-core/src/batch/simple/google_cloud.rs
@@ -1,0 +1,330 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anlg_audio_utils::Source;
+use anlg_transcribe_core::TARGET_SAMPLE_RATE;
+use owhisper_client::GoogleCloudAdapter;
+use owhisper_interface::{ListenParams, batch::Response};
+
+use super::super::{BatchParams, BatchRunMode, BatchRunOutput};
+use super::direct::{
+    DIRECT_BATCH_TIMEOUT_FLOOR, merge_segment_responses, run_direct_batch_with_timeout,
+};
+
+// Stay below the synchronous API's 60-second limit. Mono 16 kHz PCM segments
+// also fit comfortably within the 10 MB request limit after base64 encoding.
+const SEGMENT_DURATION: Duration = Duration::from_secs(55);
+
+pub(super) async fn run(
+    params: BatchParams,
+    mut listen_params: ListenParams,
+) -> crate::Result<BatchRunOutput> {
+    let path = params.file_path.clone();
+    let uploads = tokio::task::spawn_blocking(move || prepare_uploads(&path))
+        .await
+        .map_err(|_| preparation_failed())?
+        .map_err(|_| preparation_failed())?;
+    if uploads.channels.is_empty() || uploads.channels[0].is_empty() {
+        return Err(crate::BatchFailure::DirectRequestFailed {
+            provider: "google_cloud".to_string(),
+            message: "This recording has no audio to transcribe.".to_string(),
+        }
+        .into());
+    }
+
+    listen_params.channels = 1;
+    let mut channels = Vec::with_capacity(uploads.channels.len());
+    for (channel_index, segments) in uploads.channels.iter().enumerate() {
+        let mut responses = Vec::with_capacity(segments.len());
+        for segment in segments {
+            let mut segment_params = params.clone();
+            segment_params.file_path = segment.to_string_lossy().into_owned();
+            let output = run_direct_batch_with_timeout::<GoogleCloudAdapter>(
+                "google_cloud",
+                segment_params,
+                listen_params.clone(),
+                DIRECT_BATCH_TIMEOUT_FLOOR,
+            )
+            .await?;
+            responses.push(output.response);
+        }
+        let merged = merge_segment_responses(responses, SEGMENT_DURATION);
+        for mut channel in merged.results.channels {
+            for alternative in &mut channel.alternatives {
+                for word in &mut alternative.words {
+                    word.channel = channel_index as i32;
+                }
+            }
+            channels.push(channel);
+        }
+    }
+
+    Ok(BatchRunOutput {
+        session_id: params.session_id,
+        mode: BatchRunMode::Direct,
+        response: Response {
+            metadata: serde_json::json!({ "provider": "google_cloud" }),
+            results: owhisper_interface::batch::Results { channels },
+        },
+    })
+}
+
+fn preparation_failed() -> crate::BatchFailure {
+    crate::BatchFailure::DirectRequestFailed {
+        provider: "google_cloud".to_string(),
+        message: "Anarlog couldn't prepare this recording for transcription.".to_string(),
+    }
+}
+
+struct PreparedUploads {
+    _directory: tempfile::TempDir,
+    channels: Vec<Vec<PathBuf>>,
+}
+
+fn prepare_uploads(path: &str) -> Result<PreparedUploads, anlg_audio_utils::Error> {
+    let directory = tempfile::tempdir()?;
+    let source = anlg_audio_utils::source_from_path(path)?;
+    let channel_count = usize::from(u16::from(source.channels()));
+    if channel_count > 8 {
+        return Err(anlg_audio_utils::Error::TooManyChannels {
+            count: channel_count,
+        });
+    }
+    let mut files = (0..channel_count).map(|_| Vec::new()).collect::<Vec<_>>();
+    let mut writers = Vec::new();
+    let mut segment_frames = 0;
+    let max_frames = TARGET_SAMPLE_RATE as usize * SEGMENT_DURATION.as_secs() as usize;
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: TARGET_SAMPLE_RATE,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    // Decode/resample in bounded blocks; never collect the entire meeting in RAM.
+    // PCM WAV works on Google's stable v1 endpoint, unlike the shared MP3 splitter.
+    anlg_audio_utils::for_each_resampled_channel_block::<_, anlg_audio_utils::Error>(
+        source,
+        TARGET_SAMPLE_RATE,
+        |channels| {
+            let mut start = 0;
+            while start < channels[0].len() {
+                if writers.is_empty() {
+                    for (index, channel_files) in files.iter_mut().enumerate() {
+                        let path = directory.path().join(format!(
+                            "channel-{index}-segment-{}.wav",
+                            channel_files.len()
+                        ));
+                        let writer = hound::WavWriter::create(&path, spec)?;
+                        channel_files.push(path);
+                        writers.push(writer);
+                    }
+                }
+                let count = (max_frames - segment_frames).min(channels[0].len() - start);
+                for (writer, samples) in writers.iter_mut().zip(channels) {
+                    for sample in &samples[start..start + count] {
+                        writer.write_sample((sample * 32768.0).clamp(-32768.0, 32767.0) as i16)?;
+                    }
+                }
+                start += count;
+                segment_frames += count;
+                if segment_frames == max_frames {
+                    for writer in writers.drain(..) {
+                        writer.finalize()?;
+                    }
+                    segment_frames = 0;
+                }
+            }
+            Ok(())
+        },
+    )?;
+    for writer in writers {
+        writer.finalize()?;
+    }
+    Ok(PreparedUploads {
+        _directory: directory,
+        channels: files,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufWriter, Cursor};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use axum::{
+        Json, Router,
+        extract::{DefaultBodyLimit, State},
+        http::StatusCode,
+        routing::post,
+    };
+    use serde_json::{Value, json};
+
+    use super::super::direct::run_direct_batch_for_adapter_kind;
+    use super::*;
+    use crate::batch::{BatchProvider, test_fixtures};
+
+    fn recording(seconds: usize, sample_rate: u32) -> tempfile::NamedTempFile {
+        let file = tempfile::Builder::new().suffix(".wav").tempfile().unwrap();
+        let mut writer = hound::WavWriter::new(
+            BufWriter::new(file.reopen().unwrap()),
+            hound::WavSpec {
+                channels: 2,
+                sample_rate,
+                bits_per_sample: 32,
+                sample_format: hound::SampleFormat::Float,
+            },
+        )
+        .unwrap();
+        for _ in 0..seconds * sample_rate as usize {
+            writer.write_sample(0.25_f32).unwrap();
+            writer.write_sample(-0.5_f32).unwrap();
+        }
+        writer.finalize().unwrap();
+        file
+    }
+
+    #[test]
+    fn splits_long_audio_into_pcm_wav_without_losing_channels_or_samples() {
+        let source = recording(125, TARGET_SAMPLE_RATE);
+        let uploads = prepare_uploads(source.path().to_str().unwrap()).unwrap();
+        assert_eq!(uploads.channels.len(), 2);
+        let mut paths = Vec::new();
+        for (channel, segments) in uploads.channels.iter().enumerate() {
+            assert_eq!(segments.len(), 3);
+            for (segment, seconds) in segments.iter().zip([55, 55, 15]) {
+                let bytes = std::fs::read(segment.as_path()).unwrap();
+                assert!(bytes.len().div_ceil(3) * 4 + 4096 < 10_000_000);
+                let mut reader = hound::WavReader::new(Cursor::new(bytes)).unwrap();
+                assert_eq!(reader.spec().channels, 1);
+                assert_eq!(reader.spec().sample_rate, TARGET_SAMPLE_RATE);
+                assert_eq!(reader.spec().bits_per_sample, 16);
+                assert_eq!(reader.duration(), TARGET_SAMPLE_RATE * seconds);
+                let expected = if channel == 0 { 8192 } else { -16384 };
+                assert!(
+                    reader
+                        .samples::<i16>()
+                        .all(|sample| sample.unwrap() == expected)
+                );
+                paths.push(segment.as_path().to_path_buf());
+            }
+        }
+        drop(uploads);
+        assert!(paths.iter().all(|path| !path.exists()));
+        assert!(source.path().exists());
+    }
+
+    #[test]
+    fn resamples_short_recordings_and_avoids_empty_boundary_segments() {
+        for seconds in [0, 1, 55, 110] {
+            let source = recording(seconds, 44_100);
+            let uploads = prepare_uploads(source.path().to_str().unwrap()).unwrap();
+            for segments in &uploads.channels {
+                assert_eq!(segments.len(), seconds.div_ceil(55));
+                let frames: u32 = segments
+                    .iter()
+                    .map(|segment| {
+                        let reader = hound::WavReader::open(segment.as_path()).unwrap();
+                        assert_eq!(reader.spec().sample_rate, TARGET_SAMPLE_RATE);
+                        reader.duration()
+                    })
+                    .sum();
+                assert_eq!(frames, seconds as u32 * TARGET_SAMPLE_RATE);
+            }
+        }
+    }
+
+    async fn server(fail_second: bool) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route("/v1/speech:recognize", post(
+            move |State(requests): State<Arc<AtomicUsize>>, Json(body): Json<Value>| async move {
+                let index = requests.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(body["config"]["audioChannelCount"], 1);
+                assert_eq!(body["config"]["enableSeparateRecognitionPerChannel"], false);
+                assert_eq!(body["config"]["model"], "latest_long");
+                assert!(body["audio"]["content"].as_str().unwrap().starts_with("UklGR"));
+                if fail_second && index == 1 {
+                    return (StatusCode::BAD_REQUEST, Json(json!({"error": "rejected"})));
+                }
+                if index == 1 {
+                    return (StatusCode::OK, Json(json!({"results": []})));
+                }
+                (StatusCode::OK, Json(json!({"results": [{"alternatives": [{
+                    "transcript": format!("segment {index}"),
+                    "words": [{"word": format!("word{index}"), "startTime": "0.25s", "endTime": "0.75s", "speakerTag": 1}]
+                }]}]})))
+            }
+        )).layer(DefaultBodyLimit::max(3_000_000)).with_state(requests.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}/v1"), requests, task)
+    }
+
+    #[tokio::test]
+    async fn long_recording_dispatch_merges_timestamps_and_preserves_silent_segments() {
+        let (url, requests, server) = server(false).await;
+        let source = recording(125, TARGET_SAMPLE_RATE);
+        let params = test_fixtures::params(
+            BatchProvider::GoogleCloud,
+            &url,
+            source.path().to_str().unwrap(),
+        );
+        let output = run_direct_batch_for_adapter_kind(
+            owhisper_client::AdapterKind::GoogleCloud,
+            params,
+            ListenParams::default(),
+        )
+        .await
+        .unwrap();
+        server.abort();
+
+        assert_eq!(requests.load(Ordering::SeqCst), 6);
+        let channels = &output.response.results.channels;
+        assert_eq!(channels.len(), 2);
+        assert_eq!(
+            channels[0].alternatives[0].transcript,
+            "segment 0 segment 2"
+        );
+        for (channel, expected_starts) in [(0, vec![0.25, 110.25]), (1, vec![0.25, 55.25, 110.25])]
+        {
+            let words = &channels[channel].alternatives[0].words;
+            assert_eq!(
+                words.iter().map(|word| word.start).collect::<Vec<_>>(),
+                expected_starts
+            );
+            assert!(words.iter().all(|word| word.channel == channel as i32));
+            assert!(
+                words
+                    .windows(2)
+                    .all(|pair| pair[0].speaker != pair[1].speaker)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_segment_stops_the_meeting_without_returning_a_partial_transcript() {
+        let (url, requests, server) = server(true).await;
+        let source = recording(125, TARGET_SAMPLE_RATE);
+        let params = test_fixtures::params(
+            BatchProvider::GoogleCloud,
+            &url,
+            source.path().to_str().unwrap(),
+        );
+        let result = run_direct_batch_for_adapter_kind(
+            owhisper_client::AdapterKind::GoogleCloud,
+            params,
+            ListenParams::default(),
+        )
+        .await;
+        server.abort();
+        assert!(result.is_err());
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        assert!(source.path().exists());
+    }
+}


### PR DESCRIPTION
Split recordings into bounded PCM WAV requests, preserve channel timelines, and describe transcription as after recording. Add coverage for format limits, silent segments, and failed uploads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multi-request batch path for Google Cloud with segment merging and multi-channel handling; behavior is covered by integration tests but increases transcription API surface and failure modes.
> 
> **Overview**
> **Google Cloud STT** no longer assumes a single short synchronous request. Long meetings are **resampled and split** into ~55s mono 16 kHz PCM WAV chunks (bounded memory, under Google’s duration/size limits), each chunk is transcribed, and results are **merged** with adjusted word timestamps and per-channel output for multi-track recordings. A failed segment **aborts the job** without returning a partial transcript.
> 
> Settings copy and the provider badge move from **“Short batch”** to **“After recording”**, describing automatic splitting and a single combined transcript. Tests cover chunking, resampling edge cases, timestamp merge (including empty segments), and upload failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f1ce0c6633e95ef5d88fc389653a319f350691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->