### PR TITLE
Preserve undo history when applying note edits

### DIFF
--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -8,6 +8,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { redo, undo } from "prosemirror-history";
 import { Node as PMNode } from "prosemirror-model";
 import { EditorState, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
@@ -378,6 +379,50 @@ describe("browser-safe editor controls", () => {
 
     expect(ref.current?.view?.state.doc.textContent).toBe("new");
     toJSON.mockRestore();
+  });
+
+  it("preserves undo history across external edits without persisting the sync", async () => {
+    vi.useFakeTimers();
+    const ref = createRef<NoteEditorRef>();
+    const handleChange = vi.fn();
+    const props = { ref, handleChange, enforceTitleHeading: false };
+    const rendered = render(
+      createElement(NoteEditor, { ...props, initialContent: baseDoc }),
+    );
+    const view = ref.current!.view!;
+    act(() => view.dispatch(view.state.tr.insertText("!", 4)));
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    handleChange.mockClear();
+
+    rendered.rerender(
+      createElement(NoteEditor, { ...props, initialContent: nextDoc }),
+    );
+    expect(view.state.doc.textContent).toBe("new");
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    expect(handleChange).not.toHaveBeenCalled();
+
+    act(() => view.dispatch(view.state.tr.insertText("?", 4)));
+    act(() => {
+      expect(undo(view.state, view.dispatch)).toBe(true);
+    });
+    expect(view.state.doc.textContent).toBe("new");
+    act(() => {
+      expect(undo(view.state, view.dispatch)).toBe(true);
+    });
+    expect(view.state.doc.textContent).toBe("old!");
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    expect(handleChange).toHaveBeenLastCalledWith(view.state.doc.toJSON());
+    act(() => {
+      expect(undo(view.state, view.dispatch)).toBe(true);
+    });
+    expect(view.state.doc.textContent).toBe("old");
+    act(() => {
+      expect(redo(view.state, view.dispatch)).toBe(true);
+    });
+    act(() => {
+      expect(redo(view.state, view.dispatch)).toBe(true);
+    });
+    expect(view.state.doc.textContent).toBe("new");
   });
 
   it("keeps external content deferred while focus is in editor popups", async () => {

--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -425,6 +425,51 @@ describe("browser-safe editor controls", () => {
     expect(view.state.doc.textContent).toBe("new");
   });
 
+  it("reports the normalized synced document without persisting appended transactions", async () => {
+    vi.useFakeTimers();
+    const ref = createRef<NoteEditorRef>();
+    const handleChange = vi.fn();
+    const onDocumentChange = vi.fn();
+    const props = {
+      ref,
+      handleChange,
+      onDocumentChange,
+      enforceTitleHeading: false,
+    };
+    const rendered = render(
+      createElement(NoteEditor, { ...props, initialContent: baseDoc }),
+    );
+    const view = ref.current!.view!;
+
+    rendered.rerender(
+      createElement(NoteEditor, {
+        ...props,
+        initialContent: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "https://example.com" }],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(view.state.doc.firstChild?.firstChild?.marks).toEqual([
+      expect.objectContaining({ type: schema.marks.link }),
+    ]);
+    expect(onDocumentChange).toHaveBeenCalledExactlyOnceWith(
+      view.state.doc.toJSON(),
+    );
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    expect(handleChange).not.toHaveBeenCalled();
+
+    act(() => view.dispatch(view.state.tr.insertText(" more", 20)));
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    expect(handleChange).toHaveBeenLastCalledWith(view.state.doc.toJSON());
+  });
+
   it("keeps external content deferred while focus is in editor popups", async () => {
     const ref = createRef<NoteEditorRef>();
     const props = {

--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -441,18 +441,19 @@ describe("browser-safe editor controls", () => {
     );
     const view = ref.current!.view!;
 
+    const incoming: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "https://example.com" }],
+        },
+      ],
+    };
     rendered.rerender(
       createElement(NoteEditor, {
         ...props,
-        initialContent: {
-          type: "doc",
-          content: [
-            {
-              type: "paragraph",
-              content: [{ type: "text", text: "https://example.com" }],
-            },
-          ],
-        },
+        initialContent: incoming,
       }),
     );
 
@@ -465,9 +466,26 @@ describe("browser-safe editor controls", () => {
     await act(() => vi.advanceTimersByTimeAsync(500));
     expect(handleChange).not.toHaveBeenCalled();
 
+    rendered.rerender(
+      createElement(NoteEditor, {
+        ...props,
+        initialContent: structuredClone(incoming),
+      }),
+    );
+    expect(onDocumentChange).toHaveBeenCalledOnce();
+
     act(() => view.dispatch(view.state.tr.insertText(" more", 20)));
     await act(() => vi.advanceTimersByTimeAsync(500));
     expect(handleChange).toHaveBeenLastCalledWith(view.state.doc.toJSON());
+    act(() => {
+      expect(undo(view.state, view.dispatch)).toBe(true);
+    });
+    expect(view.state.doc.textContent).toBe("https://example.com");
+    expect(view.state.doc.firstChild?.firstChild?.marks).toHaveLength(1);
+    act(() => {
+      expect(undo(view.state, view.dispatch)).toBe(true);
+    });
+    expect(view.state.doc.textContent).toBe("old");
   });
 
   it("keeps external content deferred while focus is in editor popups", async () => {

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -840,6 +840,12 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         const view = viewRef.current;
         if (!view) return;
         if (previousContentRef.current === reconciledInitialContent) return;
+        if (
+          isSameContent(previousContentRef.current, reconciledInitialContent)
+        ) {
+          previousContentRef.current = reconciledInitialContent;
+          return;
+        }
 
         if (
           !reconciledInitialContent ||
@@ -896,9 +902,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
               closeHistory(
                 view.state.tr
                   .replaceWith(0, view.state.doc.content.size, doc.content)
-                  .setMeta("externalContentSync", true)
-                  // A zero history timestamp also separates subsequent typing.
-                  .setTime(0),
+                  .setMeta("externalContentSync", true),
               ),
             );
           }

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -747,7 +747,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
             doc,
             ...(content ? { content } : {}),
           });
-        }),
+        }, notifyDocumentChange),
         buildInputRules(),
         ...(enforceTitleHeading ? [titleHeadingPlugin()] : []),
         taskIdentityPlugin(),
