### PR TITLE
Load mobile notes progressively during initial sync

### DIFF
--- a/crates/db-sync/src/e2ee_sync.rs
+++ b/crates/db-sync/src/e2ee_sync.rs
@@ -449,11 +449,26 @@ impl E2eeSyncHook {
                 .get(witness.workspace_id())
                 .ok_or_else(|| std::io::Error::other("E2EE replica identity is not configured"))?;
             witness
-                .refresh_notifying_cancellable(
+                .initialize_keyring_with_page_handler_cancellable(
                     pool,
-                    keyring.active(),
-                    || {
-                        self.request_reconciliation();
+                    keyring,
+                    || async {
+                        loop {
+                            cancellation.check()?;
+                            let stats = anlg_db_app::apply_received_e2ee_replica_changes_with_witness_cancellable(
+                                pool,
+                                &keys,
+                                true,
+                                || self.received_apply_cancelled(&cancellation),
+                            )
+                            .await
+                            .map_err(|error| {
+                                std::io::Error::other(format!("E2EE witness hydration failed: {error}"))
+                            })?;
+                            if !stats.remaining_replica_changes {
+                                return Ok(());
+                            }
+                        }
                     },
                     &cancellation,
                 )

--- a/crates/db-sync/src/witness/tests.rs
+++ b/crates/db-sync/src/witness/tests.rs
@@ -544,6 +544,82 @@ async fn initialized_witness_refreshes_before_publishing_pending_state() {
 }
 
 #[tokio::test]
+async fn replica_startup_materializes_notes_when_a_later_history_page_fails() {
+    let db = anlg_db_core::Db::connect_memory_plain().await.unwrap();
+    anlg_db_app::prepare_schema(&db).await.unwrap();
+    let recovery_key = anlg_e2ee::RecoveryKey::parse(
+        "anarlog-e2ee-v1:BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc",
+    )
+    .unwrap();
+    let key = recovery_key.workspace_key("user-a").unwrap();
+    let events = [("$row", json!(true)), ("title", json!("Remote"))]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (field, value))| {
+            let sealed = key
+                .seal_field(
+                    "user-a",
+                    "sessions",
+                    "session-1",
+                    field,
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    1,
+                    false,
+                    value,
+                )
+                .unwrap();
+            json!({
+                "sequence": index + 1,
+                "recordId": sealed.record_id,
+                "payloadHash": anlg_e2ee::payload_hash(&sealed.payload),
+                "payload": sealed.payload,
+            })
+        })
+        .collect::<Vec<_>>();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/sync/e2ee/witness/user-a"))
+        .and(wiremock::matchers::query_param("afterSequence", "0"))
+        .respond_with(witness_page(&events, 3, 3))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sync/e2ee/witness/user-a"))
+        .and(wiremock::matchers::query_param("afterSequence", "2"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+    let hook = crate::E2eeSyncHook::default();
+    hook.set_personal_workspace("user-a", &recovery_key)
+        .unwrap();
+    hook.set_replica_witness(
+        E2eeWitnessClient::new(
+            E2eeWitnessConfig {
+                endpoint: format!("{}/sync/e2ee/witness/user-a", server.uri()),
+                access_token: "access-token".to_string(),
+            },
+            "user-a",
+        )
+        .unwrap(),
+    );
+
+    assert!(hook.sync_replica_transport(db.pool()).await.is_err());
+    assert_eq!(
+        sqlx::query_scalar::<_, String>("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap(),
+        "Remote"
+    );
+    assert_eq!(
+        anlg_db_app::e2ee_witness_cursor(db.pool(), "user-a")
+            .await
+            .unwrap(),
+        2
+    );
+}
+
+#[tokio::test]
 async fn pending_local_state_is_retryable_after_a_failed_publish() {
     let db = anlg_db_core::Db::connect_memory_plain().await.unwrap();
     anlg_db_app::prepare_schema(&db).await.unwrap();

--- a/crates/mobile-bridge/src/lib.rs
+++ b/crates/mobile-bridge/src/lib.rs
@@ -600,16 +600,9 @@ impl MobileDbBridge {
                 &workspace_id,
             )
             .map_err(cloudsync_error)?;
-            let key = e2ee_sync_hook
-                .workspace_key(&workspace_id)
-                .ok_or_else(|| cloudsync_error("E2EE replica identity is not configured"))?;
             let cancellation = anlg_db_sync::E2eeWitnessCancellation::default();
             e2ee_sync_hook
                 .prepare_local_snapshot(db.pool(), &cancellation)
-                .await
-                .map_err(cloudsync_error)?;
-            witness
-                .initialize_cancellable(db.pool(), &key, &cancellation)
                 .await
                 .map_err(cloudsync_error)?;
             e2ee_sync_hook.set_replica_witness(witness);
@@ -1197,6 +1190,27 @@ mod tests {
             .unwrap();
 
         assert_eq!(opened, recovery_key.expose_code().as_str());
+    }
+
+    #[test]
+    fn configuring_a_replica_does_not_wait_for_the_network() {
+        let (_dir, bridge) = new_bridge(None);
+        let recovery_key = anlg_e2ee::RecoveryKey::generate().unwrap();
+
+        let result = bridge
+            .configure_e2ee_replica(
+                "user-a".to_string(),
+                "http://127.0.0.1:9/sync/e2ee/witness/user-a".to_string(),
+                "access-token".to_string(),
+                recovery_key.expose_code().to_string(),
+            )
+            .unwrap();
+
+        assert_eq!(result, "configured");
+        let status: serde_json::Value =
+            serde_json::from_str(&bridge.cloudsync_status().unwrap()).unwrap();
+        assert_eq!(status["configured"], true);
+        assert_eq!(status["last_sync_at_ms"], serde_json::Value::Null);
     }
 
     #[test]


### PR DESCRIPTION
Large encrypted sync histories blocked mobile startup in a synchronous bridge call and kept downloaded notes invisible until the entire history finished. Move network initialization into the cancellable background sync task and materialize authenticated pages progressively, keeping the app usable and preserving completed pages after later network failures.

The shared initialization path now protects pending local edits before receiving history (#7423, already merged).

Validation: db-sync (21), mobile bridge (38), desktop database plugin (149), CloudSync (24), and db-core CloudSync (79) tests passed; affected Rust Clippy and Android Release build passed. The production-configured Release emulator restored its existing account and downloaded 453 notes matching desktop session IDs. Complete reconciliation, bidirectional sync, and physical background-recording QA remain separate checks.
