### PR TITLE
Preserve Rust tools across EAS build phases

### DIFF
--- a/apps/mobile/scripts/eas-build-post-install.sh
+++ b/apps/mobile/scripts/eas-build-post-install.sh
@@ -9,6 +9,9 @@ esac
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 
 export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+if command -v set-env >/dev/null 2>&1; then
+  set-env PATH "$PATH"
+fi
 if ! command -v rustup >/dev/null 2>&1; then
   installer=$(mktemp)
   trap 'rm -f "$installer"' EXIT

--- a/apps/mobile/scripts/eas-build-post-install.test.mjs
+++ b/apps/mobile/scripts/eas-build-post-install.test.mjs
@@ -18,6 +18,7 @@ function runHook(t, platform, { ndk = true } = {}) {
   const scripts = join(root, "apps/mobile/scripts");
   const bin = join(root, "cargo/bin");
   const log = join(root, "commands.log");
+  const persistedPath = join(root, "path");
   mkdirSync(scripts, { recursive: true });
   mkdirSync(bin, { recursive: true });
   mkdirSync(join(root, "apps/mobile/ios"), { recursive: true });
@@ -34,6 +35,13 @@ function runHook(t, platform, { ndk = true } = {}) {
     join(scripts, "hook.sh"),
   );
   writeFileSync(log, "");
+  writeFileSync(persistedPath, "");
+  writeFileSync(
+    join(bin, "set-env"),
+    '#!/bin/bash\ntest "$1" = PATH || exit 1\nprintf "%s" "$2" > "$ANARLOG_TEST_PATH_FILE"\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(join(bin, "sudo"), "#!/bin/bash\nexit 0\n", { mode: 0o755 });
   for (const command of ["rustup", "cargo", "pod"]) {
     writeFileSync(
       join(bin, command),
@@ -41,19 +49,25 @@ function runHook(t, platform, { ndk = true } = {}) {
       { mode: 0o755 },
     );
   }
+  const env = {
+    PATH: "/usr/bin:/bin",
+    CARGO_HOME: join(root, "cargo"),
+    EAS_BUILD_PLATFORM: platform,
+    ANDROID_HOME: join(root, "sdk"),
+    ANARLOG_TEST_COMMAND_LOG: log,
+    ANARLOG_TEST_PATH_FILE: persistedPath,
+  };
   const result = spawnSync("bash", [join(scripts, "hook.sh")], {
     encoding: "utf8",
-    env: {
-      PATH: "/usr/bin:/bin",
-      CARGO_HOME: join(root, "cargo"),
-      EAS_BUILD_PLATFORM: platform,
-      ANDROID_HOME: join(root, "sdk"),
-      ANARLOG_TEST_COMMAND_LOG: log,
-    },
+    env,
   });
   return {
     result,
     root,
+    nextPhaseEnv: {
+      ...env,
+      PATH: readFileSync(persistedPath, "utf8") || env.PATH,
+    },
     commands: readFileSync(log, "utf8")
       .trim()
       .split("\n")
@@ -63,7 +77,7 @@ function runHook(t, platform, { ndk = true } = {}) {
 }
 
 test("EAS Android generates every native bridge ABI before packaging", (t) => {
-  const { result, root, commands } = runHook(t, "android");
+  const { result, root, commands, nextPhaseEnv } = runHook(t, "android");
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(
     commands.map(([command, args]) => [command, args]),
@@ -78,6 +92,11 @@ test("EAS Android generates every native bridge ABI before packaging", (t) => {
   );
   assert.equal(commands.at(-1)[2], root);
   assert.equal(commands.at(-1)[3], join(root, "sdk/ndk/27.1.12297006"));
+  const nextPhase = spawnSync("bash", ["-c", "cargo --version"], {
+    encoding: "utf8",
+    env: nextPhaseEnv,
+  });
+  assert.equal(nextPhase.status, 0, nextPhase.stderr);
 });
 
 test("EAS iOS refreshes pods after generating frameworks", (t) => {


### PR DESCRIPTION
## Summary

**Problem:** Android EAS builds compile the native bridge successfully, then fail while Gradle configures the Rust TLS verifier because Cargo is missing from the next build phase's PATH.

**Fix:** Persist the Rust tool path with [EAS's build-phase environment helper](https://docs.expo.dev/eas/environment-variables/usage/). The hook test now starts a separate packaging process to verify Cargo remains available, and stubs package installation so tests stay isolated.

## Verification

- Reproduced `cargo: command not found` in the new regression check before the fix; all four hook tests now pass.
- Passed mobile typecheck and all 352 mobile tests, plus license checks and 64 shared workflow tests.
- Passed shell syntax and JavaScript formatting checks.
- Zizmor completed with the existing 410 findings; no workflow files changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the EAS post-install shell hook and its unit tests; no app runtime or security-sensitive logic is touched.
> 
> **Overview**
> Fixes Android EAS builds that lose **Cargo** after the post-install hook when Gradle runs in a later phase.
> 
> The post-install hook now calls EAS **`set-env PATH`** (when present) right after prepending **`CARGO_HOME/bin`** to **`PATH`**, so Rust tools stay on the path for subsequent build steps.
> 
> Hook tests stub **`set-env`** and **`sudo`**, capture the persisted **`PATH`**, and the Android case runs a follow-up **`cargo --version`** with that env to guard against **`cargo: command not found`** regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d35fd710e26425aa740fe0bb70f7b3ffca1c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->