### PR TITLE
Fix desktop release APT workflow reference

### DIFF
--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -734,7 +734,7 @@ jobs:
     needs: linux-package-bump
     permissions:
       contents: write
-    uses: $/.github/workflows/web_cd.yaml
+    uses: ./.github/workflows/web_cd.yaml
     with:
       sha: ${{ needs.linux-package-bump.outputs.sha }}
     secrets:

--- a/scripts/verify-apt-repository.test.mjs
+++ b/scripts/verify-apt-repository.test.mjs
@@ -113,7 +113,7 @@ test("the release deploys and verifies the merged metadata commit", async () => 
     .split("\n  linux-apt-verify:\n")[0];
   const verify = publish.split("\n  linux-apt-verify:\n")[1];
   assert.match(deploy, /needs: linux-package-bump/);
-  assert.match(deploy, /uses: \$\/\.github\/workflows\/web_cd\.yaml/);
+  assert.match(deploy, /uses: \.\/\.github\/workflows\/web_cd\.yaml/);
   assert.match(
     deploy,
     /sha: \$\{\{ needs\.linux-package-bump\.outputs\.sha \}\}/,


### PR DESCRIPTION
Correct the local reusable workflow path and update its regression test so Linux APT deployment can run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only path correction with an updated guard test; no runtime application or security logic changes.
> 
> **Overview**
> Fixes a broken reusable workflow reference in the desktop stable publish pipeline so **Linux APT metadata can deploy after the packaging PR merges**.
> 
> The `linux-apt-deploy` job now calls `./.github/workflows/web_cd.yaml` instead of the invalid `$/.github/workflows/web_cd.yaml` path, matching how other jobs in the same workflow reference local reusable workflows. The regression test in `verify-apt-repository.test.mjs` is updated to assert the corrected `uses` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2a739fde44d2bb2bd6e0bb195c1f51598c8461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->