### PR TITLE
Restore sync rate-limit composition coverage

### DIFF
--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
-    matchers::{method, path},
+    matchers::{body_json, method, path},
 };
 
 use super::*;
@@ -605,6 +605,14 @@ async fn sync_composition_keeps_devices_and_sharing_available_when_credentials_a
             "code": "42501",
             "message": "share manager access required"
         })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/v1/rpc/get_sync_device_limit"))
+        .and(body_json(json!({ "p_actor_user_id": "editor-user" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!(3)))
         .expect(1)
         .mount(&server)
         .await;


### PR DESCRIPTION
## Summary

**Problem:** Desktop release-candidate CI fails because the API rate-limit composition test does not mock the device-limit RPC added to the device-list route.

**Fix:** Mock the RPC with the authenticated actor and a three-device limit so the test verifies independent device and credential rate limits again.

## Verification

- Reproduced the original 502-versus-200 failure, then passed all 35 API binary tests.
- Passed the API workflow commands, including 344 related Rust tests, deployment/E2EE Python tests, and unchanged OpenAPI generation.
- Passed the complete desktop Rust workspace command with all 76 CI exclusions (3033 tests passed).
- Passed formatting, license boundaries, and 64 shared workflow tests.
- Zizmor completed with the existing 410 findings; this change does not modify workflows.
