### PR TITLE
Prepare desktop 1.4.22 and mobile testing distribution

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -1,19 +1,29 @@
 ---
 name: release-new-version
-description: Release a new desktop stable version for Anarlog. Use when asked to cut, publish, or prepare a new stable desktop release after checking and merging the changelog.
+description: Release Anarlog desktop stable versions and, when requested, distribute iOS and Android builds through TestFlight, the App Store, or Google Play. Validate and merge the changelog before releasing.
 metadata:
   internal: true
 ---
 
-# Release a New Desktop Version
+# Release a New Version
 
-Use this for stable desktop releases. A stable release must come from `main`, after the changelog for the computed version is present, accurate, validated, and merged.
+Use this for stable desktop releases and requested mobile store distribution. A stable desktop release must come from `main`, after the changelog for the explicit version is present, accurate, validated, and merged. Mobile uses its own app version and build numbers.
 
 ## Core Rule
 
 Do not trigger a stable release from an unmerged branch. First make the changelog up to date, merge that changelog change to `main`, then run the stable release from `main`.
 
 ## Scope Boundary
+
+Establish the exact desktop version and requested mobile destination before
+dispatching. A desktop release includes its existing Microsoft Store workflow;
+it does not imply mobile submission. When mobile is requested, distinguish
+TestFlight and Google Play internal testing from public App Store review and
+Google Play production rollout. Honor authorization already given in the task;
+do not ask again for an approved destination.
+
+App Store here means the iOS app. The repository deliberately has no Mac App
+Store release lane; do not recreate one as part of a desktop or mobile release.
 
 Release and QA are separate, explicitly requested workflows. Do not read or
 run `qa-critical-ux` or `qa-cli-mcp-api` solely because the user asked for a
@@ -25,7 +35,8 @@ approves or blocks the release.
 
 ## Release Workflow Requirements
 
-This release path approves macOS, Windows, and Linux. Mobile remains closed.
+The desktop path covers macOS, Windows, and Linux. Requested mobile distribution
+follows the separate native-build and store steps below.
 The patched CloudSync vendor bundle is rebuilt from source and
 cancellation-tested on every desktop lane: `rebuild-macos.sh` for Apple
 Silicon and Intel, `rebuild-windows.sh` under UCRT64 in `windows_ci`, and
@@ -38,15 +49,18 @@ The rebuild steps run only on `workflow_dispatch`, so a routine pull-request
 run does not prove them. Dispatch `desktop_ci.yaml` against the candidate SHA
 and confirm the `cloudsync-windows-*` and `cloudsync-linux-*` artifacts before
 treating a desktop lane as approved. Do not treat macOS artifacts or
-Rust-only tests as cross-platform approval, and do not open the mobile lane
-until its bundle gets the same treatment.
+Rust-only tests as cross-platform approval. Check the mobile coverage separately;
+its current Android job does not provide the iOS cancellation-test coverage.
 
 ## Preflight
 
 1. Inspect the workflow before assuming release behavior:
 
 ```bash
-sed -n '1,280p' .github/workflows/desktop_cd.yaml
+cat .github/workflows/desktop_cd.yaml
+cat .github/workflows/desktop_ci.yaml
+cat .github/workflows/desktop_publish.yaml
+cat .github/workflows/desktop_store_publish.yaml
 ```
 
 2. Validate the explicit stable version requested by the user:
@@ -63,12 +77,16 @@ stable semantic version and a matching changelog file.
 3. Identify the latest stable desktop tag and the commits that will ship:
 
 ```bash
-git fetch --tags --force
-git tag -l 'desktop_v*' --sort=-v:refname | grep -E '^desktop_v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1
-git log --oneline <latest-desktop-tag>..HEAD
+gh release list --limit 20
+gh api repos/fastrepl/anarlog/compare/<latest-desktop-tag>...main
+git log --oneline <latest-desktop-tag>..<candidate-sha>
 ```
 
-Use read-only `git` commands for inspection. If the workspace is on `gitbutler/workspace`, use the `but` skill for commits, pushes, PRs, merges, and other write operations.
+Verify the latest published, non-prerelease `desktop_v<semver>` tag through
+GitHub. GitHub's compare file list can be truncated; use local history and diffs
+for the complete changelog review. Use read-only `git` commands for inspection.
+Use the `but` skill for local version control, and GitHub tools for PR metadata
+and merges. Do not force-fetch tags or force-push to prepare a release.
 
 ## Changelog Gate
 
