### PR TITLE
Complete desktop 1.4.23 release documentation and package checks

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -268,6 +268,8 @@ jobs:
             "${{ steps.macos-symbols.outputs.path }}"
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify macOS updater signature
+        env:
+          EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           shopt -s nullglob
           updater_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos"
@@ -287,6 +289,8 @@ jobs:
             "${artifacts[0]}" \
             "${signatures[0]}" \
             apps/desktop/src-tauri/tauri.conf.json
+          python3 scripts/verify-packaged-cli.py \
+            "${apps[0]}" "$EXPECTED_VERSION"
       - id: find-dmg
         shell: bash
         run: |
@@ -495,6 +499,11 @@ jobs:
               "${deb_signatures[0]}" \
               apps/desktop/src-tauri/tauri.conf.json
           fi
+
+          cli_package="$RUNNER_TEMP/anarlog-cli-package"
+          dpkg-deb --extract "${debs[0]}" "$cli_package"
+          python3 scripts/verify-packaged-cli.py \
+            "$cli_package" "$package_version"
 
           bundles=("$appimage_dir"/* "$deb_dir"/*)
           for bundle in "${bundles[@]}"; do
@@ -815,6 +824,30 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 $installers[0].FullName).Hash.ToLowerInvariant()
           "$hash  $($installers[0].Name)" |
             Out-File "$($installers[0].FullName).sha256" -Encoding ascii -NoNewline
+      - name: Verify installed Windows CLI and MCP
+        shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          $bundleDir = "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          $installer = @(Get-ChildItem $bundleDir -Filter "*.exe")
+          if ($installer.Count -ne 1) {
+            throw "Expected one Windows installer"
+          }
+          $installRoot = Join-Path $env:RUNNER_TEMP "anarlog-cli-package"
+          $installation = Start-Process -FilePath $installer[0].FullName `
+            -ArgumentList @("/S", "/D=$installRoot") -PassThru
+          if (-not $installation.WaitForExit(120000)) {
+            $installation.Kill()
+            throw "Windows package installation timed out"
+          }
+          if ($installation.ExitCode -ne 0) {
+            throw "Windows package installation failed: $($installation.ExitCode)"
+          }
+          python scripts/verify-packaged-cli.py $installRoot $env:EXPECTED_VERSION
+          if ($LASTEXITCODE -ne 0) {
+            throw "Packaged Windows CLI verification failed"
+          }
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify Windows updater signature
         shell: bash

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -268,8 +268,6 @@ jobs:
             "${{ steps.macos-symbols.outputs.path }}"
       - if: ${{ inputs.channel == 'stable' }}
         name: Verify macOS updater signature
-        env:
-          EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           shopt -s nullglob
           updater_dir="apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos"
@@ -289,8 +287,18 @@ jobs:
             "${artifacts[0]}" \
             "${signatures[0]}" \
             apps/desktop/src-tauri/tauri.conf.json
-          python3 scripts/verify-packaged-cli.py \
-            "${apps[0]}" "$EXPECTED_VERSION"
+      - name: Verify packaged macOS CLI and MCP
+        env:
+          EXPECTED_VERSION: ${{ needs.compute-version.outputs.version }}
+          PACKAGE_DIR: apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos
+        run: |
+          shopt -s nullglob
+          apps=("$PACKAGE_DIR"/*.app)
+          if [[ ${#apps[@]} -ne 1 ]]; then
+            echo "Expected one packaged macOS app"
+            exit 1
+          fi
+          python3 scripts/verify-packaged-cli.py "${apps[0]}" "$EXPECTED_VERSION"
       - id: find-dmg
         shell: bash
         run: |

--- a/docs/automatic-capture.mdx
+++ b/docs/automatic-capture.mdx
@@ -11,6 +11,8 @@ Open **Settings → Meetings** and enable **Start when meeting begins**.
 
 When a calendar-backed note reaches its scheduled start time, Anarlog starts listening. This setting does not apply to ordinary notes without a calendar event.
 
+Anarlog discards empty automatic captures while preserving the calendar note and any content recorded on another device.
+
 Enable **Join scheduled meetings** on the same page to open the meeting link when listening starts. That toggle stays disabled until **Start when meeting begins** is on.
 
 Keep Anarlog running and make sure microphone and system-audio access are allowed. See [Connect a calendar](/calendar) if your events are not visible.

--- a/docs/chat.mdx
+++ b/docs/chat.mdx
@@ -21,6 +21,8 @@ Useful requests include:
 
 Chat can search meeting titles and content, recurring meeting history, contacts, and connected calendar events when the request needs them.
 
+Reasoning and tool steps appear in a single **Activity** row. Expand it to inspect the steps; a spinner shows when work is still running. Answers and proposed edits remain visible below it.
+
 ## Guide the context
 
 Chat uses the open meeting automatically and can add other meetings, people, and records when your request needs them. You can also drag another meeting into Chat to include it in your next message.

--- a/docs/notes.mdx
+++ b/docs/notes.mdx
@@ -13,6 +13,8 @@ You can edit memos and summaries like regular notes. In a transcript, select a s
 
 When CLI, MCP, or Chat stages a memo or summary replacement, the meeting shows a **pending edit** banner. Open **Review memo** or **Review summary** to inspect the unified diff, then apply or decline it. A proposal does not change the meeting until you apply it.
 
+After applying a memo or summary edit, use the editor's **Undo** command to restore the previous content. Your earlier typing remains in the undo history.
+
 ## Correct a transcript
 
 - Click **Write** above the transcript to edit its text. Click **Done writing** when you finish.
@@ -41,6 +43,14 @@ Right-click **Transcript** and choose **Resume listening** to add another record
 Use **Share** in the meeting header to invite people, send a recap, or copy a link. Anarlog shares the generated summary, not your private memo. You can include retained audio separately.
 
 See [Share meetings](/sharing) for access levels, comments, and link controls.
+
+## Review your conversation activity
+
+In the desktop app, open **Settings → Insights** to see your busiest weekdays, typical conversation length, and conversations per active day. Choose the last 7 days, last 30 days, or all time. Weekday patterns appear after at least five captured conversations in the selected range.
+
+Open **Settings → Stats** to see your activity and collectible badges. Badges recognize milestones such as your first conversation and recording in more weeks. Collected badges stay on the current device even when you delete a conversation.
+
+Insights and badge collections are desktop views. The CLI, local MCP, and Cloud API do not expose these views or badge collection controls; use their existing meeting and transcript commands to work with your conversations.
 
 ## Export a meeting
 

--- a/packages/changelog/content/1.4.23.md
+++ b/packages/changelog/content/1.4.23.md
@@ -25,3 +25,7 @@ summary: "Anarlog 1.4.23 adds conversation insights and collectible badges, impr
 - Connect to local AI servers that previously rejected requests from Anarlog
 - Save custom transcription providers that do not offer a model list
 - Restore the rounded shape of the **Ask anything** launcher
+- Keep chat reasoning and tool activity in one expandable row, with a spinner
+  while work is in progress
+- Undo applied memo and summary edits without losing your earlier undo history
+- Remove the corner sync indicator; sync controls remain in **Settings → Sync**

--- a/scripts/verify-packaged-cli.py
+++ b/scripts/verify-packaged-cli.py
@@ -1,0 +1,150 @@
+import argparse
+import json
+import os
+from pathlib import Path
+import queue
+import sqlite3
+import subprocess
+import tempfile
+import threading
+
+
+def verify(package_root: Path, version: str):
+    binaries = [
+        path
+        for path in package_root.rglob("anarlog-cli*")
+        if path.is_file() and path.name in {"anarlog-cli", "anarlog-cli.exe"}
+    ]
+    if len(binaries) != 1:
+        raise RuntimeError(f"Expected one packaged CLI, found {binaries}")
+    binary = binaries[0].resolve()
+    snapshot = (
+        Path(__file__).resolve().parent.parent
+        / "apps/cli/src/snapshots/anarlog_cli__mcp__tests__mcp_contract.snap"
+    )
+    contract = json.loads(snapshot.read_text().split("---", 2)[2])
+
+    with tempfile.TemporaryDirectory(prefix="anarlog-cli-release-") as temporary:
+        root = Path(temporary)
+        database = root / "fixture.db"
+        with sqlite3.connect(database) as connection:
+            connection.execute("PRAGMA user_version = 0")
+        env = {
+            **os.environ,
+            "ANARLOG_DISABLE_SENTRY": "1",
+            "ANARLOG_AUTH_PATH": str(root / "auth.json"),
+        }
+        actual = subprocess.check_output(
+            [str(binary), "--version"], text=True, env=env, timeout=30
+        ).strip()
+        if actual != f"anarlog {version}":
+            raise RuntimeError(f"Unexpected packaged CLI version: {actual}")
+        for command in [[], ["meetings"], ["proposals"], ["mcp"]]:
+            subprocess.run(
+                [str(binary), *command, "--help"],
+                check=True,
+                capture_output=True,
+                env=env,
+                timeout=30,
+            )
+
+        messages = queue.Queue()
+        with (root / "stderr.log").open("w+") as errors:
+            process = subprocess.Popen(
+                [str(binary), "--db-path", str(database), "mcp"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=errors,
+                text=True,
+                env=env,
+            )
+
+            def read_output():
+                for line in process.stdout:
+                    messages.put(line)
+                messages.put(None)
+
+            reader = threading.Thread(target=read_output, daemon=True)
+            reader.start()
+
+            def send(message):
+                process.stdin.write(json.dumps({"jsonrpc": "2.0", **message}) + "\n")
+                process.stdin.flush()
+
+            def request(identifier, method, params=None):
+                send({"id": identifier, "method": method, "params": params or {}})
+                line = messages.get(timeout=30)
+                if line is None:
+                    raise RuntimeError("MCP exited before responding")
+                response = json.loads(line)
+                if (
+                    response.get("jsonrpc") != "2.0"
+                    or response.get("id") != identifier
+                    or "error" in response
+                    or "result" not in response
+                ):
+                    raise RuntimeError(f"Unexpected MCP response: {response}")
+                return response["result"]
+
+            try:
+                initialized = request(
+                    1,
+                    "initialize",
+                    {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": {"name": "release-verification", "version": "1"},
+                    },
+                )
+                # Newer MCP revisions replace initialize with per-request metadata.
+                if initialized["protocolVersion"] != "2025-11-25":
+                    raise RuntimeError(
+                        "Packaged MCP did not negotiate the initialize protocol"
+                    )
+                if initialized.get("instructions") != contract["instructions"]:
+                    raise RuntimeError(
+                        "Packaged MCP instructions differ from the contract"
+                    )
+                if initialized["serverInfo"] != {"name": "anarlog", "version": version}:
+                    raise RuntimeError(
+                        "Packaged MCP server version differs from the CLI"
+                    )
+                send({"method": "notifications/initialized"})
+                tools = request(2, "tools/list")
+                templates = request(3, "resources/templates/list")
+                if tools.get("nextCursor") or templates.get("nextCursor"):
+                    raise RuntimeError("Unexpected paginated discovery")
+                if sorted(tools["tools"], key=lambda tool: tool["name"]) != sorted(
+                    contract["tools"], key=lambda tool: tool["name"]
+                ):
+                    raise RuntimeError("Packaged MCP tools differ from the contract")
+                if templates["resourceTemplates"] != contract["resource_templates"]:
+                    raise RuntimeError(
+                        "Packaged MCP resources differ from the contract"
+                    )
+                process.stdin.close()
+                if process.wait(timeout=30) != 0:
+                    raise RuntimeError("Packaged MCP did not shut down cleanly")
+                reader.join(timeout=5)
+                if reader.is_alive() or messages.get(timeout=5) is not None:
+                    raise RuntimeError("Unexpected extra MCP stdout")
+            except Exception:
+                process.kill()
+                process.wait(timeout=5)
+                errors.seek(0)
+                print(errors.read())
+                raise
+            finally:
+                process.stdout.close()
+                if not process.stdin.closed:
+                    process.stdin.close()
+
+    print(f"Verified {binary}: {actual}, help, MCP contract, and clean shutdown")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("package_root", type=Path)
+    parser.add_argument("version")
+    args = parser.parse_args()
+    verify(args.package_root, args.version)


### PR DESCRIPTION
Update the 1.4.23 notes and user guides for compact chat activity, undoable memo and summary edits, empty automatic captures, Insights, badges, and the removed corner sync indicator. Verify the CLI inside each release package before uploading it: explicit version, help, a stdio MCP initialize/discovery exchange against the reviewed schemas, and clean shutdown.

The release needs #7462 merged before freezing its candidate. #7461 and #7463 are merged. This PR prepares the release; it does not publish it.

## Release surface review

| Surface | Candidate impact and publication |
| --- | --- |
| CLI and shared agent access | Meeting, transcript, export, and proposal contracts are unchanged since desktop 1.4.22. Existing proposal approval in the editor gains undo support. Shared SQLite deletion protection ships in the bundled CLI through db-app/db-core; candidate CLI CI must cover it. |
| Local MCP | Tools and resource schemas are unchanged. Every packaged CLI must match the current MCP contract snapshot. The compatibility initialize handshake uses protocol 2025-11-25; current-protocol behavior remains covered by CLI Rust tests. |
| API, hosted MCP, generated client | No source changes since deployed source 0f4e8bb1d87987f976a000a63a5bad4c1223f146. API deployment 34129735332 succeeded; live Anarlog health reports 0.0.91. Client-side capture and encrypted deletion protection add no server contract or backend-first deployment requirement. Candidate API CI is still required. |
| Agent packages | Authored skills, generated mirrors, native manifests, and marketplace definitions are unchanged; retain independent plugin version 1.2.1. Generation consistency and all nine publication tests pass. |
| Insights and badges | Desktop presentation and local badge collection are documented as desktop-only. Existing meeting and transcript commands remain supported; no agent command or API capability is claimed for these views. |
| Docs and website | Update existing guides and changelog, with no new navigation entry. Verify Mintlify pages and LLM indexes after merge. Verify website/changelog through the release's separate web/APT deployment. |
| Related surfaces | SQLite migrations are additive and shared with mobile; no mobile distribution is requested. Installer, updater, Microsoft Store, and Linux package channels retain their independent publication gates. |

## Validation

- Formatting, changelog typecheck, Mintlify 4.2.687 validate and broken-links with anchors/redirects.
- Skill generation check, license-boundary checks, and all 70 common Node tests.
- Packaged CLI verifier passes against the installed 1.4.22 macOS artifact and rejects an incorrect expected version. Candidate platform execution remains pending the dry-run builds.
- Authenticated zizmor scan introduces no new findings; existing workflow findings remain unchanged.
- Release requires exact-candidate desktop native, CLI, and API CI; a fresh first-attempt dry run; signed artifact provenance; publication; and separate Microsoft Store/APT verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release documentation and additive CI gates; no application runtime or API behavior is modified in this diff.
> 
> **Overview**
> Prepares desktop **1.4.23** release communication and tightens desktop CD so every platform build checks the bundled CLI before artifacts ship.
> 
> **CI:** New `scripts/verify-packaged-cli.py` locates the packaged `anarlog-cli` binary, asserts `--version` and key `--help` paths, runs a stdio MCP session (initialize on protocol `2025-11-25`, `tools/list`, `resources/templates/list`) against the existing MCP contract snapshot, and requires a clean shutdown. `desktop_cd.yaml` invokes it on macOS from the `.app` bundle, on Linux after extracting the `.deb`, and on Windows after a silent NSIS install to a temp directory.
> 
> **Docs & changelog:** User guides and `packages/changelog/content/1.4.23.md` now describe empty automatic capture discard, unified chat **Activity** row, undo after applied memo/summary edits, **Settings → Insights** / **Stats** (desktop-only), and removal of the corner sync indicator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a717c938900789c0e4d4bd0c29c87a9c51528e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->