### PR TITLE
Integrate Linux APT publication into desktop releases

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -212,12 +212,15 @@ GitHub against the provenance manifest.
 
 The publish workflow calls `desktop_store_publish.yaml` with
 `submit_to_stores=true` for Microsoft Store certification. Inspect that job and
-the resulting submission separately from GitHub/CrabNebula publication. Merge
-the generated Linux package metadata PR and verify the signed APT index is live
-on `anarlog.so`. Check whether Netlify deployed that commit automatically before
-dispatching `web_cd.yaml`. Arch `PKGBUILD` and `.SRCINFO` updates ship in this
-repository; there is no AUR publication workflow. Check the AUR registry before
-claiming an AUR release. Creating the metadata PR alone is not publication.
+the resulting submission separately from GitHub/CrabNebula publication. For
+Linux, the workflow waits for the generated package metadata PR's checks,
+merges that exact PR head, calls `web_cd.yaml` with the merged commit, and
+verifies the live signed APT metadata for both architectures on `anarlog.so`.
+Require `linux-package-bump`, `linux-apt-deploy`, and `linux-apt-verify` to succeed;
+a metadata PR or successful merge alone is not APT publication. Failed checks
+leave the PR open and fail the release workflow for follow-up. Arch `PKGBUILD`
+and `.SRCINFO` updates ship in this repository; there is no AUR publication
+workflow. Check the AUR registry before claiming an AUR release.
 
 ## Mobile Store Distribution
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,4 +21,5 @@ jobs:
           scripts/verify-linux-audio-qa-run.test.mjs
           scripts/verify-linux-audio-qa-evidence.test.mjs
           scripts/update-apt-repository.test.mjs
+          scripts/verify-apt-repository.test.mjs
           scripts/update-aur-pkgbuild.test.mjs

--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -584,6 +584,9 @@ jobs:
     needs: [parse, gh-release]
     if: ${{ !cancelled() && needs.parse.outputs.include_linux == 'true' && needs.gh-release.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      sha: ${{ steps.merge.outputs.sha || steps.package-pr.outputs.sha }}
     permissions:
       contents: write
       pull-requests: write
@@ -591,12 +594,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-      - name: Point anarlog-bin at the published release
-        env:
+          persist-credentials: false
+      - env:
           VERSION: ${{ needs.parse.outputs.version }}
         run: node scripts/update-aur-pkgbuild.mjs --version "$VERSION"
       - id: linux-release
-        name: Download published Debian packages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.parse.outputs.version }}
@@ -609,8 +611,7 @@ jobs:
             --json publishedAt \
             --jq .publishedAt)
           echo "published_at=$published_at" >> "$GITHUB_OUTPUT"
-      - name: Build and sign the APT repository
-        env:
+      - env:
           APT_REPOSITORY_GPG_FINGERPRINT: ${{ vars.APT_REPOSITORY_GPG_FINGERPRINT }}
           APT_REPOSITORY_GPG_PRIVATE_KEY: ${{ secrets.APT_REPOSITORY_GPG_PRIVATE_KEY }}
           PUBLISHED_AT: ${{ steps.linux-release.outputs.published_at }}
@@ -636,60 +637,125 @@ jobs:
             exit 1
           fi
 
+          release_dir="apps/web/public/apt/dists/stable"
+          cp -R "$release_dir" "$RUNNER_TEMP/previous-apt"
           node scripts/update-apt-repository.mjs \
             --version "$VERSION" \
             --amd64 "$RUNNER_TEMP/apt-packages/anarlog-linux-x86_64.deb" \
             --arm64 "$RUNNER_TEMP/apt-packages/anarlog-linux-aarch64.deb" \
             --date "$PUBLISHED_AT"
 
