### PR TITLE
Fix Stripe deployment with workspace patches

### DIFF
--- a/apps/stripe/Dockerfile
+++ b/apps/stripe/Dockerfile
@@ -9,6 +9,7 @@ RUN corepack enable
 
 FROM node-base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches patches
 COPY apps/stripe/package.json apps/stripe/package.json
 COPY packages/supabase/package.json packages/supabase/package.json
 COPY packages/user-error/package.json packages/user-error/package.json
@@ -19,7 +20,8 @@ COPY apps/stripe apps/stripe
 COPY packages/supabase packages/supabase
 COPY packages/user-error packages/user-error
 RUN pnpm install --filter @anlg/stripe --frozen-lockfile
-RUN pnpm deploy --filter @anlg/stripe --prod --legacy /runtime
+# The filtered Stripe runtime excludes mobile-only patched dependencies.
+RUN pnpm --config.allowUnusedPatches=true deploy --filter @anlg/stripe --prod --legacy /runtime
 
 FROM oven/bun:1 AS runtime
 WORKDIR /app


### PR DESCRIPTION
Stripe Docker builds fail after the workspace adds an Expo audio patch: dependency fetch cannot find the patch, and the filtered runtime then rejects it as unused. Copy the patch directory into the build and allow unused patches only during the Stripe deploy step.

Validation: complete Docker build passed; the built image passed both error-reporting tests without network access. Stripe typecheck and 63 tests, user-error typecheck and 5 tests, formatting, 64 common Node tests, and license-boundary checks passed. Zizmor completed with 410 existing workflow findings; no workflow files changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile changes; no Stripe runtime or application logic is modified.
> 
> **Overview**
> Stripe Docker builds broke once the monorepo declared an **expo-audio** patch in `pnpm-workspace.yaml`: the image never copied `patches/`, so `pnpm fetch` could not resolve patch files, and a filtered `pnpm deploy` for `@anlg/stripe` then failed because that runtime does not include the mobile-only patched dependency.
> 
> The Dockerfile now **copies `patches` into the deps stage** and runs deploy with **`--config.allowUnusedPatches=true`**, scoped to the Stripe deploy step so unused mobile patches are tolerated without changing what ships in the Stripe runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e464abf64bf1535c0cd41d8e226d321322cff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->