### PR TITLE
Exclude unsupported Android architectures

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -187,7 +187,14 @@ jobs:
           assert apks, "No release APK was produced"
           for apk in apks:
               with ZipFile(apk) as package:
-                  for abi in ("arm64-v8a", "armeabi-v7a", "x86_64"):
+                  supported_abis = {"arm64-v8a", "armeabi-v7a", "x86_64"}
+                  packaged_abis = {
+                      name.split("/")[1]
+                      for name in package.namelist()
+                      if name.startswith("lib/") and name.endswith(".so")
+                  }
+                  assert packaged_abis == supported_abis, f"{apk}: unexpected Android architectures {sorted(packaged_abis)}"
+                  for abi in sorted(supported_abis):
                       library = package.read(f"lib/{abi}/libcloudsync.so")
                       assert b"CLOUDSYNC_CURL_TIMEOUT_MS" in library, f"{apk}: unpatched CloudSync for {abi}"
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,6 +16,7 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
+      "./app.plugin.js",
       "./modules/quick-actions/app.plugin.js",
       "expo-asset",
       "expo-dev-client",

--- a/apps/mobile/app.plugin.js
+++ b/apps/mobile/app.plugin.js
@@ -1,0 +1,17 @@
+const { withGradleProperties } = require("expo/config-plugins");
+
+module.exports = function withAnarlogAndroidArchitectures(config) {
+  return withGradleProperties(config, (config) => {
+    config.modResults = config.modResults.filter(
+      (item) =>
+        item.type !== "property" || item.key !== "reactNativeArchitectures",
+    );
+    // The bundled CloudSync library does not support 32-bit x86.
+    config.modResults.push({
+      type: "property",
+      key: "reactNativeArchitectures",
+      value: "arm64-v8a,armeabi-v7a,x86_64",
+    });
+    return config;
+  });
+};

--- a/apps/mobile/app.plugin.test.mjs
+++ b/apps/mobile/app.plugin.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync } from "node:fs";
+import test from "node:test";
+
+import withAnarlogAndroidArchitectures from "./app.plugin.js";
+
+test("packages only Android architectures with a bundled CloudSync library", async () => {
+  const vendor = new URL(
+    "../../crates/cloudsync/vendor/cloudsync/android/",
+    import.meta.url,
+  );
+  const supported = readdirSync(vendor).filter((abi) =>
+    existsSync(new URL(`${abi}/cloudsync.so`, vendor)),
+  );
+  const preserved = [
+    { type: "comment", value: "Keep project settings" },
+    { type: "property", key: "newArchEnabled", value: "true" },
+  ];
+  const config = withAnarlogAndroidArchitectures({
+    name: "Anarlog",
+    slug: "anarlog-mobile",
+  });
+  let result = {
+    ...config,
+    modRequest: {
+      platform: "android",
+      modName: "gradleProperties",
+      projectRoot: process.cwd(),
+    },
+    modResults: [
+      ...preserved,
+      {
+        type: "property",
+        key: "reactNativeArchitectures",
+        value: "x86,arm64-v8a",
+      },
+      { type: "property", key: "reactNativeArchitectures", value: "x86" },
+    ],
+  };
+  for (let pass = 0; pass < 2; pass++) {
+    result = await config.mods.android.gradleProperties(result);
+    const architectures = result.modResults.filter(
+      (item) => item.key === "reactNativeArchitectures",
+    );
+    assert.equal(architectures.length, 1);
+    assert.deepEqual(
+      architectures[0].value.split(",").sort(),
+      supported.sort(),
+    );
+    assert.deepEqual(
+      result.modResults.filter(
+        (item) => item.key !== "reactNativeArchitectures",
+      ),
+      preserved,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

**Problem:** The Android store bundle includes 32-bit x86, but CloudSync has no library for that architecture. The app therefore advertises an installable architecture that cannot open its database with CloudSync enabled.

**Fix:** Configure Expo's generated Android project to package only ARM64, ARMv7, and x86_64. Verify the configuration against the bundled libraries and reject unexpected architectures in the native CI artifact check.

## Verification

- Confirmed the completed 0.1.1 (5) AAB contains x86 native libraries without `libcloudsync.so`.
- An isolated Expo Android prebuild generated exactly `arm64-v8a,armeabi-v7a,x86_64`.
- Mobile typecheck and all 353 mobile tests passed, including preservation and idempotence coverage for the Gradle property.
- Formatting, license checks, and all 64 common workflow tests passed.
- Zizmor reported the same 410 existing findings and no new findings.
- A fresh native CI run and signed AAB build will verify the merged change before store submission.
