### PR TITLE
Start summaries while post-meeting transcription runs

### DIFF
--- a/apps/desktop/src/stt/capture-lifecycle-storage.test.ts
+++ b/apps/desktop/src/stt/capture-lifecycle-storage.test.ts
@@ -87,6 +87,32 @@ test("loads the exact durable summary recovery mode", async () => {
   );
 });
 
+test("preserves the summary refresh requirement while batch repair is pending", async () => {
+  const repairMarker = { ...marker, refreshSummaryAfterRepair: true };
+  await saveCaptureLifecycleMarker(repairMarker);
+  const statement = mocks.executeTransaction.mock.calls[0]?.[0]?.[0];
+  mocks.execute.mockResolvedValue([{ value_json: statement.params[1] }]);
+
+  await expect(loadCaptureLifecycleMarker("session-1")).resolves.toEqual(
+    repairMarker,
+  );
+});
+
+test.each([false, "true", 1, null])(
+  "ignores an invalid summary refresh flag: %s",
+  async (refreshSummaryAfterRepair) => {
+    mocks.execute.mockResolvedValue([
+      {
+        value_json: JSON.stringify({ ...marker, refreshSummaryAfterRepair }),
+      },
+    ]);
+
+    await expect(loadCaptureLifecycleMarker("session-1")).resolves.toEqual(
+      marker,
+    );
+  },
+);
+
 test("ignores malformed or mismatched capture markers", async () => {
   mocks.execute.mockResolvedValue([
     {

--- a/apps/desktop/src/stt/capture-lifecycle-storage.ts
+++ b/apps/desktop/src/stt/capture-lifecycle-storage.ts
@@ -17,6 +17,7 @@ export type CaptureLifecycleMarker = {
   provider?: string;
   model?: string;
   summaryMode?: "regenerate" | "if_empty";
+  refreshSummaryAfterRepair?: boolean;
 };
 
 export function saveCaptureLifecycleMarker(
@@ -165,6 +166,9 @@ function parseCaptureLifecycleMarker(
       ...(parsed.summaryMode === "regenerate" ||
       parsed.summaryMode === "if_empty"
         ? { summaryMode: parsed.summaryMode }
+        : {}),
+      ...(parsed.refreshSummaryAfterRepair === true
+        ? { refreshSummaryAfterRepair: true }
         : {}),
     };
   } catch {

--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -234,6 +234,8 @@ export function useCaptureLifecycle(sessionId: string) {
           shouldUseLocalBatchForSpeakerDiarization());
       const cloudsyncLeaseKey = `${sessionId}:${transcriptId}`;
       let pendingSummaryMode = recoveredMarker?.summaryMode;
+      let refreshSummaryAfterRepair =
+        recoveredMarker?.refreshSummaryAfterRepair ?? false;
       let completionTracked = false;
       let capturePhase =
         recoveredMarker?.phase ??
@@ -404,6 +406,9 @@ export function useCaptureLifecycle(sessionId: string) {
         ...(provider ? { provider } : {}),
         ...(model ? { model } : {}),
         ...(pendingSummaryMode ? { summaryMode: pendingSummaryMode } : {}),
+        ...(refreshSummaryAfterRepair
+          ? { refreshSummaryAfterRepair: true }
+          : {}),
       });
       const finalizeStoppedInner = async (
         details: Parameters<OnStoppedCallback>[1],
@@ -515,6 +520,37 @@ export function useCaptureLifecycle(sessionId: string) {
               refineSpeakerDiarization,
               transcriptWriteFailed: Boolean(transcriptWriteError),
             });
+
+        if (
+          postCaptureAction === "batch_then_enhance" &&
+          transcriptCreated &&
+          !transcriptWriteError &&
+          !recoveredMarker
+        ) {
+          try {
+            // The enhancer owns summary recovery; the capture marker must still
+            // recover the batch pass until its transcript has been saved.
+            refreshSummaryAfterRepair = true;
+            await persistTranscriptWrite(async () => {
+              await saveCaptureLifecycleMarker(await marker());
+            });
+            await flushCanonicalSessionEditorChanges(sessionId);
+            const summaryMode = preserveExistingTranscript
+              ? "regenerate"
+              : "if_empty";
+            const service = getEnhancerService();
+            if (service) {
+              await service.requestAutoEnhance(sessionId, summaryMode);
+            } else {
+              await requestMainAutoEnhance(sessionId, summaryMode);
+            }
+          } catch (error) {
+            console.warn(
+              "[listener] failed to start live transcript summary",
+              error,
+            );
+          }
+        }
 
         let batchCompleted = false;
         if (postCaptureAction === "batch_then_enhance") {
@@ -680,7 +716,9 @@ export function useCaptureLifecycle(sessionId: string) {
         if (shouldEnhance) {
           const summaryMode =
             pendingSummaryMode ??
-            (preserveExistingTranscript && (transcriptTouched || batchCompleted)
+            (refreshSummaryAfterRepair ||
+            (preserveExistingTranscript &&
+              (transcriptTouched || batchCompleted))
               ? "regenerate"
               : "if_empty");
           if (!pendingSummaryMode) {

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -2555,6 +2555,231 @@ describe("useStartListening", () => {
     consoleError.mockRestore();
   });
 
+  describe("summaries during post-stop repair", () => {
+    async function startWithLiveTranscript() {
+      const { result } = renderHook(() => useStartListening("session-1"));
+      await act(async () => {
+        await result.current();
+      });
+      const callbacks = startMock.mock.calls[0]?.[1];
+      callbacks.handlePersist({
+        new_words: [
+          {
+            id: "word-1",
+            text: "Meeting notes",
+            start_ms: 0,
+            end_ms: 100,
+            channel: 0,
+          },
+        ],
+        replaced_ids: [],
+        partials: [],
+      });
+      return callbacks;
+    }
+
+    const stoppedDetails = {
+      durationSeconds: 42,
+      audioPath: "/tmp/session.wav",
+      requestedLiveTranscription: true,
+      liveTranscriptionActive: true,
+      needsBatchRepair: true,
+    };
+
+    test.each([
+      {
+        reason: "an incomplete stream",
+        liveTranscriptionActive: true,
+        needsBatchRepair: true,
+      },
+      {
+        reason: "a disconnected stream",
+        liveTranscriptionActive: false,
+        needsBatchRepair: true,
+      },
+      {
+        reason: "speaker refinement",
+        liveTranscriptionActive: true,
+        needsBatchRepair: false,
+      },
+    ])(
+      "starts a live summary while repairing $reason, then refreshes it",
+      async (details) => {
+        useSTTConnectionMock.mockReturnValue({
+          conn: {
+            provider: "anarlog",
+            model: "cloud",
+            baseUrl: "https://api.anarlog.so/stt",
+            apiKey: "test",
+          },
+        });
+        useSessionParticipantHumanIdsMock.mockReturnValue([
+          "user-1",
+          "speaker-1",
+          "speaker-2",
+        ]);
+        let finishBatch: (() => void) | undefined;
+        runBatchMock.mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              finishBatch = resolve;
+            }),
+        );
+        const callbacks = await startWithLiveTranscript();
+        const stopped = callbacks.onStopped("session-1", {
+          ...stoppedDetails,
+          ...details,
+        });
+
+        await waitFor(() => expect(runBatchMock).toHaveBeenCalledOnce());
+        expect(requestAutoEnhanceMock.mock.calls).toEqual([
+          ["session-1", "if_empty"],
+        ]);
+        expect(flushLiveTranscriptDeltasToDatabaseMock).toHaveBeenCalledBefore(
+          requestAutoEnhanceMock,
+        );
+        expect(flushCanonicalSessionEditorChangesMock).toHaveBeenCalledBefore(
+          requestAutoEnhanceMock,
+        );
+        expect(requestAutoEnhanceMock).toHaveBeenCalledBefore(runBatchMock);
+        expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+        expect(
+          markSessionAudioTranscriptionCompleteMock,
+        ).not.toHaveBeenCalled();
+        expect(saveCaptureLifecycleMarkerMock).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            refreshSummaryAfterRepair: true,
+          }),
+        );
+        expect(
+          saveCaptureLifecycleMarkerMock.mock.calls.slice(-1)[0]?.[0]
+            .summaryMode,
+        ).toBeUndefined();
+
+        finishBatch?.();
+        await act(async () => await stopped);
+
+        expect(requestAutoEnhanceMock.mock.calls).toEqual([
+          ["session-1", "if_empty"],
+          ["session-1", "regenerate"],
+        ]);
+        expect(saveCaptureLifecycleMarkerMock).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            summaryMode: "regenerate",
+          }),
+        );
+        expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledOnce();
+      },
+    );
+
+    test.each(["upload failed", "Transcription stopped."])(
+      "keeps the first summary when repair ends with %s",
+      async (message) => {
+        const consoleError = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        runBatchMock.mockRejectedValueOnce(new Error(message));
+        const callbacks = await startWithLiveTranscript();
+
+        await act(
+          async () => await callbacks.onStopped("session-1", stoppedDetails),
+        );
+
+        expect(requestAutoEnhanceMock.mock.calls).toEqual([
+          ["session-1", "if_empty"],
+        ]);
+        expect(resetEnhanceTasksMock).not.toHaveBeenCalled();
+        expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+        expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+        expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+        expect(
+          saveCaptureLifecycleMarkerMock.mock.calls.slice(-1)[0]?.[0],
+        ).toMatchObject({
+          refreshSummaryAfterRepair: true,
+        });
+        expect(
+          saveCaptureLifecycleMarkerMock.mock.calls.slice(-1)[0]?.[0]
+            .summaryMode,
+        ).toBeUndefined();
+        consoleError.mockRestore();
+      },
+    );
+
+    test("continues repair when the first summary cannot be scheduled", async () => {
+      const consoleWarn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      requestAutoEnhanceMock.mockRejectedValueOnce(
+        new Error("summary unavailable"),
+      );
+      const callbacks = await startWithLiveTranscript();
+
+      await act(
+        async () => await callbacks.onStopped("session-1", stoppedDetails),
+      );
+
+      expect(runBatchMock).toHaveBeenCalledOnce();
+      expect(requestAutoEnhanceMock.mock.calls).toEqual([
+        ["session-1", "if_empty"],
+        ["session-1", "regenerate"],
+      ]);
+      expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledOnce();
+      expect(requestCaptureRecoveryMock).not.toHaveBeenCalled();
+      consoleWarn.mockRestore();
+    });
+
+    test("forwards both summary passes from a secondary window", async () => {
+      getEnhancerServiceMock.mockReturnValue(null);
+      const callbacks = await startWithLiveTranscript();
+
+      await act(
+        async () => await callbacks.onStopped("session-1", stoppedDetails),
+      );
+
+      expect(requestMainAutoEnhanceMock.mock.calls).toEqual([
+        ["session-1", "if_empty"],
+        ["session-1", "regenerate"],
+      ]);
+      expect(requestMainAutoEnhanceMock).toHaveBeenCalledBefore(runBatchMock);
+      expect(requestAutoEnhanceMock).not.toHaveBeenCalled();
+    });
+
+    test("refreshes the early summary after repair recovers across a reload", async () => {
+      attachLiveSessionMock.mockResolvedValue("inactive");
+      transcriptExistsMock.mockResolvedValue(true);
+      const marker = {
+        version: 1 as const,
+        sessionId: "session-1",
+        transcriptId: "transcript-before-reload",
+        startedAt: 1_000,
+        createdAt: "2026-07-24T00:00:00.000Z",
+        audioOffsetMs: 0,
+        preserveExistingTranscript: false,
+        ownerUserId: "user-1",
+        memo: "Existing memo",
+        refreshSummaryAfterRepair: true,
+      };
+      loadCaptureLifecycleMarkerMock
+        .mockResolvedValueOnce(marker)
+        .mockResolvedValueOnce(marker)
+        .mockResolvedValueOnce(null);
+      const { result } = renderHook(() =>
+        useResumeListeningLifecycle("session-1"),
+      );
+
+      await act(async () => {
+        await expect(result.current()).resolves.toBe("inactive");
+      });
+
+      expect(runBatchMock).toHaveBeenCalledOnce();
+      expect(runBatchMock).toHaveBeenCalledBefore(requestAutoEnhanceMock);
+      expect(requestAutoEnhanceMock.mock.calls).toEqual([
+        ["session-1", "regenerate"],
+      ]);
+      expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledOnce();
+    });
+  });
+
   test("coalesces live transcript deltas in arrival order", async () => {
     let resolveCreate: (() => void) | undefined;
     createLiveTranscriptMock.mockImplementationOnce(


### PR DESCRIPTION
Generate from saved live text before batch repair and refresh after repair completes. Preserve the refresh requirement across reloads and cover repair failure, cancellation, and secondary windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders post-capture summary and batch repair in capture finalization and recovery, which could affect summary timing, duplicate enhance calls, or marker state if edge cases are missed.
> 
> **Overview**
> When capture stop needs **batch_then_enhance**, the app now kicks off an **early summary** from the saved live transcript **before** post-stop batch repair runs, then **regenerates** the summary after repair finishes so notes reflect the repaired text.
> 
> A durable **`refreshSummaryAfterRepair`** flag on the capture lifecycle marker records that two-pass behavior, is validated on load (only strict `true` is kept), and survives reload so recovery can run batch first and still schedule the **regenerate** pass. Early enhance runs after transcript/editor flush; if the first enhance fails, repair still continues and the post-repair regenerate is attempted. Failed or cancelled repair keeps the first summary and leaves recovery state intact.
> 
> Tests cover marker persistence, the stop/repair ordering, repair failures, secondary-window `requestMainAutoEnhance`, and reload recovery with the flag set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee77d007ebb0f5fc55acf7150fa1f51051cb513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->