### PR TITLE
fix/workspace-share-proxy-host

### DIFF
--- a/apps/web/src/cloudflare/workspace-share-router.test.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.test.ts
@@ -34,6 +34,7 @@ test("routes a workspace hostname to Netlify with its original host", async () =
     "fastrepl.anarlog.so",
   );
   assert.equal(originRequest?.headers.get("cookie"), "session=secret");
+  assert.equal(originRequest?.redirect, "manual");
 
   const netlifyHeaders = new Headers(originRequest?.headers);
   netlifyHeaders.set("host", "anarlog.netlify.app");

--- a/apps/web/src/cloudflare/workspace-share-router.test.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { getWorkspaceShareSlugFromHeaders } from "../lib/request-workspace-share-host.ts";
 import { createWorkspaceShareOriginRequest } from "./workspace-share-router.ts";
 
 test("routes a workspace hostname to Netlify with its original host", async () => {
@@ -10,6 +11,7 @@ test("routes a workspace hostname to Netlify with its original host", async () =
       headers: {
         cookie: "session=secret",
         "x-forwarded-host": "spoofed.example.com",
+        "x-anarlog-workspace-share-host": "another-workspace.anarlog.so",
       },
     },
   );
@@ -26,6 +28,11 @@ test("routes a workspace hostname to Netlify with its original host", async () =
     "fastrepl.anarlog.so",
   );
   assert.equal(originRequest?.headers.get("cookie"), "session=secret");
+
+  const netlifyHeaders = new Headers(originRequest?.headers);
+  netlifyHeaders.set("host", "anarlog.netlify.app");
+  netlifyHeaders.set("x-forwarded-host", "anarlog.netlify.app");
+  assert.equal(getWorkspaceShareSlugFromHeaders(netlifyHeaders), "fastrepl");
 });
 
 test("does not route reserved or malformed workspace hostnames", () => {

--- a/apps/web/src/cloudflare/workspace-share-router.test.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { getWorkspaceShareSlugFromHeaders } from "../lib/request-workspace-share-host.ts";
-import { createWorkspaceShareOriginRequest } from "./workspace-share-router.ts";
+import worker, {
+  createWorkspaceShareOriginRequest,
+} from "./workspace-share-router.ts";
 
 test("routes a workspace hostname to Netlify with its original host", async () => {
   const request = new Request(
@@ -12,11 +14,15 @@ test("routes a workspace hostname to Netlify with its original host", async () =
         cookie: "session=secret",
         "x-forwarded-host": "spoofed.example.com",
         "x-anarlog-workspace-share-host": "another-workspace.anarlog.so",
+        "x-anarlog-workspace-share-token": "spoofed-token",
       },
     },
   );
 
-  const originRequest = createWorkspaceShareOriginRequest(request);
+  const originRequest = createWorkspaceShareOriginRequest(
+    request,
+    "test-secret",
+  );
 
   assert.notEqual(originRequest, null);
   assert.equal(
@@ -32,20 +38,61 @@ test("routes a workspace hostname to Netlify with its original host", async () =
   const netlifyHeaders = new Headers(originRequest?.headers);
   netlifyHeaders.set("host", "anarlog.netlify.app");
   netlifyHeaders.set("x-forwarded-host", "anarlog.netlify.app");
-  assert.equal(getWorkspaceShareSlugFromHeaders(netlifyHeaders), "fastrepl");
+  assert.equal(
+    getWorkspaceShareSlugFromHeaders(netlifyHeaders, "test-secret"),
+    "fastrepl",
+  );
 });
 
 test("does not route reserved or malformed workspace hostnames", () => {
   assert.equal(
     createWorkspaceShareOriginRequest(
       new Request("https://models.anarlog.so/model.bin"),
+      "test-secret",
     ),
     null,
   );
   assert.equal(
     createWorkspaceShareOriginRequest(
       new Request("https://nested.fastrepl.anarlog.so/share/note"),
+      "test-secret",
     ),
     null,
   );
+});
+
+test("rejects workspace requests when the proxy secret is missing", async () => {
+  const response = await worker.fetch(
+    new Request("https://fastrepl.anarlog.so/app/"),
+    {},
+  );
+  assert.equal(response.status, 503);
+});
+
+test("removes workspace proxy headers when passing through platform hosts", async (t) => {
+  const fetchMock = t.mock.method(
+    globalThis,
+    "fetch",
+    async (request: Request) => {
+      assert.equal(request.headers.get("x-anarlog-workspace-share-host"), null);
+      assert.equal(
+        request.headers.get("x-anarlog-workspace-share-token"),
+        null,
+      );
+      return new Response("ok");
+    },
+  );
+
+  const response = await worker.fetch(
+    new Request("https://api.anarlog.so/health", {
+      headers: {
+        "x-anarlog-workspace-share-host": "fastrepl.anarlog.so",
+        "x-anarlog-workspace-share-token": "spoofed-token",
+      },
+    }),
+    { WORKSPACE_SHARE_PROXY_SECRET: "test-secret" },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(fetchMock.mock.callCount(), 1);
 });

--- a/apps/web/src/cloudflare/workspace-share-router.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.ts
@@ -20,7 +20,9 @@ export const createWorkspaceShareOriginRequest = (
     incomingUrl.pathname + incomingUrl.search,
     APP_ORIGIN,
   );
-  const originRequest = new Request(originUrl, request);
+  const originRequest = new Request(new Request(originUrl, request), {
+    redirect: "manual",
+  });
   // Netlify replaces x-forwarded-host with the origin hostname.
   originRequest.headers.set("x-anarlog-workspace-share-host", incomingUrl.host);
   originRequest.headers.set("x-anarlog-workspace-share-token", proxySecret);

--- a/apps/web/src/cloudflare/workspace-share-router.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.ts
@@ -9,7 +9,10 @@ const PLATFORM_HOSTS = new Set([
   "www.anarlog.so",
 ]);
 
-export const createWorkspaceShareOriginRequest = (request: Request) => {
+export const createWorkspaceShareOriginRequest = (
+  request: Request,
+  proxySecret: string,
+) => {
   const incomingUrl = new URL(request.url);
   if (getWorkspaceShareSlug(incomingUrl.hostname) === null) return null;
 
@@ -20,24 +23,40 @@ export const createWorkspaceShareOriginRequest = (request: Request) => {
   const originRequest = new Request(originUrl, request);
   // Netlify replaces x-forwarded-host with the origin hostname.
   originRequest.headers.set("x-anarlog-workspace-share-host", incomingUrl.host);
+  originRequest.headers.set("x-anarlog-workspace-share-token", proxySecret);
   originRequest.headers.set("x-forwarded-host", incomingUrl.host);
   originRequest.headers.set("x-forwarded-proto", "https");
   return originRequest;
 };
 
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: { WORKSPACE_SHARE_PROXY_SECRET?: string },
+  ): Promise<Response> {
     const incomingUrl = new URL(request.url);
-    const originRequest = createWorkspaceShareOriginRequest(request);
+    const originRequest = createWorkspaceShareOriginRequest(
+      request,
+      env.WORKSPACE_SHARE_PROXY_SECRET ?? "",
+    );
 
     if (originRequest === null) {
-      if (PLATFORM_HOSTS.has(incomingUrl.hostname)) return fetch(request);
+      if (PLATFORM_HOSTS.has(incomingUrl.hostname)) {
+        const platformRequest = new Request(request);
+        platformRequest.headers.delete("x-anarlog-workspace-share-host");
+        platformRequest.headers.delete("x-anarlog-workspace-share-token");
+        return fetch(platformRequest);
+      }
       return new Response("Not found", { status: 404 });
     }
 
     if (incomingUrl.protocol !== "https:") {
       incomingUrl.protocol = "https:";
       return Response.redirect(incomingUrl, 308);
+    }
+
+    if (!env.WORKSPACE_SHARE_PROXY_SECRET) {
+      return new Response("Sharing domain unavailable", { status: 503 });
     }
 
     return fetch(originRequest);

--- a/apps/web/src/cloudflare/workspace-share-router.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.ts
@@ -18,6 +18,8 @@ export const createWorkspaceShareOriginRequest = (request: Request) => {
     APP_ORIGIN,
   );
   const originRequest = new Request(originUrl, request);
+  // Netlify replaces x-forwarded-host with the origin hostname.
+  originRequest.headers.set("x-anarlog-workspace-share-host", incomingUrl.host);
   originRequest.headers.set("x-forwarded-host", incomingUrl.host);
   originRequest.headers.set("x-forwarded-proto", "https");
   return originRequest;

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -21,6 +21,7 @@ export const env = createEnv({
     SUPABASE_URL: requiredInProd(z.string().min(1)),
     SUPABASE_ANON_KEY: requiredInProd(z.string().min(1)),
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
+    WORKSPACE_SHARE_PROXY_SECRET: z.string().min(1).optional(),
 
     STRIPE_SECRET_KEY: requiredInProd(z.string().min(1)),
     STRIPE_MONTHLY_PRICE_ID: requiredInProd(z.string().min(1)),

--- a/apps/web/src/functions/app-origin.ts
+++ b/apps/web/src/functions/app-origin.ts
@@ -10,7 +10,7 @@ const LOCAL_APP_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 export const getRequestAppOrigin = () => {
   const headers = getRequestHeaders();
-  const host = getRequestHost(headers);
+  const host = getRequestHost(headers, env.WORKSPACE_SHARE_PROXY_SECRET);
 
   if (!host) {
     return env.VITE_APP_URL;

--- a/apps/web/src/functions/app-origin.ts
+++ b/apps/web/src/functions/app-origin.ts
@@ -1,23 +1,16 @@
 import { getRequestHeaders } from "@tanstack/react-start/server";
 
 import { env } from "@/env";
+import { getRequestHost } from "@/lib/request-workspace-share-host";
 import { isWorkspaceShareHostname } from "@/lib/workspace-share-host";
 
 const PUBLIC_APP_HOSTS = new Set(["anarlog.so", "www.anarlog.so"]);
 
 const LOCAL_APP_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
-const firstHeaderValue = (value: string | null) =>
-  value
-    ?.split(",")
-    .map((part) => part.trim())
-    .find(Boolean);
-
 export const getRequestAppOrigin = () => {
   const headers = getRequestHeaders();
-  const host =
-    firstHeaderValue(headers.get("x-forwarded-host")) ??
-    firstHeaderValue(headers.get("host"));
+  const host = getRequestHost(headers);
 
   if (!host) {
     return env.VITE_APP_URL;

--- a/apps/web/src/lib/request-workspace-share-host.test.ts
+++ b/apps/web/src/lib/request-workspace-share-host.test.ts
@@ -1,7 +1,21 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getWorkspaceShareSlugFromHeaders } from "./request-workspace-share-host.ts";
+import {
+  getRequestHost,
+  getWorkspaceShareSlugFromHeaders,
+} from "./request-workspace-share-host.ts";
+
+test("preserves the workspace host when Netlify replaces forwarded headers", () => {
+  const headers = new Headers({
+    host: "anarlog.netlify.app",
+    "x-forwarded-host": "anarlog.netlify.app",
+    "x-anarlog-workspace-share-host": "fastrepl.anarlog.so",
+  });
+
+  assert.equal(getRequestHost(headers), "fastrepl.anarlog.so");
+  assert.equal(getWorkspaceShareSlugFromHeaders(headers), "fastrepl");
+});
 
 test("reads the workspace slug from the Cloudflare forwarded host", () => {
   const headers = new Headers({

--- a/apps/web/src/lib/request-workspace-share-host.test.ts
+++ b/apps/web/src/lib/request-workspace-share-host.test.ts
@@ -11,10 +11,39 @@ test("preserves the workspace host when Netlify replaces forwarded headers", () 
     host: "anarlog.netlify.app",
     "x-forwarded-host": "anarlog.netlify.app",
     "x-anarlog-workspace-share-host": "fastrepl.anarlog.so",
+    "x-anarlog-workspace-share-token": "test-secret",
   });
 
-  assert.equal(getRequestHost(headers), "fastrepl.anarlog.so");
-  assert.equal(getWorkspaceShareSlugFromHeaders(headers), "fastrepl");
+  assert.equal(getRequestHost(headers, "test-secret"), "fastrepl.anarlog.so");
+  assert.equal(
+    getWorkspaceShareSlugFromHeaders(headers, "test-secret"),
+    "fastrepl",
+  );
+});
+
+test("ignores workspace headers without the configured proxy secret", () => {
+  for (const host of ["anarlog.so", "www.anarlog.so", "anarlog.netlify.app"]) {
+    for (const token of [undefined, "wrong-secret"]) {
+      const headers = new Headers({
+        host,
+        "x-forwarded-host": host,
+        "x-anarlog-workspace-share-host": "fastrepl.anarlog.so",
+      });
+      if (token) headers.set("x-anarlog-workspace-share-token", token);
+      assert.equal(getRequestHost(headers, "test-secret"), host);
+      assert.equal(
+        getWorkspaceShareSlugFromHeaders(headers, "test-secret"),
+        null,
+      );
+    }
+  }
+
+  const headers = new Headers({
+    host: "anarlog.so",
+    "x-anarlog-workspace-share-host": "fastrepl.anarlog.so",
+    "x-anarlog-workspace-share-token": "test-secret",
+  });
+  assert.equal(getRequestHost(headers), "anarlog.so");
 });
 
 test("reads the workspace slug from the Cloudflare forwarded host", () => {

--- a/apps/web/src/lib/request-workspace-share-host.ts
+++ b/apps/web/src/lib/request-workspace-share-host.ts
@@ -6,10 +6,13 @@ const firstHeaderValue = (value: string | null) =>
     .map((part) => part.trim())
     .find(Boolean);
 
+export const getRequestHost = (headers: Headers) =>
+  firstHeaderValue(headers.get("x-anarlog-workspace-share-host")) ??
+  firstHeaderValue(headers.get("x-forwarded-host")) ??
+  firstHeaderValue(headers.get("host"));
+
 export const getWorkspaceShareSlugFromHeaders = (headers: Headers) => {
-  const host =
-    firstHeaderValue(headers.get("x-forwarded-host")) ??
-    firstHeaderValue(headers.get("host"));
+  const host = getRequestHost(headers);
   if (!host) return null;
 
   try {

--- a/apps/web/src/lib/request-workspace-share-host.ts
+++ b/apps/web/src/lib/request-workspace-share-host.ts
@@ -6,13 +6,25 @@ const firstHeaderValue = (value: string | null) =>
     .map((part) => part.trim())
     .find(Boolean);
 
-export const getRequestHost = (headers: Headers) =>
-  firstHeaderValue(headers.get("x-anarlog-workspace-share-host")) ??
-  firstHeaderValue(headers.get("x-forwarded-host")) ??
-  firstHeaderValue(headers.get("host"));
+export const getRequestHost = (headers: Headers, proxySecret?: string) => {
+  if (
+    proxySecret &&
+    headers.get("x-anarlog-workspace-share-token") === proxySecret
+  ) {
+    return firstHeaderValue(headers.get("x-anarlog-workspace-share-host"));
+  }
 
-export const getWorkspaceShareSlugFromHeaders = (headers: Headers) => {
-  const host = getRequestHost(headers);
+  return (
+    firstHeaderValue(headers.get("x-forwarded-host")) ??
+    firstHeaderValue(headers.get("host"))
+  );
+};
+
+export const getWorkspaceShareSlugFromHeaders = (
+  headers: Headers,
+  proxySecret?: string,
+) => {
+  const host = getRequestHost(headers, proxySecret);
   if (!host) return null;
 
   try {

--- a/apps/web/src/middleware/workspace-share-host.ts
+++ b/apps/web/src/middleware/workspace-share-host.ts
@@ -1,12 +1,16 @@
 import { createMiddleware } from "@tanstack/react-start";
 
+import { env } from "../env";
 import { getSupabasePublicServerClient } from "../functions/supabase";
 import { getWorkspaceShareSlugFromHeaders } from "../lib/request-workspace-share-host";
 
 export const workspaceShareHostMiddleware = createMiddleware({
   type: "request",
 }).server(async ({ next, request }) => {
-  const slug = getWorkspaceShareSlugFromHeaders(request.headers);
+  const slug = getWorkspaceShareSlugFromHeaders(
+    request.headers,
+    env.WORKSPACE_SHARE_PROXY_SECRET,
+  );
   if (slug === null) return next();
 
   const { data, error } = await getSupabasePublicServerClient().rpc(

--- a/apps/web/wrangler.workspace-share.jsonc
+++ b/apps/web/wrangler.workspace-share.jsonc
@@ -4,6 +4,7 @@
   "main": "src/cloudflare/workspace-share-router.ts",
   "compatibility_date": "2026-08-04",
   "workers_dev": false,
+  // Set WORKSPACE_SHARE_PROXY_SECRET in this Worker and Netlify Functions.
   "routes": [
     {
       "pattern": "*.anarlog.so/*",

--- a/apps/web/wrangler.workspace-share.jsonc
+++ b/apps/web/wrangler.workspace-share.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "anarlog-workspace-share-router",
   "main": "src/cloudflare/workspace-share-router.ts",
-  "compatibility_date": "2026-09-04",
+  "compatibility_date": "2026-08-04",
   "workers_dev": false,
   "routes": [
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request host resolution and adds a shared-secret trust boundary for workspace sharing; misconfiguration could break shares or weaken spoofing protections on platform routes.
> 
> **Overview**
> Fixes workspace share subdomain routing when Cloudflare forwards to Netlify, which overwrites `x-forwarded-host` with the Netlify origin.
> 
> The Cloudflare worker now stamps **`x-anarlog-workspace-share-host`** and a shared **`x-anarlog-workspace-share-token`** on proxied requests (using new optional **`WORKSPACE_SHARE_PROXY_SECRET`** on the Worker and Netlify). The app resolves the real host via **`getRequestHost`** only when the token matches; **`getRequestAppOrigin`** and workspace-share middleware use the same secret. Workspace routes return **503** if the secret is unset; platform host pass-through **strips** the workspace headers so clients cannot spoof them. Origin fetches use **`redirect: manual`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18865b5369e5fec2775d2b55bc4cd205b98be93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->