@@ -902,7 +902,6 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
               ),
             );
           }
-          notifyDocumentChange(doc);
           previousContentRef.current = reconciledInitialContent;
         } catch {
           // invalid content
@@ -924,7 +923,6 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       enforceTitleHeading,
       readOnly,
       onUpdate,
-      notifyDocumentChange,
     ]);
 
     const onViewReady = useCallback(

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@handlewithcare/react-prosemirror";
 import { dropCursor } from "prosemirror-dropcursor";
 import { gapCursor } from "prosemirror-gapcursor";
-import { history } from "prosemirror-history";
+import { closeHistory, history } from "prosemirror-history";
 import { Node as PMNode } from "prosemirror-model";
 import {
   EditorState,
@@ -886,13 +886,23 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
           if (enforceTitleHeading) {
             doc = normalizeTitleHeadingDoc(doc);
           }
-          const state = EditorState.create({
-            doc,
-            plugins: view.state.plugins,
-          });
           onUpdate.cancel();
-          view.updateState(state);
-          notifyDocumentChange(view.state.doc);
+          if (readOnly) {
+            view.updateState(
+              EditorState.create({ doc, plugins: view.state.plugins }),
+            );
+          } else {
+            view.dispatch(
+              closeHistory(
+                view.state.tr
+                  .replaceWith(0, view.state.doc.content.size, doc.content)
+                  .setMeta("externalContentSync", true)
+                  // A zero history timestamp also separates subsequent typing.
+                  .setTime(0),
+              ),
+            );
+          }
+          notifyDocumentChange(doc);
           previousContentRef.current = reconciledInitialContent;
         } catch {
           // invalid content
@@ -912,6 +922,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       reconciledInitialContent,
       syncContentWhenFocused,
       enforceTitleHeading,
+      readOnly,
       onUpdate,
       notifyDocumentChange,
     ]);

