### PR TITLE
Fix Windows package verification and complete recording release notes

### DIFF
--- a/docs/automatic-capture.mdx
+++ b/docs/automatic-capture.mdx
@@ -11,6 +11,8 @@ Open **Settings → Meetings** and enable **Start when meeting begins**.
 
 When a calendar-backed note reaches its scheduled start time, Anarlog starts listening. This setting does not apply to ordinary notes without a calendar event.
 
+If another meeting is already recording, Anarlog skips the overlapping scheduled start. It does not queue that meeting to start after your current recording ends.
+
 Anarlog discards empty automatic captures while preserving the calendar note and any content recorded on another device.
 
 Enable **Join scheduled meetings** on the same page to open the meeting link when listening starts. That toggle stays disabled until **Start when meeting begins** is on.

--- a/docs/meetings.mdx
+++ b/docs/meetings.mdx
@@ -23,6 +23,8 @@ Use **Memos** for your own notes. You can keep them rough: the generated summary
 
 Open **Transcript** to follow live text when your selected transcription model supports it. Models marked **After recording** process the audio when you stop.
 
+If live transcription from a remote provider stalls during speech, Anarlog attempts to reconnect while keeping audio capture running. The warning clears when finalized transcript text resumes.
+
 If you enabled **Show floating bar** in **Settings → Meetings**, you can control recording without keeping the full Anarlog window open.
 
 ## Finish the meeting

--- a/packages/changelog/content/1.4.23.md
+++ b/packages/changelog/content/1.4.23.md
@@ -18,6 +18,8 @@ summary: "Anarlog 1.4.23 adds conversation insights and collectible badges, impr
   a deletion before receiving that content
 - Discard empty automatic recordings without removing the calendar note or
   content recorded on another device
+- Reconnect stalled live transcription while keeping audio capture running
+- Skip scheduled auto-starts while another meeting is recording
 - Keep other meeting apps running while Anarlog is open
 
 ## Providers and navigation

--- a/scripts/verify-packaged-cli.py
+++ b/scripts/verify-packaged-cli.py
@@ -1,4 +1,5 @@
 import argparse
+from contextlib import closing
 import json
 import os
 from pathlib import Path
@@ -27,7 +28,7 @@ def verify(package_root: Path, version: str):
     with tempfile.TemporaryDirectory(prefix="anarlog-cli-release-") as temporary:
         root = Path(temporary)
         database = root / "fixture.db"
-        with sqlite3.connect(database) as connection:
+        with closing(sqlite3.connect(database)) as connection:
             connection.execute("PRAGMA user_version = 0")
         env = {
             **os.environ,


### PR DESCRIPTION
Close the packaged CLI fixture database explicitly before temporary-directory cleanup. The stable dry run completed its Windows CLI/MCP assertions but failed because SQLite retained the fixture handle. This preserves all existing checks and allows Windows cleanup to finish.

Add the newly merged transcription recovery and overlapping auto-start behavior to the 1.4.23 changelog and meeting guides. These changes affect desktop recording; CLI/MCP schemas, stored transcript formats, API contracts, and agent package capabilities are unchanged. No backend deployment or plugin version bump is needed. Mintlify publishes these guide changes separately; public guides and the generated LLM index will be checked before desktop publication.

Validation: the actual packaged CLI verifier passed against the installed desktop CLI, with a retained-connection assertion proving the fixture is closed; repository invariant tests 70/70; license boundary tests 9/9 and boundary check; changelog typecheck; generated agent skill check and 9 tests; Mintlify 4.2.687 build, links, anchors, and redirects; formatting. A fresh candidate native CI and first-attempt stable build will replace failed dry run 34199867440 after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and changelog updates plus a release-verification script change; no product runtime or API contract changes in this diff.
> 
> **Overview**
> **Fixes Windows packaged CLI verification** by wrapping the release-test SQLite fixture in `contextlib.closing` so the connection is released before the temp directory is torn down. That unblocks stable Windows CLI/MCP checks that were failing with a retained database handle.
> 
> **Documents two desktop recording behaviors in 1.4.23:** live transcription reconnects while capture keeps running when a remote provider stalls, and scheduled auto-start is skipped (not queued) when another meeting is already recording. These appear in the changelog and in the automatic-capture and meetings guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5262a1b754f67f22ab0465e98414790c4a555c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->