-          release_dir="apps/web/public/apt/dists/stable"
-          gpg --batch --yes --armor \
-            --local-user "$APT_REPOSITORY_GPG_FINGERPRINT" \
-            --output "$release_dir/InRelease" \
-            --clearsign "$release_dir/Release"
-          gpg --batch --yes --armor --detach-sign \
-            --local-user "$APT_REPOSITORY_GPG_FINGERPRINT" \
-            --output "$release_dir/Release.gpg" \
-            "$release_dir/Release"
+          if cmp -s "$release_dir/Release" "$RUNNER_TEMP/previous-apt/Release"; then
+            cp "$RUNNER_TEMP/previous-apt/"{InRelease,Release.gpg} "$release_dir/"
+          else
+            gpg --batch --yes --armor \
+              --local-user "$APT_REPOSITORY_GPG_FINGERPRINT" \
+              --output "$release_dir/InRelease" \
+              --clearsign "$release_dir/Release"
+            gpg --batch --yes --armor --detach-sign \
+              --local-user "$APT_REPOSITORY_GPG_FINGERPRINT" \
+              --output "$release_dir/Release.gpg" \
+              "$release_dir/Release"
+          fi
           gpg --batch --verify "$release_dir/InRelease"
           gpg --batch --verify "$release_dir/Release.gpg" "$release_dir/Release"
-      - name: Open the Linux package bump pull request
+      - id: package-pr
         env:
           GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
           VERSION: ${{ needs.parse.outputs.version }}
         run: |
           if git diff --quiet -- packaging/aur/anarlog-bin apps/web/public/apt; then
             echo "Linux package metadata already tracks $VERSION"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           BRANCH="chore/linux-packages-$VERSION"
+          gh auth setup-git
+          remote_sha=$(git ls-remote --heads origin "$BRANCH" | cut -f 1)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add packaging/aur/anarlog-bin apps/web/public/apt
           git commit -m "chore(packaging): publish Linux packages for $VERSION" \
             -m "Refresh the AUR package and signed APT repository metadata for the desktop_v$VERSION release."
-          git push --force origin "$BRANCH"
+          head_sha=$(git rev-parse HEAD)
+          git push --force-with-lease="refs/heads/$BRANCH:$remote_sha" origin "$BRANCH"
 
-          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            echo "Pull request for $BRANCH already open"
-            exit 0
+          pr_number=$(gh pr list --state open --head "$BRANCH" --base main --json number --jq '.[0].number // empty')
+          if [[ -z "$pr_number" ]]; then
+            printf '%s\n' \
+              "Refresh the AUR package and signed APT metadata for desktop_v$VERSION." \
+              "" \
+              "The desktop publish workflow verified the APT signatures and will merge this PR after checks pass, deploy the metadata, and verify the live APT repository." \
+              > "$RUNNER_TEMP/linux-package-pr.md"
+
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(packaging): publish Linux packages for $VERSION" \
+              --body-file "$RUNNER_TEMP/linux-package-pr.md"
+            pr_number=$(gh pr view "$BRANCH" --json number --jq .number)
           fi
 
