### PR TITLE
Homepage/Enterprise polish: pricing tokens, GitHub icon, concise hero copy

### DIFF
--- a/apps/web/src/components/home-page/index.tsx
+++ b/apps/web/src/components/home-page/index.tsx
@@ -1,6 +1,7 @@
+import { Icon } from "@iconify-icon/react";
 import { Link } from "@tanstack/react-router";
 
-import { ArrowRight, GithubLogo } from "@anlg/ui/components/icons";
+import { ArrowRight } from "@anlg/ui/components/icons";
 
 import { SiteFooter } from "@/components/site-footer";
 import { getResizedImageSrcSet, getResizedImageUrl } from "@/lib/image-cdn";
@@ -177,7 +178,13 @@ function OpenSourceSection({
           rel="noopener noreferrer"
           className="mt-6 inline-flex items-center gap-2 rounded-full border border-neutral-300 bg-white px-5 py-3 text-sm font-medium text-neutral-900 transition-colors hover:border-neutral-900 hover:bg-neutral-900 hover:text-white"
         >
-          <GithubLogo size={18} className="shrink-0" aria-hidden="true" />
+          <Icon
+            icon="simple-icons:github"
+            width={18}
+            height={18}
+            className="shrink-0"
+            aria-hidden="true"
+          />
           <span>{formattedGithubStars} stars on GitHub</span>
         </a>
       </div>

--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -119,11 +119,13 @@ function PlanPrice({ price }: { price: MarketingPlanPrice }) {
   const unit = price.billingUnit === "person" ? "/person" : "";
 
   return (
-    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-      <span className="text-color font-mono text-4xl leading-none font-semibold">
-        ${price.monthly}
-      </span>
-      <span className="text-color-muted text-sm">{unit}/month</span>
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-color font-mono text-4xl leading-none font-semibold">
+          ${price.monthly}
+        </span>
+        <span className="text-color-muted text-sm">{unit}/month</span>
+      </div>
       {price.yearly != null ? (
         <span className="text-color-muted text-sm">
           or ${price.yearly}

--- a/apps/web/src/routes/enterprise/index.tsx
+++ b/apps/web/src/routes/enterprise/index.tsx
@@ -86,9 +86,9 @@ function EnterprisePage() {
               Enterprise meeting memory your company owns
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
-              Enterprise adds org-wide security, policy, and deployment
-              controls to Anarlog Team — built to forward straight to IT,
-              security, and legal.
+              Enterprise adds org-wide security, policy, and deployment controls
+              to Anarlog Team — built to forward straight to IT, security, and
+              legal.
             </p>
             <div className="mt-8 flex flex-col items-center gap-3">
               <BookFounderCall location="hero" page="enterprise" />

--- a/apps/web/src/routes/enterprise/index.tsx
+++ b/apps/web/src/routes/enterprise/index.tsx
@@ -86,10 +86,9 @@ function EnterprisePage() {
               Enterprise meeting memory your company owns
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
-              Enterprise adds organization-wide security, policy, and deployment
-              controls to Anarlog Team. Notes stay on employee machines, Cloud
-              Sync is end-to-end encrypted, and no bot joins the call. This page
-              is written so you can forward it to IT, security, and legal.
+              Enterprise adds org-wide security, policy, and deployment
+              controls to Anarlog Team — built to forward straight to IT,
+              security, and legal.
             </p>
             <div className="mt-8 flex flex-col items-center gap-3">
               <BookFounderCall location="hero" page="enterprise" />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -46,6 +46,14 @@
   --color-fg-muted: var(--grey-500);
   --color-fg-secondary: var(--grey-600);
 
+  /* Shim for shared components (e.g. @anlg/pricing's PlanFeatureList) that
+     use shadcn-style semantic tokens. Without these, `text-foreground` /
+     `text-muted-foreground` resolve to no color at all on the marketing
+     site (this stylesheet never defines them otherwise), so that text
+     rendered near-black instead of this site's warm-grey palette. */
+  --color-foreground: var(--color-fg);
+  --color-muted-foreground: var(--color-fg-secondary);
+
   /* ── Colors: borders ─────────────────────────── */
   --color-border: var(--grey-500);
   --color-border-subtle: var(--grey-300);


### PR DESCRIPTION
Small polish batch across the marketing site:

**1. Pricing section color tokens and price-line wrapping**
- `PlanFeatureList` (shared from `@anlg/pricing`) used shadcn-style `text-foreground`/`text-muted-foreground` tokens that are never defined in the web app's Tailwind theme, so checklist text silently rendered near-black instead of the site's warm-grey palette.
- Defined `--color-foreground`/`--color-muted-foreground` in `apps/web/src/styles.css` mapped to the site's existing tokens.
- Restructured `PlanPrice` so the monthly amount and the "or $X/year" line always render as two stable stacked rows instead of a flex-wrap container that reflowed inconsistently across breakpoints.

**2. Real GitHub brand mark on the "stars on GitHub" button**
- Swapped `GithubLogo` (a generic HugeIcons outline glyph) for `simple-icons:github` via `@iconify-icon/react`, matching the existing convention used for the download-dropdown platform logos.

**3. Tightened Enterprise page hero copy**
- The hero paragraph repeated details already covered by the "Why organizations pick Anarlog" pillars right below, burying the CTAs under 4 lines of text. Cut from 41 words to 20, keeping the core value prop and the forward-to-IT/security/legal framing.

**Verification**
- `pnpm exec tsc --noEmit` on `apps/web`: clean
- `pnpm exec oxlint` on touched files: 0 warnings/errors
- Visually verified each change via live-DOM preview on production (the web app dev server can't start in this sandbox - EMFILE/fs-watcher limit
EOF
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, copy, and CSS token shims only; no auth, data, or API behavior changes.
> 
> **Overview**
> **Marketing site polish** across homepage, pricing, enterprise, and global styles.
> 
> Adds **`--color-foreground`** and **`--color-muted-foreground`** in `styles.css` mapped to the site’s existing fg tokens so shared `@anlg/pricing` components using shadcn-style `text-foreground` / `text-muted-foreground` pick up the warm-grey palette instead of rendering near-black.
> 
> In **`PlanPrice`**, wraps the monthly line and optional yearly line in a **column layout** so price display stacks consistently instead of flex-wrapping awkwardly at breakpoints.
> 
> On the homepage GitHub CTA, replaces **`GithubLogo`** with **`Icon`** (`simple-icons:github`) via `@iconify-icon/react`, aligned with other platform icons.
> 
> **Enterprise** hero paragraph is **shortened** to emphasize org-wide controls and the forward-to-IT/security/legal angle, dropping redundant product details covered below the fold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510897e9ee68243114dfd37876950e31c605a371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->