### PR TITLE
Remove technical-looking mono font from brand/UI surfaces

### DIFF
--- a/apps/web/src/components/home-page/index.tsx
+++ b/apps/web/src/components/home-page/index.tsx
@@ -163,7 +163,7 @@ function OpenSourceSection({
       <div className="mx-auto max-w-[700px] px-5 md:px-8">
         <h2
           id="open-source-heading"
-          className="text-color-muted font-mono text-3xl leading-none font-semibold"
+          className="font-hand text-3xl leading-none font-semibold text-[#756b5d]"
         >
           Open source by default
         </h2>

--- a/apps/web/src/components/home-page/pricing-section.tsx
+++ b/apps/web/src/components/home-page/pricing-section.tsx
@@ -16,10 +16,10 @@ export function PricingSection({
   return (
     <section id="pricing" className="pt-24 pb-8 md:pt-28 md:pb-10">
       <div>
-        <h2 className="text-color-muted font-mono text-3xl leading-none font-semibold">
+        <h2 className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
           Simple pricing
         </h2>
-        <p className="text-color-secondary mx-auto mt-6 max-w-2xl text-lg leading-8">
+        <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-[#4f4940]">
           Start local for free, add personal cloud features with Pro, put
           collaboration on Team, and reserve organization-wide controls for
           Enterprise.
@@ -59,7 +59,7 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
       ])}
     >
       <div className="flex items-start">
-        <h3 className="text-color font-mono text-2xl leading-none font-semibold">
+        <h3 className="font-hand text-2xl leading-none font-semibold text-[#181613]">
           {plan.name}
         </h3>
       </div>
@@ -80,7 +80,7 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
         <Link
           to={plan.id === "enterprise" ? "/enterprise/" : "/download/"}
           className={cn([
-            "flex h-11 w-full items-center justify-center rounded-full font-mono text-sm font-medium transition-all hover:scale-[102%] active:scale-[98%]",
+            "flex h-11 w-full items-center justify-center rounded-full text-sm font-medium transition-all hover:scale-[102%] active:scale-[98%]",
             plan.popular
               ? "bg-linear-to-t from-stone-600 to-stone-500 text-white"
               : "surface-subtle text-color hover:bg-page",
@@ -97,7 +97,7 @@ function PlanPrice({ price }: { price: MarketingPlanPrice }) {
   if (price.kind === "custom") {
     return (
       <div className="flex flex-col gap-1">
-        <span className="text-color font-mono text-4xl leading-none font-semibold">
+        <span className="text-color text-4xl leading-none font-semibold">
           Custom
         </span>
         <span className="text-color-muted text-sm">Founder-led rollout</span>
@@ -108,7 +108,7 @@ function PlanPrice({ price }: { price: MarketingPlanPrice }) {
   if (price.kind === "free") {
     return (
       <div className="flex items-baseline gap-2">
-        <span className="text-color font-mono text-4xl leading-none font-semibold">
+        <span className="text-color text-4xl leading-none font-semibold">
           $0
         </span>
         <span className="text-color-muted text-sm">/month</span>
@@ -121,7 +121,7 @@ function PlanPrice({ price }: { price: MarketingPlanPrice }) {
   return (
     <div className="flex flex-col gap-1">
       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <span className="text-color font-mono text-4xl leading-none font-semibold">
+        <span className="text-color text-4xl leading-none font-semibold">
           ${price.monthly}
         </span>
         <span className="text-color-muted text-sm">{unit}/month</span>

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -54,9 +54,7 @@ function CtaCard({
       href={href}
       className="my-6 block rounded-md border border-neutral-200 p-6 no-underline transition-colors hover:border-stone-400 hover:bg-stone-50"
     >
-      {title && (
-        <div className="mb-1 text-base text-stone-800">{title}</div>
-      )}
+      {title && <div className="mb-1 text-base text-stone-800">{title}</div>}
       {description && (
         <div className="mb-3 text-sm text-neutral-600">{description}</div>
       )}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -55,7 +55,7 @@ function CtaCard({
       className="my-6 block rounded-md border border-neutral-200 p-6 no-underline transition-colors hover:border-stone-400 hover:bg-stone-50"
     >
       {title && (
-        <div className="mb-1 font-mono text-base text-stone-800">{title}</div>
+        <div className="mb-1 text-base text-stone-800">{title}</div>
       )}
       {description && (
         <div className="mb-3 text-sm text-neutral-600">{description}</div>

--- a/apps/web/src/components/shared-note-audio-player.tsx
+++ b/apps/web/src/components/shared-note-audio-player.tsx
@@ -224,7 +224,7 @@ export function SharedNoteAudioPlayer({
           <Play className="ml-0.5 size-3.5" aria-hidden="true" />
         )}
       </button>
-      <span className="flex shrink-0 gap-1 font-mono text-[10px] tabular-nums">
+      <span className="flex shrink-0 gap-1 text-[10px] tabular-nums">
         <span>{formatSharedNotePlaybackTime(currentTime)}</span>
         <span aria-hidden="true">/</span>
         <span>{formatSharedNotePlaybackTime(duration)}</span>

--- a/apps/web/src/components/shared-note-chat-panel.tsx
+++ b/apps/web/src/components/shared-note-chat-panel.tsx
@@ -198,7 +198,7 @@ export function SharedNoteChatPanel({
         <header className="border-color-subtle flex items-center gap-3 border-b px-5 py-4 pr-14">
           <div className="text-color flex items-center gap-2">
             <Sparkle className="size-4" aria-hidden="true" />
-            <DialogTitle className="font-mono text-sm font-medium">
+            <DialogTitle className="text-sm font-medium">
               Ask about this note
             </DialogTitle>
           </div>
@@ -332,7 +332,7 @@ function SignInToChat({ returnPath }: { returnPath: string }) {
   });
   return (
     <div className="surface-subtle border-color-subtle rounded-2xl border px-4 py-5">
-      <p className="text-color font-mono text-sm font-medium">
+      <p className="text-color text-sm font-medium">
         Sign in to ask about this note
       </p>
       <p className="text-color-muted mt-1 text-sm leading-6">

--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -214,7 +214,7 @@ function SignInToCollaborate({ returnPath }: { returnPath: string }) {
   return (
     <div className="sm:flex sm:items-center sm:justify-between sm:gap-5">
       <div>
-        <p className="text-color font-mono text-sm font-medium">
+        <p className="text-color text-sm font-medium">
           Sign in to join the conversation
         </p>
         <p className="text-color-muted mt-1 text-sm leading-6">
@@ -271,7 +271,7 @@ function AccessRequestPanel({
   return (
     <div className="sm:flex sm:items-center sm:justify-between sm:gap-5">
       <div>
-        <p className="text-color flex items-center gap-2 font-mono text-sm font-medium">
+        <p className="text-color flex items-center gap-2 text-sm font-medium">
           {isPending && <Clock className="size-4" aria-hidden="true" />}
           {isApproved ? "Comment access approved" : "Want to comment?"}
         </p>
@@ -353,7 +353,7 @@ function ManagerRequests({
 
   return (
     <div>
-      <h2 className="text-color font-mono text-sm font-medium">
+      <h2 className="text-color text-sm font-medium">
         Comment access requests
       </h2>
       {requests.length > 0 && (

--- a/apps/web/src/components/shared-note-read-surface.tsx
+++ b/apps/web/src/components/shared-note-read-surface.tsx
@@ -388,7 +388,7 @@ export function SharedNoteReadSurface({
       </SharedReadAttachmentsContext.Provider>
       {unreferencedAttachments.length > 0 && (
         <section className="border-color-subtle mt-10 border-t pt-6">
-          <h2 className="mb-3 font-mono text-sm font-medium">Attachments</h2>
+          <h2 className="mb-3 text-sm font-medium">Attachments</h2>
           {unreferencedAttachments.map((attachment) => (
             <SharedReadAttachment
               key={attachment.id}

--- a/apps/web/src/components/shared-note-selection-comment.tsx
+++ b/apps/web/src/components/shared-note-selection-comment.tsx
@@ -78,7 +78,7 @@ export function SharedNoteSelectionComment({
       className={cn([
         "z-50 inline-flex items-center gap-1.5",
         "surface border-color-subtle rounded-full border px-3 py-1.5 shadow-md",
-        "text-color font-mono text-xs font-medium",
+        "text-color text-xs font-medium",
         "hover:bg-surface-subtle transition-colors",
         "focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden",
       ])}

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -267,7 +267,7 @@ export function SharedNotePrompt({
             {icon}
           </div>
         )}
-        <h1 className="text-color font-mono text-2xl font-medium">{title}</h1>
+        <h1 className="text-color text-2xl font-medium">{title}</h1>
         <p className="text-color-muted mx-auto mt-3 max-w-lg text-base leading-7">
           {description}
         </p>


### PR DESCRIPTION
font-mono (a technical/code cue) was used across the homepage and
shared-note pages for plain headings, labels, and price displays that
have nothing to do with code or data — reading as an out-of-place
'techy' accent against the site's warm, handwritten brand voice.

- Homepage: 'Simple pricing', 'Open source by default', and the plan
  card titles now use font-hand (Caveat) + the brand's heading/body
  colors (#756b5d / #4f4940 / #181613), matching hero/Privacy/
  Testimonials. Price numbers and CTA buttons in the pricing cards
  drop font-mono for the site's default sans body font.
- Shared-note pages: dropped font-mono from plain labels/headings
  (note title, 'Ask about this note', sign-in prompts, comment access
  copy, 'Attachments' heading, selection-comment pill, playback
  timestamp) in favor of the default sans font.
- Blog resource-card title in mdx-components.tsx also dropped
  font-mono.

Left font-mono in place only where it is functionally correct, not a
style bug: inline <code> spans in blog markdown (mdx-components.tsx)
and the literal API key value/prefix on the account API keys page —
both are genuine technical/credential strings where a monospaced,
unambiguous glyph set is the right call.

Verified with tsc --noEmit and oxlint (clean).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/class-only presentation changes with no logic, auth, or data handling impact.
> 
> **Overview**
> **Aligns typography with the warm, handwritten brand** by removing `font-mono` from headings, labels, prices, and CTAs that are not code or credentials.
> 
> On the **homepage**, section titles like “Open source by default” and “Simple pricing” now use **`font-hand`** with explicit stone/brown heading and body colors (`#756b5d`, `#4f4940`, `#181613`), matching other marketing blocks. Pricing cards drop mono from plan names, dollar amounts, and action buttons in favor of the default sans stack.
> 
> On **shared-note** surfaces (viewer, chat, collaboration, attachments, playback timestamps, selection comment pill) and the **blog `CtaCard` title**, the same change replaces mono with default sans for plain copy. **`font-mono` stays** where it belongs (e.g. inline `code` in MDX and API key display), per the PR intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abf48d793bb1ba7de9419115d133c5b47013692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->