### PR TITLE
Allow Android certificate revocation checks in Release

### DIFF
--- a/packages/mobile-bridge-rn/android/src/release/AndroidManifest.xml
+++ b/packages/mobile-bridge-rn/android/src/release/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:networkSecurityConfig="@xml/anarlog_tls_network_security_config" />
+</manifest>

--- a/packages/mobile-bridge-rn/android/src/release/res/xml/anarlog_tls_network_security_config.xml
+++ b/packages/mobile-bridge-rn/android/src/release/res/xml/anarlog_tls_network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+  <!-- Let's Encrypt publishes signed revocation lists over HTTP. The native
+       verifier must fetch these to validate the API certificate in Release.
+       https://github.com/rustls/rustls-platform-verifier/issues/221 -->
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">c.lencr.org</domain>
+  </domain-config>
+</network-security-config>


### PR DESCRIPTION
Native HTTPS sync failed only in Android Release because the certificate verifier could not download Let's Encrypt's signed HTTP revocation lists and reported `InvalidCertificate(Revoked)`. Allow the CA's `c.lencr.org` revocation endpoints while keeping ordinary Release traffic HTTPS-only. Debug retains its existing development network policy.

Validation: Android Release build and packaged network policy verified; Debug manifest verified unchanged; common CI and license checks passed. Installed over the existing signed-in emulator without clearing its data: Android downloaded 71 notes whose session IDs all matched the running desktop database. Initial history is still loading, so complete reconciliation and bidirectional sync remain separate QA checks.

The API certificate was absent from the current CA revocation list and its signature verified successfully. Upstream context: https://github.com/rustls/rustls-platform-verifier/issues/221.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only Android networking policy with a single-domain cleartext exception; no auth or API logic changes.
> 
> **Overview**
> **Android Release** now applies a dedicated **network security config** so native TLS verification can fetch Let's Encrypt **revocation lists** without treating the API cert as revoked.
> 
> Release builds keep **cleartext disabled** globally, with a narrow exception for **`c.lencr.org`** (HTTP CRL endpoints used by `rustls-platform-verifier`). The release manifest wires this policy via `android:networkSecurityConfig`; **Debug** is unchanged and keeps its existing dev network rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437cb49398df91448549a83804757f681d606790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->