### PR TITLE
Reduce the Android header avatar size

### DIFF
--- a/apps/mobile/src/components/user-avatar.tsx
+++ b/apps/mobile/src/components/user-avatar.tsx
@@ -94,7 +94,10 @@ export function UserAvatarButton({
       onPress={onPress}
       style={({ pressed }) => [styles.button, pressed && styles.pressed]}
     >
-      <UserAvatar user={user} />
+      <UserAvatar
+        size={process.env.EXPO_OS === "android" ? 32 : undefined}
+        user={user}
+      />
     </Pressable>
   );
 }


### PR DESCRIPTION
Use a 32 dp avatar while preserving the 44 dp settings button tap target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Platform-specific visual sizing in the header avatar with no auth, data, or API changes.
> 
> **Overview**
> Shrinks the profile avatar shown in the header **on Android only** by passing `size={32}` into `UserAvatar` from `UserAvatarButton`, instead of the default 40dp.
> 
> The surrounding `Pressable` still uses `ControlSize.default` dimensions, so the tap target stays the same while the visible avatar is smaller on Android. iOS behavior is unchanged (`size` remains the default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2e4ae1165a354ebfd7472993fc03ecefb9e2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->