### PR TITLE
docs: flag buried warnings as callouts, fix stale/inconsistent content

### DIFF
--- a/docs/agents/cli.mdx
+++ b/docs/agents/cli.mdx
@@ -38,7 +38,9 @@ anarlog --json proposals show PROPOSAL_ID
 anarlog --json proposals decline PROPOSAL_ID
 ```
 
-The create command returns a pending proposal. Do not claim the meeting changed. Open the meeting in the desktop app to apply it, or decline it from the CLI or desktop app. Only pending proposals can be declined.
+<Note>
+  The create command returns a pending proposal. Do not claim the meeting changed. Open the meeting in the desktop app to apply it, or decline it from the CLI or desktop app. Only pending proposals can be declined.
+</Note>
 
 ## Transcripts
 
@@ -66,6 +68,8 @@ anarlog meetings export MEETING_ID --format json --output meeting.json
 anarlog meetings --source cloud export MEETING_ID --format json --output meeting.json
 ```
 
-Export refuses to replace an existing file. Use `--force` only after the user explicitly approves overwriting that exact path.
+<Warning>
+  Export refuses to replace an existing file. Use `--force` only after the user explicitly approves overwriting that exact path.
+</Warning>
 
 See the [CLI reference](/reference/cli) for every option.

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -55,7 +55,9 @@ For a custom database path:
 }
 ```
 
-Do not run local stdio and Cloud MCP as two `list_meetings` servers in the same client. Use Cloud first and the local CLI or local MCP only to fill gaps.
+<Note>
+  Do not run local stdio and Cloud MCP as two `list_meetings` servers in the same client. Use Cloud first and the local CLI or local MCP only to fill gaps.
+</Note>
 
 ## Use tools deliberately
 

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -23,7 +23,9 @@ The published file is self-contained. The repository package adds references for
 
 The `Anarlog` plugin connects to hosted Cloud MCP and bundles the skill. Enable **Settings → Developers → Cloud API & Connectors** first. [Install the Anarlog CLI](/installation) when the skill needs to fill a meeting that is not in Cloud.
 
-If you previously installed **Anarlog Cloud**, replace it with **Anarlog**.
+<Note>
+  If you previously installed **Anarlog Cloud**, replace it with **Anarlog**.
+</Note>
 
 For Claude Code:
 

--- a/docs/ai-setup.mdx
+++ b/docs/ai-setup.mdx
@@ -45,7 +45,9 @@ On an eligible Mac running macOS 26 or later:
 2. In Anarlog, open **Settings → Intelligence → Configure Providers → Apple Intelligence**.
 3. Select **System Language Model** under **Model being used**.
 
-Apple Intelligence support is experimental and currently handles text only.
+<Note>
+  Apple Intelligence support is experimental and currently handles text only.
+</Note>
 
 ## LM Studio
 

--- a/docs/automatic-capture.mdx
+++ b/docs/automatic-capture.mdx
@@ -27,16 +27,24 @@ Microphone detection is available on macOS and Linux. On macOS, Accessibility pe
 
 Under **Settings → Meetings**, enable **Stop when meeting ends**. Anarlog stops listening when the meeting app releases the microphone.
 
-This control is available on macOS and Linux. If you switch audio devices or use an app with unusual microphone behavior, check that the recording is still active before closing the meeting.
+This control is available on macOS and Linux.
+
+<Warning>
+  If you switch audio devices or use an app with unusual microphone behavior, automatic stop detection can misfire and end the recording early without warning. Check that the recording is still active before closing the meeting.
+</Warning>
 
 ## Capture meeting chat
 
 On macOS and Linux, **Settings → Meetings** also includes:
 
-- **Post recording disclosure in meeting chat**, which tells participants when listening starts. This does not confirm consent.
+- **Post recording disclosure in meeting chat**, which tells participants when listening starts.
 - **Capture meeting chat in Memos**, which saves visible chat from supported meetings. On macOS this uses Accessibility; on Linux it uses assistive-technology access.
 
 These features are not available on Windows.
+
+<Note>
+  Posting a disclosure does not by itself confirm consent. Recording-consent rules depend on where you and the other participants are located; see [Record meetings](/meetings).
+</Note>
 
 ## Keep controls nearby
 

--- a/docs/automations.mdx
+++ b/docs/automations.mdx
@@ -45,4 +45,6 @@ Examples:
 - After the summary is ready, post to Slack and append the same recap to a Notion page.
 - After the meeting ends, export Markdown and create Linear issues from action items.
 
-Automations send meeting content to the destination you configure. Use only workspaces, channels, pages, teams, and folders that should receive that content.
+<Warning>
+  Automations send meeting content to the destination you configure. Use only workspaces, channels, pages, teams, and folders that should receive that content.
+</Warning>

--- a/docs/calendar.mdx
+++ b/docs/calendar.mdx
@@ -55,6 +55,10 @@ You can also revoke Anarlog's access from your [Google Account connections](http
 
 To permanently remove calendar-derived data retained on a Mac, you currently need to remove all local Anarlog app data from that Mac:
 
+<Warning>
+  This deletes Anarlog's entire local database on that Mac, not just calendar data — including notes, memos, summaries, and settings that have not been exported, synced, or shared elsewhere. Export anything you want to keep first, and contact us before deleting anything if you need help identifying the correct folder.
+</Warning>
+
 1. Export anything you want to keep, then quit Anarlog.
 2. In Finder, choose **Go → Go to Folder**.
 3. Move any of these folders that exist to Trash:
@@ -63,7 +67,7 @@ To permanently remove calendar-derived data retained on a Mac, you currently nee
    - `~/Library/Application Support/com.hyprnote.stable`
 4. Empty Trash before reopening Anarlog.
 
-This removes Anarlog's local database and settings on that Mac, including cached calendar data and event context stored with local records. It can also remove other Anarlog data stored in those folders. It does not delete files you exported or copies you chose to sync or share. You can request deletion of your Anarlog account and cloud-stored data at [founders@anarlog.so](mailto:founders@anarlog.so). Contact us before deleting anything if you need help identifying the correct folder.
+This removes Anarlog's local database and settings on that Mac, including cached calendar data and event context stored with local records. It can also remove other Anarlog data stored in those folders. It does not delete files you exported or copies you chose to sync or share. You can request deletion of your Anarlog account and cloud-stored data at [founders@anarlog.so](mailto:founders@anarlog.so).
 
 <Note>
   Google and Outlook connections are included with Anarlog Pro. Apple Calendar uses the calendar accounts already connected to your Mac.

--- a/docs/chat.mdx
+++ b/docs/chat.mdx
@@ -37,4 +37,6 @@ For direct transcript editing, speaker reassignment, and re-transcription, see [
 
 Chat sends the prompt and required context to your selected Intelligence provider. A local provider keeps that model request on your computer. A hosted provider receives the text needed to answer.
 
-Chat can also search the public web when a request needs current external information. The search query leaves your device. See [Data, privacy, and retention](/data-and-privacy) before using sensitive context with hosted models or web search.
+<Warning>
+  Chat can also search the public web when a request needs current external information. The search query leaves your device even if your Transcription and Intelligence models are local. See [Data, privacy, and retention](/data-and-privacy) before using sensitive context with hosted models or web search.
+</Warning>

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -13,7 +13,9 @@ Your notes, local transcripts, settings, recordings you choose to keep, and down
 
 [Cloud Sync](/sync#what-cloud-sync-replicates) can copy encrypted notes to your other signed-in devices. Transcription and Intelligence API keys, model selections, calendar connections, and most other settings stay on the computer where you set them.
 
-Use Anarlog's export tools when you need a portable copy. Do not edit the app database directly.
+<Warning>
+  Do not edit the app database directly — this can corrupt your notes. Use Anarlog's export tools when you need a portable copy.
+</Warning>
 
 ## When content is sent elsewhere
 
@@ -22,7 +24,7 @@ The destination depends on the feature you choose:
 - A hosted **Transcription** provider receives the audio needed to create a transcript.
 - A hosted **Intelligence** provider receives the text and instructions needed to create a summary or chat response.
 - Connected calendars send the calendar and event details needed to show upcoming events and associate them with your notes.
-- [Sync](/sync#what-cloud-sync-replicates) sends end-to-end encrypted notes to keep your devices up to date. Anarlog cannot read the recovery key. API keys and most settings stay on each device.
+- [Cloud Sync](/sync#what-cloud-sync-replicates) sends end-to-end encrypted notes to keep your devices up to date. Anarlog cannot read the recovery key. API keys and most settings stay on each device.
 - [Sharing](/sharing) uploads the generated summary and any audio you explicitly include. Your private memo is not part of the shared note.
 - [Chat](/chat) sends the prompt and required context to your selected Intelligence provider. Public web search also sends the search query to the search service.
 - [Cloud API & Connectors](/reference/api-cloud), when you explicitly enable it, uploads a separate server-readable copy of meeting titles, notes, summaries, participants, action items, and transcripts so remote agents can work while your desktop is offline. Turning it off deletes those copies.
@@ -50,7 +52,9 @@ Open **Settings → Meetings** and find **Audio file retention** under **Audio**
 - **1 month**
 - **Forever**
 
-Deleting retained audio does not remove the meeting note or transcript. If you need the recording later, open the meeting's **•••** menu, choose **Show in Finder**, and copy the audio before its retention period ends.
+<Warning>
+  Once the retention period passes, the audio is gone for good — the meeting note and transcript remain, but the recording does not. If you need the recording later, open the meeting's **•••** menu, choose **Show in Finder**, and copy the audio before its retention period ends.
+</Warning>
 
 ## Turn off usage analytics
 

--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -34,7 +34,7 @@ The managed Transcription route chooses a provider from the meeting's languages 
 
 - Deepgram currently resolves the route to **Nova 3** or **Nova 2**, depending on language support.
 - Soniox currently resolves it to **Soniox 5**: `stt-rt-v5` for live transcription and `stt-async-v5` after recording.
-- AssemblyAI currently resolves it to **Universal 3.5 Pro** (`universal-3-5-pro`) for live and after-recording transcription.
+- AssemblyAI currently resolves it to **Universal 3.5 Pro**: `universal-3-5-pro-realtime` for live transcription and `universal-3-5-pro` after recording.
 - After-recording transcription prefers Soniox when it supports the selected languages.
 - The eligible fallback pool also includes configured routes for Gladia (currently **Solaria 1**), ElevenLabs, OpenAI, Mistral, and Alibaba Cloud Model Studio.
 
@@ -87,7 +87,9 @@ Not every AI-adjacent feature is controlled by AI Settings:
 | Speaker voiceprints | `wespeaker-embedding-onnx-1` voice embeddings | On your computer |
 | Audio cleanup and speech detection | Bundled ONNX models | On your computer |
 
-When chat uses web search, Anarlog sends the search query to its hosted research endpoint, which currently uses Exa. The returned text can then become context for your selected Intelligence model.
+<Note>
+  When chat uses web search, Anarlog sends the search query to its hosted research endpoint, which currently uses Exa, even when your Transcription and Intelligence models are local. The returned text can then become context for your selected Intelligence model.
+</Note>
 
 ## Your own provider
 

--- a/docs/notes.mdx
+++ b/docs/notes.mdx
@@ -20,7 +20,9 @@ When CLI, MCP, or Chat stages a memo or summary replacement, the meeting shows a
 - Select a speaker label to choose an existing participant or **Create new speaker**. Use **Apply to all** to update every matching speaker segment.
 - Right-click **Transcript** to copy the transcript, resume listening, re-transcribe retained audio, or delete the recording.
 
-Re-transcribing replaces the current transcript with output from your selected Transcription model. Edit or export anything you need before you start it.
+<Warning>
+  Re-transcribing permanently replaces the current transcript with output from your selected Transcription model. Edit or export anything you need before you start it.
+</Warning>
 
 Deleting the recording does not delete the memo, summary, or transcript. It only removes the retained audio file.
 

--- a/docs/offline.mdx
+++ b/docs/offline.mdx
@@ -41,3 +41,7 @@ Before a sensitive meeting, confirm both selections:
 - **Settings → Intelligence → Model being used** points to LM Studio, Ollama, Unsloth, or Apple Intelligence.
 
 Choosing a local model for only one setting does not make the other setting local. See [How can I use on-device models?](/help#use-on-device-models) for each transcription path, [Models and providers](/models-and-providers) for the current model list, and [Data, privacy, and retention](/data-and-privacy) for what each provider receives.
+
+<Warning>
+  Chat's web search always sends your search query to a hosted research endpoint, even when Transcription and Intelligence are both fully local. Avoid web search in Chat for a sensitive meeting.
+</Warning>

--- a/docs/reference/api-cloud.mdx
+++ b/docs/reference/api-cloud.mdx
@@ -36,7 +36,7 @@ The read endpoints are:
 | Endpoint | Returns |
 | --- | --- |
 | `GET /v1/meetings` | Meeting list. Accepts `query`, `series_id`, `limit` (default 20, clamped to `1..200`), and `offset`. |
-| `GET /v1/meetings/{meeting_id}` | Meeting metadata, the canonical note, summaries, participants, and action items. Note and summary bodies are markdown. |
+| `GET /v1/meetings/{meeting_id}` | Meeting metadata, the canonical memo, summaries, participants, and action items. Memo and summary bodies are markdown. |
 | `GET /v1/meetings/{meeting_id}/transcript` | Joined `text`, the raw `words`, and `pagination`. Accepts `offset` and `limit` (default 200, clamped to `1..500`). |
 | `GET /v1/meetings/{meeting_id}/history` | Meetings in the same recurring series, newest first. Accepts `limit` and `offset`. |
 | `GET /v1/meetings/{meeting_id}/export` | Full export including transcripts. `format=json` (default) or `format=markdown`. |
@@ -180,7 +180,11 @@ const response = await client.responses.create({
 
 ### Poke
 
-Poke does not complete MCP OAuth. Create a personal cloud API key in Anarlog and paste it only into your own Poke recipe or connection. Do not share that key, put it in a public recipe, or reuse one key across users.
+Poke does not complete MCP OAuth. Create a personal cloud API key in Anarlog and paste it only into your own Poke recipe or connection.
+
+<Warning>
+  Do not share that key, put it in a public recipe, or reuse one key across users.
+</Warning>
 
 ### Other MCP clients
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -53,7 +53,7 @@ All meeting read commands support all three sources. `--base`, `--db-path`, and 
 | Command | Options | Result |
 | --- | --- | --- |
 | `meetings list` | `-q, --query TEXT`, `--series-id ID`, `--limit 1..200`, `--offset NUMBER` | Meetings ordered by the application query layer. Defaults to 20 results. |
-| `meetings get ID` | — | Metadata, canonical note, summaries, participants, and action items. |
+| `meetings get ID` | — | Metadata, canonical memo, summaries, participants, and action items. |
 | `meetings note ID` | `--kind note\|summary\|all` | The selected note documents. Defaults to `note`. |
 | `meetings transcript ID` | `--limit 1..500`, `--offset NUMBER` | A bounded transcript word page. Defaults to 200 words from offset 0. |
 | `meetings history ID` | `--limit 1..200`, `--offset NUMBER` | A page of meetings from the same recurring series. Defaults to 20 from offset 0. |
@@ -97,7 +97,11 @@ Checks the resolved database path, read-only access, and required schema without
 anarlog mcp
 ```
 
