### PR TITLE
Collapse chat activity into one expandable line

### DIFF
--- a/apps/desktop/src/chat/components/message/normal.tsx
+++ b/apps/desktop/src/chat/components/message/normal.tsx
@@ -36,6 +36,10 @@ export function NormalMessage({
 }) {
   const { t } = useLingui();
   const isUser = message.role === "user";
+  const activityParts = isUser ? [] : message.parts.filter(isActivityPart);
+  const visibleParts = isUser
+    ? message.parts
+    : message.parts.filter((part) => !isActivityPart(part));
   const [copied, setCopied] = useState(false);
   const copiedResetTimeoutRef = useRef<number | null>(null);
 
@@ -77,7 +81,17 @@ export function NormalMessage({
         ])}
       >
         <MessageBubble variant={isUser ? "user" : "assistant"}>
-          {message.parts.map((part, i) => (
+          {activityParts.length > 0 && (
+            <Disclosure
+              icon={<Brain className="h-3 w-3" />}
+              title={t`Activity`}
+            >
+              {activityParts.map((part, i) => (
+                <Part key={i} part={part as Part} />
+              ))}
+            </Disclosure>
+          )}
+          {visibleParts.map((part, i) => (
             <Part key={i} part={part as Part} />
           ))}
         </MessageBubble>
@@ -103,6 +117,19 @@ export function NormalMessage({
         )}
       </div>
     </MessageContainer>
+  );
+}
+
+function isActivityPart(part: AnlgUIMessage["parts"][number]) {
+  if (part.type === "reasoning") {
+    return part.text.trim().length > 0;
+  }
+
+  return (
+    (part.type.startsWith("tool-") || part.type === "dynamic-tool") &&
+    part.type !== "tool-edit_memo" &&
+    part.type !== "tool-edit_summary" &&
+    part.type !== "tool-update_prompt_template"
   );
 }
 

--- a/apps/desktop/src/chat/components/message/normal.tsx
+++ b/apps/desktop/src/chat/components/message/normal.tsx
@@ -6,6 +6,7 @@ import {
   ArrowCounterClockwise,
   Brain,
   Check,
+  CircleNotch,
   Copy,
 } from "@anlg/ui/components/icons";
 import { streamdownIcons } from "@anlg/ui/components/streamdown-icons";
@@ -37,6 +38,12 @@ export function NormalMessage({
   const { t } = useLingui();
   const isUser = message.role === "user";
   const activityParts = isUser ? [] : message.parts.filter(isActivityPart);
+  const activityRunning = activityParts.some((part) =>
+    part.type === "reasoning"
+      ? part.state === "streaming"
+      : "state" in part &&
+        (part.state === "input-streaming" || part.state === "input-available"),
+  );
   const visibleParts = isUser
     ? message.parts
     : message.parts.filter((part) => !isActivityPart(part));
@@ -83,7 +90,13 @@ export function NormalMessage({
         <MessageBubble variant={isUser ? "user" : "assistant"}>
           {activityParts.length > 0 && (
             <Disclosure
-              icon={<Brain className="h-3 w-3" />}
+              icon={
+                activityRunning ? (
+                  <CircleNotch className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Brain className="h-3 w-3" />
+                )
+              }
               title={t`Activity`}
             >
               {activityParts.map((part, i) => (

--- a/apps/desktop/src/chat/components/message/shared.tsx
+++ b/apps/desktop/src/chat/components/message/shared.tsx
@@ -108,8 +108,9 @@ export function Disclosure({
   return (
     <details
       className={cn([
-        "group my-2 rounded-md border px-2 py-1 transition-colors",
+        "my-2 rounded-md border px-2 py-1 transition-colors",
         "border-border hover:border-border cursor-pointer",
+        "[&[open]>summary>span:last-of-type]:font-medium [&[open]>summary>svg:last-child]:rotate-90",
       ])}
     >
       <summary
@@ -128,10 +129,8 @@ export function Disclosure({
       >
         {disabled ? <CircleNotch className="h-3 w-3 animate-spin" /> : null}
         {!disabled && icon && <span className="shrink-0">{icon}</span>}
-        <span className={cn(["flex-1 truncate", "group-open:font-medium"])}>
-          {title}
-        </span>
-        <CaretRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
+        <span className="flex-1 truncate">{title}</span>
+        <CaretRight className="h-3 w-3 shrink-0 transition-transform" />
       </summary>
       <div className="border-border mt-1 border-t px-1 pt-2">{children}</div>
     </details>

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -223,6 +223,7 @@ msgstr "Action"
 msgid "Active days"
 msgstr "Active days"
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr "Activity"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -223,6 +223,7 @@ msgstr ""
 msgid "Active days"
 msgstr ""
 
+#: src/chat/components/message/normal.tsx
 #: src/templates/template-icon-picker.tsx
 msgid "Activity"
 msgstr ""


### PR DESCRIPTION
Group reasoning and tool steps while keeping responses and edit controls visible. Scope disclosure styling to each row and refresh translation references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop chat UI presentation only; no auth, sync, or data-path changes.
> 
> **Overview**
> Assistant chat messages no longer render reasoning and tool steps inline with the reply. **Reasoning** (when non-empty) and most **tool** parts are grouped into a single collapsible **Activity** block at the top of the bubble, with a spinning icon while any step is still streaming.
> 
> **Text** and user-visible edits stay in the main flow: `tool-edit_memo`, `tool-edit_summary`, and `tool-update_prompt_template` are excluded from Activity so memo/summary/prompt changes remain visible without expanding.
> 
> `Disclosure` open-state styling in `shared.tsx` switches from Tailwind `group-open` to `[open]` attribute selectors on the `<details>` element. Locale catalogs only add a source reference for the reused **Activity** string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b20c85bae3ab9255d84d9c3b752b955f0b2d95b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->