### PR TITLE
Blend the Open Source section heading in with its neighbors

### DIFF
--- a/apps/web/src/components/home-page/index.tsx
+++ b/apps/web/src/components/home-page/index.tsx
@@ -163,7 +163,7 @@ function OpenSourceSection({
       <div className="mx-auto max-w-[700px] px-5 md:px-8">
         <h2
           id="open-source-heading"
-          className="font-hand text-3xl leading-none font-semibold text-[#756b5d]"
+          className="text-color-muted font-mono text-3xl leading-none font-semibold"
         >
           Open source by default
         </h2>


### PR DESCRIPTION
'Open source by default' used the decorative font-hand (Caveat
cursive) heading style shared by the warmer storytelling sections
(hero, Privacy, Testimonials). But this section sits sandwiched
between a testimonial card and the plain-monospace 'Simple pricing'
heading, and reads as a technical/trust claim (GitHub stars, open
source) rather than a story beat - the cursive script looked like a
stray decorative element dropped between two more structured pieces.
Switched the heading to the same font-mono + text-color-muted style
already used by the adjacent Simple pricing heading so the two
trust/technical sections read as a matched pair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage heading class change only; no logic, data, or routing impact.
> 
> **Overview**
> The **Open source by default** heading no longer uses the decorative `font-hand` / warm brown styling used on storytelling sections. It now uses **`font-mono`** and **`text-color-muted`**, matching the adjacent **Simple pricing** heading so the open-source and pricing blocks read as a consistent trust/technical pair on the homepage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9efbbb5543690fe0623460ea0d292e38596e7350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->