### PR TITLE
Load mobile content on demand

### DIFF
--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -24,6 +24,7 @@ import { ActionButtonCard } from "@/components/action-button-card";
 import { SearchPalette } from "@/components/search-palette";
 import { SessionCard } from "@/components/session-card";
 import { StartListeningButton } from "@/components/start-listening-button";
+import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
 import { UserAvatarButton } from "@/components/user-avatar";
 import {
@@ -46,7 +47,8 @@ export default function HomeScreen() {
   const styles = useStyles();
   const router = useRouter();
   const auth = useAuth();
-  const { items, isLoading } = useTimelineSessions();
+  const { items, isLoading, error, hasMore, loadMore, retry } =
+    useTimelineSessions();
   const sidebarPreferences = useSidebarItemPreferences();
   const insets = useSafeAreaInsets();
   const reducedMotion = useReducedMotion();
@@ -203,7 +205,14 @@ export default function HomeScreen() {
       </View>
 
       <View style={styles.timeline}>
-        <Animated.ScrollView
+        <Animated.FlatList
+          data={items}
+          keyExtractor={(item) => item.key}
+          initialNumToRender={12}
+          maxToRenderPerBatch={12}
+          windowSize={7}
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.5}
           style={styles.list}
           contentContainerStyle={[
             styles.listContent,
@@ -216,32 +225,52 @@ export default function HomeScreen() {
           }
           onScroll={onScroll}
           scrollEventThrottle={16}
-        >
-          {showActionButtonCard && (
-            <ActionButtonCard
-              onConfigure={() => router.push("/action-button")}
-              onDismiss={dismissActionButtonCard}
-            />
-          )}
-          {!isLoading && items.length === 0 && (
+          ListHeaderComponent={
+            showActionButtonCard ? (
+              <ActionButtonCard
+                onConfigure={() => router.push("/action-button")}
+                onDismiss={dismissActionButtonCard}
+              />
+            ) : null
+          }
+          ListEmptyComponent={
             <View style={styles.empty}>
-              <Text style={styles.emptyTitle}>No meetings yet</Text>
-              <Text style={styles.emptyBody}>
-                Start listening or create a new note.
+              <Text style={styles.emptyTitle}>
+                {isLoading
+                  ? "Loading meetings…"
+                  : error
+                    ? "Couldn't load meetings"
+                    : "No meetings yet"}
               </Text>
-            </View>
-          )}
-          {items.map((item) => {
-            if (item.type === "header") {
-              return (
-                <Text key={item.key} style={styles.sectionLabel}>
-                  {item.label}
+              {!isLoading && !error && (
+                <Text style={styles.emptyBody}>
+                  Start listening or create a new note.
                 </Text>
-              );
+              )}
+            </View>
+          }
+          ListFooterComponent={
+            error ? (
+              <Button
+                label="Retry loading meetings"
+                onPress={retry}
+                variant="ghost"
+              />
+            ) : items.length > 0 && (isLoading || hasMore) ? (
+              <Button
+                label="Load more meetings"
+                onPress={loadMore}
+                loading={isLoading}
+                variant="ghost"
+              />
+            ) : null
+          }
+          renderItem={({ item }) => {
+            if (item.type === "header") {
+              return <Text style={styles.sectionLabel}>{item.label}</Text>;
             }
             return (
               <SessionCard
-                key={item.key}
                 session={item.session}
                 showFolder={sidebarPreferences.showFolder}
                 showTags={sidebarPreferences.showTags}
@@ -249,8 +278,8 @@ export default function HomeScreen() {
                 onDelete={() => void handleDelete(item.session)}
               />
             );
-          })}
-        </Animated.ScrollView>
+          }}
+        />
 
         <Animated.View
           style={[styles.listeningButton, buttonStyle]}

--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -55,7 +55,10 @@ import {
 } from "@/data/session";
 import { summarizeSession, useSessionSummaryState } from "@/data/summarize";
 import { transcribeSession, useTranscriptionState } from "@/data/transcribe";
-import { useSessionTranscripts } from "@/data/transcripts";
+import {
+  loadSessionTranscripts,
+  useSessionHasTranscript,
+} from "@/data/transcripts";
 import { captureAnalytics } from "@/lib/analytics";
 import { confirmDestructive } from "@/lib/confirm";
 import { applyEditorFormat, type EditorFormat } from "@/lib/editor-format";
@@ -257,7 +260,7 @@ export default function NoteScreen() {
   const { data, isLoading } = useSessionDetail(id);
   const audio = useSessionAudio(id);
   const noteAttachments = useNoteAttachments(id);
-  const transcripts = useSessionTranscripts(id);
+  const transcriptState = useSessionHasTranscript(id);
   const summaryState = useSessionSummaryState(id);
   const [selectedTab, setSelectedTab] = useState(0);
   const transcription = useTranscriptionState(id);
@@ -286,7 +289,8 @@ export default function NoteScreen() {
     : null;
   const localAudioAvailable =
     audio.data?.availableLocally === true && localAudioFile?.exists === true;
-  const hasRecordingHistory = audio.data !== null || transcripts.length > 0;
+  const hasRecordingHistory =
+    audio.data !== null || transcriptState.data === true;
   const active = listening && recorder.phase !== "saved";
   const showTabs = !active && (hasRecordingHistory || Boolean(data?.summary));
   const showMemos = !showTabs || selectedTab === 1;
@@ -314,6 +318,8 @@ export default function NoteScreen() {
     !active &&
     !editorFocused &&
     !audio.isLoading &&
+    !transcriptState.isLoading &&
+    !transcriptState.error &&
     data !== null &&
     data.title.trim() === "" &&
     data.noteText.trim() === "" &&
@@ -659,20 +665,21 @@ export default function NoteScreen() {
 
     const title = (draft.title ?? current.title).trim() || "Untitled";
     const note = (draft.body ?? current.noteText).trim();
-    const transcript = transcripts
-      .map((segment) => `${segment.speaker}: ${segment.text}`)
-      .join("\n\n")
-      .trim();
-    const sections = [`# ${title}`];
-    if (current.summary) {
-      sections.push(
-        `## ${current.summary.title}\n\n${current.summary.text}`.trim(),
-      );
-    }
-    if (note) sections.push(`## Notes\n\n${note}`);
-    if (transcript) sections.push(`## Transcript\n\n${transcript}`);
-
     try {
+      const transcripts = await loadSessionTranscripts(id);
+      const transcript = transcripts
+        .map((segment) => `${segment.speaker}: ${segment.text}`)
+        .join("\n\n")
+        .trim();
+      const sections = [`# ${title}`];
+      if (current.summary) {
+        sections.push(
+          `## ${current.summary.title}\n\n${current.summary.text}`.trim(),
+        );
+      }
+      if (note) sections.push(`## Notes\n\n${note}`);
+      if (transcript) sections.push(`## Transcript\n\n${transcript}`);
+
       await Share.share({
         title,
         message: sections.join("\n\n"),
@@ -687,7 +694,12 @@ export default function NoteScreen() {
 
   const handleListeningAction = () => {
     if (active) void handleStop();
-    else if (!audio.isLoading && !hasRecordingHistory) {
+    else if (
+      !audio.isLoading &&
+      !transcriptState.isLoading &&
+      !transcriptState.error &&
+      !hasRecordingHistory
+    ) {
       setListening(true);
       void recorder.start();
     }
@@ -875,7 +887,7 @@ export default function NoteScreen() {
       {(active || hasRecordingHistory) && (
         <ListeningSheet
           active={active}
-          transcripts={transcripts}
+          sessionId={id}
           recordingDetails={
             <>
               {audio.data && localAudioAvailable && localAudioFile && (
@@ -905,7 +917,7 @@ export default function NoteScreen() {
               {audio.data &&
                 localAudioAvailable &&
                 audio.data.transcriptStatus !== "complete" &&
-                transcripts.length === 0 &&
+                transcriptState.data === false &&
                 (transcription === "running" ? (
                   <Text style={styles.transcribeStatus}>Transcribing…</Text>
                 ) : (

--- a/apps/mobile/src/components/listening-sheet.tsx
+++ b/apps/mobile/src/components/listening-sheet.tsx
@@ -23,7 +23,10 @@ import {
   Spacing,
   Typography,
 } from "@/constants/theme";
-import type { TranscriptSegment } from "@/data/transcripts";
+import {
+  useSessionTranscripts,
+  type TranscriptSegment,
+} from "@/data/transcripts";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
 
 function formatDuration(ms: number): string {
@@ -73,7 +76,7 @@ export function ListeningSheet({
   durationMs,
   liveStatus,
   liveTranscript,
-  transcripts,
+  sessionId,
   recordingDetails,
   onStop,
   onRetry,
@@ -86,7 +89,7 @@ export function ListeningSheet({
   durationMs: number;
   liveStatus: "connecting" | "live" | "fallback";
   liveTranscript: string;
-  transcripts: TranscriptSegment[];
+  sessionId: string;
   recordingDetails: ReactNode;
   onStop: () => void;
   onRetry: () => void;
@@ -95,6 +98,11 @@ export function ListeningSheet({
   const styles = useStyles();
   const Colors = useColors();
   const [expanded, setExpanded] = useState(false);
+  const {
+    segments: transcripts,
+    isLoading,
+    error,
+  } = useSessionTranscripts(sessionId, expanded);
   const listRef = useRef<FlatList<TranscriptSegment>>(null);
   const following = useRef(active);
   const permissionDenied =
@@ -231,11 +239,15 @@ export function ListeningSheet({
               ListEmptyComponent={
                 !liveTranscript ? (
                   <Text style={styles.hint}>
-                    {active
-                      ? liveStatus === "fallback"
-                        ? "Your recording will be transcribed after you stop listening."
-                        : "Your transcript will appear here as you speak."
-                      : "No transcript yet."}
+                    {isLoading
+                      ? "Loading transcript…"
+                      : error
+                        ? "Couldn't load the transcript. Close and reopen to retry."
+                        : active
+                          ? liveStatus === "fallback"
+                            ? "Your recording will be transcribed after you stop listening."
+                            : "Your transcript will appear here as you speak."
+                          : "No transcript yet."}
                   </Text>
                 ) : null
               }

--- a/apps/mobile/src/components/search-palette.tsx
+++ b/apps/mobile/src/components/search-palette.tsx
@@ -59,7 +59,8 @@ export function SearchPalette({
   const sidebarPreferences = useSidebarItemPreferences();
   const [query, setQuery] = useState("");
   const [settledQuery, setSettledQuery] = useState("");
-  const search = useSessionSearch(query);
+  const isSettled = settledQuery === query.trim();
+  const search = useSessionSearch(isSettled ? settledQuery : "");
   const inputRef = useRef<TextInput>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasQuery = query.trim() !== "";
@@ -151,6 +152,7 @@ export function SearchPalette({
             </View>
             {settledQuery !== "" &&
               settledQuery === query.trim() &&
+              !search.error &&
               !search.isLoading && (
                 <SearchAnalytics
                   key={settledQuery}
@@ -164,13 +166,23 @@ export function SearchPalette({
               keyboardDismissMode="on-drag"
               style={styles.results}
               contentContainerStyle={styles.resultContent}
+              ListFooterComponent={
+                search.hasMore ? (
+                  <Text style={styles.empty}>
+                    Showing the first 50 matches. Narrow your search to find
+                    more.
+                  </Text>
+                ) : null
+              }
               ListEmptyComponent={
                 <Text style={styles.empty} accessibilityLiveRegion="polite">
                   {!hasQuery
                     ? "Search by title or note content"
-                    : search.isLoading
+                    : !isSettled || search.isLoading
                       ? "Searching…"
-                      : "No matches"}
+                      : search.error
+                        ? "Couldn't search meetings. Try again."
+                        : "No matches"}
                 </Text>
               }
               renderItem={({ item }) => (

--- a/apps/mobile/src/data/search.ts
+++ b/apps/mobile/src/data/search.ts
@@ -31,7 +31,7 @@ LEFT JOIN session_documents AS note
 WHERE sessions.deleted_at IS NULL
   AND (sessions.title LIKE ? ESCAPE '\\' OR note.body LIKE ? ESCAPE '\\')
 ORDER BY sessions.created_at DESC
-LIMIT 50
+LIMIT 51
 `;
 
 function escapeLike(term: string): string {
@@ -41,14 +41,24 @@ function escapeLike(term: string): string {
 export function useSessionSearch(query: string): {
   results: TimelineSession[];
   isLoading: boolean;
+  error: Error | null;
+  hasMore: boolean;
 } {
   const term = query.trim();
   const pattern = `%${escapeLike(term)}%`;
-  const { data, isLoading } = useLiveQuery<TimelineRow, TimelineSession[]>({
+  const { data, isLoading, error } = useLiveQuery<
+    TimelineRow,
+    TimelineSession[]
+  >({
     sql: SEARCH_SQL,
     params: [pattern, pattern],
     enabled: term !== "",
     mapRows: mapTimelineRows,
   });
-  return { results: term === "" ? [] : (data ?? []), isLoading };
+  return {
+    results: term === "" ? [] : (data?.slice(0, 50) ?? []),
+    isLoading,
+    error,
+    hasMore: term !== "" && (data?.length ?? 0) > 50,
+  };
 }

--- a/apps/mobile/src/data/timeline-query.test.mjs
+++ b/apps/mobile/src/data/timeline-query.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { buildSessionList, mapTimelineRows } from "./timeline-model.ts";
+import { TIMELINE_PAGE_SIZE, TIMELINE_SQL } from "./timeline-query.ts";
+import { SESSION_HAS_TRANSCRIPT_SQL } from "./transcript-model.ts";
+
+const now = "2026-09-07T12:00:00.000Z";
+let db;
+beforeEach(() => {
+  db = new DatabaseSync(":memory:");
+  db.exec(
+    readFileSync(
+      new URL(
+        "../../../../crates/db-app/migrations/20260710223922_canonical_data_model.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+});
+afterEach(() => db.close());
+
+function insert(id, createdAt, event = "", deletedAt = null) {
+  db.prepare(
+    "INSERT INTO sessions (id, title, created_at, event_json, deleted_at) VALUES (?, ?, ?, ?, ?)",
+  ).run(id, id, createdAt, event, deletedAt);
+}
+const query = (limit, at = now) => db.prepare(TIMELINE_SQL).all(at, limit + 1);
+const ids = (rows) => rows.map((row) => row.id);
+
+test("a large library crosses the bridge only as a bounded window with one lookahead row", () => {
+  for (let i = 0; i < 1205; i++) {
+    insert(
+      `session-${String(i).padStart(4, "0")}`,
+      new Date(Date.parse(now) - i * 60000).toISOString(),
+    );
+  }
+  insert("deleted-newest", now, "", now);
+  const first = query(TIMELINE_PAGE_SIZE);
+  assert.equal(first.length, 41);
+  assert.equal(first[0].id, "session-0000");
+  assert.equal(first.at(-1).id, "session-0040");
+  const next = query(TIMELINE_PAGE_SIZE * 2);
+  assert.equal(next.length, 81);
+  assert.deepEqual(ids(next.slice(0, 40)), ids(first.slice(0, 40)));
+  const all = query(1240);
+  assert.equal(all.length, 1205);
+  assert.equal(new Set(ids(all)).size, 1205);
+});
+
+test("SQL limits in display order using event dates, upcoming meetings, timezones and malformed fallbacks", () => {
+  insert(
+    "upcoming-far",
+    "2020-01-01",
+    JSON.stringify({ started_at: "2026-09-09T12:00:00Z" }),
+  );
+  insert(
+    "upcoming-near",
+    "2020-01-01",
+    JSON.stringify({ started_at: "2026-09-07T13:00:00Z" }),
+  );
+  insert(
+    "timezone",
+    "2020-01-01",
+    JSON.stringify({ started_at: "2026-09-07T23:00:00+09:00" }),
+  );
+  insert(
+    "past-recent",
+    "2020-01-01",
+    JSON.stringify({ started_at: "2026-09-07T11:00:00Z" }),
+  );
+  insert(
+    "past-old",
+    now,
+    JSON.stringify({ started_at: "2025-01-01T12:00:00Z" }),
+  );
+  insert("malformed", "2026-09-07T10:00:00Z", "not-json");
+  insert(
+    "invalid-start",
+    "2026-09-07T09:00:00Z",
+    '{"started_at":"not-a-date"}',
+  );
+  insert("numeric-start", "2026-09-07T08:00:00Z", '{"started_at":2461291}');
+  insert("invalid-date", "not-a-date");
+
+  const expected = [
+    "upcoming-near",
+    "timezone",
+    "upcoming-far",
+    "past-recent",
+    "malformed",
+    "invalid-start",
+    "numeric-start",
+    "past-old",
+    "invalid-date",
+  ];
+  assert.deepEqual(ids(query(20)), expected);
+  assert.deepEqual(ids(query(3)), expected.slice(0, 4));
+  assert.deepEqual(
+    buildSessionList(mapTimelineRows(query(20)), Date.parse(now))
+      .filter((item) => item.type === "session")
+      .map((item) => item.key),
+    expected,
+  );
+});
+
+test("the window stays consistent when synced rows arrive, disappear or cross a meeting boundary", () => {
+  insert("a", "2026-09-07T10:00:00Z");
+  insert("b", "2026-09-07T10:00:00Z");
+  insert("upcoming", "2020-01-01", '{"started_at":"2026-09-07T12:01:00Z"}');
+  insert("later", "2020-01-01", '{"started_at":"2026-09-07T12:02:00Z"}');
+  assert.deepEqual(ids(query(2)), ["upcoming", "later", "b"]);
+  insert("synced", "2026-09-07T11:00:00Z");
+  assert.deepEqual(ids(query(2)), ["upcoming", "later", "synced"]);
+  db.exec("UPDATE sessions SET deleted_at = 'deleted' WHERE id = 'synced'");
+  assert.deepEqual(ids(query(2)), ["upcoming", "later", "b"]);
+  assert.deepEqual(ids(query(2, "2026-09-07T12:01:01Z")), [
+    "later",
+    "upcoming",
+    "b",
+  ]);
+  assert.deepEqual(ids(query(4)), ["upcoming", "later", "b", "a"]);
+});
+
+test("only card metadata and active tags are returned", () => {
+  insert("note", now);
+  db.exec(`
+    UPDATE sessions SET folder_path = 'Work/Planning';
+    INSERT INTO session_documents (id, session_id, body) VALUES ('note', 'note', 'large note body');
+    INSERT INTO tags (id, name) VALUES ('a', 'Planning'), ('b', 'Deleted');
+    INSERT INTO session_tags (id, session_id, tag_id) VALUES ('a', 'note', 'a'), ('duplicate', 'note', 'a'), ('b', 'note', 'b');
+    UPDATE tags SET deleted_at = 'deleted' WHERE id = 'b';
+  `);
+  const [row] = query(40);
+  assert.equal(row.tags_json, '["Planning"]');
+  assert.equal(row.folder_path, "Work/Planning");
+  assert.deepEqual(Object.keys(row).sort(), [
+    "created_at",
+    "event_json",
+    "folder_path",
+    "id",
+    "tags_json",
+    "title",
+  ]);
+});
+
+test("note opening can detect transcript history without reading transcript or contact payloads", () => {
+  insert("note", now);
+  const exists = db.prepare(SESSION_HAS_TRANSCRIPT_SQL);
+  assert.equal(exists.get("note").has_transcript, 0);
+  db.exec(
+    "INSERT INTO transcripts (id, session_id, words_json) VALUES ('transcript', 'note', 'not parsed by the existence query')",
+  );
+  assert.equal(exists.get("note").has_transcript, 1);
+  assert.equal(exists.get("other").has_transcript, 0);
+  db.exec("UPDATE transcripts SET deleted_at = 'deleted'");
+  assert.equal(exists.get("note").has_transcript, 0);
+});

--- a/apps/mobile/src/data/timeline-query.ts
+++ b/apps/mobile/src/data/timeline-query.ts
@@ -1,0 +1,48 @@
+export const TIMELINE_PAGE_SIZE = 40;
+
+export const TIMELINE_SQL = `
+WITH dated_sessions AS (
+  SELECT id, title, created_at, event_json, folder_path,
+    COALESCE(
+      CASE WHEN json_valid(event_json) THEN
+        CASE WHEN json_type(event_json, '$.started_at') = 'text'
+          THEN julianday(json_extract(event_json, '$.started_at')) END
+      END,
+      julianday(created_at)
+    ) AS started_at_day
+  FROM sessions
+  WHERE deleted_at IS NULL
+), grouped_sessions AS (
+  SELECT *, CASE WHEN started_at_day > julianday(?) THEN 0 ELSE 1 END AS time_group
+  FROM dated_sessions
+), timeline_page AS MATERIALIZED (
+  SELECT * FROM grouped_sessions
+  ORDER BY time_group,
+    CASE WHEN time_group = 0 THEN started_at_day END ASC,
+    started_at_day DESC, id DESC
+  LIMIT ?
+)
+SELECT
+  sessions.id,
+  sessions.title,
+  sessions.created_at,
+  sessions.event_json,
+  sessions.folder_path,
+  COALESCE((
+    SELECT json_group_array(name)
+    FROM (
+      SELECT DISTINCT tags.name AS name
+      FROM session_tags
+      JOIN tags ON tags.id = session_tags.tag_id
+      WHERE session_tags.session_id = sessions.id
+        AND session_tags.deleted_at IS NULL
+        AND tags.deleted_at IS NULL
+        AND trim(tags.name) <> ''
+      ORDER BY tags.name COLLATE NOCASE
+    )
+  ), '[]') AS tags_json
+FROM timeline_page AS sessions
+ORDER BY time_group,
+  CASE WHEN time_group = 0 THEN started_at_day END ASC,
+  started_at_day DESC, sessions.id DESC
+`;

--- a/apps/mobile/src/data/timeline.ts
+++ b/apps/mobile/src/data/timeline.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useMemo, useRef, useState, useSyncExternalStore } from "react";
 
 import { useLiveQuery } from "@/db";
 
@@ -6,37 +6,12 @@ import {
   buildSessionList,
   mapTimelineRows,
   nextTimelineRefreshAt,
-  type SessionListItem,
   type TimelineRow,
   type TimelineSession,
 } from "./timeline-model";
+import { TIMELINE_PAGE_SIZE, TIMELINE_SQL } from "./timeline-query";
 
 export * from "./timeline-model";
-
-const TIMELINE_SQL = `
-SELECT
-  sessions.id,
-  sessions.title,
-  sessions.created_at,
-  sessions.event_json,
-  sessions.folder_path,
-  COALESCE((
-    SELECT json_group_array(name)
-    FROM (
-      SELECT DISTINCT tags.name AS name
-      FROM session_tags
-      JOIN tags ON tags.id = session_tags.tag_id
-      WHERE session_tags.session_id = sessions.id
-        AND session_tags.deleted_at IS NULL
-        AND tags.deleted_at IS NULL
-        AND trim(tags.name) <> ''
-      ORDER BY tags.name COLLATE NOCASE
-    )
-  ), '[]') AS tags_json
-FROM sessions
-WHERE sessions.deleted_at IS NULL
-ORDER BY sessions.created_at DESC
-`;
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
@@ -74,15 +49,22 @@ function createTimelineClock(sessions: TimelineSession[]) {
   };
 }
 
-export function useTimelineSessions(): {
-  items: SessionListItem[];
-  isLoading: boolean;
-} {
-  const { data, isLoading } = useLiveQuery<TimelineRow, TimelineSession[]>({
+export function useTimelineSessions() {
+  const [limit, setLimit] = useState(TIMELINE_PAGE_SIZE);
+  const [orderedAt, setOrderedAt] = useState(Date.now);
+  const previousData = useRef<TimelineSession[]>([]);
+  const { data, isLoading, error } = useLiveQuery<
+    TimelineRow,
+    TimelineSession[]
+  >({
     sql: TIMELINE_SQL,
+    params: [new Date(orderedAt).toISOString(), limit + 1],
     mapRows: mapTimelineRows,
   });
-  const sessions = useMemo(() => data ?? [], [data]);
+  // Keep the current rows mounted while the larger live query subscribes.
+  if (data !== undefined) previousData.current = data;
+  const rows = data ?? previousData.current;
+  const sessions = useMemo(() => rows.slice(0, limit), [rows, limit]);
   const clock = useMemo(() => createTimelineClock(sessions), [sessions]);
   const now = useSyncExternalStore(
     clock.subscribe,
@@ -90,5 +72,25 @@ export function useTimelineSessions(): {
     clock.getSnapshot,
   );
   const items = useMemo(() => buildSessionList(sessions, now), [sessions, now]);
-  return { items, isLoading };
+  const hasMore = rows.length > limit;
+
+  // A meeting crossing into the past can change which rows belong in the window.
+  if (
+    sessions.some((session) => {
+      const startedAt = new Date(session.startedAt).getTime();
+      return startedAt > orderedAt && startedAt <= now;
+    })
+  )
+    setOrderedAt(now);
+
+  return {
+    items,
+    isLoading,
+    error,
+    hasMore,
+    loadMore: () => {
+      if (!isLoading && !error && hasMore) setLimit(limit + TIMELINE_PAGE_SIZE);
+    },
+    retry: () => setOrderedAt(Date.now()),
+  };
 }

--- a/apps/mobile/src/data/transcript-model.ts
+++ b/apps/mobile/src/data/transcript-model.ts
@@ -8,6 +8,10 @@ export const SESSION_TRANSCRIPTS_SQL = `SELECT transcript.id, transcript.started
 
 export const SESSION_SPEAKERS_SQL = `SELECT id, name FROM humans WHERE workspace_id = (SELECT workspace_id FROM sessions WHERE id = ?) AND deleted_at IS NULL`;
 
+export const SESSION_HAS_TRANSCRIPT_SQL = `SELECT EXISTS (
+  SELECT 1 FROM transcripts WHERE session_id = ? AND deleted_at IS NULL
+) AS has_transcript`;
+
 export type TranscriptRow = {
   id: string;
   started_at_ms: number;

--- a/apps/mobile/src/data/transcripts.ts
+++ b/apps/mobile/src/data/transcripts.ts
@@ -1,14 +1,14 @@
 import { useMemo } from "react";
 
-import { useLiveQuery } from "@/db";
+import { execute, useLiveQuery } from "@/db";
 import { captureOperationalError } from "@/lib/error-reporting";
 
 import {
   transcriptSegments,
   SESSION_TRANSCRIPTS_SQL,
   SESSION_SPEAKERS_SQL,
+  SESSION_HAS_TRANSCRIPT_SQL,
   type TranscriptRow,
-  type TranscriptSegment,
 } from "./transcript-model";
 export type { TranscriptSegment } from "./transcript-model";
 
@@ -26,37 +26,78 @@ function rememberInvalidRow(rowId: string) {
   }
 }
 
-export function useSessionTranscripts(sessionId: string): TranscriptSegment[] {
-  const { data: rows } = useLiveQuery<TranscriptRow, TranscriptRow[]>({
+function mapTranscripts(
+  rows: TranscriptRow[],
+  humans: { id: string; name: string }[],
+) {
+  const names = new Map(humans.map((human) => [human.id, human.name]));
+  return rows.flatMap((row) => {
+    try {
+      return transcriptSegments(row, names);
+    } catch (error) {
+      if (!reportedInvalidRows.has(row.id)) {
+        rememberInvalidRow(row.id);
+        captureOperationalError(error, {
+          operation: "transcript_words_parse",
+          level: "warning",
+        });
+      }
+      return [];
+    }
+  });
+}
+
+export function useSessionHasTranscript(sessionId: string) {
+  return useLiveQuery<{ has_transcript: number }, boolean>({
+    sql: SESSION_HAS_TRANSCRIPT_SQL,
+    params: [sessionId],
+    mapRows: (rows) => rows[0]?.has_transcript === 1,
+  });
+}
+
+export async function loadSessionTranscripts(sessionId: string) {
+  const rows = await execute<TranscriptRow>(SESSION_TRANSCRIPTS_SQL, [
+    sessionId,
+  ]);
+  if (rows.length === 0) return [];
+  const humans = await execute<{ id: string; name: string }>(
+    SESSION_SPEAKERS_SQL,
+    [sessionId],
+  );
+  return mapTranscripts(rows, humans);
+}
+
+export function useSessionTranscripts(sessionId: string, enabled: boolean) {
+  const {
+    data: rows,
+    isLoading,
+    error,
+  } = useLiveQuery<TranscriptRow, TranscriptRow[]>({
     sql: SESSION_TRANSCRIPTS_SQL,
     params: [sessionId],
+    enabled,
     mapRows: (rows) => rows,
   });
-  const { data: humans } = useLiveQuery<
+  const {
+    data: humans,
+    isLoading: speakersLoading,
+    error: speakersError,
+  } = useLiveQuery<
     { id: string; name: string },
     { id: string; name: string }[]
   >({
     sql: SESSION_SPEAKERS_SQL,
     params: [sessionId],
+    enabled: enabled && (rows?.length ?? 0) > 0,
     mapRows: (rows) => rows,
   });
-  return useMemo(() => {
-    const names = new Map(
-      (humans ?? []).map((human) => [human.id, human.name]),
-    );
-    return (rows ?? []).flatMap((row) => {
-      try {
-        return transcriptSegments(row, names);
-      } catch (error) {
-        if (!reportedInvalidRows.has(row.id)) {
-          rememberInvalidRow(row.id);
-          captureOperationalError(error, {
-            operation: "transcript_words_parse",
-            level: "warning",
-          });
-        }
-        return [];
-      }
-    });
-  }, [rows, humans]);
+  const segments = useMemo(
+    () => mapTranscripts(rows ?? [], humans ?? []),
+    [rows, humans],
+  );
+  return {
+    segments,
+    isLoading: isLoading || speakersLoading,
+    error: error ?? speakersError,
+  };
 }

--- a/apps/mobile/src/settings/settings-runtime.test.mjs
+++ b/apps/mobile/src/settings/settings-runtime.test.mjs
@@ -120,6 +120,7 @@ const {
 const { requestProviderTranscription } =
   await import("../data/provider-transcription.ts");
 const { summarizeSession } = await import("../data/summarize.ts");
+const { loadSessionTranscripts } = await import("../data/transcripts.ts");
 const { Platform } = await import("react-native");
 
 function signedInWith(claims) {
@@ -1782,6 +1783,12 @@ test("summaries read the full visible transcript, including uncompact live revis
       new_words: [word("second", "Wrong ending", 100)],
     }),
   );
+  const exported = await loadSessionTranscripts("note-1");
+  assert.deepEqual(
+    exported.map(({ speaker, text }) => ({ speaker, text })),
+    [{ speaker: "John", text: "First snapshot Corrected ending" }],
+  );
+  assert.deepEqual(await loadSessionTranscripts("missing-session"), []);
   await summarizeSession("note-1");
   const request = JSON.stringify(JSON.parse(fixture.requests[0].options.body));
   assert.match(request, /John: First snapshot Corrected ending/);


### PR DESCRIPTION
Bound and virtualize the session timeline, debounce search queries, and defer full transcript reads until opening or export. Cover pagination ordering, live changes, and complete transcript export.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main timeline SQL ordering/pagination and when transcript data is read, so regressions could affect list order, infinite scroll, or note/listening UX on large accounts.
> 
> **Overview**
> **Paginates and virtualizes the home meeting list** so large libraries no longer load every session up front. Timeline data now comes from a bounded SQL window (upcoming vs past ordering, 40-item pages with a lookahead row), exposed via `loadMore`, `hasMore`, `error`, and `retry`. The home screen switches from a scroll view to an **`Animated.FlatList`** with end-reached loading and clearer empty/error states.
> 
> **Search is debounced** (300ms settled query) so live queries do not fire on every keystroke. Results stay capped at 50 with a **`hasMore`** hint when the query returns more than 50 rows, plus error copy in the palette.
> 
> **Transcript work is deferred**: opening a note uses a lightweight **`useSessionHasTranscript`** check instead of parsing full transcript payloads; the listening sheet loads segments only when expanded; **export** pulls transcripts via **`loadSessionTranscripts`** on demand. New **`timeline-query.test.mjs`** (and a summary test) lock in pagination ordering, live sync edge cases, and transcript existence/export behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ef5791e1c43d22d8203b4beff30d770f455e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->