@@ -93,7 +111,8 @@ summary: "One concise, user-facing sentence for the changelog index preview."
 After editing the changelog, run:
 
 ```bash
-pnpm exec dprint fmt
+pnpm exec dprint fmt --allow-no-files packages/changelog/content/<version>.md
+pnpm exec dprint check --allow-no-files packages/changelog/content/<version>.md
 pnpm -F @anlg/changelog typecheck
 ```
 
@@ -112,15 +131,26 @@ If using GitButler, prefer:
 
 ```bash
 but diff
-but commit chore/release-changelog -c -m "Update desktop release changelog
+but commit -b chore/release-changelog -m "Update desktop release changelog
 
-Refresh the desktop changelog for the next stable release." --changes <ids>
-but pr new <branch-id> -t
+Refresh the desktop changelog for the next stable release." <file-or-hunk-ids>
+but pr new chore/release-changelog -t
 ```
 
 Use actual IDs from `but diff` / `but status -fv`; do not invent IDs.
 
 ## Trigger Stable Release
+
+Dispatch the native verification workflow from `main`, then identify its run and
+verify `headSha` equals the recorded candidate before accepting any job:
+
+```bash
+gh workflow run desktop_ci.yaml --ref main
+```
+
+Verify every native job and the source-rebuilt CloudSync artifacts, including
+both macOS architectures, Windows, and both Linux architectures. A green
+pull-request run skips these jobs. Keep the candidate fixed through publication.
 
 After the changelog merge, verify `main` has not moved, then build the stable
 candidate without publishing:
@@ -129,6 +159,9 @@ candidate without publishing:
 gh workflow run desktop_cd.yaml \
   --ref main \
   -f channel=stable \
+  -f candidate_sha=<40-character-main-sha> \
+  -f include_windows=true \
+  -f include_linux=true \
   -f version=<version>
 ```
 
@@ -167,7 +200,9 @@ gh workflow run desktop_publish.yaml \
   --ref main \
   -f version=<version> \
   -f candidate_sha=<40-character-main-sha> \
-  -f dry_run_id=<dry-run-id>
+  -f dry_run_id=<dry-run-id> \
+  -f include_windows=true \
+  -f include_linux=true
 ```
 
 Watch that workflow to completion. It must verify the dry-run run identity,
@@ -175,11 +210,124 @@ artifact hashes, CrabNebula tool identity and hash, current `main`, and the
 immutable tag before publishing. It must also verify every file mirrored to
 GitHub against the provenance manifest.
 