-Starts the local MCP server over stdio. Meeting reads are idempotent. Proposal tools stage or decline pending edits without applying them to the meeting. Do not write other output to the server's stdout.
+Starts the local MCP server over stdio. Meeting reads are idempotent. Proposal tools stage or decline pending edits without applying them to the meeting.
+
+<Warning>
+  Do not write other output to the server's stdout. Anything else written there corrupts the MCP stdio protocol stream.
+</Warning>
 
 ## Help and version
 

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -19,4 +19,6 @@ Cloud meeting commands preserve hosted error codes: `unauthorized`, `insufficien
 
 MCP maps missing meetings and proposals to invalid parameters. Validation and conflict failures—such as empty proposal content, multiple summaries without `target_id`, or declining a non-pending proposal—are reported as internal MCP errors. Database and serialization failures are also internal errors.
 
-Do not recover by creating tables, running migrations, or issuing SQL. The desktop app owns schema initialization and migrations.
+<Warning>
+  Do not recover by creating tables, running migrations, or issuing SQL. The desktop app owns schema initialization and migrations, and manual changes can corrupt the database.
+</Warning>

--- a/docs/reference/mcp.mdx
+++ b/docs/reference/mcp.mdx
@@ -18,7 +18,7 @@ Run the server with `anarlog mcp`. It supports the current MCP `2026-07-28` prot
 
 ### `get_meeting`
 
-Accepts required string `meeting_id`. Returns meeting metadata, the canonical note, summaries, participants, and action items. Transcript words are intentionally separate.
+Accepts required string `meeting_id`. Returns meeting metadata, the canonical memo, summaries, participants, and action items. Transcript words are intentionally separate.
 
 ### `get_meeting_transcript`
 

--- a/docs/reference/webhooks.mdx
+++ b/docs/reference/webhooks.mdx
@@ -18,6 +18,10 @@ To read meeting data instead of receiving it, use the [CLI](/reference/cli), the
 3. Copy the signing secret (`whsec_...`). It is shown once.
 4. Click **Test** to send one `webhook.test` delivery and confirm your endpoint responds.
 
+<Note>
+  The signing secret is shown once during setup. Store it before leaving the page — Anarlog does not display it again.
+</Note>
+
 A new endpoint is subscribed to all events. One installation can configure at most 64 endpoints.
 
 ## Events
@@ -74,4 +78,8 @@ Verify the raw body before parsing it. For replay protection, reject stale signe
 
 ## Limits
 
-Deliveries only run while the desktop app is open; events that occur while it is closed are not queued for later. Anarlog delivers to at most 64 endpoints per event and runs at most 4 deliveries at a time.
+<Warning>
+  Deliveries only run while the desktop app is open. Events that occur while it is closed are dropped, not queued for later delivery.
+</Warning>
+
+Anarlog delivers to at most 64 endpoints per event and runs at most 4 deliveries at a time.

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -23,8 +23,14 @@ See [Data, privacy, and retention](/data-and-privacy) for the in-app settings th
 - [Terms of Service](https://anarlog.so/terms)
 - Data Processing Addendum: email [founders@anarlog.so](mailto:founders@anarlog.so?subject=Anarlog%20DPA)
 
-We do not claim SOC 2, ISO 27001, or HIPAA on these pages.
+<Note>
+  We do not claim SOC 2, ISO 27001, or HIPAA on these pages.
+</Note>
 
 ## Report a vulnerability
 
-Use [private GitHub reporting](https://github.com/fastrepl/anarlog/security/advisories/new) or email founders@fastrepl.com. Do not open a public issue. See the repository [security policy](https://github.com/fastrepl/anarlog/blob/main/SECURITY.md).
+Use [private GitHub reporting](https://github.com/fastrepl/anarlog/security/advisories/new) or email [founders@anarlog.so](mailto:founders@anarlog.so). See the repository [security policy](https://github.com/fastrepl/anarlog/blob/main/SECURITY.md).
+
+<Warning>
+  Do not open a public GitHub issue for a security vulnerability. Use private reporting so it isn't disclosed before a fix ships.
+</Warning>

--- a/docs/sharing.mdx
+++ b/docs/sharing.mdx
@@ -21,7 +21,11 @@ The first share creates an online copy of the summary. Later summary edits sync 
 
 Opening **Share** does not send an email, create an invitation, grant access, or publish an unshared note.
 
-For meetings with attendee email addresses, Anarlog lists those people under **Suggested attendees**. They do not have access yet. Clicking **Invite** sends an invitation to every person still listed, including any address you entered. Remove a suggestion before inviting if you do not want to include that person.
+For meetings with attendee email addresses, Anarlog lists those people under **Suggested attendees**. They do not have access yet.
+
+<Warning>
+  Clicking **Invite** sends an invitation to every person still listed, including any address you entered. Remove a suggestion first if you do not want to include that person.
+</Warning>
 
 Sharing emails are action-based:
 

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -23,7 +23,9 @@ Workspace owners and admins can open **Members** to:
 - Change a member between the Admin and Member roles
 - Remove a member
 
-Only the owner can transfer ownership. Transfer ownership before leaving when someone else should keep the workspace. Deleting a workspace removes it for everyone.
+<Warning>
+  Deleting a workspace removes it for everyone in it, and cannot be undone. Only the owner can transfer ownership, so transfer it before leaving if someone else should keep the workspace.
+</Warning>
 
 ## Share a meeting with the workspace
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -82,7 +82,11 @@ Open **Settings → Sync** and use the message shown there:
 - **Device limit reached:** Remove an unused device before adding another one. An account can sync up to five devices.
 - **macOS Keychain error:** Click **Repair Keychain Access**, then resume sync.
 
-Do not move or delete local data while an identity problem is unresolved. See [Cloud sync](/sync#fix-a-blocked-sync).
+<Warning>
+  Do not move or delete local data while an identity problem is unresolved.
+</Warning>
+
+See [Cloud sync](/sync#fix-a-blocked-sync).
 
 ## The app does not open after installation
 
@@ -110,6 +114,10 @@ The same variables work for the installed `anarlog` command. See [Install the de
 
 Email [founders@anarlog.so](mailto:founders@anarlog.so), [join Discord](https://anarlog.so/discord), or [open a GitHub issue](https://github.com/fastrepl/anarlog/issues).
 
-Include your operating system, Anarlog version, the exact error, what you expected, and the shortest steps that reproduce the problem. For AI failures, include the selected provider and model, but never include API keys, recovery keys, meeting content, or private share links.
+Include your operating system, Anarlog version, the exact error, what you expected, and the shortest steps that reproduce the problem. For AI failures, include the selected provider and model.
+
+<Warning>
+  Never include API keys, recovery keys, meeting content, or private share links when reporting a problem.
+</Warning>
 
 For CLI and MCP errors, use the [error reference](/reference/errors).


### PR DESCRIPTION
Follow-up to the sync.mdx cloud-storage warning fix (#7457): a full docs audit found the same pattern (important risk/irreversibility text left as plain prose, easy to miss) repeated across most pages.

- Wraps ~20 previously-plain-text cautions in <Warning>/<Note> callouts: workspace deletion, re-transcribing overwrites the transcript, editing the app database directly, audio unrecoverable after retention window, calendar-disconnect local-data deletion, webhook secret shown once / events dropped while closed, Chat web search always leaves the device even fully offline, Invite sends to everyone listed, don't run SQL/migrations manually, don't open a public security issue, never paste keys into support requests, plus a few agent/CLI/MCP gotchas.
- Fixes 3 factual bugs: wrong vulnerability-report email in security.mdx (founders@fastrepl.com -> founders@anarlog.so), a self-contradictory AssemblyAI live-transcription model ID in models-and-providers.mdx, and inconsistent "canonical note" vs "canonical meeting memo" terminology across reference/mcp.mdx, reference/api-cloud.mdx, and reference/cli.mdx (now "canonical memo" everywhere).
- Minor: consistent "Cloud Sync" link label in data-and-privacy.mdx.

No broken internal links found in the audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API changes; factual fixes reduce misconfiguration and support risk.
> 
> **Overview**
> This PR makes high-impact docs guidance harder to miss by moving many risks that were buried in plain paragraphs into **`<Warning>`** and **`<Note>`** callouts across agent, privacy, sharing, teams, calendar, webhooks, CLI/MCP reference, and related pages — covering irreversible actions (re-transcribe, workspace delete, local DB wipe), data leaving the device (Chat web search even with local models), export `--force`, MCP stdio stdout, webhook secrets/dropped events, and similar gotchas.
> 
> It also corrects a few factual inconsistencies: vulnerability reporting email is **`founders@anarlog.so`**, AssemblyAI live transcription is documented as **`universal-3-5-pro-realtime`** (separate from after-recording **`universal-3-5-pro`**), and Cloud API/CLI/MCP reference text now consistently says **canonical memo** instead of mixed “note” wording. **`data-and-privacy.mdx`** uses a consistent **Cloud Sync** link label; automatic-capture and security pages get clearer consent and private-disclosure wording without changing product behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952868acdc9328c0edc9174b5a66055185a17f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->