-          BODY=$(printf '%s\n' \
-            "## Summary" \
-            "" \
-            "**Problem:** The desktop_v$VERSION release changed Linux artifacts, leaving the AUR package and signed APT repository metadata on the previous version." \
-            "" \
-            "**Fix:** Refresh the AUR package and signed APT repository metadata so Linux package managers install the current desktop_v$VERSION release." \
-            "" \
-            "## Verification" \
-            "" \
-            "- Generated and verified the signed APT repository metadata during the desktop publish run.")
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+      - id: merge
+        if: ${{ steps.package-pr.outputs.number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.package-pr.outputs.number }}
+          PR_HEAD_SHA: ${{ steps.package-pr.outputs.head_sha }}
+        run: |
+          deadline=$((SECONDS + 300))
+          while true; do
+            checks=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
+              --jq '[.statusCheckRollup[] | .name // .context]')
+            if jq -e '["ci", "fmt", "lint", "zizmor"] - . | length == 0' <<< "$checks" > /dev/null; then
+              break
+            fi
+            if (( SECONDS >= deadline )); then
+              echo "::error::CI checks did not register for Linux package PR #$PR_NUMBER"
+              exit 1
+            fi
+            sleep 10
+          done
+          gh pr checks "$PR_NUMBER" --watch --fail-fast --interval 15
+          gh pr merge "$PR_NUMBER" --squash --match-head-commit "$PR_HEAD_SHA"
+          merge_sha=$(gh pr view "$PR_NUMBER" --json state,mergeCommit \
+            --jq 'select(.state == "MERGED") | .mergeCommit.oid')
+          if [[ ! "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Linux package PR #$PR_NUMBER did not merge"
+            exit 1
+          fi
+          echo "sha=$merge_sha" >> "$GITHUB_OUTPUT"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(packaging): publish Linux packages for $VERSION" \
-            --body "$BODY"
+  linux-apt-deploy:
+    needs: linux-package-bump
+    permissions:
+      contents: write
+    uses: $/.github/workflows/web_cd.yaml
+    with:
+      sha: ${{ needs.linux-package-bump.outputs.sha }}
+    secrets:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
+      INFISICAL_SENTRY_TOKEN: ${{ secrets.INFISICAL_SENTRY_TOKEN }}
+
+  linux-apt-verify:
+    needs: [parse, linux-package-bump, linux-apt-deploy]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ needs.linux-package-bump.outputs.sha }}
+          persist-credentials: false
+      - env:
+          VERSION: ${{ needs.parse.outputs.version }}
+        run: |
+          node scripts/verify-apt-repository.mjs --version "$VERSION"
+          echo "Signed APT repository for $VERSION is live at https://anarlog.so/apt/ (amd64 and arm64)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -1,14 +1,30 @@
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      sha:
+        required: true
+        type: string
+    secrets:
+      NETLIFY_AUTH_TOKEN:
+        required: true
+      NETLIFY_SITE_ID:
+        required: true
+      INFISICAL_PROJECT_ID:
+        required: true
+      INFISICAL_SENTRY_TOKEN:
+        required: true
 
 jobs:
   compute-version:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.version.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.sha || github.sha }}
           fetch-depth: 0
           fetch-tags: true
       - run: git fetch --tags --force
@@ -17,6 +33,7 @@ jobs:
         run: |
           VERSION=$(doxxer --config doxxer.web.toml next patch)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"
 
   deploy:
@@ -26,6 +43,8 @@ jobs:
     concurrency: web-netlify-deploy
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.compute-version.outputs.sha }}
       - uses: ./.github/actions/pnpm_install
       - uses: denoland/setup-deno@v2
       - name: Check Netlify deployment credentials
@@ -83,8 +102,10 @@ jobs:
             --no-build \
             --site "$NETLIFY_SITE_ID" \
             --filter @anlg/web \
-            --message "web v${{ needs.compute-version.outputs.version }} ($GITHUB_SHA)"
+            --message "web v$WEB_VERSION ($DEPLOY_SHA)"
         env:
+          WEB_VERSION: ${{ needs.compute-version.outputs.version }}
+          DEPLOY_SHA: ${{ needs.compute-version.outputs.sha }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
@@ -95,8 +116,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.compute-version.outputs.sha }}
       - uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ needs.compute-version.outputs.sha }}
           custom_tag: web_v${{ needs.compute-version.outputs.version }}
           tag_prefix: ""

--- a/packaging/aur/anarlog-bin/README.md
+++ b/packaging/aur/anarlog-bin/README.md
@@ -24,8 +24,10 @@ verifies its checksum, and installs it through pacman.
 
 ## Updating
 
-Each stable publish opens a `chore(packaging): bump anarlog-bin to <version>` pull
-request automatically, so this normally needs no manual work.
+Each stable publish opens a `chore(packaging): publish Linux packages for <version>`
+pull request, waits for its checks, and merges it automatically. The same workflow
+deploys and verifies the signed APT repository. Publishing this package to the AUR
+registry remains a separate step.
 
 To bump by hand, or to refresh the files before an AUR push:
 