+The publish workflow calls `desktop_store_publish.yaml` with
+`submit_to_stores=true` for Microsoft Store certification. Inspect that job and
+the resulting submission separately from GitHub/CrabNebula publication. Also
+follow the generated Linux package update through its package-publication jobs;
+creating its PR is not package publication.
+
+## Mobile Store Distribution
+
+Read `apps/mobile/AGENTS.md`, `apps/mobile/app.json`,
+`apps/mobile/app.config.ts`, `apps/mobile/eas.json`, the EAS build hook, and the
+current `mobile_ci.yaml`. Use Expo's store-distribution skill when available and
+verify commands against the installed EAS CLI and current official docs:
+
+- https://docs.expo.dev/submit/ios/
+- https://docs.expo.dev/submit/android/
+- https://docs.expo.dev/submit/eas-json/
+- https://docs.expo.dev/build-reference/app-versions/
+
+### Identity, versions, and credentials
+
+Run EAS commands from `apps/mobile` with `APP_VARIANT=stable`. Use the repository's
+`stable` profile, not an assumed `production` profile. Pin and record the EAS CLI
+version used for the release. Verify the signed-in account and project before
+building or submitting. Current repository identities are:
+
+- Project: `@john_fastrepl/anarlog-mobile`, ID `fcaa4e46-0da5-4dfc-a9e2-6447de0030d2`
+- iOS bundle ID and Android package: `so.anarlog.mobile`
+- App Store Connect app ID: `6807350358`
+- EAS build environment: `production`; app variant: `stable`
+
+Re-read these values rather than treating this list as authority if configuration
+changes. Never access an environment whose name matches `*-char`.
+
+The mobile marketing version comes from `apps/mobile/app.json`; do not copy the
+desktop version into it. `appVersionSource: remote` and `autoIncrement: true`
+manage iOS build numbers and Android version codes. Check remote build history
+and store versions before selecting a build. Merge intentional version/profile
+changes before freezing the candidate.
+
+Confirm signing and submission credential availability without printing secrets.
+Use credentials already managed by EAS where possible. Google Play submission
+requires the correct app record and a service account with access to its testing
+track. Do not commit credential files or broaden account permissions to bypass a
+failed submission.
+
+### Native verification and candidate builds
+
+Dispatch `mobile_ci.yaml` from `main` and verify its run SHA matches the mobile
+candidate. Wait for `mobile_checks`, `ios_build`, `android_build`, `watchos_build`,
+and the aggregate job; pull-request runs skip native builds.
+
+- iOS dispatch rebuilds the CloudSync framework, runs `test-ios.sh` on a
+  simulator, builds Release, and verifies embedded CloudSync and App Shortcuts.
+- Android dispatch rebuilds all shipped CloudSync ABIs, builds Release, and
+  checks the packaged libraries for the request-deadline patch marker. The
+  current workflow does not execute the native CloudSync cancellation suite on
+  Android. Report this coverage gap; a marker check is not a passing runtime test.
+- Record the `cloudsync-ios-<sha>` and `cloudsync-android-<sha>` artifacts and all
+  job results. Never report desktop tests as native mobile coverage.
+
+Build from a clean checkout of the merged candidate, including Git LFS objects
+and submodules. Do not upload a combined GitButler workspace or use `EAS_NO_VCS`
+to hide source identity. If using an exported source archive, record its origin
+SHA and hash and verify that no local changes entered it. The EAS post-install
+hook must generate the native bridge before packaging. EAS builds use the
+candidate's committed CloudSync bundle; a separate CI rebuild alone does not
+prove which bytes are embedded in a signed store artifact.
+
+```bash
+APP_VARIANT=stable eas build --platform ios --profile stable --non-interactive --no-wait
+APP_VARIANT=stable eas build --platform android --profile stable --non-interactive --no-wait
+APP_VARIANT=stable eas build:view <build-id> --json
+```
+
+Record each build ID, source SHA, profile, app version, build number/version
+code, status, artifact URL, and SHA-256. Verify an iOS device archive and Android
+AAB, not a simulator build or development APK. Inspect packaged identity,
+CloudSync inclusion, and signing metadata before submission. Never select
+`--latest` when concurrent builds can select a different candidate.
+
+### TestFlight and Google Play internal testing
+
+Use the explicit completed build IDs:
+
+```bash
+APP_VARIANT=stable eas submit --platform ios --profile stable --id <ios-build-id> --non-interactive --wait
+APP_VARIANT=stable eas submit --platform android --profile stable --id <android-build-id> --non-interactive --wait
+```
+
+For Google Play internal testing, require the selected submission profile to
+specify `android.track: internal`. A `completed` release makes the build
+available on that track; `draft` uploads it without completing rollout. Do not
+silently switch to `production`. An EAS `distribution: internal` build is a
+separate sideloading mechanism and is not Play internal testing.
+
+Follow the returned submission URLs to terminal status. For iOS, verify Apple
+processing completes and the exact version/build appears in TestFlight; check
+availability to the intended existing tester group. External TestFlight testing
+can require Beta App Review. For Android, verify the exact version code on the
+internal track and the release status. Report missing credentials, app setup,
+store processing, or tester-group access as concrete pending steps.
+
+### Public App Store and Google Play releases
+
+Run only when public distribution was requested. EAS iOS submission uploads to
+App Store Connect/TestFlight; public distribution additionally requires selecting
+the build for an App Store version, completing metadata and review requirements,
+submitting for review, and verifying the approved release becomes available.
+Google Play public distribution requires an explicitly selected production
+profile or promotion of the verified internal build, with the requested rollout
+fraction and release status. Keep store review and public availability distinct
+from a successful upload. Never accept new legal agreements on the user's behalf.
+
 ## Final Checks
 
 Before reporting success, capture:
 
-- computed stable version
+- explicit stable version and candidate SHA
 - dry-run workflow URL and head SHA
 - publish workflow URL and head SHA
 - `desktop_v<version>` tag
