### PR TITLE
Recover stalled transcript output and isolate meeting handoffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10184,6 +10184,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tracing",
  "tracing-subscriber",

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -135,6 +135,134 @@ describe("General Listener Slice", () => {
     vaultBaseMock.mockResolvedValue({ status: "ok", data: "/tmp/anarlog" });
   });
 
+  test("keeps the next live transcript after the previous meeting finishes batch and summary work", async () => {
+    const previousPersist = vi.fn();
+    const nextPersist = vi.fn();
+    const batchPersist = vi.fn();
+    let finishSummary!: () => void;
+    const summaryDone = new Promise<void>((resolve) => {
+      finishSummary = resolve;
+    });
+    const onStopped = vi.fn(() => summaryDone);
+    getCaptureSnapshotMock.mockResolvedValueOnce({
+      status: "ok",
+      data: {
+        activeSessionId: "previous",
+        finalizingSessionIds: [],
+        liveTranscriptionActive: true,
+        requestedLiveTranscription: true,
+        state: "active",
+      },
+    });
+    await store.getState().attachLiveSession("previous", {
+      handlePersist: previousPersist,
+      onStopped,
+    });
+    const previousLifecycle = listenCaptureLifecycleMock.mock.calls[0][0];
+    const previousData = listenCaptureDataMock.mock.calls[0][0];
+    previousLifecycle({
+      payload: { type: "finalizing", session_id: "previous" },
+    });
+    getCaptureSnapshotMock.mockResolvedValueOnce({
+      status: "ok",
+      data: {
+        activeSessionId: "next",
+        finalizingSessionIds: ["previous"],
+        liveTranscriptionActive: true,
+        requestedLiveTranscription: true,
+        state: "active",
+      },
+    });
+    await store
+      .getState()
+      .attachLiveSession("next", { handlePersist: nextPersist });
+    const nextData = listenCaptureDataMock.mock.calls[1][0];
+    const word = (id: string) => ({
+      id,
+      text: id,
+      start_ms: 0,
+      end_ms: 500,
+      channel: 0,
+    });
+    const deliver = (handler: typeof nextData, sessionId: string, id: string) =>
+      handler({
+        payload: {
+          session_id: sessionId,
+          type: "transcript_delta",
+          delta: { new_words: [word(id)], replaced_ids: [], partials: [] },
+        },
+      });
+    try {
+      deliver(nextData, "next", "before");
+      deliver(previousData, "previous", "previous-final");
+      previousLifecycle({
+        payload: {
+          type: "stopped",
+          session_id: "previous",
+          audio_path: "/tmp/previous.wav",
+          requested_live_transcription: true,
+          live_transcription_active: true,
+          error: null,
+        },
+      });
+      expect(onStopped).toHaveBeenCalledOnce();
+      expect(store.getState().live.postStopProcessingBySession.previous).toBe(
+        true,
+      );
+      expect(store.getState().liveCaptionText).toBe("before");
+      store.getState().handleBatchStarted("previous");
+      store.getState().setBatchPersist("previous", batchPersist);
+      expect(
+        store.getState().handleBatchResponse("previous", {
+          metadata: null,
+          results: {
+            channels: [
+              {
+                alternatives: [
+                  {
+                    transcript: "previous batch",
+                    confidence: 1,
+                    words: [
+                      {
+                        word: "previous batch",
+                        start: 0,
+                        end: 1,
+                        confidence: 1,
+                        speaker: null,
+                        punctuated_word: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ).toBe(true);
+      store.getState().clearBatchPersist("previous");
+      deliver(nextData, "next", "during");
+      finishSummary();
+      await vi.waitFor(() =>
+        expect(
+          store.getState().live.postStopProcessingBySession.previous,
+        ).toBeUndefined(),
+      );
+      deliver(nextData, "next", "after");
+      expect(store.getState().live.sessionId).toBe("next");
+      expect(store.getState().live.status).toBe("active");
+      expect(store.getState().live.liveTranscriptionActive).toBe(true);
+      expect(store.getState().handlePersistBySession.next).toBe(nextPersist);
+      expect(nextPersist).toHaveBeenCalledTimes(3);
+      expect(previousPersist).toHaveBeenCalledOnce();
+      expect(batchPersist).toHaveBeenCalledOnce();
+      expect(store.getState().liveCaptionText).toBe("beforeduringafter");
+      expect(stopCaptureMock).not.toHaveBeenCalled();
+    } finally {
+      finishSummary();
+      clearInterval(store.getState().live.intervalId);
+    }
+  });
+
   describe("Initial State", () => {
     test("initializes with correct default values", () => {
       const state = store.getState();

--- a/crates/listener-core/Cargo.toml
+++ b/crates/listener-core/Cargo.toml
@@ -49,4 +49,5 @@ sentry = { workspace = true }
 [dev-dependencies]
 anlg-data = { workspace = true }
 tempfile = { workspace = true }
+tokio-tungstenite = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -89,8 +89,8 @@ pub(super) enum ChannelSender {
 pub struct ListenerActor;
 
 impl ListenerActor {
-    pub fn name() -> ActorName {
-        "listener_actor".into()
+    pub fn name(session_id: &str) -> ActorName {
+        format!("listener_actor_{session_id}")
     }
 }
 

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -331,9 +331,6 @@ impl Actor for ListenerActor {
             }
 
             ListenerMsg::StreamResponse(response, reply) => {
-                if let Some(progress) = &mut state.progress {
-                    progress.observe_response(&response, Instant::now());
-                }
                 let degraded = process_stream_response(state, response);
                 let _ = reply.send(());
                 if let Some(degraded) = degraded {
@@ -478,6 +475,9 @@ fn process_stream_response(
     }
 
     if let Some(update) = state.transcript.process(&response) {
+        if let Some(progress) = &mut state.progress {
+            progress.observe_delta(&update.transcript_delta, Instant::now());
+        }
         state
             .args
             .runtime

--- a/crates/listener-core/src/actors/listener/stream.rs
+++ b/crates/listener-core/src/actors/listener/stream.rs
@@ -1,3 +1,5 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
 use futures_util::StreamExt;
 use owhisper_client::FinalizeHandle;
 use owhisper_interface::stream::{Extra, StreamResponse};
@@ -13,7 +15,8 @@ const MIN_ACTIVE_AUDIO_SAMPLES: usize = crate::actors::SAMPLE_RATE as usize * 5;
 const MAX_UNFINALIZED_AUDIO_SAMPLES: usize = crate::actors::SAMPLE_RATE as usize * 90;
 
 pub(super) struct StreamProgress {
-    last_response_at: std::time::Instant,
+    last_progress_at: std::time::Instant,
+    last_partials_hash: Option<u64>,
     active_samples: usize,
     unfinalized_samples: usize,
 }
@@ -21,7 +24,8 @@ pub(super) struct StreamProgress {
 impl StreamProgress {
     pub(super) fn new(now: std::time::Instant) -> Self {
         Self {
-            last_response_at: now,
+            last_progress_at: now,
+            last_partials_hash: None,
             active_samples: 0,
             unfinalized_samples: 0,
         }
@@ -31,23 +35,36 @@ impl StreamProgress {
         self.active_samples = self.active_samples.saturating_add(samples);
         self.unfinalized_samples = self.unfinalized_samples.saturating_add(samples);
         (self.active_samples >= MIN_ACTIVE_AUDIO_SAMPLES
-            && now.duration_since(self.last_response_at) >= TRANSCRIPT_PROGRESS_TIMEOUT)
+            && now.duration_since(self.last_progress_at) >= TRANSCRIPT_PROGRESS_TIMEOUT)
             || self.unfinalized_samples >= MAX_UNFINALIZED_AUDIO_SAMPLES
     }
 
-    pub(super) fn observe_response(&mut self, response: &StreamResponse, now: std::time::Instant) {
-        if let StreamResponse::TranscriptResponse {
-            channel, is_final, ..
-        } = response
-            && channel.alternatives.iter().any(|alternative| {
-                !alternative.transcript.trim().is_empty() || !alternative.words.is_empty()
-            })
+    pub(super) fn observe_delta(
+        &mut self,
+        delta: &crate::LiveTranscriptDelta,
+        now: std::time::Instant,
+    ) {
+        let finalized = delta
+            .new_words
+            .iter()
+            .any(|word| !word.text.trim().is_empty());
+        let mut partials_hash = None;
+        let mut hasher = DefaultHasher::new();
+        for word in delta
+            .partials
+            .iter()
+            .filter(|word| !word.text.trim().is_empty())
         {
-            self.last_response_at = now;
+            (&word.text, word.start_ms, word.end_ms, word.channel).hash(&mut hasher);
+            partials_hash = Some(hasher.finish());
+        }
+        if finalized || (partials_hash.is_some() && partials_hash != self.last_partials_hash) {
+            self.last_progress_at = now;
             self.active_samples = 0;
-            if *is_final {
-                self.unfinalized_samples = 0;
-            }
+        }
+        self.last_partials_hash = partials_hash;
+        if finalized {
+            self.unfinalized_samples = 0;
         }
     }
 }
@@ -390,7 +407,7 @@ mod tests {
     }
 
     fn transcript_response(is_final: bool) -> StreamResponse {
-        use owhisper_interface::stream::{Alternatives, Channel, Metadata};
+        use owhisper_interface::stream::{Alternatives, Channel, Metadata, Word};
 
         StreamResponse::TranscriptResponse {
             start: 0.0,
@@ -400,8 +417,20 @@ mod tests {
             from_finalize: false,
             channel: Channel {
                 alternatives: vec![Alternatives {
-                    transcript: "hello".to_string(),
-                    words: vec![],
+                    transcript: "hello world".to_string(),
+                    words: ["hello", "world"]
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, text)| Word {
+                            word: text.to_string(),
+                            start: index as f64 * 0.5,
+                            end: (index + 1) as f64 * 0.5,
+                            confidence: 1.0,
+                            speaker: None,
+                            punctuated_word: None,
+                            language: None,
+                        })
+                        .collect(),
                     confidence: 1.0,
                     languages: vec![],
                 }],
@@ -409,6 +438,34 @@ mod tests {
             metadata: Metadata::default(),
             channel_index: vec![0, 1],
         }
+    }
+
+    fn transcript_delta(is_final: bool, second: i64) -> crate::LiveTranscriptDelta {
+        let mut delta = crate::LiveTranscriptDelta {
+            new_words: vec![],
+            replaced_ids: vec![],
+            partials: vec![],
+        };
+        if is_final {
+            delta.new_words.push(anlg_transcript::FinalizedWord {
+                id: second.to_string(),
+                text: "hello".to_string(),
+                start_ms: second * 1000,
+                end_ms: second * 1000 + 500,
+                channel: 0,
+                speaker_index: None,
+                state: anlg_transcript::WordState::Final,
+            });
+        } else {
+            delta.partials.push(anlg_transcript::PartialWord {
+                text: "hello".to_string(),
+                start_ms: second * 1000,
+                end_ms: second * 1000 + 500,
+                channel: 0,
+                speaker_index: None,
+            });
+        }
+        delta
     }
 
     #[test]
@@ -455,17 +512,24 @@ mod tests {
         let now = Instant::now();
         let mut progress = StreamProgress::new(now);
         assert!(!progress.observe_audio(MIN_ACTIVE_AUDIO_SAMPLES, now + Duration::from_secs(29)));
-        progress.observe_response(&transcript_response(false), now + Duration::from_secs(29));
+        progress.observe_delta(&transcript_delta(false, 29), now + Duration::from_secs(29));
         assert!(!progress.observe_audio(MIN_ACTIVE_AUDIO_SAMPLES, now + Duration::from_secs(30)));
         assert!(progress.observe_audio(0, now + Duration::from_secs(59)));
     }
 
     #[test]
-    fn metadata_does_not_hide_a_stalled_transcript() {
+    fn empty_updates_do_not_hide_a_stalled_transcript() {
         let now = Instant::now();
         let mut progress = StreamProgress::new(now);
         assert!(!progress.observe_audio(MIN_ACTIVE_AUDIO_SAMPLES, now + Duration::from_secs(29)));
-        progress.observe_response(&terminal_response(), now + Duration::from_secs(29));
+        progress.observe_delta(
+            &crate::LiveTranscriptDelta {
+                new_words: vec![],
+                replaced_ids: vec![],
+                partials: vec![],
+            },
+            now + Duration::from_secs(29),
+        );
         assert!(progress.observe_audio(0, now + Duration::from_secs(30)));
     }
 
@@ -475,14 +539,53 @@ mod tests {
         let mut progress = StreamProgress::new(now);
         for second in 1..90 {
             let time = now + Duration::from_secs(second);
-            progress.observe_response(&transcript_response(false), time);
+            progress.observe_delta(&transcript_delta(false, second as i64), time);
             assert!(!progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time));
         }
-        progress.observe_response(&transcript_response(false), now + Duration::from_secs(90));
+        progress.observe_delta(&transcript_delta(false, 90), now + Duration::from_secs(90));
         assert!(progress.observe_audio(
             crate::actors::SAMPLE_RATE as usize,
             now + Duration::from_secs(90)
         ));
+    }
+
+    #[test]
+    fn repeated_final_responses_do_not_hide_stalled_transcripts() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        let mut engine = crate::LiveTranscriptEngine::new("anarlog", &[], None);
+        let response = transcript_response(true);
+        let initial = engine
+            .process(&response)
+            .expect("initial response should produce words");
+        progress.observe_delta(&initial.transcript_delta, now);
+        for second in 1..=30 {
+            let time = now + Duration::from_secs(second);
+            assert!(
+                engine.process(&response).is_none(),
+                "duplicate provider words must not count as app progress"
+            );
+            assert_eq!(
+                progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time),
+                second == 30,
+            );
+        }
+    }
+
+    #[test]
+    fn repeated_partials_do_not_hide_stalled_transcripts() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        let delta = transcript_delta(false, 0);
+        progress.observe_delta(&delta, now);
+        for second in 1..=30 {
+            let time = now + Duration::from_secs(second);
+            progress.observe_delta(&delta, time);
+            assert_eq!(
+                progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time),
+                second == 30
+            );
+        }
     }
 
     #[test]
@@ -491,7 +594,7 @@ mod tests {
         let mut progress = StreamProgress::new(now);
         for second in 1..300 {
             let time = now + Duration::from_secs(second);
-            progress.observe_response(&transcript_response(second % 20 == 0), time);
+            progress.observe_delta(&transcript_delta(second % 20 == 0, second as i64), time);
             assert!(!progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time));
         }
     }

--- a/crates/listener-core/src/actors/listener/stream.rs
+++ b/crates/listener-core/src/actors/listener/stream.rs
@@ -589,6 +589,33 @@ mod tests {
     }
 
     #[test]
+    fn advancing_single_word_finals_keep_an_active_stream_healthy() {
+        let now = Instant::now();
+        let mut progress = StreamProgress::new(now);
+        let mut engine = crate::LiveTranscriptEngine::new("anarlog", &[], None);
+        let mut response = transcript_response(true);
+        if let StreamResponse::TranscriptResponse { channel, .. } = &mut response {
+            channel.alternatives[0].words.truncate(1);
+            channel.alternatives[0].transcript = "hello".to_string();
+        }
+        assert!(engine.process(&response).is_none());
+
+        for second in 1..300 {
+            let time = now + Duration::from_secs(second);
+            if second % 20 == 0 {
+                let mut next = response.clone();
+                next.apply_offset(second as f64);
+                let update = engine
+                    .process(&next)
+                    .expect("the next single-word final must release the held word");
+                assert!(!update.transcript_delta.new_words.is_empty());
+                progress.observe_delta(&update.transcript_delta, time);
+            }
+            assert!(!progress.observe_audio(crate::actors::SAMPLE_RATE as usize, time));
+        }
+    }
+
+    #[test]
     fn finalized_words_keep_an_active_stream_healthy() {
         let now = Instant::now();
         let mut progress = StreamProgress::new(now);

--- a/crates/listener-core/src/actors/recorder/mod.rs
+++ b/crates/listener-core/src/actors/recorder/mod.rs
@@ -69,8 +69,8 @@ impl RecorderActor {
         Self
     }
 
-    pub fn name() -> ActorName {
-        "recorder_actor".into()
+    pub fn name(session_id: &str) -> ActorName {
+        format!("recorder_actor_{session_id}")
     }
 }
 

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -1,5 +1,7 @@
 mod children;
 mod mode;
+#[cfg(test)]
+mod reliability_tests;
 
 use std::hash::{DefaultHasher, Hash, Hasher};
 
@@ -552,7 +554,7 @@ mod tests {
 
     impl AudioProvider for TestRuntime {
         fn open_capture(&self, _config: CaptureConfig) -> Result<CaptureStream, anlg_audio::Error> {
-            unimplemented!()
+            Ok(CaptureStream::new(futures_util::stream::pending()))
         }
         fn open_speaker_capture(
             &self,
@@ -620,7 +622,7 @@ mod tests {
         }
     }
 
-    struct SessionStopProbe;
+    pub(super) struct SessionStopProbe;
 
     struct SessionRetryProbe(tokio::sync::mpsc::UnboundedSender<()>);
 
@@ -692,7 +694,7 @@ mod tests {
         fn emit_data(&self, _event: SessionDataEvent) {}
     }
 
-    fn test_ctx() -> SessionContext {
+    pub(super) fn test_ctx() -> SessionContext {
         SessionContext {
             runtime: Arc::new(TestRuntime),
             audio: Arc::new(TestRuntime),
@@ -717,7 +719,7 @@ mod tests {
         }
     }
 
-    fn test_state(ctx: SessionContext) -> SessionState {
+    pub(super) fn test_state(ctx: SessionContext) -> SessionState {
         SessionState {
             ctx,
             source_cell: None,

--- a/crates/listener-core/src/actors/session/supervisor/children.rs
+++ b/crates/listener-core/src/actors/session/supervisor/children.rs
@@ -79,7 +79,7 @@ pub(super) async fn spawn_source(
 ) -> Result<ActorRef<SourceMsg>, ractor::SpawnErr> {
     let recorder = recorder_cell.map(Into::into);
     let (source_ref, _) = Actor::spawn_linked(
-        Some(SourceActor::name()),
+        Some(SourceActor::name(&ctx.params.session_id)),
         SourceActor,
         SourceArgs {
             mic_device: ctx.params.mic_device.clone(),
@@ -101,7 +101,7 @@ pub(super) async fn spawn_recorder(
     ctx: &SessionContext,
 ) -> Result<ActorCell, ractor::SpawnErr> {
     let (recorder_ref, _): (ActorRef<RecMsg>, _) = Actor::spawn_linked(
-        Some(RecorderActor::name()),
+        Some(RecorderActor::name(&ctx.params.session_id)),
         RecorderActor::new(),
         RecArgs {
             app_dir: ctx.app_dir.clone(),
@@ -120,7 +120,7 @@ pub(super) async fn spawn_listener(
 ) -> Result<ActorCell, ractor::SpawnErr> {
     let mode = ChannelMode::determine(ctx.params.onboarding);
     let (listener_ref, _): (ActorRef<crate::actors::ListenerMsg>, _) = Actor::spawn_linked(
-        Some(ListenerActor::name()),
+        Some(ListenerActor::name(&ctx.params.session_id)),
         ListenerActor,
         ListenerArgs {
             runtime: ctx.runtime.clone(),

--- a/crates/listener-core/src/actors/session/supervisor/reliability_tests.rs
+++ b/crates/listener-core/src/actors/session/supervisor/reliability_tests.rs
@@ -1,0 +1,313 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use ractor::{Actor, ActorProcessingErr, ActorRef, ActorStatus, registry};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Duration, timeout};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+use super::tests::{SessionStopProbe, test_ctx, test_state};
+use super::{SessionActor, SessionMsg, children};
+use crate::actors::{
+    ListenerActor, ListenerAudioResult, ListenerMsg, RecMsg, RecorderActor, SourceActor,
+};
+use crate::{
+    ListenerRuntime, SessionDataEvent, SessionErrorEvent, SessionLifecycleEvent,
+    SessionProgressEvent,
+};
+
+struct FinalizationGate;
+
+#[ractor::async_trait]
+impl Actor for FinalizationGate {
+    type Msg = ();
+    type State = (Option<oneshot::Sender<()>>, Option<oneshot::Receiver<()>>);
+    type Arguments = Self::State;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<()>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(args)
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<()>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let _ = state.0.take().unwrap().send(());
+        let _ = state.1.take().unwrap().await;
+        Ok(())
+    }
+}
+
+async fn record_audio(recorder: &ractor::ActorCell) {
+    let recorder: ActorRef<RecMsg> = recorder.clone().into();
+    let audio = Arc::from(vec![0.1_f32; crate::actors::SAMPLE_RATE as usize]);
+    assert_eq!(
+        ractor::call_t!(recorder, RecMsg::AudioSingle, 1000, audio).unwrap(),
+        crate::actors::RecorderEnqueueResult::Accepted,
+    );
+}
+
+#[tokio::test]
+async fn next_recorder_runs_while_previous_listener_finalizes() {
+    let vault = tempfile::tempdir().unwrap();
+    let (supervisor, supervisor_task) = Actor::spawn(None, SessionStopProbe, ()).await.unwrap();
+    let mut previous_ctx = test_ctx();
+    previous_ctx.app_dir = vault.path().to_path_buf();
+    previous_ctx.params.session_id = uuid::Uuid::new_v4().to_string();
+    let recorder = children::spawn_recorder(supervisor.get_cell(), &previous_ctx)
+        .await
+        .unwrap();
+    record_audio(&recorder).await;
+    let (entered_tx, entered_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let (listener, listener_task) =
+        Actor::spawn(None, FinalizationGate, (Some(entered_tx), Some(release_rx)))
+            .await
+            .unwrap();
+    let mut previous = test_state(previous_ctx);
+    previous.recorder_cell = Some(recorder.clone());
+    previous.listener_cell = Some(listener.get_cell());
+    let shutdown =
+        tokio::spawn(
+            async move { children::shutdown_children(&mut previous, "session_stop").await },
+        );
+    timeout(Duration::from_secs(5), entered_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(recorder.get_status(), ActorStatus::Running);
+
+    let mut next_ctx = test_ctx();
+    next_ctx.app_dir = vault.path().to_path_buf();
+    next_ctx.params.session_id = uuid::Uuid::new_v4().to_string();
+    let (next_supervisor, next_supervisor_task) =
+        Actor::spawn(None, SessionStopProbe, ()).await.unwrap();
+    let next_recorder = children::spawn_recorder(next_supervisor.get_cell(), &next_ctx)
+        .await
+        .expect("previous finalization must not reserve the next meeting's recorder");
+    record_audio(&next_recorder).await;
+    release_tx.send(()).unwrap();
+    timeout(Duration::from_secs(5), shutdown)
+        .await
+        .unwrap()
+        .unwrap();
+    listener_task.await.unwrap();
+    assert_eq!(next_recorder.get_status(), ActorStatus::Running);
+    record_audio(&next_recorder).await;
+    next_recorder
+        .stop_and_wait(None, Some(Duration::from_secs(5)))
+        .await
+        .unwrap();
+    assert!(
+        vault
+            .path()
+            .join(&next_ctx.params.session_id)
+            .join("audio.mp3")
+            .metadata()
+            .unwrap()
+            .len()
+            > 0
+    );
+    supervisor.stop(None);
+    next_supervisor.stop(None);
+    supervisor_task.await.unwrap();
+    next_supervisor_task.await.unwrap();
+}
+
+struct TranscriptRuntime {
+    events: mpsc::UnboundedSender<SessionDataEvent>,
+}
+
+impl anlg_storage::StorageRuntime for TranscriptRuntime {
+    fn global_base(&self) -> Result<PathBuf, anlg_storage::Error> {
+        Ok(std::env::temp_dir())
+    }
+    fn vault_base(&self) -> Result<PathBuf, anlg_storage::Error> {
+        Ok(std::env::temp_dir())
+    }
+}
+
+impl ListenerRuntime for TranscriptRuntime {
+    fn emit_lifecycle(&self, _event: SessionLifecycleEvent) {}
+    fn emit_progress(&self, _event: SessionProgressEvent) {}
+    fn emit_error(&self, _event: SessionErrorEvent) {}
+    fn emit_data(&self, event: SessionDataEvent) {
+        let _ = self.events.send(event);
+    }
+}
+
+fn response(word: &str, is_final: bool) -> Message {
+    let raw = serde_json::json!({
+        "type": "Results", "start": 0.0, "duration": 1.0,
+        "is_final": is_final, "speech_final": is_final, "from_finalize": false,
+        "channel_index": [0, 2],
+        "channel": {"alternatives": [{"transcript": format!("{word} speech"), "confidence": 1.0,
+            "words": [
+                {"word": word, "start": 0.0, "end": 0.5, "confidence": 1.0, "speaker": 0},
+                {"word": "speech", "start": 0.5, "end": 1.0, "confidence": 1.0, "speaker": 0}
+            ]}]},
+        "metadata": {"request_id": "test", "model_uuid": "test", "model_info": {"name": "test", "version": "1", "arch": "test"}}
+    });
+    Message::Text(raw.to_string().into())
+}
+
+async fn wait_for_word(events: &mut mpsc::UnboundedReceiver<SessionDataEvent>, word: &str) {
+    timeout(Duration::from_secs(10), async {
+        while let Some(event) = events.recv().await {
+            if let SessionDataEvent::TranscriptDelta { delta, .. } = event
+                && delta
+                    .new_words
+                    .iter()
+                    .any(|value| value.text.trim() == word)
+            {
+                return;
+            }
+        }
+        panic!("transcript event channel closed before {word}");
+    })
+    .await
+    .expect("finalized transcript should resume");
+}
+
+async fn wait_for_listener(
+    session_id: &str,
+    previous_id: Option<ractor::ActorId>,
+) -> ActorRef<ListenerMsg> {
+    timeout(Duration::from_secs(15), async {
+        loop {
+            if let Some(actor) = registry::where_is(ListenerActor::name(session_id))
+                && actor.get_status() == ActorStatus::Running
+                && Some(actor.get_id()) != previous_id
+            {
+                return actor.into();
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("listener should connect automatically")
+}
+
+async fn send_audio(listener: &ActorRef<ListenerMsg>) {
+    let audio = Bytes::from(
+        1000_i16
+            .to_le_bytes()
+            .repeat(crate::actors::SAMPLE_RATE as usize),
+    );
+    assert_eq!(
+        ractor::call_t!(listener, ListenerMsg::AudioDual, 1000, audio.clone(), audio).unwrap(),
+        ListenerAudioResult::Accepted
+    );
+}
+
+#[tokio::test]
+async fn live_words_resume_after_silent_and_partial_only_streams_without_restarting_recorder() {
+    for partial_only in [false, true] {
+        let socket = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = socket.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for connection in 0..2 {
+                let (stream, _) = socket.accept().await.unwrap();
+                let mut ws = accept_async(stream).await.unwrap();
+                let mut first_audio = true;
+                while let Some(Ok(message)) = ws.next().await {
+                    match message {
+                        Message::Binary(_) => {
+                            if first_audio || connection == 1 {
+                                ws.send(response(
+                                    if connection == 0 { "before" } else { "after" },
+                                    true,
+                                ))
+                                .await
+                                .unwrap();
+                                first_audio = false;
+                            } else if partial_only
+                                && ws.send(response("unfinished", false)).await.is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Message::Text(text) if text.contains("Finalize") => {
+                            let _ = ws.close(None).await;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        });
+        let vault = tempfile::tempdir().unwrap();
+        let (events_tx, mut events) = mpsc::unbounded_channel();
+        let mut ctx = test_ctx();
+        ctx.runtime = Arc::new(TranscriptRuntime { events: events_tx });
+        ctx.app_dir = vault.path().to_path_buf();
+        ctx.params.session_id = uuid::Uuid::new_v4().to_string();
+        ctx.params.base_url = format!("http://{address}/stt");
+        ctx.params.model = "cloud".to_string();
+        let session_id = ctx.params.session_id.clone();
+        let (supervisor, supervisor_task) = Actor::spawn(None, SessionActor, ctx).await.unwrap();
+        let listener = wait_for_listener(&session_id, None).await;
+        let recorder = registry::where_is(RecorderActor::name(&session_id)).unwrap();
+        let source = registry::where_is(SourceActor::name(&session_id)).unwrap();
+        record_audio(&recorder).await;
+        send_audio(&listener).await;
+        wait_for_word(&mut events, "before").await;
+
+        if partial_only {
+            for _ in 0..89 {
+                send_audio(&listener).await;
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        } else {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            for _ in 0..4 {
+                send_audio(&listener).await;
+            }
+        }
+        // The first finalized response resets the audio count for the stalled period.
+        send_audio(&listener).await;
+        let recovered = wait_for_listener(&session_id, Some(listener.get_id())).await;
+        assert_eq!(
+            registry::where_is(RecorderActor::name(&session_id))
+                .unwrap()
+                .get_id(),
+            recorder.get_id()
+        );
+        assert_eq!(
+            registry::where_is(SourceActor::name(&session_id))
+                .unwrap()
+                .get_id(),
+            source.get_id()
+        );
+        assert_eq!(recorder.get_status(), ActorStatus::Running);
+        record_audio(&recorder).await;
+        send_audio(&recovered).await;
+        wait_for_word(&mut events, "after").await;
+        supervisor.cast(SessionMsg::Shutdown).unwrap();
+        timeout(Duration::from_secs(10), supervisor_task)
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(5), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            vault
+                .path()
+                .join(&session_id)
+                .join("audio.mp3")
+                .metadata()
+                .unwrap()
+                .len()
+                > 0
+        );
+    }
+}

--- a/crates/listener-core/src/actors/session/supervisor/reliability_tests.rs
+++ b/crates/listener-core/src/actors/session/supervisor/reliability_tests.rs
@@ -207,9 +207,20 @@ async fn send_audio(listener: &ActorRef<ListenerMsg>) {
     );
 }
 
+#[derive(Clone, Copy)]
+enum StreamFailure {
+    Silent,
+    Unfinalized,
+    RepeatedFinal,
+}
+
 #[tokio::test]
-async fn live_words_resume_after_silent_and_partial_only_streams_without_restarting_recorder() {
-    for partial_only in [false, true] {
+async fn live_words_resume_after_stalled_streams_without_restarting_recorder() {
+    for failure in [
+        StreamFailure::Silent,
+        StreamFailure::Unfinalized,
+        StreamFailure::RepeatedFinal,
+    ] {
         let socket = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = socket.local_addr().unwrap();
         let server = tokio::spawn(async move {
@@ -228,10 +239,19 @@ async fn live_words_resume_after_silent_and_partial_only_streams_without_restart
                                 .await
                                 .unwrap();
                                 first_audio = false;
-                            } else if partial_only
-                                && ws.send(response("unfinished", false)).await.is_err()
-                            {
-                                break;
+                            } else {
+                                let update = match failure {
+                                    StreamFailure::Silent => None,
+                                    StreamFailure::Unfinalized => {
+                                        Some(response("unfinished", false))
+                                    }
+                                    StreamFailure::RepeatedFinal => Some(response("before", true)),
+                                };
+                                if let Some(update) = update
+                                    && ws.send(update).await.is_err()
+                                {
+                                    break;
+                                }
                             }
                         }
                         Message::Text(text) if text.contains("Finalize") => {
@@ -260,15 +280,24 @@ async fn live_words_resume_after_silent_and_partial_only_streams_without_restart
         send_audio(&listener).await;
         wait_for_word(&mut events, "before").await;
 
-        if partial_only {
-            for _ in 0..89 {
-                send_audio(&listener).await;
-                tokio::time::sleep(Duration::from_millis(5)).await;
+        match failure {
+            StreamFailure::Unfinalized => {
+                for _ in 0..89 {
+                    send_audio(&listener).await;
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
             }
-        } else {
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            for _ in 0..4 {
-                send_audio(&listener).await;
+            StreamFailure::Silent => {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                for _ in 0..4 {
+                    send_audio(&listener).await;
+                }
+            }
+            StreamFailure::RepeatedFinal => {
+                for _ in 0..5 {
+                    send_audio(&listener).await;
+                    tokio::time::sleep(Duration::from_secs(6)).await;
+                }
             }
         }
         // The first finalized response resets the audio count for the stalled period.

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -189,8 +189,8 @@ impl OutputRoutingTracker {
 }
 
 impl SourceActor {
-    pub fn name() -> ActorName {
-        "source".into()
+    pub fn name(session_id: &str) -> ActorName {
+        format!("source_{session_id}")
     }
 }
 

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -343,6 +343,48 @@ impl From<TranscriptionParams> for listener2::BatchParams {
     }
 }
 
+impl From<listener2::BatchRunOutput> for TranscriptionOutput {
+    fn from(value: listener2::BatchRunOutput) -> Self {
+        Self {
+            session_id: value.session_id,
+            mode: value.mode,
+            response: value.response,
+        }
+    }
+}
+
+impl From<listener2::BatchEvent> for TranscriptionEvent {
+    fn from(value: listener2::BatchEvent) -> Self {
+        match value {
+            listener2::BatchEvent::BatchStarted { session_id } => Self::Started { session_id },
+            listener2::BatchEvent::BatchCompleted { .. } => {
+                unreachable!("batch completed is represented by transcription completed")
+            }
+            listener2::BatchEvent::BatchResponse {
+                session_id,
+                response,
+                mode,
+            } => Self::Completed {
+                session_id,
+                response,
+                mode,
+            },
+            listener2::BatchEvent::BatchResponseStreamed { session_id, event } => {
+                Self::Progress { session_id, event }
+            }
+            listener2::BatchEvent::BatchFailed {
+                session_id,
+                code,
+                error,
+            } => Self::Failed {
+                session_id,
+                code,
+                error,
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::CaptureParams;
@@ -574,47 +616,5 @@ mod tests {
         let params = capture_params("soniqo://local", "nova-3");
 
         assert_eq!(resolved(&params), TranscriptionMode::Batch);
-    }
-}
-
-impl From<listener2::BatchRunOutput> for TranscriptionOutput {
-    fn from(value: listener2::BatchRunOutput) -> Self {
-        Self {
-            session_id: value.session_id,
-            mode: value.mode,
-            response: value.response,
-        }
-    }
-}
-
-impl From<listener2::BatchEvent> for TranscriptionEvent {
-    fn from(value: listener2::BatchEvent) -> Self {
-        match value {
-            listener2::BatchEvent::BatchStarted { session_id } => Self::Started { session_id },
-            listener2::BatchEvent::BatchCompleted { .. } => {
-                unreachable!("batch completed is represented by transcription completed")
-            }
-            listener2::BatchEvent::BatchResponse {
-                session_id,
-                response,
-                mode,
-            } => Self::Completed {
-                session_id,
-                response,
-                mode,
-            },
-            listener2::BatchEvent::BatchResponseStreamed { session_id, event } => {
-                Self::Progress { session_id, event }
-            }
-            listener2::BatchEvent::BatchFailed {
-                session_id,
-                code,
-                error,
-            } => Self::Failed {
-                session_id,
-                code,
-                error,
-            },
-        }
     }
 }

--- a/plugins/transcription/src/listener/ext.rs
+++ b/plugins/transcription/src/listener/ext.rs
@@ -15,6 +15,13 @@ fn capture_snapshot_from_result<E: std::fmt::Debug>(
     })
 }
 
+async fn active_source() -> Option<ActorRef<SourceMsg>> {
+    let root: ActorRef<RootMsg> = registry::where_is(RootActor::name())?.into();
+    let snapshot = call_t!(root, RootMsg::GetSnapshot, 100).ok()?;
+    let session_id = snapshot.active_session_id?;
+    registry::where_is(SourceActor::name(&session_id)).map(Into::into)
+}
+
 fn hydrate_session_state(
     snapshot: &mut CaptureSnapshot,
     session_id: String,
@@ -51,14 +58,13 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener<'a, R, M> {
 
     #[tracing::instrument(skip_all)]
     pub async fn get_current_microphone_device(&self) -> Result<Option<String>, crate::Error> {
-        if let Some(cell) = registry::where_is(SourceActor::name()) {
-            let actor: ActorRef<SourceMsg> = cell.into();
+        if let Some(actor) = active_source().await {
             match call_t!(actor, SourceMsg::GetMicDevice, 500) {
                 Ok(device_name) => Ok(device_name),
                 Err(_) => Ok(None),
             }
         } else {
-            Err(crate::Error::ActorNotFound(SourceActor::name()))
+            Err(crate::Error::ActorNotFound("active source".to_string()))
         }
     }
 
@@ -108,8 +114,7 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener<'a, R, M> {
 
     #[tracing::instrument(skip_all)]
     pub async fn get_mic_muted(&self) -> bool {
-        if let Some(cell) = registry::where_is(SourceActor::name()) {
-            let actor: ActorRef<SourceMsg> = cell.into();
+        if let Some(actor) = active_source().await {
             call_t!(actor, SourceMsg::GetMicMute, 100).unwrap_or_default()
         } else {
             false
@@ -118,8 +123,7 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener<'a, R, M> {
 
     #[tracing::instrument(skip_all)]
     pub async fn set_mic_muted(&self, muted: bool) {
-        if let Some(cell) = registry::where_is(SourceActor::name()) {
-            let actor: ActorRef<SourceMsg> = cell.into();
+        if let Some(actor) = active_source().await {
             let _ = actor.cast(SourceMsg::SetMicMute(muted));
         }
     }
@@ -160,9 +164,136 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener<'a, R, M> {
     }
 }
 
+pub trait ListenerPluginExt<R: tauri::Runtime> {
+    fn listener(&self) -> Listener<'_, R, Self>
+    where
+        Self: tauri::Manager<R> + Sized;
+}
+
+impl<R: tauri::Runtime, T: tauri::Manager<R>> ListenerPluginExt<R> for T {
+    fn listener(&self) -> Listener<'_, R, Self>
+    where
+        Self: Sized,
+    {
+        Listener {
+            manager: self,
+            _runtime: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct SnapshotProbe;
+
+    #[ractor::async_trait]
+    impl ractor::Actor for SnapshotProbe {
+        type Msg = RootMsg;
+        type State = Option<String>;
+        type Arguments = Self::State;
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<RootMsg>,
+            args: Self::Arguments,
+        ) -> Result<Self::State, ractor::ActorProcessingErr> {
+            Ok(args)
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<RootMsg>,
+            message: RootMsg,
+            state: &mut Self::State,
+        ) -> Result<(), ractor::ActorProcessingErr> {
+            match message {
+                RootMsg::GetSnapshot(reply) => {
+                    let _ = reply.send(anlg_transcription_core::listener::Snapshot {
+                        state: if state.is_some() {
+                            anlg_transcription_core::listener::State::Active
+                        } else {
+                            anlg_transcription_core::listener::State::Finalizing
+                        },
+                        active_session_id: state.clone(),
+                        finalizing_session_ids: vec!["previous".to_string()],
+                    });
+                }
+                RootMsg::StopSession(reply) => {
+                    *state = None;
+                    let _ = reply.send(());
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+    }
+
+    struct MicProbe;
+
+    #[ractor::async_trait]
+    impl ractor::Actor for MicProbe {
+        type Msg = SourceMsg;
+        type State = bool;
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<SourceMsg>,
+            _args: (),
+        ) -> Result<bool, ractor::ActorProcessingErr> {
+            Ok(false)
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<SourceMsg>,
+            message: SourceMsg,
+            muted: &mut bool,
+        ) -> Result<(), ractor::ActorProcessingErr> {
+            match message {
+                SourceMsg::SetMicMute(value) => *muted = value,
+                SourceMsg::GetMicMute(reply) => {
+                    let _ = reply.send(*muted);
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn microphone_controls_target_active_session_and_ignore_finalizing_sessions() {
+        use ractor::Actor;
+
+        let (previous, previous_task) =
+            Actor::spawn(Some(SourceActor::name("previous")), MicProbe, ())
+                .await
+                .unwrap();
+        let next_id = uuid::Uuid::new_v4().to_string();
+        let (next, next_task) = Actor::spawn(Some(SourceActor::name(&next_id)), MicProbe, ())
+            .await
+            .unwrap();
+        let (root, root_task) = Actor::spawn(Some(RootActor::name()), SnapshotProbe, Some(next_id))
+            .await
+            .unwrap();
+
+        let active = active_source().await.unwrap();
+        assert_eq!(active.get_id(), next.get_id());
+        active.cast(SourceMsg::SetMicMute(true)).unwrap();
+        assert!(call_t!(next, SourceMsg::GetMicMute, 1000).unwrap());
+        assert!(!call_t!(previous, SourceMsg::GetMicMute, 1000).unwrap());
+        call_t!(root, RootMsg::StopSession, 1000).unwrap();
+        assert!(active_source().await.is_none());
+
+        root.stop(None);
+        previous.stop(None);
+        next.stop(None);
+        root_task.await.unwrap();
+        previous_task.await.unwrap();
+        next_task.await.unwrap();
+    }
 
     #[test]
     fn capture_snapshot_failure_is_not_reported_as_inactive() {
@@ -191,23 +322,5 @@ mod tests {
             Some("session-a")
         );
         assert_eq!(snapshot.live_segments, Some(Vec::new()));
-    }
-}
-
-pub trait ListenerPluginExt<R: tauri::Runtime> {
-    fn listener(&self) -> Listener<'_, R, Self>
-    where
-        Self: tauri::Manager<R> + Sized;
-}
-
-impl<R: tauri::Runtime, T: tauri::Manager<R>> ListenerPluginExt<R> for T {
-    fn listener(&self) -> Listener<'_, R, Self>
-    where
-        Self: Sized,
-    {
-        Listener {
-            manager: self,
-            _runtime: std::marker::PhantomData,
-        }
     }
 }

--- a/plugins/transcription/src/listener/runtime.rs
+++ b/plugins/transcription/src/listener/runtime.rs
@@ -212,6 +212,15 @@ fn apply_segment_delta(
     }
 }
 
+async fn current_root_state() -> RootState {
+    let Some(cell) = registry::where_is(RootActor::name()) else {
+        return RootState::Inactive;
+    };
+
+    let actor: ActorRef<RootMsg> = cell.into();
+    call_t!(actor, RootMsg::GetState, 100).unwrap_or(RootState::Inactive)
+}
+
 #[cfg(test)]
 mod tests {
     use anlg_transcript::{ChannelProfile, SegmentKey};
@@ -283,13 +292,4 @@ mod tests {
             Some("segment-5")
         );
     }
-}
-
-async fn current_root_state() -> RootState {
-    let Some(cell) = registry::where_is(RootActor::name()) else {
-        return RootState::Inactive;
-    };
-
-    let actor: ActorRef<RootMsg> = cell.into();
-    call_t!(actor, RootMsg::GetState, 100).unwrap_or(RootState::Inactive)
 }

--- a/plugins/transcription/src/listener2/ext.rs
+++ b/plugins/transcription/src/listener2/ext.rs
@@ -304,11 +304,11 @@ fn finish_batch_session(
     control: &Arc<BatchSessionControl>,
 ) {
     {
-        if let Ok(mut state) = lock_terminal_state(control) {
-            if *state == BatchTerminalState::Running {
-                *state = BatchTerminalState::Finished;
-                control.cancellation_token.cancel();
-            }
+        if let Ok(mut state) = lock_terminal_state(control)
+            && *state == BatchTerminalState::Running
+        {
+            *state = BatchTerminalState::Finished;
+            control.cancellation_token.cancel();
         }
     }
 

--- a/plugins/transcription/src/voiceprint.rs
+++ b/plugins/transcription/src/voiceprint.rs
@@ -169,7 +169,7 @@ pub async fn extract_voiceprint_candidates<R: tauri::Runtime>(
                 source_session_id: &session_id,
                 source_transcript_id: &transcript_id,
                 source_attachment_id: &attachment_id,
-                source_speaker_label: &speaker_label(&span),
+                source_speaker_label: &speaker_label(span),
                 speaker_channel: span.channel,
                 speaker_index: span.speaker_index,
                 source_start_ms: span.start_ms,


### PR DESCRIPTION
## Summary

**Problem:** The stream watchdog treated repeated provider responses as progress even when deduplication produced no new text for the app. Starting the next meeting while the previous listener was finalizing could fail with `ActorAlreadyRegistered("recorder_actor")`. Source, listener, and recorder workers all shared global names despite allowing a different meeting to start during finalization.

**Fix:** Measure progress after transcript processing, require changing partials or new finalized words, and reconnect when audible input continues without progress. Scope worker names to their meeting and resolve microphone controls through the active meeting. Add regression coverage for overlapping recorder finalization and previous-meeting post-processing. A local WebSocket test starts with working live words, injects silent streams, partials that never finalize, and repeated final responses, and verifies automatic reconnection restores finalized words while preserving the original source and recorder. Separate mechanical cleanup makes the transcription plugin pass strict Clippy.

## Verification

- Reproduced duplicate final responses defeating the previous watchdog before fixing it. All three WebSocket failure scenarios now resume finalized words with the same recorder and audio source.
- Listener core and transcription plugin tests: 196 passed, 1 existing ignored test in the locked workspace run. After adding the single-word review regression, all 138 listener-core tests passed again.
- `cargo clippy --locked -p listener-core -p tauri-plugin-transcription --all-targets --no-deps -- -D warnings`.
- `cargo check --locked -p desktop --features direct-distribution` and `--features app-store`.
- `cargo test --locked -p desktop -- --test-threads=1`: 49 passed. The initial parallel run failed the unchanged startup-lock test; that test passed in isolation and the full suite passed serially.
- Full macOS workspace test command from `desktop_ci.yaml`, retaining its exclusions and adding `--locked`: 3,061 passed, 157 existing ignored tests.
- UI build, desktop typecheck, 4,232 desktop tests, i18n check, desktop lint, touched-file ESLint and formatting.
- Both license-boundary checks and all 70 Node tests from `ci.yaml`.
- Workflow scan completed; its existing findings are outside this change. No workflows changed in this PR. Export tests also exposed existing Todo binding drift (optional reminder fields); unrelated generated outputs were restored and excluded.

The watchdog intentionally measures output reaching the app. An initial final word held for stitching does not reset it; advancing single-word finals release the held word and keep the stream healthy, covered by an added regression test.

Recovery tests use synthetic audio and a local WebSocket server; this is not a stable release or live-provider hardware QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live STT reconnection logic and concurrent session actor lifecycle—core capture path—but behavior is heavily regression-tested and scoped naming reduces prior handoff failures.
> 
> **Overview**
> Fixes live transcription **stall detection** so the watchdog tracks **app-visible progress** (new finalized words or changing partials) after `LiveTranscriptEngine` processing, not raw provider responses. Duplicate finals, empty deltas, and identical partials no longer reset the timer; audible input without progress can still trigger reconnection.
> 
> **Meeting handoffs** scope **source, listener, and recorder** actor registry names per `session_id`, so a new capture can start while the previous session finalizes without `ActorAlreadyRegistered` on a shared recorder name. The transcription plugin resolves **mic mute/device** through the root snapshot’s **active** session instead of a single global source actor.
> 
> Adds **regression tests**: Rust WebSocket scenarios (silent stream, stuck partials, repeated finals) asserting listener reconnect while recorder/source stay put; supervisor test for overlapping recorder during listener finalization; desktop store test that the **next** live caption survives previous batch/summary post-stop work; plugin test that mic controls hit the active session only. Minor Clippy/layout tweaks in the transcription plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0047678db61f67fe22c02fa4fa231849979db856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->