### PR TITLE
docs: callout cloud-storage sync warning in sync.mdx

### DIFF
--- a/docs/sync.mdx
+++ b/docs/sync.mdx
@@ -68,13 +68,15 @@ Cloud API & Connectors is a separate, optional feature. If you enable it under *
 
 ## Don't combine sync with a cloud-storage folder
 
-Keep your Anarlog storage location out of folders managed by a file-syncing service such as iCloud Drive, Dropbox, Google Drive, or OneDrive. Two sync systems changing the same files can cause:
+<Warning>
+  Keep your Anarlog storage location out of folders managed by a file-syncing service such as iCloud Drive, Dropbox, Google Drive, or OneDrive. This includes Obsidian vaults stored in iCloud Drive.
+</Warning>
+
+Two sync systems changing the same files can cause:
 
 - Conflicted or duplicate copies of recordings and attachments
 - Incomplete audio files when a service uploads a recording while Anarlog is still writing it
 - Files that are offloaded to the cloud and unavailable offline
-
-This includes Obsidian vaults stored in iCloud Drive.
 
 Anarlog shows a warning in **Settings → Sync** when your storage location is inside a known cloud-storage folder. Backup tools that snapshot files without continuously syncing them back are fine.
 


### PR DESCRIPTION
Wraps the core caution in "Don't combine sync with a cloud-storage folder" in a <Warning> callout, matching the existing Warning style used elsewhere in the docs (e.g. the recovery-key warning on the same page), so it stands out from the surrounding instructional text instead of reading as a regular paragraph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting change with no product or runtime impact.
> 
> **Overview**
> The **Don't combine sync with a cloud-storage folder** section now puts the main caution in a `<Warning>` callout (same pattern as the recovery-key warning on this page), instead of burying it in body text.
> 
> The iCloud Drive / Obsidian vault note is folded into that callout; the bullet list of what can go wrong still follows as normal prose below the callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4cd7d843f82df0bf0d63656d4eaf98f71e6c749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->