### PR TITLE
Verify capture protection across sync batches

### DIFF
--- a/plugins/db/src/runtime/tests/sync_hook.rs
+++ b/plugins/db/src/runtime/tests/sync_hook.rs
@@ -251,10 +251,46 @@ async fn capture_lifecycle_marker_defers_only_its_transcript() {
         }
     }))
     .unwrap();
-    let outcome = anlg_db_core::CloudsyncSyncHook::after_sync(&hook, db.pool(), &result)
+    let mut pending_records: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_replica_pending")
+        .fetch_one(db.pool())
         .await
         .unwrap();
-    assert!(!outcome.local_work_remaining);
+    loop {
+        let outcome = anlg_db_core::CloudsyncSyncHook::after_sync(&hook, db.pool(), &result)
+            .await
+            .unwrap();
+        if !outcome.local_work_remaining {
+            break;
+        }
+        // Schema growth can make the fixture span multiple bounded apply batches.
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_replica_pending")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(
+            remaining < pending_records,
+            "replica reconciliation must make progress"
+        );
+        pending_records = remaining;
+    }
+    let remaining_dirty: Vec<(String, String)> = sqlx::query_as(
+        "SELECT table_name, row_id FROM e2ee_dirty_rows ORDER BY table_name, row_id",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        remaining_dirty,
+        vec![("transcripts".to_string(), "transcript-1".to_string())]
+    );
+    let protected_records: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM e2ee_local_state
+         WHERE table_name = 'transcripts' AND row_id = 'transcript-1'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(protected_records, 0);
     let keys = hook.snapshot();
 
     sqlx::query(


### PR DESCRIPTION
The capture-lifecycle fixture now exceeds the 64-record replica preflight limit after the session-deletion schema additions. Drain reconciliation while asserting that every pass reduces the pending queue, then verify that only the active transcript remains dirty and has no encrypted local state. Production sync behavior is unchanged.

Validation: all 149 tauri-plugin-db library tests, 64 repository Node tests, both license-boundary checks, and changed-file formatting passed. Native release verification will run again on the merged candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in sync_hook.rs with no production code paths modified.
> 
> **Overview**
> Updates **`capture_lifecycle_marker_defers_only_its_transcript`** so **`after_sync`** is invoked in a loop until replica reconciliation finishes, instead of assuming a single pass clears all local work.
> 
> Each iteration **asserts `e2ee_replica_pending` shrinks**, matching bounded apply batches after schema growth pushed the fixture past the replica preflight record limit. After draining, the test **re-checks** that only **`transcript-1`** stays in **`e2ee_dirty_rows`** and still has **no `e2ee_local_state`**—i.e. capture protection holds across sync batches.
> 
> **Production sync behavior is unchanged**; this is test coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06f3d78d95d76ea4a326bd1a4ff6818977f8171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->