--- a/scripts/verify-apt-repository.mjs
+++ b/scripts/verify-apt-repository.mjs
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+const FILES = [
+  "anarlog-archive-keyring.asc",
+  "dists/stable/Release",
+  "dists/stable/InRelease",
+  "dists/stable/Release.gpg",
+  ...["amd64", "arm64"].flatMap((architecture) => [
+    `dists/stable/main/binary-${architecture}/Packages`,
+    `dists/stable/main/binary-${architecture}/Packages.gz`,
+  ]),
+];
+
+export async function readExpectedRepository(directory, version) {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error("--version must be a stable version such as 1.4.22");
+  }
+  const files = new Map(
+    await Promise.all(
+      FILES.map(async (file) => [
+        file,
+        await readFile(path.join(directory, file)),
+      ]),
+    ),
+  );
+  const release = files.get("dists/stable/Release").toString("utf8");
+  if (!release.split("\n").includes(`Version: ${version}`)) {
+    throw new Error(`Expected APT metadata for ${version} in ${directory}`);
+  }
+  return files;
+}
+
+export async function verifyRepository(files, fetchFile = fetch) {
+  for (const [file, expected] of files) {
+    const url = `https://anarlog.so/apt/${file}`;
+    const response = await fetchFile(url, {
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!response.ok)
+      throw new Error(`GET ${url} failed with ${response.status}`);
+    const actual = Buffer.from(await response.arrayBuffer());
+    if (!actual.equals(expected)) {
+      throw new Error(
+        `Live APT file differs from the published metadata: ${file}`,
+      );
+    }
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: { version: { type: "string" } },
+  });
+  const directory = fileURLToPath(
+    new URL("../apps/web/public/apt/", import.meta.url),
+  );
+  const files = await readExpectedRepository(directory, values.version);
+  const deadline = Date.now() + 10 * 60_000;
+  while (true) {
+    try {
+      await verifyRepository(files);
+      console.log(
+        `Verified live APT repository for ${values.version} (amd64 and arm64)`,
+      );
+      return;
+    } catch (error) {
+      if (Date.now() >= deadline) throw error;
+      console.log(`${error.message}; waiting for the deployment and CDN cache`);
+      await setTimeout(15_000);
+    }
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/verify-apt-repository.test.mjs
+++ b/scripts/verify-apt-repository.test.mjs
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildRepository, writeRepository } from "./update-apt-repository.mjs";
+import {
+  readExpectedRepository,
+  verifyRepository,
+} from "./verify-apt-repository.mjs";
+
+async function fixture(t) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "anarlog-live-apt-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const packages = Object.fromEntries(
+    ["amd64", "arm64"].map((architecture) => [
+      architecture,
+      {
+        control: `Package: anarlog\nVersion: 1.4.22\nArchitecture: ${architecture}\n`,
+        hashes: {
+          md5: "a".repeat(32),
+          sha1: "a".repeat(40),
+          sha256: "a".repeat(64),
+        },
+        size: 123,
+      },
+    ]),
+  );
+  await writeRepository(
+    directory,
+    buildRepository({
+      version: "1.4.22",
+      date: "2026-09-08T00:00:00Z",
+      packages,
+    }),
+  );
+  for (const file of [
+    "anarlog-archive-keyring.asc",
+    "dists/stable/InRelease",
+    "dists/stable/Release.gpg",
+  ]) {
+    await writeFile(path.join(directory, file), `fixture ${file}`);
+  }
+  return directory;
+}
+
+test("verifies the key, signatures, and both architectures including compressed indexes", async (t) => {
+  const files = await readExpectedRepository(await fixture(t), "1.4.22");
+  const visited = [];
+  await verifyRepository(files, async (url) => {
+    assert.ok(url.startsWith("https://anarlog.so/apt/"));
+    const file = url.slice("https://anarlog.so/apt/".length);
+    visited.push(file);
+    return new Response(files.get(file));
+  });
+  assert.equal(visited.length, 8);
+  assert.ok(visited.includes("dists/stable/main/binary-arm64/Packages.gz"));
+  assert.ok(visited.includes("dists/stable/main/binary-amd64/Packages.gz"));
+});
+
+test("rejects a checkout with the wrong release version before checking production", async (t) => {
+  const directory = await fixture(t);
+  await assert.rejects(
+    readExpectedRepository(directory, "1.4.21"),
+    /Expected APT metadata for 1.4.21/,
+  );
+  await assert.rejects(
+    readExpectedRepository(directory, undefined),
+    /must be a stable version/,
+  );
+});
+
+test("rejects each stale or corrupted live file, even when the Release version matches", async (t) => {
+  const files = await readExpectedRepository(await fixture(t), "1.4.22");
+  for (const staleFile of files.keys()) {
+    await assert.rejects(
+      verifyRepository(files, async (url) => {
+        const file = url.slice("https://anarlog.so/apt/".length);
+        return new Response(file === staleFile ? "stale" : files.get(file));
+      }),
+      /Live APT file differs/,
+    );
+  }
+});
+
+test("rejects unsuccessful responses and network failures", async (t) => {
+  const files = await readExpectedRepository(await fixture(t), "1.4.22");
+  await assert.rejects(
+    verifyRepository(
+      files,
+      async () => new Response("unavailable", { status: 503 }),
+    ),
+    /failed with 503/,
+  );
+  await assert.rejects(
+    verifyRepository(files, async () => {
+      throw new Error("network unavailable");
+    }),
+    /network unavailable/,
+  );
+});
+
+test("the release deploys and verifies the merged metadata commit", async () => {
+  const publish = await readFile(
+    ".github/workflows/desktop_publish.yaml",
+    "utf8",
+  );
+  const web = await readFile(".github/workflows/web_cd.yaml", "utf8");
+  const deploy = publish
+    .split("\n  linux-apt-deploy:\n")[1]
+    .split("\n  linux-apt-verify:\n")[0];
+  const verify = publish.split("\n  linux-apt-verify:\n")[1];
+  assert.match(deploy, /needs: linux-package-bump/);
+  assert.match(deploy, /uses: \$\/\.github\/workflows\/web_cd\.yaml/);
+  assert.match(
+    deploy,
+    /sha: \$\{\{ needs\.linux-package-bump\.outputs\.sha \}\}/,
+  );
+  assert.match(
+    verify,
+    /needs: \[parse, linux-package-bump, linux-apt-deploy\]/,
+  );
+  assert.match(
+    verify,
+    /ref: \$\{\{ needs\.linux-package-bump\.outputs\.sha \}\}/,
+  );
+  assert.match(
+    verify,
+    /node scripts\/verify-apt-repository\.mjs --version "\$VERSION"/,
+  );
+  assert.match(web, /workflow_call:/);
+  assert.match(web, /ref: \$\{\{ inputs\.sha \|\| github\.sha \}\}/);
+  assert.equal(
+    web.match(/ref: \$\{\{ needs\.compute-version\.outputs\.sha \}\}/g)?.length,
+    2,
+  );
+  assert.match(
+    web,
+    /commit_sha: \$\{\{ needs\.compute-version\.outputs\.sha \}\}/,
+  );
+});
+
+test("the merge step waits for checks and refuses failed checks or a changed PR head", async (t) => {
+  const publish = await readFile(
+    ".github/workflows/desktop_publish.yaml",
+    "utf8",
+  );
+  const step = publish
+    .split("      - id: merge\n")[1]
+    .split("\n  linux-apt-deploy:\n")[0];
+  const script = step.split("        run: |\n")[1].replace(/^          /gm, "");
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "anarlog-package-merge-"),
+  );
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const head = "a".repeat(40);
+  const merged = "b".repeat(40);
+  for (const scenario of [
+    "success",
+    "failed-checks",
+    "changed-head",
+    "unmerged",
+  ]) {
+    const output = path.join(directory, `${scenario}.output`);
+    await writeFile(output, "");
+    const mocks = `
+      waited=false
+      checked=false
+      sleep() { waited=true; }
+      gh() {
+        if [[ "$*" == *statusCheckRollup* ]]; then
+          if [[ "$waited" == true ]]; then
+            echo '["ci", "fmt", "lint", "zizmor"]'
+          else
+            echo '[]'
+          fi
+        elif [[ "$1 $2" == 'pr checks' ]]; then
+          [[ "$waited" == true ]] || return 90
+          [[ "$*" == *'--watch --fail-fast'* ]] || return 91
+          [[ "$SCENARIO" != failed-checks ]] || return 1
+          checked=true
+        elif [[ "$1 $2" == 'pr merge' ]]; then
+          [[ "$checked" == true ]] || return 92
+          [[ "$*" == "pr merge 123 --squash --match-head-commit $PR_HEAD_SHA" ]] || return 93
+          [[ "$SCENARIO" != changed-head ]] || return 1
+          echo merge-requested >> "$GITHUB_OUTPUT"
+        elif [[ "$*" == *mergeCommit* ]]; then
+          if [[ "$SCENARIO" != unmerged ]]; then echo '${merged}'; fi
+        else
+          return 94
+        fi
+      }
+    `;
+    const result = spawnSync(
+      "bash",
+      ["--noprofile", "--norc", "-eo", "pipefail", "-c", `${mocks}\n${script}`],
+      {
+        env: {
+          ...process.env,
+          PR_NUMBER: "123",
+          PR_HEAD_SHA: head,
+          GITHUB_OUTPUT: output,
+          SCENARIO: scenario,
+        },
+        encoding: "utf8",
+        timeout: 5000,
+      },
+    );
+    assert.ifError(result.error);
+    const written = await readFile(output, "utf8");
+    if (scenario === "success") {
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(written, new RegExp(`sha=${merged}`));
+    } else {
+      assert.notEqual(result.status, 0);
+      assert.doesNotMatch(written, /sha=/);
+      if (scenario !== "unmerged")
+        assert.doesNotMatch(written, /merge-requested/);
+    }
+  }
+});


