### PR TITLE
Add LinkedIn link to site footer

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -26,6 +26,7 @@ const footerGroups = [
     links: [
       { label: "GitHub", href: "https://github.com/fastrepl/anarlog" },
       { label: "X", href: "https://x.com/anarlogapp" },
+      { label: "LinkedIn", href: "https://www.linkedin.com/company/anarlog/" },
       { label: "Discord", to: "/discord/" },
       { label: "Reddit", href: "https://www.reddit.com/r/anarlog/" },
     ],


### PR DESCRIPTION
Adds Anarlog's LinkedIn company page (https://www.linkedin.com/company/anarlog/) to the Community group in the site footer, alongside GitHub, X, Discord, and Reddit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static footer link with no auth, data, or routing changes.
> 
> **Overview**
> Adds a **LinkedIn** entry to the **Community** column in `site-footer`, pointing to Anarlog’s company page (`https://www.linkedin.com/company/anarlog/`), placed after **X** and before **Discord**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10dce3888dd4d716868fc66c1052cf886d9c56b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->