### PR TITLE
Prepare desktop 1.4.23 release notes

### DIFF
--- a/packages/changelog/content/1.4.23.md
+++ b/packages/changelog/content/1.4.23.md
@@ -1,0 +1,20 @@
+---
+date: "2026-09-08"
+summary: "Anarlog 1.4.23 starts summaries sooner, protects recordings across devices, and fixes local AI and custom transcription setup."
+---
+
+## Summaries and recordings
+
+- Start summaries from the live transcript while transcription after recording
+  continues, then refresh them when the final transcript is ready
+- Protect newer notes, transcripts, and attachments when an older device syncs
+  a deletion before receiving that content
+- Discard empty automatic recordings without removing the calendar note or
+  content recorded on another device
+- Keep other meeting apps running while Anarlog is open
+
+## Providers and navigation
+
+- Connect to local AI servers that previously rejected requests from Anarlog
+- Save custom transcription providers that do not offer a model list
+- Restore the rounded shape of the **Ask anything** launcher


### PR DESCRIPTION
Document desktop changes since 1.4.22: earlier summaries, recording and sync protection, local AI and custom transcription setup, and navigation fixes.

Validation: changelog typecheck and formatting passed, along with 64 release/workflow tests and both license-boundary checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.4.23.md`** for the desktop **1.4.23** release, dated 2026-09-08, in the same frontmatter + sectioned bullet format as prior versions.
> 
> The entry documents **summaries and recordings** (earlier summaries from live transcript with refresh on final transcript, sync protection for newer content against stale deletions, empty auto-recording cleanup without wiping cross-device notes, coexistence with other meeting apps) and **providers and navigation** (local AI connectivity, custom transcription providers without model lists, **Ask anything** launcher shape fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0be1d92328ed0c42c1a80934b705568d9a446c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->