### PR DESCRIPTION
Wait for package PR checks and merge the generated head, deploy its commit through web CD, and verify the live signed APT metadata. Preserve unchanged signatures on retries and update release guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release automation (auto-merge PRs, Netlify deploy, and live APT verification) and reusable web CD behavior; mistakes could ship stale APT metadata or merge without proper checks.
> 
> **Overview**
> Desktop publish now **closes the loop on Linux APT publication** instead of only opening a metadata PR. After building signed APT metadata and opening (or reusing) the `chore(packaging): publish Linux packages for <version>` PR, **`linux-package-bump` waits for required checks, squash-merges at the exact PR head**, and exports the merged commit SHA. Failed checks leave the PR open and fail the release.
> 
> **`linux-apt-deploy`** invokes **`web_cd.yaml` as a reusable workflow** with that SHA so Netlify ships the APT tree from the merge commit, not an ad-hoc manual deploy. **`web_cd`** gains `workflow_call`, pins checkout/deploy/tag to the input SHA, and records that SHA in deploy messages and web tags.
> 
> **`linux-apt-verify`** runs new **`verify-apt-repository.mjs`**, which byte-compares live `https://anarlog.so/apt/` artifacts (amd64 and arm64, including compressed indexes) against the merged repo metadata, with retries for CDN lag.
> 
> APT signing **reuses existing `InRelease` / `Release.gpg` when `Release` is unchanged**, avoiding bad re-signs on retries. Release skill docs and the AUR README describe the three jobs (`linux-package-bump`, `linux-apt-deploy`, `linux-apt-verify`) as the APT publication gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319333b27ed99d1971be5ec563f655d08227417e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->