### PR TITLE
Restore the chat launcher pill shape

### DIFF
--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -62,7 +62,7 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain("origin-bottom");
     expect(surface?.className).toContain("h-2");
     expect(surface?.className).toContain("dark:h-3");
-    expect(surface?.className).toContain("rounded-full");
+    expect(surface?.className).toContain("rounded-pill");
     expect(surface?.className).toContain(
       "bg-[linear-gradient(180deg,#faf8f6_0%,#e3e1df_100%)]",
     );

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -37,7 +37,7 @@ export function ChatCTA({
         data-chat-cta-surface
         aria-hidden="true"
         className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[180px] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent dark:h-3",
+          "rounded-pill pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[180px] -translate-x-1/2 items-center overflow-hidden border border-transparent dark:h-3",
           "origin-bottom bg-[linear-gradient(180deg,#faf8f6_0%,#e3e1df_100%)] px-0 text-sm shadow-[0_0_0_1px_rgba(0,0,0,0.1),0_4px_12px_rgba(0,0,0,0.16),0_4px_16px_rgba(0,0,0,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)] transition-[width,height,padding,background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] dark:bg-[linear-gradient(180deg,#211d1d_0%,#574f3b_100%)] dark:shadow-[0_4px_12px_rgba(33,29,29,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)]",
           "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
           "group-hover/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] group-focus-visible/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] dark:group-hover/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)] dark:group-focus-visible/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)]",


### PR DESCRIPTION
Use the explicit pill radius so the Ask anything launcher stays rounded under the global corner styles. Update its existing style assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class swap on the chat CTA with a matching test update; no logic or data-path changes.
> 
> **Overview**
> The **Ask anything** chat launcher surface no longer uses `rounded-full`; it now uses the **`rounded-pill`** token so the handle keeps a full pill silhouette when app-wide corner styling would otherwise flatten it.
> 
> The hover/expand behavior is unchanged. The component test now asserts `rounded-pill` on the surface instead of `rounded-full`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91fc6091c36edec8814d3529e9cfc4c1a42598d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->