### PR TITLE
fix(web): preserve workspace domains through redirects

### DIFF
--- a/apps/web/src/cloudflare/workspace-share-router.test.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.test.ts
@@ -97,3 +97,29 @@ test("removes workspace proxy headers when passing through platform hosts", asyn
   assert.equal(response.status, 200);
   assert.equal(fetchMock.mock.callCount(), 1);
 });
+
+for (const [location, expected] of [
+  [
+    "https://anarlog.netlify.app/app/?view=compact#notes",
+    "https://fastrepl.anarlog.so/app/?view=compact#notes",
+  ],
+  ["/auth/?flow=web", "https://fastrepl.anarlog.so/auth/?flow=web"],
+  ["https://accounts.google.com/auth", "https://accounts.google.com/auth"],
+]) {
+  test(`preserves the browser destination for redirect ${location}`, async (t) => {
+    const fetchMock = t.mock.method(
+      globalThis,
+      "fetch",
+      async () => new Response(null, { status: 308, headers: { location } }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://fastrepl.anarlog.so/app"),
+      { WORKSPACE_SHARE_PROXY_SECRET: "test-secret" },
+    );
+
+    assert.equal(response.status, 308);
+    assert.equal(response.headers.get("location"), expected);
+    assert.equal(fetchMock.mock.callCount(), 1);
+  });
+}

--- a/apps/web/src/cloudflare/workspace-share-router.ts
+++ b/apps/web/src/cloudflare/workspace-share-router.ts
@@ -61,6 +61,22 @@ export default {
       return new Response("Sharing domain unavailable", { status: 503 });
     }
 
-    return fetch(originRequest);
+    const response = await fetch(originRequest);
+    const location = response.headers.get("location");
+    if (response.status < 300 || response.status >= 400 || !location) {
+      return response;
+    }
+
+    const redirectUrl = new URL(location, originRequest.url);
+    if (redirectUrl.origin !== APP_ORIGIN) return response;
+
+    redirectUrl.host = incomingUrl.host;
+    const headers = new Headers(response.headers);
+    headers.set("location", redirectUrl.toString());
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
   },
 };


### PR DESCRIPTION
Netlify can return absolute redirect destinations using its origin hostname. Rewrite those destinations to the incoming workspace hostname so trailing-slash and auth redirects keep users on their workspace domain. Preserve external redirects and keep redirect following disabled so proxy credentials stay on the origin.

Validation: web typecheck, 317 web tests, formatting, and Wrangler dry-run passed. Tests cover absolute and relative origin redirects and an external auth destination. This only changes the Cloudflare Worker and its tests; the web application deployment is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes redirect handling on the workspace proxy edge path; incorrect rewriting could break auth or trailing-slash flows, though scope is limited to the Cloudflare worker.
> 
> **Overview**
> The Cloudflare workspace-share worker now **rewrites redirect `Location` headers** from the Netlify origin so users stay on their workspace hostname (e.g. `fastrepl.anarlog.so`) instead of being sent to `anarlog.netlify.app`.
> 
> After proxying to origin with `redirect: manual`, **3xx responses** are inspected: if the resolved URL’s origin matches the app origin, only the **host** is swapped to the incoming request’s host; query strings, fragments, and relative paths are preserved. **External redirects** (e.g. Google OAuth) are passed through unchanged.
> 
> New tests cover absolute Netlify URLs, relative `/auth/` paths, and an external auth URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 186d0651cfc1300ec658c361fa5959c252155ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->