### PR TITLE
Match mobile meeting tabs to desktop

### DIFF
--- a/apps/mobile/src/app/note/[id].tsx
+++ b/apps/mobile/src/app/note/[id].tsx
@@ -27,6 +27,7 @@ import { NoteActionsSheet } from "@/components/note-actions-sheet";
 import { NoteAttachmentCard } from "@/components/note-attachment-card";
 import { RecordingSyncCard } from "@/components/recording-sync-card";
 import { RemoteAudioCard } from "@/components/remote-audio-card";
+import { SessionTranscript } from "@/components/session-transcript";
 import { StartListeningButton } from "@/components/start-listening-button";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
@@ -745,7 +746,7 @@ export default function NoteScreen() {
           {showTabs && (
             <View style={styles.tabs}>
               <SegmentedControl
-                values={["Summary", "Memos"]}
+                values={["Summary", "Memos", "Transcript"]}
                 selectedIndex={selectedTab}
                 onChange={(event) => {
                   void flush();
@@ -756,7 +757,7 @@ export default function NoteScreen() {
               />
             </View>
           )}
-          {showTabs && !showMemos && (
+          {showTabs && selectedTab === 0 && (
             <ScrollView
               style={styles.summaryScroll}
               contentContainerStyle={styles.summary}
@@ -810,6 +811,68 @@ export default function NoteScreen() {
                 }
               />
             </ScrollView>
+          )}
+          {showTabs && selectedTab === 2 && (
+            <SessionTranscript
+              sessionId={id}
+              recordingDetails={
+                <>
+                  {audio.data && localAudioAvailable && localAudioFile && (
+                    <View
+                      key={`${audio.data.filename}:${audio.data.createdAt}`}
+                    >
+                      <AudioChip
+                        uri={localAudioFile.uri}
+                        filename={audio.data.filename}
+                        sizeBytes={audio.data.sizeBytes}
+                      />
+                      <RecordingSyncCard audio={audio.data} />
+                    </View>
+                  )}
+                  {audio.data && !localAudioAvailable && (
+                    <RemoteAudioCard
+                      cloudAvailable={Boolean(
+                        audio.data.cloudObjectKey &&
+                        auth.billing.isPro &&
+                        auth.session?.access_token &&
+                        env.supabaseUrl,
+                      )}
+                      errorMessage={audioRestoreError}
+                      loading={restoringAudio}
+                      onDownloadRecording={() => void handleDownloadRecording()}
+                      onChooseRecording={() => void handleChooseRecording()}
+                    />
+                  )}
+                  {audio.data &&
+                    localAudioAvailable &&
+                    audio.data.transcriptStatus !== "complete" &&
+                    transcriptState.data === false &&
+                    (transcription === "running" ? (
+                      <Text style={styles.transcribeStatus}>Transcribing…</Text>
+                    ) : (
+                      <Pressable
+                        hitSlop={4}
+                        onPress={() =>
+                          canTranscribe
+                            ? void transcribeSession(id)
+                            : router.push("/settings/transcription-provider")
+                        }
+                        style={({ pressed }) =>
+                          pressed && styles.transcribePressed
+                        }
+                      >
+                        <Text style={styles.transcribeAction}>
+                          {!canTranscribe
+                            ? "Choose transcription provider"
+                            : transcription === "failed"
+                              ? "Transcription failed — tap to retry"
+                              : "Tap to transcribe"}
+                        </Text>
+                      </Pressable>
+                    ))}
+                </>
+              }
+            />
           )}
           <View style={[styles.editor, !showMemos && styles.hidden]}>
             {localNoteAttachments.length > 0 && (
@@ -884,63 +947,9 @@ export default function NoteScreen() {
         visible={actionsOpen}
       />
 
-      {(active || hasRecordingHistory) && (
+      {active && (
         <ListeningSheet
-          active={active}
           sessionId={id}
-          recordingDetails={
-            <>
-              {audio.data && localAudioAvailable && localAudioFile && (
-                <View key={`${audio.data.filename}:${audio.data.createdAt}`}>
-                  <AudioChip
-                    uri={localAudioFile.uri}
-                    filename={audio.data.filename}
-                    sizeBytes={audio.data.sizeBytes}
-                  />
-                  <RecordingSyncCard audio={audio.data} />
-                </View>
-              )}
-              {audio.data && !localAudioAvailable && (
-                <RemoteAudioCard
-                  cloudAvailable={Boolean(
-                    audio.data.cloudObjectKey &&
-                    auth.billing.isPro &&
-                    auth.session?.access_token &&
-                    env.supabaseUrl,
-                  )}
-                  errorMessage={audioRestoreError}
-                  loading={restoringAudio}
-                  onDownloadRecording={() => void handleDownloadRecording()}
-                  onChooseRecording={() => void handleChooseRecording()}
-                />
-              )}
-              {audio.data &&
-                localAudioAvailable &&
-                audio.data.transcriptStatus !== "complete" &&
-                transcriptState.data === false &&
-                (transcription === "running" ? (
-                  <Text style={styles.transcribeStatus}>Transcribing…</Text>
-                ) : (
-                  <Pressable
-                    hitSlop={4}
-                    onPress={() =>
-                      canTranscribe
-                        ? void transcribeSession(id)
-                        : router.push("/settings/transcription-provider")
-                    }
-                    style={({ pressed }) => pressed && styles.transcribePressed}
-                  >
-                    <Text style={styles.transcribeAction}>
-                      {!canTranscribe
-                        ? "Choose transcription provider"
-                        : transcription === "failed"
-                          ? "Transcription failed — tap to retry"
-                          : "Tap to transcribe"}
-                    </Text>
-                  </Pressable>
-                ))}
-            </>
-          }
           phase={recorder.phase}
           failure={recorder.failure}
           amplitude={recorder.amplitude}

--- a/apps/mobile/src/components/listening-sheet.tsx
+++ b/apps/mobile/src/components/listening-sheet.tsx
@@ -1,9 +1,8 @@
 import { BottomSheet, RNHostView } from "@expo/ui";
 import { Ionicons } from "@expo/vector-icons";
-import { useRef, useState, type ReactNode } from "react";
+import { useState } from "react";
 import {
   ActivityIndicator,
-  FlatList,
   Keyboard,
   Pressable,
   StyleSheet,
@@ -16,6 +15,7 @@ import type {
   RecorderPhase,
 } from "@/audio/use-session-recorder";
 import { DancingSticks } from "@/components/dancing-sticks";
+import { SessionTranscript } from "@/components/session-transcript";
 import {
   CornerCurve,
   LISTENING_CONTROL_HEIGHT,
@@ -23,10 +23,6 @@ import {
   Spacing,
   Typography,
 } from "@/constants/theme";
-import {
-  useSessionTranscripts,
-  type TranscriptSegment,
-} from "@/data/transcripts";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
 
 function formatDuration(ms: number): string {
@@ -69,7 +65,6 @@ function transcriptionLabel(status: "connecting" | "live" | "fallback") {
 }
 
 export function ListeningSheet({
-  active,
   phase,
   failure,
   amplitude,
@@ -77,12 +72,10 @@ export function ListeningSheet({
   liveStatus,
   liveTranscript,
   sessionId,
-  recordingDetails,
   onStop,
   onRetry,
   onOpenSettings,
 }: {
-  active: boolean;
   phase: RecorderPhase;
   failure: RecorderFailure | null;
   amplitude: number;
@@ -90,7 +83,6 @@ export function ListeningSheet({
   liveStatus: "connecting" | "live" | "fallback";
   liveTranscript: string;
   sessionId: string;
-  recordingDetails: ReactNode;
   onStop: () => void;
   onRetry: () => void;
   onOpenSettings: () => void;
@@ -98,13 +90,6 @@ export function ListeningSheet({
   const styles = useStyles();
   const Colors = useColors();
   const [expanded, setExpanded] = useState(false);
-  const {
-    segments: transcripts,
-    isLoading,
-    error,
-  } = useSessionTranscripts(sessionId, expanded);
-  const listRef = useRef<FlatList<TranscriptSegment>>(null);
-  const following = useRef(active);
   const permissionDenied =
     phase === "unavailable" &&
     (failure === "permission_denied" ||
@@ -167,7 +152,7 @@ export function ListeningSheet({
       )}
     </Pressable>
   );
-  const label = active ? statusLabel(phase, durationMs) : "Transcript";
+  const label = statusLabel(phase, durationMs);
 
   return (
     <>
@@ -177,16 +162,15 @@ export function ListeningSheet({
           accessibilityLabel="Open full transcript"
           onPress={() => {
             Keyboard.dismiss();
-            following.current = active;
             setExpanded(true);
           }}
           style={styles.heading}
         >
-          {active && <View style={styles.recordingDot} />}
+          <View style={styles.recordingDot} />
           <Text style={styles.headingText}>{label}</Text>
           <Ionicons name="chevron-up" size={20} color={Colors.muted} />
         </Pressable>
-        {active && control}
+        {control}
       </View>
       <BottomSheet
         isPresented={expanded}
@@ -197,7 +181,7 @@ export function ListeningSheet({
         <RNHostView>
           <View style={styles.content}>
             <View style={styles.heading}>
-              {active && <View style={styles.recordingDot} />}
+              <View style={styles.recordingDot} />
               <Text style={styles.headingText}>{label}</Text>
               <Pressable
                 accessibilityRole="button"
@@ -208,69 +192,16 @@ export function ListeningSheet({
                 <Ionicons name="chevron-down" size={22} color={Colors.muted} />
               </Pressable>
             </View>
-            <FlatList
-              ref={listRef}
-              style={styles.list}
-              contentContainerStyle={styles.transcriptContent}
-              data={transcripts}
-              keyExtractor={(item) => item.id}
-              onScroll={({
-                nativeEvent: { contentOffset, contentSize, layoutMeasurement },
-              }) => {
-                following.current =
-                  contentSize.height -
-                    layoutMeasurement.height -
-                    contentOffset.y <
-                  80;
-              }}
-              scrollEventThrottle={100}
-              onContentSizeChange={() => {
-                if (active && following.current)
-                  listRef.current?.scrollToEnd({ animated: true });
-              }}
-              renderItem={({ item }) => (
-                <View style={styles.turn}>
-                  <Text style={styles.speaker}>{item.speaker}</Text>
-                  <Text selectable style={styles.transcriptText}>
-                    {item.text}
-                  </Text>
-                </View>
-              )}
-              ListEmptyComponent={
-                !liveTranscript ? (
-                  <Text style={styles.hint}>
-                    {isLoading
-                      ? "Loading transcript…"
-                      : error
-                        ? "Couldn't load the transcript. Close and reopen to retry."
-                        : active
-                          ? liveStatus === "fallback"
-                            ? "Your recording will be transcribed after you stop listening."
-                            : "Your transcript will appear here as you speak."
-                          : "No transcript yet."}
-                  </Text>
-                ) : null
-              }
-              ListFooterComponent={
-                <View>
-                  {active && liveTranscript !== "" && (
-                    <View style={styles.turn}>
-                      <Text style={styles.speaker}>Speaking…</Text>
-                      <Text style={styles.hint}>{liveTranscript}</Text>
-                    </View>
-                  )}
-                  {!active && recordingDetails}
-                </View>
-              }
-            />
-            {active && (
-              <View style={styles.controls}>
-                <Text style={styles.hint}>
-                  {transcriptionLabel(liveStatus)}
-                </Text>
-                {control}
-              </View>
+            {expanded && (
+              <SessionTranscript
+                sessionId={sessionId}
+                live={{ status: liveStatus, text: liveTranscript }}
+              />
             )}
+            <View style={styles.controls}>
+              <Text style={styles.hint}>{transcriptionLabel(liveStatus)}</Text>
+              {control}
+            </View>
           </View>
         </RNHostView>
       </BottomSheet>
@@ -293,14 +224,6 @@ const useStyles = createStyleHook((Colors) => ({
     padding: Spacing.md,
   },
   headingText: { flex: 1, ...Typography.bodyStrong, color: Colors.ink },
-  list: { flex: 1 },
-  transcriptContent: {
-    paddingHorizontal: Spacing.lg,
-    paddingBottom: Spacing.lg,
-  },
-  turn: { paddingVertical: Spacing.sm, gap: Spacing.xs },
-  speaker: { ...Typography.captionStrong, color: Colors.muted },
-  transcriptText: { ...Typography.body, color: Colors.ink },
   hint: { ...Typography.caption, color: Colors.muted },
   controls: { padding: Spacing.md, gap: Spacing.sm },
   recordingDot: {

--- a/apps/mobile/src/components/session-transcript.tsx
+++ b/apps/mobile/src/components/session-transcript.tsx
@@ -1,0 +1,94 @@
+import { useRef, type ReactNode } from "react";
+import { FlatList, Text, View } from "react-native";
+
+import { Spacing, Typography } from "@/constants/theme";
+import {
+  useSessionTranscripts,
+  type TranscriptSegment,
+} from "@/data/transcripts";
+import { createStyleHook } from "@/settings/theme-provider";
+
+export function SessionTranscript({
+  sessionId,
+  live,
+  recordingDetails,
+}: {
+  sessionId: string;
+  live?: {
+    status: "connecting" | "live" | "fallback";
+    text: string;
+  };
+  recordingDetails?: ReactNode;
+}) {
+  const styles = useStyles();
+  const { segments, isLoading, error } = useSessionTranscripts(sessionId, true);
+  const listRef = useRef<FlatList<TranscriptSegment>>(null);
+  const following = useRef(Boolean(live));
+
+  return (
+    <FlatList
+      ref={listRef}
+      style={styles.list}
+      contentContainerStyle={styles.content}
+      data={segments}
+      keyExtractor={(item) => item.id}
+      onScroll={({
+        nativeEvent: { contentOffset, contentSize, layoutMeasurement },
+      }) => {
+        following.current =
+          contentSize.height - layoutMeasurement.height - contentOffset.y < 80;
+      }}
+      scrollEventThrottle={100}
+      onContentSizeChange={() => {
+        if (live && following.current)
+          listRef.current?.scrollToEnd({ animated: true });
+      }}
+      renderItem={({ item }) => (
+        <View style={styles.turn}>
+          <Text style={styles.speaker}>{item.speaker}</Text>
+          <Text selectable style={styles.transcriptText}>
+            {item.text}
+          </Text>
+        </View>
+      )}
+      ListEmptyComponent={
+        !live?.text ? (
+          <Text style={styles.hint}>
+            {isLoading
+              ? "Loading transcript…"
+              : error
+                ? "Couldn't load the transcript. Reopen the transcript to retry."
+                : live
+                  ? live.status === "fallback"
+                    ? "Your recording will be transcribed after you stop listening."
+                    : "Your transcript will appear here as you speak."
+                  : "No transcript yet."}
+          </Text>
+        ) : null
+      }
+      ListFooterComponent={
+        <View>
+          {Boolean(live?.text) && (
+            <View style={styles.turn}>
+              <Text style={styles.speaker}>Speaking…</Text>
+              <Text style={styles.hint}>{live?.text}</Text>
+            </View>
+          )}
+          {recordingDetails}
+        </View>
+      }
+    />
+  );
+}
+
+const useStyles = createStyleHook((Colors) => ({
+  list: { flex: 1 },
+  content: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.lg,
+  },
+  turn: { paddingVertical: Spacing.sm, gap: Spacing.xs },
+  speaker: { ...Typography.captionStrong, color: Colors.muted },
+  transcriptText: { ...Typography.body, color: Colors.ink },
+  hint: { ...Typography.caption, color: Colors.muted },
+}));


### PR DESCRIPTION
Show Summary, Memos, and Transcript after recording ends. Share transcript rendering with the live sheet and keep playback and retry controls in the Transcript tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor and tab routing only; transcription and audio flows are relocated, not rewritten.
> 
> **Overview**
> Adds a **Transcript** segment alongside Summary and Memos on the note screen when recording has ended, aligning mobile with desktop’s three-tab meeting view.
> 
> Transcript UI is centralized in a new **`SessionTranscript`** component (segment list, empty/error states, optional live “Speaking…” footer, auto-scroll while listening). The live **ListeningSheet** now renders that component with live transcription props and no longer accepts **`recordingDetails`**; it only mounts while a session is actively listening.
> 
> **Playback, cloud restore, sync, and transcribe/retry** controls that used to appear in the listening sheet footer after recording are moved into the **Transcript** tab via **`recordingDetails`**. Summary content is shown only when tab index is **0** instead of the previous “not Memos” rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f6a85d9d3fb1b7ec9e0afca6aa3d244b435077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->