### PR TITLE
Fix Android EAS setup and clarify release verification

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -278,6 +278,12 @@ hook must generate the native bridge before packaging. EAS builds use the
 candidate's committed CloudSync bundle; a separate CI rebuild alone does not
 prove which bytes are embedded in a signed store artifact.
 
+For an exported source tree, resolve both `EAS_PROJECT_ROOT` and `apps/mobile`
+to their physical paths before invoking EAS. Confirm their relative path is
+exactly `apps/mobile`. On macOS, mixing `/tmp` with its physical `/private/tmp`
+path produces an invalid project directory in the remote build job. Check the
+job's `projectRootDirectory` before accepting a build.
+
 ```bash
 APP_VARIANT=stable eas build --platform ios --profile stable --non-interactive --no-wait
 APP_VARIANT=stable eas build --platform android --profile stable --non-interactive --no-wait

--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -212,9 +212,12 @@ GitHub against the provenance manifest.
 
 The publish workflow calls `desktop_store_publish.yaml` with
 `submit_to_stores=true` for Microsoft Store certification. Inspect that job and
-the resulting submission separately from GitHub/CrabNebula publication. Also
-follow the generated Linux package update through its package-publication jobs;
-creating its PR is not package publication.
+the resulting submission separately from GitHub/CrabNebula publication. Merge
+the generated Linux package metadata PR and verify the signed APT index is live
+on `anarlog.so`. Check whether Netlify deployed that commit automatically before
+dispatching `web_cd.yaml`. Arch `PKGBUILD` and `.SRCINFO` updates ship in this
+repository; there is no AUR publication workflow. Check the AUR registry before
+claiming an AUR release. Creating the metadata PR alone is not publication.
 
 ## Mobile Store Distribution
 

--- a/apps/mobile/scripts/eas-build-post-install.sh
+++ b/apps/mobile/scripts/eas-build-post-install.sh
@@ -17,6 +17,10 @@ if ! command -v rustup >/dev/null 2>&1; then
 fi
 
 if [[ $EAS_BUILD_PLATFORM == android ]]; then
+  if [[ $(uname -s) == Linux ]]; then
+    sudo apt-get -o Acquire::Retries=5 update
+    sudo apt-get -o Acquire::Retries=5 install -y --no-install-recommends libclang-dev
+  fi
   rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
   export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-${ANDROID_HOME:-${ANDROID_SDK_ROOT:?Android SDK is required}}/ndk/27.1.12297006}}"
   test -f "$ANDROID_NDK_HOME/source.properties"


### PR DESCRIPTION
Android EAS builds fail while compiling libsqlite3-sys because the SDK 57 Linux image lacks libclang. Install libclang-dev in the Android Linux post-install hook before compiling the native bridge.

Document the physical-path preflight for exported EAS sources and the actual Linux distribution checks: live signed APT metadata and repository Arch packaging, with AUR publication reported separately.

Validation: bash syntax and documentation formatting passed; mobile typecheck, 352 mobile tests, 64 repository tests, and 9 license tests passed. A fresh Android EAS build will verify installation on the remote Linux image after merge.

Keep this PR in draft until desktop 1.4.22 is published so its candidate remains the current main commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to EAS build hook dependencies and internal release documentation; no auth, data, or production runtime paths are modified.
> 
> **Overview**
> **Android EAS builds** on the Linux image now run `apt-get` to install `libclang-dev` in `eas-build-post-install.sh` before the native bridge compile, addressing failures when building `libsqlite3-sys` on the SDK 57 image without Clang headers.
> 
> The **release-new-version** skill is updated with clearer post-publish checks: merge the Linux metadata PR and confirm the signed APT index on `anarlog.so`, Netlify vs `web_cd.yaml`, and that Arch packaging lives in-repo while AUR must be verified separately. It also adds **exported EAS source** preflight—resolve `EAS_PROJECT_ROOT` and `apps/mobile` to physical paths (macOS `/tmp` vs `/private/tmp`) and validate `projectRootDirectory` on the remote job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b1c7cd30735d4dadfef03ce9a23440f3e036b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->