@@ -187,6 +335,12 @@ Before reporting success, capture:
 - whether CrabNebula publish completed
 - changelog URL
 - stable DMG SHA-256
+- Microsoft Store submission/certification state and Linux package publication state
+- mobile version, build IDs/numbers, candidate SHA, artifact hashes, submission
+  URLs, TestFlight processing/tester availability, and Google Play track/version
+  code when mobile distribution was requested
+- pending store reviews, native coverage gaps, or unavailable checks, separately
+  from completed publication
 
 If the workflow fails, inspect the failed job logs with:
 

--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -295,7 +295,7 @@ CloudSync inclusion, and signing metadata before submission. Never select
 Use the explicit completed build IDs:
 
 ```bash
-APP_VARIANT=stable eas submit --platform ios --profile stable --id <ios-build-id> --non-interactive --wait
+APP_VARIANT=stable eas submit --platform ios --profile stable --id <ios-build-id> --non-interactive --no-auto-testflight-setup --wait
 APP_VARIANT=stable eas submit --platform android --profile stable --id <android-build-id> --non-interactive --wait
 ```
 
@@ -311,6 +311,11 @@ availability to the intended existing tester group. External TestFlight testing
 can require Beta App Review. For Android, verify the exact version code on the
 internal track and the release status. Report missing credentials, app setup,
 store processing, or tester-group access as concrete pending steps.
+
+Current EAS Submit enables automatic TestFlight setup by default, which can
+create a group and invite every App Store Connect admin. Keep
+`--no-auto-testflight-setup` unless those invitations were explicitly requested.
+An upload request alone does not authorize inviting additional testers.
 
 ### Public App Store and Google Play releases
 

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -34,6 +34,10 @@
       "ios": {
         "appleId": "john@fastrepl.com",
         "ascAppId": "6807350358"
+      },
+      "android": {
+        "track": "internal",
+        "releaseStatus": "completed"
       }
     }
   }

--- a/packages/changelog/content/1.4.22.md
+++ b/packages/changelog/content/1.4.22.md
@@ -1,0 +1,21 @@
+---
+date: "2026-09-07"
+summary: "Anarlog 1.4.22 improves offline sync, supports longer Google Cloud recordings, and refines Windows navigation and provider settings."
+---
+
+## Sync and transcription
+
+- Preserve offline edits when reconnecting and load synced notes progressively
+- Transcribe longer recordings with Google Cloud Speech-to-Text
+- Use custom Deepgram-compatible endpoints for transcription after recording
+- See used and available device slots in Sync settings, with clearer messages
+  when your plan's limit is reached
+
+## Navigation and settings
+
+- Access search, new note, and note filters from the Windows title bar
+- Keep note titles sized to the text you see, including non-Latin characters
+- Find more consistent outline icons and clearer distinctions between
+  transcription and intelligence settings
+- Identify providers that transcribe **After recording**, and find local model
+  files under **BYO-model**


### PR DESCRIPTION
Add the desktop changelog, extend the release skill with TestFlight/App Store and Google Play distribution, and explicitly target Android submissions to internal testing. Preserve independent desktop/mobile versions and document the current Android native cancellation-test coverage gap.

Validation: changed-file dprint checks, changelog/mobile typechecks, 352 mobile tests, 64 repository script tests, and both license-boundary checks passed. This PR prepares the release; builds and store submissions follow after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-prep only; the EAS change limits Android submits to internal testing and does not alter app runtime or auth.
> 
> **Overview**
> Prepares **desktop 1.4.22** with a new user-facing changelog (`packages/changelog/content/1.4.22.md`) covering sync/transcription improvements and Windows navigation/settings polish.
> 
> Expands the **`release-new-version`** agent skill from desktop-only to full release ops: explicit version/candidate SHA gates, `desktop_ci` dispatch before CD/publish, updated `gh`/`but` preflight, Microsoft Store/Linux follow-through, and a large **mobile store distribution** section (EAS `stable` profile, `mobile_ci`, TestFlight with `--no-auto-testflight-setup`, internal vs public Play/App Store, and documented Android CloudSync cancellation coverage gap).
> 
> Configures **`apps/mobile/eas.json`** so `eas submit --profile stable` for Android targets the **internal** track with **`completed`** release status, aligning automated submissions with internal testing rather than production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a53a56e4277e3cd5cd59d57dd0c23212ee6eb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->