### PR TITLE
Match iOS provider icon artwork sizing

### DIFF
--- a/apps/mobile/src/settings/provider-icon.ios.tsx
+++ b/apps/mobile/src/settings/provider-icon.ios.tsx
@@ -7,7 +7,10 @@ import {
 } from "@expo/ui/swift-ui/modifiers";
 import { useAssets } from "expo-asset";
 
-import { providerIconSource } from "./provider-icon-assets";
+import {
+  providerIconArtworkSize,
+  providerIconSource,
+} from "./provider-icon-assets";
 import { useAppColorScheme, useColors } from "./theme-provider";
 
 export function ProviderIcon({
@@ -20,10 +23,21 @@ export function ProviderIcon({
   const scheme = useAppColorScheme();
   const Colors = useColors();
   const source = providerIconSource(provider, scheme);
-  return source ? (
-    <BundledIcon key={source} source={source} size={size} />
-  ) : (
-    <Icon name="shuffle" size={size} color={Colors.muted} />
+  const artworkSize = providerIconArtworkSize(provider, size);
+  return (
+    <Column
+      alignment="center"
+      style={{
+        width: size,
+        paddingVertical: (size - artworkSize) / 2,
+      }}
+    >
+      {source ? (
+        <BundledIcon key={source} source={source} size={artworkSize} />
+      ) : (
+        <Icon name="shuffle" size={artworkSize} color={Colors.muted} />
+      )}
+    </Column>
   );
 }
 


### PR DESCRIPTION
Apply the shared provider artwork scale to the iOS settings icons while preserving their row footprint. This completes the iOS follow-up to #7411.

Validation: mobile and provider-validation typechecks; 352 mobile tests; 33 provider-validation tests; changed-file formatting; license-boundary checks and 64 repository script tests passed. Native simulator QA was not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI-only sizing change with no auth, data, or API impact.
> 
> **Overview**
> Aligns **iOS settings provider icons** with the shared artwork scale already used on Android and the default implementation.
> 
> `ProviderIcon` on iOS now calls `providerIconArtworkSize` and wraps the icon in a centered `Column` whose width stays at the requested `size`, with vertical padding so the **drawn artwork is smaller** (typically 60% of the slot, full size for Soniox) while the **row footprint is unchanged**. Bundled images and the shuffle fallback both render at `artworkSize` instead of filling the full slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cccc40d27d93a48d5e4134b742c551f90e689e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->