### PR TITLE
Keep live transcription recovering and skip overlapping auto-starts

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -207,7 +207,7 @@ const notifyTranscriptionStalled = () => {
     id: "live-transcription-stalled",
     duration: Infinity,
     description:
-      "Anarlog keeps recording. The missing part of the transcript will be rebuilt from the recording when you stop listening.",
+      "Anarlog keeps recording while live transcription reconnects. Any missing text will be rebuilt from the recording after you stop listening.",
   });
 };
 
@@ -407,6 +407,9 @@ const createSessionEventHandlers = <T extends LiveStore>(
             (currentLive.finalStallAudibleSeconds !== 0 ||
               currentLive.transcriptionStalled)))
       ) {
+        if (hasFinalWords && currentLive.transcriptionStalled) {
+          sonnerToast.dismiss("live-transcription-stalled");
+        }
         setLiveState(set, (live) => {
           noteLiveTranscriptActivity(live, {
             hasFinalWords,

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -1,6 +1,8 @@
 import { create as mutate } from "mutative";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { sonnerToast } from "@anlg/ui/components/ui/toast";
+
 const {
   dispatchEventMock,
   getIdentifierMock,
@@ -1012,6 +1014,63 @@ describe("General Listener Slice", () => {
           liveTranscriptionActive: true,
         }),
       );
+    });
+
+    test("clears the stall warning only after finalized transcript words resume", async () => {
+      const dismiss = vi.spyOn(sonnerToast, "dismiss");
+      getCaptureSnapshotMock.mockResolvedValueOnce({
+        status: "ok",
+        data: {
+          activeSessionId: "session-a",
+          finalizingSessionIds: [],
+          liveTranscriptionActive: true,
+          requestedLiveTranscription: true,
+          state: "active",
+        },
+      });
+      await store.getState().attachLiveSession("session-a");
+      store.setState((state) => ({
+        live: {
+          ...state.live,
+          transcriptionStalled: true,
+          needsBatchRepair: true,
+        },
+      }));
+      const dataHandler = listenCaptureDataMock.mock.calls[0][0];
+      const word = {
+        id: "recovered",
+        text: "hello",
+        start_ms: 0,
+        end_ms: 500,
+        channel: 0,
+      };
+
+      try {
+        dataHandler({
+          payload: {
+            session_id: "session-a",
+            type: "transcript_delta",
+            delta: { new_words: [], replaced_ids: [], partials: [word] },
+          },
+        });
+        expect(dismiss).not.toHaveBeenCalled();
+        expect(store.getState().live.transcriptionStalled).toBe(true);
+
+        dataHandler({
+          payload: {
+            session_id: "session-a",
+            type: "transcript_delta",
+            delta: { new_words: [word], replaced_ids: [], partials: [] },
+          },
+        });
+        expect(dismiss).toHaveBeenCalledWith("live-transcription-stalled");
+        expect(store.getState().live.transcriptionStalled).toBe(false);
+        expect(store.getState().live.needsBatchRepair).toBe(true);
+        expect(store.getState().live.status).toBe("active");
+      } finally {
+        clearInterval(store.getState().live.intervalId);
+        dismiss.mockRestore();
+      }
     });
 
     test("keeps recovery callbacks installed when the native snapshot is unavailable", async () => {

--- a/apps/desktop/src/stt/scheduled-auto-start.test.ts
+++ b/apps/desktop/src/stt/scheduled-auto-start.test.ts
@@ -1,10 +1,13 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   getScheduledAutoStartAction,
   hasPendingAutoStart,
   SCHEDULED_AUTO_START_GRACE_MS,
   type ScheduledMeetingRow,
+  ScheduledMeetingAutoStart,
   selectDueMeetings,
   startScheduledMeeting,
 } from "./scheduled-auto-start";
@@ -13,10 +16,30 @@ import type { Tab } from "~/store/zustand/tabs";
 
 const mocks = vi.hoisted(() => ({
   canStart: true,
+  liveStatus: "inactive",
   getIgnoredEventSets: vi.fn(),
   getOrCreateSessionForEventId: vi.fn(),
   openNew: vi.fn(),
   openUrl: vi.fn(),
+  subscribeMeetings: vi.fn(),
+  subscribeListener: vi.fn(),
+  subscribeTabs: vi.fn(),
+  tabs: [] as Tab[],
+}));
+
+vi.mock("@anlg/plugin-windows", () => ({
+  getCurrentWebviewWindowLabel: () => "main",
+}));
+
+vi.mock("~/db", () => ({
+  liveQueryClient: { subscribe: mocks.subscribeMeetings },
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValues: () => ({
+    auto_start_scheduled_meetings: true,
+    auto_join_scheduled_meetings: true,
+  }),
 }));
 
 vi.mock("@anlg/plugin-opener2", () => ({
@@ -35,20 +58,25 @@ vi.mock("~/store/zustand/listener/instance", () => ({
   listenerStore: {
     getState: () => ({
       canStartLiveSession: () => mocks.canStart,
-      live: { status: "inactive" },
+      live: { status: mocks.liveStatus },
     }),
-    subscribe: () => () => {},
+    subscribe: mocks.subscribeListener,
   },
 }));
 
 vi.mock("~/store/zustand/tabs", () => ({
   useTabs: {
-    getState: () => ({ openNew: mocks.openNew }),
-    subscribe: () => () => {},
+    getState: () => ({ openNew: mocks.openNew, tabs: mocks.tabs }),
+    subscribe: mocks.subscribeTabs,
   },
 }));
 
 const NOW = new Date("2026-05-15T12:00:00.000Z").getTime();
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 function meeting(
   id: string,
@@ -172,6 +200,7 @@ describe("hasPendingAutoStart", () => {
 describe("startScheduledMeeting", () => {
   beforeEach(() => {
     mocks.canStart = true;
+    mocks.liveStatus = "inactive";
     mocks.getIgnoredEventSets.mockReset().mockResolvedValue({
       ignoredIds: new Set<string>(),
       ignoredSeriesIds: new Set<string>(),
@@ -181,6 +210,10 @@ describe("startScheduledMeeting", () => {
       .mockResolvedValue("session-a");
     mocks.openNew.mockReset();
     mocks.openUrl.mockReset().mockResolvedValue({ status: "ok", data: null });
+    mocks.subscribeMeetings.mockReset().mockResolvedValue(async () => {});
+    mocks.subscribeListener.mockReset().mockReturnValue(() => {});
+    mocks.subscribeTabs.mockReset().mockReturnValue(() => {});
+    mocks.tabs = [];
   });
 
   test("opens the meeting link and arms the session when the meeting is due", async () => {
@@ -226,6 +259,75 @@ describe("startScheduledMeeting", () => {
       "ignored",
     );
 
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+    expect(mocks.openNew).not.toHaveBeenCalled();
+  });
+
+  test("ignores the next meeting while the previous recording runs overtime", async () => {
+    mocks.liveStatus = "active";
+
+    await expect(startScheduledMeeting(meeting("a", 0), true)).resolves.toBe(
+      "ignored",
+    );
+
+    expect(mocks.getOrCreateSessionForEventId).not.toHaveBeenCalled();
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+    expect(mocks.openNew).not.toHaveBeenCalled();
+  });
+
+  test("ignores a recording that becomes active while the calendar lookup is pending", async () => {
+    mocks.getIgnoredEventSets.mockImplementation(async () => {
+      mocks.liveStatus = "active";
+      return { ignoredIds: new Set(), ignoredSeriesIds: new Set() };
+    });
+
+    await expect(startScheduledMeeting(meeting("a", 0), true)).resolves.toBe(
+      "ignored",
+    );
+
+    expect(mocks.getOrCreateSessionForEventId).not.toHaveBeenCalled();
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+    expect(mocks.openNew).not.toHaveBeenCalled();
+  });
+
+  test("does not queue or join a meeting if recording starts during session creation", async () => {
+    mocks.getOrCreateSessionForEventId.mockImplementation(async () => {
+      mocks.liveStatus = "active";
+      mocks.canStart = false;
+      return "session-a";
+    });
+
+    await expect(startScheduledMeeting(meeting("a", 0), true)).resolves.toBe(
+      "ignored",
+    );
+
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+    expect(mocks.openNew).not.toHaveBeenCalled();
+  });
+
+  test("an overlapping meeting stays skipped after a pending tab and the active recording clear", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    mocks.liveStatus = "active";
+    mocks.tabs = [
+      {
+        type: "sessions",
+        id: "pending",
+        slotId: "pending",
+        active: true,
+        pinned: false,
+        state: { view: null, autoStart: true },
+      },
+    ];
+    render(createElement(ScheduledMeetingAutoStart));
+    mocks.subscribeMeetings.mock.calls[0][2].onData([meeting("a", 0)]);
+
+    mocks.liveStatus = "inactive";
+    mocks.tabs = [];
+    mocks.subscribeTabs.mock.calls[0][0]();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(mocks.getOrCreateSessionForEventId).not.toHaveBeenCalled();
     expect(mocks.openUrl).not.toHaveBeenCalled();
     expect(mocks.openNew).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/stt/scheduled-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-auto-start.tsx
@@ -101,8 +101,13 @@ export async function startScheduledMeeting(
   row: ScheduledMeetingRow,
   autoJoin: boolean,
 ): Promise<"started" | "ignored" | "blocked"> {
+  if (listenerStore.getState().live.status === "active") {
+    return "ignored";
+  }
+
   const { ignoredIds, ignoredSeriesIds } = await getIgnoredEventSets();
   if (
+    listenerStore.getState().live.status === "active" ||
     ignoredIds.has(row.tracking_id_event) ||
     (row.recurrence_series_id && ignoredSeriesIds.has(row.recurrence_series_id))
   ) {
@@ -110,6 +115,9 @@ export async function startScheduledMeeting(
   }
 
   const sessionId = await getOrCreateSessionForEventId(row.id);
+  if (listenerStore.getState().live.status === "active") {
+    return "ignored";
+  }
   if (!listenerStore.getState().canStartLiveSession(sessionId)) {
     return "blocked";
   }
@@ -231,27 +239,23 @@ export function ScheduledMeetingAutoStart() {
         else scheduleNextStart();
       };
 
-      if (
-        hasScheduledAutoStartInFlight() ||
-        hasPendingAutoStart(useTabs.getState().tabs)
-      ) {
-        scheduleAfterTransientBlock();
-        return;
-      }
-
       const liveStatus = listenerStore.getState().live.status;
       const action = getScheduledAutoStartAction(liveStatus);
-      if (action === "retry") {
-        scheduleAfterTransientBlock();
-        return;
-      }
-
       if (action === "skip") {
         // Do not let an overlapping meeting start after the active recording ends.
         for (const row of due) {
           firedEventIds.add(row.id);
         }
         scheduleNextStart();
+        return;
+      }
+
+      if (
+        action === "retry" ||
+        hasScheduledAutoStartInFlight() ||
+        hasPendingAutoStart(useTabs.getState().tabs)
+      ) {
+        scheduleAfterTransientBlock();
         return;
       }
 

--- a/apps/desktop/src/stt/scheduled-session-auto-start.test.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.test.tsx
@@ -8,6 +8,7 @@ import { useAppLock } from "~/lock/store";
 const mocks = vi.hoisted(() => ({
   beginScheduledAutoStart: vi.fn(),
   canStart: true,
+  liveStatus: "inactive",
   finishScheduledAutoStart: vi.fn(),
   inFlight: false,
   connectionReady: true,
@@ -56,7 +57,10 @@ vi.mock("~/store/zustand/tabs", () => ({
 
 vi.mock("~/stt/contexts", () => ({
   useListener: (selector: (state: any) => unknown) =>
-    selector({ canStartLiveSession: () => mocks.canStart }),
+    selector({
+      canStartLiveSession: () => mocks.canStart,
+      live: { status: mocks.liveStatus },
+    }),
 }));
 
 vi.mock("~/session/queries", () => ({
@@ -78,6 +82,7 @@ vi.mock("~/stt/useStartListening", () => ({
 
 beforeEach(() => {
   mocks.canStart = true;
+  mocks.liveStatus = "inactive";
   mocks.inFlight = false;
   mocks.session = {
     id: "session-1",
@@ -139,6 +144,35 @@ test("starts when capture readiness becomes available", () => {
   view.rerender(<ScheduledSessionAutoStart sessionId="session-1" />);
 
   expect(mocks.startListening).toHaveBeenCalledTimes(1);
+});
+
+test("abandons an armed auto-start immediately while another meeting is recording", () => {
+  mocks.canStart = false;
+  mocks.liveStatus = "active";
+
+  render(<ScheduledSessionAutoStart sessionId="session-1" />);
+
+  expect(mocks.startListening).not.toHaveBeenCalled();
+  expect(mocks.beginScheduledAutoStart).not.toHaveBeenCalled();
+  expect(mocks.updateSessionTabState).toHaveBeenCalledWith(tab, {
+    view: null,
+    autoStart: null,
+  });
+});
+
+test("abandons a pending auto-start when another meeting becomes active", () => {
+  mocks.connectionReady = false;
+  const view = render(<ScheduledSessionAutoStart sessionId="session-1" />);
+  mocks.liveStatus = "active";
+  mocks.canStart = false;
+
+  view.rerender(<ScheduledSessionAutoStart sessionId="session-1" />);
+
+  expect(mocks.startListening).not.toHaveBeenCalled();
+  expect(mocks.updateSessionTabState).toHaveBeenCalledWith(tab, {
+    view: null,
+    autoStart: null,
+  });
 });
 
 test("starts when the session record becomes available", () => {

--- a/apps/desktop/src/stt/scheduled-session-auto-start.tsx
+++ b/apps/desktop/src/stt/scheduled-session-auto-start.tsx
@@ -22,13 +22,16 @@ export function ScheduledSessionAutoStart({
   const canStartLiveSession = useListener((state) =>
     state.canStartLiveSession(sessionId),
   );
+  const recordingActive = useListener(
+    (state) => state.live.status === "active",
+  );
   const session = useSession(sessionId);
   const revealed = useAppLock((state) =>
     Boolean(state.revealedNoteIds[sessionId]),
   );
   const locked = isLockedFlag(session?.locked) && !revealed;
 
-  if (session && locked) {
+  if (recordingActive || (session && locked)) {
     return <AbandonedScheduledSessionAutoStart sessionId={sessionId} />;
   }
 

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -78,6 +78,7 @@ pub struct ListenerState {
     tx: ChannelSender,
     rx_task: tokio::task::JoinHandle<Vec<StreamResponse>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    progress: Option<stream::StreamProgress>,
 }
 
 pub(super) enum ChannelSender {
@@ -176,6 +177,8 @@ impl Actor for ListenerActor {
                 tx,
                 rx_task,
                 shutdown_tx: Some(shutdown_tx),
+                progress: (!matches!(adapter_name.as_str(), "soniqo" | "apple-speech"))
+                    .then(|| stream::StreamProgress::new(Instant::now())),
             };
 
             Ok(state)
@@ -235,6 +238,7 @@ impl Actor for ListenerActor {
 
         match message {
             ListenerMsg::AudioSingle(audio, reply) => {
+                let active_samples = stream::active_audio_samples(&audio);
                 let result = match &state.tx {
                     ChannelSender::Single(tx) => match tx.try_send(MixedMessage::Audio(audio)) {
                         Ok(()) => ListenerAudioResult::Accepted,
@@ -248,6 +252,14 @@ impl Actor for ListenerActor {
                     ChannelSender::Dual(_) => ListenerAudioResult::ModeMismatch,
                 };
                 let _ = reply.send(result);
+                if result == ListenerAudioResult::Accepted
+                    && state.progress.as_mut().is_some_and(|progress| {
+                        progress.observe_audio(active_samples, Instant::now())
+                    })
+                {
+                    tracing::warn!("listen_stream_stalled_during_audio");
+                    stop_with_degraded_error(&myself, DegradedError::ConnectionTimeout);
+                }
                 if matches!(
                     result,
                     ListenerAudioResult::Closed | ListenerAudioResult::ModeMismatch
@@ -262,6 +274,8 @@ impl Actor for ListenerActor {
             }
 
             ListenerMsg::AudioDual(mic, spk, reply) => {
+                let active_samples =
+                    stream::active_audio_samples(&mic).max(stream::active_audio_samples(&spk));
                 let result = match &state.tx {
                     ChannelSender::Dual(tx) => match tx.try_send(MixedMessage::Audio((mic, spk))) {
                         Ok(()) => ListenerAudioResult::Accepted,
@@ -275,6 +289,14 @@ impl Actor for ListenerActor {
                     ChannelSender::Single(_) => ListenerAudioResult::ModeMismatch,
                 };
                 let _ = reply.send(result);
+                if result == ListenerAudioResult::Accepted
+                    && state.progress.as_mut().is_some_and(|progress| {
+                        progress.observe_audio(active_samples, Instant::now())
+                    })
+                {
+                    tracing::warn!("listen_stream_stalled_during_audio");
+                    stop_with_degraded_error(&myself, DegradedError::ConnectionTimeout);
+                }
                 if matches!(
                     result,
                     ListenerAudioResult::Closed | ListenerAudioResult::ModeMismatch
@@ -309,6 +331,9 @@ impl Actor for ListenerActor {
             }
 
             ListenerMsg::StreamResponse(response, reply) => {
+                if let Some(progress) = &mut state.progress {
+                    progress.observe_response(&response, Instant::now());
+                }
                 let degraded = process_stream_response(state, response);
                 let _ = reply.send(());
                 if let Some(degraded) = degraded {

--- a/crates/listener-core/src/actors/listener/stream.rs
+++ b/crates/listener-core/src/actors/listener/stream.rs
@@ -8,6 +8,70 @@ use super::{FINALIZE_STREAM_TIMEOUT, LISTEN_STREAM_TIMEOUT, ListenerMsg};
 const PROVIDER_RESPONSE_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 const FINALIZE_HANDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 const MAX_FINAL_RESPONSES: usize = 64;
+const TRANSCRIPT_PROGRESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const MIN_ACTIVE_AUDIO_SAMPLES: usize = crate::actors::SAMPLE_RATE as usize * 5;
+const MAX_UNFINALIZED_AUDIO_SAMPLES: usize = crate::actors::SAMPLE_RATE as usize * 90;
+
+pub(super) struct StreamProgress {
+    last_response_at: std::time::Instant,
+    active_samples: usize,
+    unfinalized_samples: usize,
+}
+
+impl StreamProgress {
+    pub(super) fn new(now: std::time::Instant) -> Self {
+        Self {
+            last_response_at: now,
+            active_samples: 0,
+            unfinalized_samples: 0,
+        }
+    }
+
+    pub(super) fn observe_audio(&mut self, samples: usize, now: std::time::Instant) -> bool {
+        self.active_samples = self.active_samples.saturating_add(samples);
+        self.unfinalized_samples = self.unfinalized_samples.saturating_add(samples);
+        (self.active_samples >= MIN_ACTIVE_AUDIO_SAMPLES
+            && now.duration_since(self.last_response_at) >= TRANSCRIPT_PROGRESS_TIMEOUT)
+            || self.unfinalized_samples >= MAX_UNFINALIZED_AUDIO_SAMPLES
+    }
+
+    pub(super) fn observe_response(&mut self, response: &StreamResponse, now: std::time::Instant) {
+        if let StreamResponse::TranscriptResponse {
+            channel, is_final, ..
+        } = response
+            && channel.alternatives.iter().any(|alternative| {
+                !alternative.transcript.trim().is_empty() || !alternative.words.is_empty()
+            })
+        {
+            self.last_response_at = now;
+            self.active_samples = 0;
+            if *is_final {
+                self.unfinalized_samples = 0;
+            }
+        }
+    }
+}
+
+pub(super) fn active_audio_samples(audio: &[u8]) -> usize {
+    let samples = audio.len() / 2;
+    if samples == 0 {
+        return 0;
+    }
+    let energy = audio
+        .chunks_exact(2)
+        .map(|bytes| {
+            let sample = f64::from(i16::from_le_bytes([bytes[0], bytes[1]])) / 32768.0;
+            sample * sample
+        })
+        .sum::<f64>();
+
+    // Quiet meetings must not reconnect just because there is no transcript.
+    if energy / samples as f64 >= 0.005_f64.powi(2) {
+        samples
+    } else {
+        0
+    }
+}
 
 pub(super) async fn process_stream<S, E, H>(
     mut listen_stream: std::pin::Pin<&mut S>,
@@ -322,6 +386,113 @@ mod tests {
     fn extra() -> Extra {
         Extra {
             started_unix_millis: 0,
+        }
+    }
+
+    fn transcript_response(is_final: bool) -> StreamResponse {
+        use owhisper_interface::stream::{Alternatives, Channel, Metadata};
+
+        StreamResponse::TranscriptResponse {
+            start: 0.0,
+            duration: 1.0,
+            is_final,
+            speech_final: false,
+            from_finalize: false,
+            channel: Channel {
+                alternatives: vec![Alternatives {
+                    transcript: "hello".to_string(),
+                    words: vec![],
+                    confidence: 1.0,
+                    languages: vec![],
+                }],
+            },
+            metadata: Metadata::default(),
+            channel_index: vec![0, 1],
+        }
+    }
+
+    #[test]
+    fn stalled_transcript_is_detected_while_audio_continues() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        let audio = 1000_i16
+            .to_le_bytes()
+            .repeat(crate::actors::SAMPLE_RATE as usize);
+
+        for second in 1..30 {
+            assert!(!progress.observe_audio(
+                active_audio_samples(&audio),
+                now + Duration::from_secs(second),
+            ));
+        }
+        assert!(
+            progress.observe_audio(active_audio_samples(&audio), now + Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn silence_and_low_background_noise_do_not_trigger_reconnection() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        for sample in [0_i16, 16, -16] {
+            let audio = sample
+                .to_le_bytes()
+                .repeat(crate::actors::SAMPLE_RATE as usize);
+            assert!(
+                !progress
+                    .observe_audio(active_audio_samples(&audio), now + Duration::from_secs(600))
+            );
+        }
+        assert_eq!(active_audio_samples(&[]), 0);
+        assert!(!progress.observe_audio(
+            crate::actors::SAMPLE_RATE as usize,
+            now + Duration::from_secs(601)
+        ));
+    }
+
+    #[test]
+    fn partial_transcripts_reset_the_stall_watchdog() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        assert!(!progress.observe_audio(MIN_ACTIVE_AUDIO_SAMPLES, now + Duration::from_secs(29)));
+        progress.observe_response(&transcript_response(false), now + Duration::from_secs(29));
+        assert!(!progress.observe_audio(MIN_ACTIVE_AUDIO_SAMPLES, now + Duration::from_secs(30)));
+        assert!(progress.observe_audio(0, now + Duration::from_secs(59)));
+    }
+
+    #[test]
+    fn metadata_does_not_hide_a_stalled_transcript() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        assert!(!progress.observe_audio(MIN_ACTIVE_AUDIO_SAMPLES, now + Duration::from_secs(29)));
+        progress.observe_response(&terminal_response(), now + Duration::from_secs(29));
+        assert!(progress.observe_audio(0, now + Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn partial_words_that_never_finalize_trigger_reconnection() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        for second in 1..90 {
+            let time = now + Duration::from_secs(second);
+            progress.observe_response(&transcript_response(false), time);
+            assert!(!progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time));
+        }
+        progress.observe_response(&transcript_response(false), now + Duration::from_secs(90));
+        assert!(progress.observe_audio(
+            crate::actors::SAMPLE_RATE as usize,
+            now + Duration::from_secs(90)
+        ));
+    }
+
+    #[test]
+    fn finalized_words_keep_an_active_stream_healthy() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        for second in 1..300 {
+            let time = now + Duration::from_secs(second);
+            progress.observe_response(&transcript_response(second % 20 == 0), time);
+            assert!(!progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time));
         }
     }
 

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -12,7 +12,6 @@ use crate::actors::session::types::{
     SessionConfigUpdate, SessionContext, SessionParams, session_span, session_supervisor_name,
 };
 use crate::actors::{ListenerConfigUpdate, ListenerInitError, ListenerMsg};
-use owhisper_client::AdapterKind;
 
 use self::children::ChildKind;
 use self::mode::SessionModeState;
@@ -493,14 +492,6 @@ async fn retry_listener(myself: ActorRef<SessionMsg>, state: &mut SessionState) 
 fn should_stop_on_listener_failure(state: &SessionState) -> bool {
     state.ctx.params.uses_local_soniqo_live_model()
         || state.ctx.params.uses_local_apple_speech_live_model()
-        || matches!(
-            AdapterKind::from_url_and_languages(
-                &state.ctx.params.base_url,
-                &state.ctx.params.languages,
-                Some(&state.ctx.params.model),
-            ),
-            AdapterKind::Soniox
-        )
 }
 
 async fn stop_after_listener_failure(
@@ -630,6 +621,35 @@ mod tests {
     }
 
     struct SessionStopProbe;
+
+    struct SessionRetryProbe(tokio::sync::mpsc::UnboundedSender<()>);
+
+    #[ractor::async_trait]
+    impl Actor for SessionRetryProbe {
+        type Msg = SessionMsg;
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            message: Self::Msg,
+            _state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            if matches!(message, SessionMsg::RetryListener) {
+                let _ = self.0.send(());
+            }
+            Ok(())
+        }
+    }
 
     #[ractor::async_trait]
     impl Actor for SessionStopProbe {
@@ -802,13 +822,13 @@ mod tests {
     }
 
     #[test]
-    fn direct_soniox_listener_failure_stops_session() {
+    fn direct_soniox_listener_failure_preserves_recording() {
         let mut ctx = test_ctx();
         ctx.params.base_url = "https://api.soniox.com".to_string();
         ctx.params.model = "stt-v4".to_string();
         let state = test_state(ctx);
 
-        assert!(should_stop_on_listener_failure(&state));
+        assert!(!should_stop_on_listener_failure(&state));
     }
 
     #[test]
@@ -913,6 +933,67 @@ mod tests {
             assert_eq!(message, "listener failed");
         }
         let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn stalled_cloud_and_soniox_listeners_schedule_reconnection_without_stopping_recording() {
+        for base_url in ["https://api.anarlog.so/stt", "https://api.soniox.com"] {
+            let runtime = Arc::new(RecordingRuntime {
+                lifecycle_events: std::sync::Mutex::new(vec![]),
+            });
+            let mut ctx = test_ctx();
+            ctx.runtime = runtime.clone();
+            ctx.params.base_url = base_url.to_string();
+            let mut state = test_state(ctx);
+            let (stop_tx, mut stop_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (recorder, recorder_handle) = Actor::spawn(
+                None,
+                StopProbe {
+                    label: "recorder",
+                    tx: stop_tx,
+                },
+                (),
+            )
+            .await
+            .unwrap();
+            state.recorder_cell = Some(recorder.get_cell());
+            let (retry_tx, mut retry_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (supervisor, supervisor_handle) =
+                Actor::spawn(None, SessionRetryProbe(retry_tx), ())
+                    .await
+                    .unwrap();
+
+            handle_listener_failure(
+                &supervisor,
+                &mut state,
+                DegradedError::ConnectionTimeout,
+                None,
+            )
+            .await;
+
+            tokio::time::timeout(Duration::from_secs(3), retry_rx.recv())
+                .await
+                .expect("stalled streams should schedule a reconnect")
+                .unwrap();
+            assert!(!state.shutting_down);
+            assert!(state.mode.should_retry_listener());
+            assert_eq!(recorder.get_status(), ActorStatus::Running);
+            assert!(stop_rx.try_recv().is_err());
+            assert!(matches!(
+                runtime.lifecycle_events.lock().unwrap().last(),
+                Some(crate::SessionLifecycleEvent::Active {
+                    requested_transcription_mode: TranscriptionMode::Live,
+                    current_transcription_mode: TranscriptionMode::Batch,
+                    error: Some(DegradedError::ConnectionTimeout),
+                    ..
+                })
+            ));
+
+            recorder.stop(None);
+            supervisor.stop(None);
+            recorder_handle.await.unwrap();
+            supervisor_handle.await.unwrap();
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

**Problem:** A stalled live transcript could leave recording running without reconnecting, and a scheduled meeting could remain queued while the current meeting ran overtime.

**Fix:** Detect remote streams that stop producing meaningful transcript progress or finalized text, reconnect them while preserving audio capture, and clear the warning when finalized words resume. Skip overlapping scheduled starts and abandon pending starts when another recording becomes active, including during asynchronous calendar lookups.

The watchdog requires audible audio: it retries after 30 seconds without meaningful transcript progress and at least 5 seconds of audible input, or 90 seconds of audible input without finalization. Quiet meetings do not trigger it. Direct Soniox failures now use the existing retry path without stopping recording.

## Verification

- Desktop tests: 4,231 passed; listener-core tests: 133 passed, including stalled/partial-only streams, recording preservation during retries, and overlapping auto-start races.
- Desktop typecheck, UI build, Oxlint, targeted ESLint, formatting, and i18n validation passed.
- macOS desktop checks passed with both `direct-distribution` and `app-store`; desktop native tests and the workflow's native workspace suite passed (3,054 passed, 157 ignored). The final watchdog changes were then covered by the 133 listener tests and both desktop feature checks.
- Repository invariant tests and both license-boundary checks passed.
- Existing unrelated findings: native builds regenerate todo bindings with pre-existing schema drift; authenticated `uvx zizmor --format sarif .` reports 406 findings in existing workflows/actions. Generated test/build outputs were removed from the change.
- Windows/Linux native checks and live-provider fault-injection testing were not run locally. The installed stable app was inspected without interrupting its recording.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live STT reconnection, session supervisor failure handling, and calendar auto-start timing—high-impact user flows, but heavily covered by new tests and scoped guards (audible-audio thresholds, active-recording checks).
> 
> **Overview**
> **Live transcription recovery:** Remote streaming adapters now run an audio-aware stall watchdog that triggers reconnection (without stopping capture) when meaningful transcript progress stops during audible speech, or partial text never finalizes for too long. Direct Soniox listener failures follow the same retry path as other cloud streams instead of ending the session. The desktop stall toast copy is updated, and the warning clears only when **finalized** words resume—not partials alone.
> 
> **Scheduled meetings:** Overlapping calendar auto-starts are suppressed while a recording is active, including races during ignored-event lookup and session creation. Due meetings are marked handled so they do not fire after an overtime recording ends, and armed session tabs abandon auto-start if another meeting is already recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081064f2b56bd4410750963310289e1a1226b2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->