### PR TITLE
Fix local provider requests rejected by origin checks

### DIFF
--- a/apps/desktop/src/ai/hooks/useLLMConnection.test.ts
+++ b/apps/desktop/src/ai/hooks/useLLMConnection.test.ts
@@ -1,6 +1,88 @@
-import { describe, expect, it } from "vitest";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { renderHook } from "@testing-library/react";
+import { generateText, streamText } from "ai";
+import { describe, expect, it, vi } from "vitest";
 
-import { normalizeLLMProviderId } from "./useLLMConnection";
+import { normalizeLLMProviderId, useLanguageModel } from "./useLLMConnection";
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: vi.fn() }));
+vi.mock("~/auth", () => ({ useAuth: () => ({ session: null }) }));
+vi.mock("~/auth/billing-context", () => ({
+  useBillingAccess: () => ({ isPaid: false }),
+}));
+vi.mock("~/settings/providers", () => ({
+  useAiProvider: () => ({
+    type: "llm",
+    base_url: "http://127.0.0.1:8000/v1",
+    api_key: "local-key",
+  }),
+}));
+vi.mock("~/shared/config", () => ({
+  useConfigValues: () => ({
+    current_llm_provider: "custom",
+    current_llm_model: "mtplx",
+    current_llm_reasoning_effort: "default",
+  }),
+}));
+
+it.each([false, true])(
+  "generates through Custom with an origin-restricted local server (stream: %s)",
+  async (stream) => {
+    vi.mocked(tauriFetch).mockImplementation(async (input, init) => {
+      const headers = new Headers(init?.headers);
+      if (headers.get("Origin") !== "")
+        return new Response(null, { status: 403 });
+      if (headers.get("Authorization") !== "Bearer local-key")
+        return new Response(null, { status: 401 });
+      expect(String(input)).toBe("http://127.0.0.1:8000/v1/chat/completions");
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe("mtplx");
+      if (body.stream) {
+        const chunk = {
+          id: "local-completion",
+          model: "mtplx",
+          created: 0,
+          choices: [
+            {
+              index: 0,
+              delta: { content: "Local summary" },
+              finish_reason: "stop",
+            },
+          ],
+        };
+        return new Response(
+          `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return Response.json({
+        id: "local-completion",
+        model: "mtplx",
+        created: 0,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "Local summary" },
+            finish_reason: "stop",
+          },
+        ],
+      });
+    });
+
+    const { result, unmount } = renderHook(() => useLanguageModel());
+    expect(result.current).not.toBeNull();
+    const options = {
+      model: result.current!,
+      prompt: "Summarize the meeting",
+      maxRetries: 0,
+    };
+    const completion = stream
+      ? streamText(options)
+      : await generateText(options);
+    expect(await completion.text).toBe("Local summary");
+    unmount();
+  },
+);
 
 describe("normalizeLLMProviderId", () => {
   it("maps the legacy hosted provider id to Anarlog", () => {

--- a/apps/desktop/src/ai/hooks/useLLMConnection.ts
+++ b/apps/desktop/src/ai/hooks/useLLMConnection.ts
@@ -4,7 +4,6 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import {
   defaultSettingsMiddleware,
   extractReasoningMiddleware,
@@ -17,6 +16,7 @@ import type { AIProviderStorage } from "@anlg/store";
 
 import { createAppleFoundationModel } from "../apple-foundation-model";
 import { createAuthFetch } from "../auth-fetch";
+import { providerFetch } from "../provider-fetch";
 import {
   normalizeReasoningEffort,
   type ReasoningEffort,
@@ -305,7 +305,7 @@ const createProviderModel = (
 
     case "anthropic": {
       const provider = createAnthropic({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         apiKey: conn.apiKey,
         headers: {
           "anthropic-version": "2023-06-01",
@@ -320,7 +320,7 @@ const createProviderModel = (
       const provider = createAnthropic({
         fetch: oauth
           ? createSubscriptionFetch(conn.providerId, conn.apiKey)
-          : tauriFetch,
+          : providerFetch,
         apiKey: oauth ? "oauth" : conn.apiKey,
         headers: {
           "anthropic-version": "2023-06-01",
@@ -335,7 +335,7 @@ const createProviderModel = (
       const provider = createOpenAI({
         fetch: oauth
           ? createSubscriptionFetch(conn.providerId, conn.apiKey)
-          : tauriFetch,
+          : providerFetch,
         baseURL: oauth ? CHATGPT_API_BASE_URL : conn.baseUrl,
         apiKey: oauth ? "oauth" : conn.apiKey,
       });
@@ -363,7 +363,7 @@ const createProviderModel = (
 
     case "google_generative_ai": {
       const provider = createGoogleGenerativeAI({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -372,7 +372,7 @@ const createProviderModel = (
 
     case "openrouter": {
       const provider = createOpenRouter({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         apiKey: conn.apiKey,
       });
       return wrapWithThinkingMiddleware(provider.chat(conn.modelId));
@@ -380,7 +380,7 @@ const createProviderModel = (
 
     case "openai": {
       const provider = createOpenAI({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -389,7 +389,7 @@ const createProviderModel = (
 
     case "azure_openai": {
       const provider = createAzure({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
       });
@@ -398,7 +398,7 @@ const createProviderModel = (
 
     case "azure_ai": {
       const provider = createOpenAICompatible({
-        fetch: tauriFetch,
+        fetch: providerFetch,
         name: "azure_ai",
         baseURL: conn.baseUrl,
         apiKey: conn.apiKey,
@@ -412,7 +412,7 @@ const createProviderModel = (
       const ollamaFetch: typeof fetch = async (input, init) => {
         const headers = new Headers(init?.headers);
         headers.set("Origin", ollamaOrigin);
-        return tauriFetch(input as RequestInfo | URL, {
+        return providerFetch(input as RequestInfo | URL, {
           ...init,
           headers,
         });
@@ -430,7 +430,7 @@ const createProviderModel = (
 
     default: {
       const config: Parameters<typeof createOpenAICompatible>[0] = {
-        fetch: tauriFetch,
+        fetch: providerFetch,
         name: conn.providerId,
         baseURL: conn.baseUrl,
       };

--- a/apps/desktop/src/ai/provider-fetch.test.ts
+++ b/apps/desktop/src/ai/provider-fetch.test.ts
@@ -1,0 +1,134 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { verifyProviderCredentials } from "@anlg/provider-validation";
+
+import { providerFetch } from "./provider-fetch";
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(tauriFetch).mockReset();
+  vi.mocked(tauriFetch).mockResolvedValue(Response.json({ data: [] }));
+});
+
+describe("providerFetch", () => {
+  it.each([
+    "http://localhost:8000/v1/models",
+    "http://127.0.0.1:8000/v1/models",
+    "http://[::1]:8000/v1/models",
+    "https://localhost:8000/v1/models",
+  ])(
+    "suppresses the injected origin for %s without changing credentials",
+    async (url) => {
+      const controller = new AbortController();
+      const headers = { Authorization: "Bearer local-key" };
+      const init = {
+        headers,
+        signal: controller.signal,
+        redirect: "error" as const,
+      };
+
+      await providerFetch(url, init);
+
+      const sent = vi.mocked(tauriFetch).mock.calls[0][1];
+      expect(new Headers(sent?.headers).get("Origin")).toBe("");
+      expect(new Headers(sent?.headers).get("Authorization")).toBe(
+        "Bearer local-key",
+      );
+      expect(sent?.signal).toBe(controller.signal);
+      expect(sent?.redirect).toBe("error");
+      expect(init.headers).toEqual({ Authorization: "Bearer local-key" });
+    },
+  );
+
+  it("preserves a Request's headers and body and honors init header overrides", async () => {
+    const request = new Request("http://127.0.0.1:8000/v1/chat/completions", {
+      method: "POST",
+      headers: { Authorization: "Bearer original-key" },
+      body: '{"model":"mtplx"}',
+    });
+    await providerFetch(request);
+    const [input, init] = vi.mocked(tauriFetch).mock.calls[0];
+    expect(input).toBe(request);
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer original-key",
+    );
+    expect(new Headers(init?.headers).get("Origin")).toBe("");
+    expect(await request.clone().text()).toBe('{"model":"mtplx"}');
+
+    await providerFetch(request, {
+      headers: { Authorization: "Bearer replacement-key" },
+    });
+    expect(
+      new Headers(vi.mocked(tauriFetch).mock.calls[1][1]?.headers).get(
+        "Authorization",
+      ),
+    ).toBe("Bearer replacement-key");
+  });
+
+  it("preserves an explicitly configured provider origin", async () => {
+    const url = new URL("http://localhost:11434/v1/chat/completions");
+    const init = { headers: { Origin: "http://localhost:11434" } };
+    await providerFetch(url, init);
+    expect(tauriFetch).toHaveBeenCalledWith(url, init);
+    expect(vi.mocked(tauriFetch).mock.calls[0][1]).toBe(init);
+  });
+
+  it.each([
+    "https://api.openai.com/v1/models",
+    "http://192.168.1.10:8000/v1/models",
+    "https://localhost.example.com/v1/models",
+    "https://127.0.0.1.example.com/v1/models",
+  ])("leaves other endpoints unchanged: %s", async (url) => {
+    const init = { headers: { Authorization: "Bearer remote-key" } };
+    await providerFetch(url, init);
+    expect(vi.mocked(tauriFetch).mock.calls[0]).toEqual([url, init]);
+    expect(vi.mocked(tauriFetch).mock.calls[0][1]).toBe(init);
+  });
+
+  it.each(["custom", "openai"])(
+    "verifies %s against an origin-restricted local endpoint and still rejects invalid keys",
+    async (provider) => {
+      vi.mocked(tauriFetch).mockImplementation(async (_input, init) => {
+        const headers = new Headers(init?.headers);
+        if (headers.get("Origin") !== "") {
+          return Response.json(
+            { error: { type: "origin_error" } },
+            { status: 403 },
+          );
+        }
+        return headers.get("Authorization") === "Bearer local-key"
+          ? Response.json({ data: [{ id: "mtplx" }] })
+          : Response.json(
+              { error: { type: "authentication_error" } },
+              { status: 401 },
+            );
+      });
+      const credential = {
+        provider,
+        baseUrl: "http://127.0.0.1:8000/v1",
+        apiKey: "local-key",
+      };
+      await expect(
+        verifyProviderCredentials(credential, providerFetch),
+      ).resolves.toBeUndefined();
+      expect(
+        vi
+          .mocked(tauriFetch)
+          .mock.calls.map(([, init]) =>
+            new Headers(init?.headers).get("Authorization"),
+          ),
+      ).toEqual([
+        "Bearer local-key",
+        "Bearer anarlog-invalid-key-verification",
+      ]);
+      await expect(
+        verifyProviderCredentials(
+          { ...credential, apiKey: "wrong-key" },
+          providerFetch,
+        ),
+      ).rejects.toThrow("The provider rejected this key");
+    },
+  );
+});

--- a/apps/desktop/src/ai/provider-fetch.ts
+++ b/apps/desktop/src/ai/provider-fetch.ts
@@ -1,0 +1,21 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+
+export const providerFetch: typeof fetch = (input, init) => {
+  const url = new URL(input instanceof Request ? input.url : input);
+  if (
+    (url.protocol === "http:" || url.protocol === "https:") &&
+    ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)
+  ) {
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    if (!headers.has("Origin")) {
+      // Tauri's unsafe-headers transport removes an empty Origin instead of
+      // injecting the webview origin, which local servers can reject.
+      headers.set("Origin", "");
+      return tauriFetch(input, { ...init, headers });
+    }
+  }
+
+  return tauriFetch(input, init);
+};

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -1,7 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { type AnyFieldApi, useForm } from "@tanstack/react-form";
 import { useMutation, useQueries } from "@tanstack/react-query";
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { type ComponentType, type ReactNode, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
 
@@ -44,6 +43,7 @@ import {
 } from "./eligibility";
 import { useProviderSelectionPrompt } from "./provider-selection-prompt";
 
+import { providerFetch } from "~/ai/provider-fetch";
 import { useBillingAccess } from "~/auth/billing-context";
 import {
   isKeychainAccessError,
@@ -256,7 +256,7 @@ export function useProviderAvailability(
         try {
           await verifyProviderCredentials(
             { provider: provider.id, baseUrl, apiKey },
-            tauriFetch,
+            providerFetch,
             signal,
           );
         } catch (error) {

--- a/apps/desktop/src/settings/ai/shared/list-common.ts
+++ b/apps/desktop/src/settings/ai/shared/list-common.ts
@@ -1,7 +1,8 @@
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { Effect } from "effect";
 
 import { modelName } from "./model-id";
+
+import { providerFetch } from "~/ai/provider-fetch";
 
 export type ModelIgnoreReason =
   | "common_keyword"
@@ -103,7 +104,7 @@ const modelPriorityPatterns = [
 export const fetchJson = (url: string, headers: Record<string, string>) =>
   Effect.tryPromise({
     try: async () => {
-      const r = await tauriFetch(url, { method: "GET", headers });
+      const r = await providerFetch(url, { method: "GET", headers });
       if (!r.ok) {
         const errorBody = await readResponseTextWithLimit(
           r,

--- a/apps/desktop/src/settings/ai/shared/list-openai.test.ts
+++ b/apps/desktop/src/settings/ai/shared/list-openai.test.ts
@@ -1,6 +1,28 @@
-import { describe, expect, test } from "vitest";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { describe, expect, test, vi } from "vitest";
 
-import { processGenericModels } from "./list-openai";
+import { listGenericModels, processGenericModels } from "./list-openai";
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: vi.fn() }));
+
+test("discovers models from an authenticated local provider that rejects foreign origins", async () => {
+  vi.mocked(tauriFetch).mockImplementation(async (_input, init) => {
+    const headers = new Headers(init?.headers);
+    if (headers.get("Origin") !== "")
+      return new Response(null, { status: 403 });
+    if (headers.get("Authorization") !== "Bearer local-key")
+      return new Response(null, { status: 401 });
+    return Response.json({
+      data: [{ id: "mtplx-qwen38-27b-optimized-quality" }],
+    });
+  });
+
+  const result = await listGenericModels(
+    "http://127.0.0.1:8000/v1",
+    "local-key",
+  );
+  expect(result.models).toEqual(["mtplx-qwen38-27b-optimized-quality"]);
+});
 
 describe("processGenericModels", () => {
   test("keeps Cohere model versions while still filtering non-chat models", () => {

--- a/apps/desktop/src/settings/ai/shared/provider-availability.test.tsx
+++ b/apps/desktop/src/settings/ai/shared/provider-availability.test.tsx
@@ -27,6 +27,23 @@ beforeEach(() => {
 });
 afterEach(cleanup);
 
+test("makes an authenticated local provider available despite its origin restriction", async () => {
+  mocks.baseUrl = "http://127.0.0.1:8000/v1";
+  mocks.fetch.mockImplementation(async (_input, init) => {
+    const headers = new Headers(init?.headers);
+    if (headers.get("Origin") !== "")
+      return new Response(null, { status: 403 });
+    return headers.get("Authorization") === `Bearer saved-key-${mocks.key}`
+      ? Response.json({ data: [{ id: "mtplx" }] })
+      : new Response(null, { status: 401 });
+  });
+
+  const { result, client, unmount } = setup("llm");
+  await waitFor(() => expect(result.current.openai).toBe(true));
+  unmount();
+  client.clear();
+});
+
 test.each([
   "http://192.168.1.10/v1",
   "https://provider.test/v1?key=invalid",

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -5,7 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   execute: vi.fn(),
-  verify: vi.fn(async () => {}),
+  verify: vi.fn<
+    typeof import("@anlg/provider-validation").verifyProviderCredentials
+  >(async () => {}),
+  fetch: vi.fn(),
   useLiveQuery: vi.fn(),
   getSecret: vi.fn(async () => ({
     status: "ok",
@@ -23,6 +26,8 @@ const mocks = vi.hoisted(() => ({
       Promise.resolve([1]),
   ),
 }));
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: mocks.fetch }));
 
 vi.mock("@anlg/provider-validation", () => ({
   verifyProviderCredentials: mocks.verify,
@@ -114,6 +119,46 @@ describe("SQLite AI providers", () => {
     });
     expect(mocks.verify).not.toHaveBeenCalled();
     expect(mocks.setSecret).toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it("saves a valid local provider and rejects an invalid replacement when the server restricts origins", async () => {
+    const { verifyProviderCredentials } = await vi.importActual<
+      typeof import("@anlg/provider-validation")
+    >("@anlg/provider-validation");
+    mocks.verify.mockImplementation(verifyProviderCredentials);
+    mocks.execute.mockResolvedValue([]);
+    mocks.fetch.mockImplementation(async (_input, init) => {
+      const headers = new Headers(init?.headers);
+      if (headers.get("Origin") !== "")
+        return new Response(null, { status: 403 });
+      return headers.get("Authorization") === "Bearer local-key"
+        ? Response.json({ data: [{ id: "mtplx" }] })
+        : new Response(null, { status: 401 });
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result, unmount } = renderHook(
+      () => useSetAiProvider("llm", "custom", { verifyCredentials: true }),
+      { wrapper },
+    );
+    const draft = {
+      base_url: "http://127.0.0.1:8000/v1",
+      api_key: "local-key",
+    };
+
+    await result.current.mutateAsync(draft);
+    expect(mocks.setSecret).toHaveBeenCalledOnce();
+    expect(mocks.executeTransaction).toHaveBeenCalledOnce();
+    await expect(
+      result.current.mutateAsync({ ...draft, api_key: "wrong-key" }),
+    ).rejects.toThrow("The provider rejected this key");
+    expect(mocks.setSecret).toHaveBeenCalledOnce();
+    expect(mocks.executeTransaction).toHaveBeenCalledOnce();
+    unmount();
     queryClient.clear();
   });
 

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { useMemo } from "react";
 
 import { commands as store2Commands } from "@anlg/plugin-store2";
 import { verifyProviderCredentials } from "@anlg/provider-validation";
 
+import { providerFetch } from "~/ai/provider-fetch";
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 
@@ -227,7 +227,7 @@ export function useSetAiProvider(
             baseUrl,
             apiKey,
           },
-          tauriFetch,
+          providerFetch,
         );
         changes = { ...changes, base_url: baseUrl, api_key: apiKey };
       }


### PR DESCRIPTION
Suppress the injected Tauri origin for loopback provider verification, model discovery, and generation. Preserve credentials and explicit origins, with regression coverage for saving, availability, and streaming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped HTTP header behavior for loopback hosts only; remote providers and explicit Origins are untouched, with broad test coverage.
> 
> **Overview**
> Fixes **local LLM providers** (custom/OpenAI-compatible on `localhost` / `127.0.0.1` / `[::1]`) that **403 on non-empty `Origin`** when called from the Tauri webview.
> 
> Introduces **`providerFetch`**, a thin wrapper around Tauri HTTP that sets **`Origin: ""`** on loopback URLs when no `Origin` is already present (so Tauri drops the header instead of injecting the app origin). **Explicit `Origin` headers** (e.g. Ollama) and **remote endpoints** are unchanged; auth and other headers are preserved.
> 
> **`useLLMConnection`** and settings flows (**credential verification**, **provider availability**, **model discovery**) now route provider traffic through `providerFetch` instead of raw `tauriFetch`. Regression tests cover streaming/non-streaming generation, saving keys, availability, and model listing against origin-restricted local servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20e4cadfc9beed7c024da1003e63d4af8733534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->