### PR TITLE
Show Team and Enterprise plans correctly on mobile

### DIFF
--- a/apps/mobile/src/app/settings/account.tsx
+++ b/apps/mobile/src/app/settings/account.tsx
@@ -1,7 +1,9 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 
+import { accountPlanLabel, fetchWorkspacePlan } from "@/auth/account-plan";
+import { supabase } from "@/auth/client";
 import { useAuth } from "@/auth/context";
 import { useTrial } from "@/auth/use-trial";
 import { env } from "@/lib/env";
@@ -17,7 +19,29 @@ export default function AccountSettings() {
   const auth = useAuth();
   const trial = useTrial();
   const router = useRouter();
-  const refresh = useMutation({ mutationFn: auth.refreshBilling });
+  const accountId = auth.session?.user.id;
+  const workspacePlan = useQuery({
+    queryKey: ["mobile-account-plan", accountId],
+    enabled: Boolean(accountId) && !auth.bypass,
+    retry: 1,
+    queryFn: async ({ signal }) => {
+      const current = await supabase!.auth.getSession();
+      const session = current.data.session;
+      if (current.error || !session || session.user.id !== accountId)
+        throw new Error("Sign in again to refresh your plan.");
+      return fetchWorkspacePlan({
+        client: supabase!,
+        accessToken: session.access_token,
+        signal,
+      });
+    },
+  });
+  const refresh = useMutation({
+    mutationFn: async () => {
+      await auth.refreshBilling();
+      await workspacePlan.refetch({ throwOnError: true });
+    },
+  });
   const signOut = useMutation({ mutationFn: auth.signOut });
   const manage = useMutation({
     mutationFn: () =>
@@ -37,11 +61,11 @@ export default function AccountSettings() {
           value={
             auth.bypass
               ? "Local dev"
-              : auth.billing.plan === "trial"
-                ? `Pro trial · ${auth.billing.trialDaysRemaining ?? 0} days left`
-                : auth.billing.plan === "pro"
-                  ? "Anarlog Pro"
-                  : "Free"
+              : workspacePlan.isPending
+                ? "Checking…"
+                : workspacePlan.data === undefined
+                  ? "Could not verify plan"
+                  : accountPlanLabel(auth.billing, workspacePlan.data)
           }
         />
       </FieldGroup.Section>
@@ -79,7 +103,9 @@ export default function AccountSettings() {
             title={refresh.isPending ? "Refreshing…" : "Refresh plan"}
             onPress={() => refresh.mutate()}
           />
-          <SettingsError error={refresh.error || manage.error} />
+          <SettingsError
+            error={refresh.error || manage.error || workspacePlan.error}
+          />
         </FieldGroup.Section>
       )}
       {!auth.bypass && (

--- a/apps/mobile/src/auth/account-plan.test.mjs
+++ b/apps/mobile/src/auth/account-plan.test.mjs
@@ -1,0 +1,127 @@
+import { createClient } from "@supabase/supabase-js";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { accountPlanLabel, fetchWorkspacePlan } from "./account-plan.ts";
+import { deriveBillingInfo } from "./billing.ts";
+
+function fixture(workspaceTiers, failure) {
+  const requests = [];
+  const client = createClient(
+    "https://example.supabase.co",
+    "public-test-key",
+    {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: {
+        fetch: async (input, init) => {
+          const url = new URL(input);
+          requests.push({ url, init });
+          assert.equal(
+            new Headers(init.headers).get("Authorization"),
+            "Bearer account-a-token",
+          );
+          if (failure?.path === url.pathname)
+            return Response.json(
+              { message: "Plan lookup failed" },
+              { status: 403 },
+            );
+          if (url.pathname === "/rest/v1/workspaces") {
+            assert.equal(url.searchParams.get("kind"), "eq.shared");
+            assert.equal(url.searchParams.get("select"), "id");
+            return Response.json(
+              workspaceTiers.map((_, index) => ({ id: `workspace-${index}` })),
+            );
+          }
+          assert.equal(url.pathname, "/rest/v1/rpc/get_workspace_access");
+          const { p_workspace_id } = JSON.parse(init.body);
+          const index = Number(p_workspace_id.replace("workspace-", ""));
+          return Response.json([{ workspace_tier: workspaceTiers[index] }]);
+        },
+      },
+    },
+  );
+  return {
+    requests,
+    load: () =>
+      fetchWorkspacePlan({
+        client,
+        accessToken: "account-a-token",
+        signal: new AbortController().signal,
+      }),
+  };
+}
+
+test("a Team member with the shared Pro entitlement is shown as Team", async () => {
+  const billing = deriveBillingInfo({
+    subscription_status: "active",
+    entitlements: ["hyprnote_pro"],
+  });
+  const { load } = fixture(["free", "team"]);
+  assert.equal(accountPlanLabel(billing, await load()), "Anarlog Team");
+  assert.equal(billing.isPro, true);
+});
+
+test("Enterprise takes precedence over Team across memberships", async () => {
+  for (const tiers of [
+    ["team", "enterprise"],
+    ["enterprise", "team"],
+  ]) {
+    const { load } = fixture(tiers);
+    assert.equal(
+      accountPlanLabel(deriveBillingInfo(null), await load()),
+      "Anarlog Enterprise",
+    );
+  }
+});
+
+test("a free workspace does not upgrade an individual Pro subscription", async () => {
+  const { load } = fixture(["free"]);
+  assert.equal(
+    accountPlanLabel(
+      deriveBillingInfo({ entitlements: ["hyprnote_pro"] }),
+      await load(),
+    ),
+    "Anarlog Pro",
+  );
+});
+
+test("an account with no shared workspaces keeps its individual plan", async () => {
+  const { load, requests } = fixture([]);
+  const tier = await load();
+  assert.equal(tier, null);
+  assert.equal(requests.length, 1);
+  assert.equal(accountPlanLabel(deriveBillingInfo(null), tier), "Free");
+  const now = Date.UTC(2026, 8, 7);
+  const trial = deriveBillingInfo(
+    {
+      subscription_status: "trialing",
+      trial_end: now / 1000 + 21 * 86400,
+    },
+    now,
+  );
+  assert.equal(accountPlanLabel(trial, tier), "Pro trial · 21 days left");
+  assert.equal(accountPlanLabel(trial, "team"), "Anarlog Team");
+});
+
+test("a plan refresh reflects a workspace subscription ending", async () => {
+  const tiers = ["team"];
+  const { load } = fixture(tiers);
+  assert.equal(await load(), "team");
+  tiers[0] = "free";
+  assert.equal(await load(), null);
+});
+
+test("failed lookups do not silently mislabel a Team member as Pro", async () => {
+  for (const path of [
+    "/rest/v1/workspaces",
+    "/rest/v1/rpc/get_workspace_access",
+  ]) {
+    const { load } = fixture(["team"], { path });
+    await assert.rejects(load(), { message: "Plan lookup failed" });
+  }
+});
+
+test("an unknown workspace tier cannot silently fall back to Pro", async () => {
+  const { load } = fixture(["unknown"]);
+  await assert.rejects(load(), /Could not verify your plan/);
+});

--- a/apps/mobile/src/auth/account-plan.ts
+++ b/apps/mobile/src/auth/account-plan.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { BillingInfo } from "./billing";
+
+export async function fetchWorkspacePlan({
+  client,
+  accessToken,
+  signal,
+}: {
+  client: SupabaseClient;
+  accessToken: string;
+  signal: AbortSignal;
+}): Promise<"team" | "enterprise" | null> {
+  const authorization = `Bearer ${accessToken}`;
+  const workspaces = await client
+    .from("workspaces")
+    .select("id")
+    .eq("kind", "shared")
+    .setHeader("Authorization", authorization)
+    .abortSignal(signal);
+  if (workspaces.error) throw workspaces.error;
+  if (!Array.isArray(workspaces.data))
+    throw new Error("Could not verify your plan. Try refreshing it.");
+
+  const tiers = await Promise.all(
+    workspaces.data.map(async (workspace) => {
+      if (typeof workspace.id !== "string")
+        throw new Error("Could not verify your plan. Try refreshing it.");
+      const access = await client
+        .rpc("get_workspace_access", { p_workspace_id: workspace.id })
+        .setHeader("Authorization", authorization)
+        .abortSignal(signal);
+      if (access.error) throw access.error;
+      const tier = access.data?.[0]?.workspace_tier;
+      if (tier !== "free" && tier !== "team" && tier !== "enterprise")
+        throw new Error("Could not verify your plan. Try refreshing it.");
+      return tier;
+    }),
+  );
+  return tiers.includes("enterprise")
+    ? "enterprise"
+    : tiers.includes("team")
+      ? "team"
+      : null;
+}
+
+export function accountPlanLabel(
+  billing: BillingInfo,
+  workspacePlan: "team" | "enterprise" | null,
+) {
+  if (workspacePlan === "enterprise") return "Anarlog Enterprise";
+  if (workspacePlan === "team") return "Anarlog Team";
+  if (billing.plan === "trial")
+    return `Pro trial · ${billing.trialDaysRemaining ?? 0} days left`;
+  return billing.plan === "pro" ? "Anarlog Pro" : "Free";
+}


### PR DESCRIPTION
Mobile Account settings labeled every paid subscription as Pro, including Team members. Resolve the displayed tier using the same workspace-access lookup as desktop, with Enterprise taking precedence over Team. Refresh plan now refreshes both the subscription and workspace tier; failed lookups show an error instead of guessing Pro.

Validated with 347 mobile tests, mobile typecheck, formatting, license-boundary checks, and 64 common CI tests. A read-only lookup using the signed-in Android account returned Team.

Android Release build passed. Installed the production-configured QA APK, verified Anarlog Team for the existing signed-in account, and confirmed Refresh plan retains the correct label. The UI change is shared with iOS; iOS visual verification is still separate.
