### PR TITLE
Fix the Linux release website workflow reference

### DIFF
--- a/.github/workflows/desktop_publish.yaml
+++ b/.github/workflows/desktop_publish.yaml
@@ -734,7 +734,7 @@ jobs:
     needs: linux-package-bump
     permissions:
       contents: write
-    uses: $/.github/workflows/web_cd.yaml
+    uses: ./.github/workflows/web_cd.yaml
     with:
       sha: ${{ needs.linux-package-bump.outputs.sha }}
     secrets:

--- a/scripts/verify-apt-repository.test.mjs
+++ b/scripts/verify-apt-repository.test.mjs
@@ -113,7 +113,7 @@ test("the release deploys and verifies the merged metadata commit", async () => 
     .split("\n  linux-apt-verify:\n")[0];
   const verify = publish.split("\n  linux-apt-verify:\n")[1];
   assert.match(deploy, /needs: linux-package-bump/);
-  assert.match(deploy, /uses: \$\/\.github\/workflows\/web_cd\.yaml/);
+  assert.match(deploy, /uses: \.\/\.github\/workflows\/web_cd\.yaml/);
   assert.match(
     deploy,
     /sha: \$\{\{ needs\.linux-package-bump\.outputs\.sha \}\}/,


### PR DESCRIPTION
The Linux package publication job references `web_cd.yaml` with `$/`, which is not a valid local reusable-workflow path. Change it to `./` so the stable release can deploy and verify the signed APT metadata. Correct the existing regression assertion that repeated the typo.

Validation: all 70 common Node tests pass in an isolated main snapshot with these two changes; license boundary checks and formatting pass. Zizmor reports existing pinning, artifact, and permission findings, with no new risky workflow behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line workflow path correction with a matching test update; no change to deploy inputs, secrets, or verification logic.
> 
> **Overview**
> Fixes the **`linux-apt-deploy`** job in the desktop stable publish workflow so it can call the in-repo **`web_cd`** workflow. The reusable workflow reference is changed from invalid **`$/`** to **`./.github/workflows/web_cd.yaml`**, which is the correct form for a same-repository workflow.
> 
> The APT repository regression test is updated to assert the corrected path, so CI continues to guard the deploy → verify chain (merged Linux package SHA into **`web_cd`**, then live APT verification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf9078f397955dd76c715ab4deec83255d8244b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->