--- a/packages/editor/src/plugins/doc-change-listener.ts
+++ b/packages/editor/src/plugins/doc-change-listener.ts
@@ -10,7 +10,10 @@ export function docChangeListenerPlugin(onDocChanged: (doc: PMNode) => void) {
     key: docChangedByTransactionKey,
     state: {
       init: () => false,
-      apply: (transaction, previous) => transaction.docChanged || previous,
+      apply: (transaction, previous) =>
+        transaction.getMeta("externalContentSync")
+          ? false
+          : transaction.docChanged || previous,
     },
     view() {
       return {

--- a/packages/editor/src/plugins/doc-change-listener.ts
+++ b/packages/editor/src/plugins/doc-change-listener.ts
@@ -13,12 +13,17 @@ export function docChangeListenerPlugin(
     key: docChangedByTransactionKey,
     state: {
       init: () => false,
-      apply: (transaction, previous) =>
-        (transaction.getMeta("appendedTransaction") ?? transaction).getMeta(
-          "externalContentSync",
-        )
-          ? false
-          : transaction.docChanged || previous,
+      apply(transaction, previous) {
+        const appended = transaction.getMeta("appendedTransaction");
+        if ((appended ?? transaction).getMeta("externalContentSync")) {
+          return false;
+        }
+        if (transaction.docChanged && !appended && !previous) {
+          // This plugin precedes history so the first user edit after sync starts a group.
+          closeHistory(transaction);
+        }
+        return transaction.docChanged || previous;
+      },
     },
     view() {
       return {
@@ -38,3 +43,4 @@ export function docChangeListenerPlugin(
     },
   });
 }
+import { closeHistory } from "prosemirror-history";

--- a/packages/editor/src/plugins/doc-change-listener.ts
+++ b/packages/editor/src/plugins/doc-change-listener.ts
@@ -5,13 +5,18 @@ const docChangedByTransactionKey = new PluginKey<boolean>(
   "docChangedByTransaction",
 );
 
-export function docChangeListenerPlugin(onDocChanged: (doc: PMNode) => void) {
+export function docChangeListenerPlugin(
+  onDocChanged: (doc: PMNode) => void,
+  onContentSynced?: (doc: PMNode) => void,
+) {
   return new Plugin({
     key: docChangedByTransactionKey,
     state: {
       init: () => false,
       apply: (transaction, previous) =>
-        transaction.getMeta("externalContentSync")
+        (transaction.getMeta("appendedTransaction") ?? transaction).getMeta(
+          "externalContentSync",
+        )
           ? false
           : transaction.docChanged || previous,
     },
@@ -23,6 +28,7 @@ export function docChangeListenerPlugin(onDocChanged: (doc: PMNode) => void) {
           }
 
           if (!docChangedByTransactionKey.getState(view.state)) {
+            onContentSynced?.(view.state.doc);
             return;
           }
 


### PR DESCRIPTION
Apply external content through editor transactions as separate undo steps, avoid redundant saves, and cover undo and redo across replacements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how external content merges with local edits, undo history, and what triggers persistence—core note editor behavior, though scoped and covered by new tests.
> 
> **Overview**
> External **`initialContent`** updates no longer reset the ProseMirror editor with **`updateState`** (editable mode). They apply via a **`replaceWith`** transaction wrapped in **`closeHistory`**, tagged with **`externalContentSync`**, so remote/collaborative replacements become their own undo step while prior local edits stay on the stack.
> 
> **`docChangeListenerPlugin`** now treats those sync transactions separately: they fire **`onDocumentChange`** (normalized doc, e.g. autolinks) but **not** the debounced **`handleChange`** persist path, including when input rules append follow-up transactions. The first real user edit after a sync calls **`closeHistory`** so undo grouping stays sensible.
> 
> The note editor also skips redundant sync when stored and incoming JSON are equivalent (reference or deep equality), and read-only mode still uses **`updateState`**. New tests cover undo/redo across external edits and sync-without-save behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5381f5af6d1322daf302b593bea9b048632a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->