### PR TITLE
Use a filled icon for changed sidebar views

### DIFF
--- a/apps/desktop/src/sidebar/note-filter-menu.tsx
+++ b/apps/desktop/src/sidebar/note-filter-menu.tsx
@@ -45,11 +45,14 @@ export function SidebarNoteFilterMenu() {
           className={cn([
             "pointer-events-auto relative flex size-7 items-center justify-center rounded-full",
             "text-muted-foreground hover:bg-accent hover:text-foreground transition-colors",
-            "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
-            !isDefaultView && "bg-accent text-foreground",
+            "focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-hidden",
+            !isDefaultView && "text-foreground",
           ])}
         >
-          <FunnelSimple size={15} weight={isDefaultView ? "regular" : "bold"} />
+          <FunnelSimple
+            size={15}
+            className={cn([!isDefaultView && "fill-current"])}
+          />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent variant="app" align="start" className="w-56">


### PR DESCRIPTION
Changing sidebar grouping or sort order now fills the filter icon with the current theme foreground. Replace its focus ring with a subtle theme-aware background.

Validation: desktop typecheck and all 4,239 tests pass, along with formatting, i18n, license-boundary checks, and 64 repository script tests. Existing repository-wide lint warnings and workflow audit findings remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic and focus styling on a single sidebar control; no logic or data changes.
> 
> **Overview**
> Updates the sidebar **Sort notes** filter trigger so non-default grouping or sort is obvious without a persistent accent pill on the button.
> 
> When the view is not the default (date + newest), the funnel icon uses **`fill-current`** instead of switching to a bold stroke weight, and only the icon/text pick up **foreground** color— the always-on **`bg-accent`** active background is removed. Keyboard focus now uses the same **accent background + foreground text** treatment as hover instead of a **focus-visible ring**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a956e3deeb8c17fb2cfaa420718ceeac6ca4ae09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->