### PR TITLE
Include insights and badges in 1.4.23 notes

### DIFF
--- a/packages/changelog/content/1.4.23.md
+++ b/packages/changelog/content/1.4.23.md
@@ -1,12 +1,14 @@
 ---
 date: "2026-09-08"
-summary: "Anarlog 1.4.23 adds conversation insights, starts summaries sooner, and protects recordings across devices."
+summary: "Anarlog 1.4.23 adds conversation insights and collectible badges, improves summaries, and protects recordings across devices."
 ---
 
-## Conversation insights
+## Insights and achievements
 
 - See your busiest weekdays, typical conversation length, and conversations
   per active day in **Settings → Insights**
+- Collect illustrated badges as you capture conversations and build recording
+  habits
 
 ## Summaries and recordings
 

--- a/packages/changelog/content/1.4.23.md
+++ b/packages/changelog/content/1.4.23.md
@@ -1,7 +1,12 @@
 ---
 date: "2026-09-08"
-summary: "Anarlog 1.4.23 starts summaries sooner, protects recordings across devices, and fixes local AI and custom transcription setup."
+summary: "Anarlog 1.4.23 adds conversation insights, starts summaries sooner, and protects recordings across devices."
 ---
+
+## Conversation insights
+
+- See your busiest weekdays, typical conversation length, and conversations
+  per active day in **Settings → Insights**
 
 ## Summaries and recordings
 


### PR DESCRIPTION
Document the Insights settings page and collectible achievement badges in the 1.4.23 changelog. Refresh the summary to reflect the desktop features shipping in this release.

Validation: changed-file formatting and @anlg/changelog typecheck passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog copy only; no application or API behavior changes.
> 
> **Overview**
> Updates the **1.4.23** changelog so the release matches what ships on desktop, especially the new Insights experience.
> 
> The frontmatter **summary** now calls out conversation insights and collectible badges alongside summaries and cross-device recording protection. A new **Insights and achievements** section documents **Settings → Insights** (busiest weekdays, typical length, conversations per active day) and illustrated badges for recording habits. Existing **Summaries and recordings** bullets are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1acc6c0dcf8efc03c34704c64c7151470a02d51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->