### PR TITLE
Honor cancellation of post-meeting transcription

### DIFF
--- a/apps/desktop/src/stt/capture-lifecycle.ts
+++ b/apps/desktop/src/stt/capture-lifecycle.ts
@@ -646,7 +646,11 @@ export function useCaptureLifecycle(sessionId: string) {
             });
           } catch (error) {
             if (isStoppedTranscriptionError(error)) {
-              await requestRecovery();
+              await persistTranscriptWrite(() =>
+                clearCaptureLifecycleMarker(sessionId, transcriptId),
+              );
+              recoveryPending = false;
+              recoveryStateCleared = true;
               return;
             }
             console.error("[listener] post-stop transcript repair failed", {

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -2760,8 +2760,13 @@ describe("useStartListening", () => {
         ]);
         expect(resetEnhanceTasksMock).not.toHaveBeenCalled();
         expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
-        expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
-        expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+        if (message === "Transcription stopped.") {
+          expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledOnce();
+          expect(requestCaptureRecoveryMock).not.toHaveBeenCalled();
+        } else {
+          expect(clearCaptureLifecycleMarkerMock).not.toHaveBeenCalled();
+          expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+        }
         expect(
           saveCaptureLifecycleMarkerMock.mock.calls.slice(-1)[0]?.[0],
         ).toMatchObject({
@@ -3161,7 +3166,7 @@ describe("useStartListening", () => {
     expect(requestMainAutoEnhanceMock).not.toHaveBeenCalled();
   });
 
-  test("does not auto-enhance after the user cancels the batch repair", async () => {
+  test("ends automatic recovery after the user cancels the batch repair", async () => {
     useSessionHasTranscriptMock.mockReturnValue(true);
     runBatchMock.mockRejectedValueOnce(new Error("Transcription stopped."));
 
@@ -3188,8 +3193,68 @@ describe("useStartListening", () => {
     expect(saveCaptureLifecycleMarkerMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ phase: "finalizing" }),
     );
-    expect(endCloudsyncActivityMock).not.toHaveBeenCalled();
-    expect(requestCaptureRecoveryMock).toHaveBeenCalledWith("session-1");
+    expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledWith(
+      "session-1",
+      "generated-id",
+    );
+    expect(endCloudsyncActivityMock).toHaveBeenCalledWith(
+      "capture",
+      "session-1:generated-id",
+    );
+    expect(requestCaptureRecoveryMock).not.toHaveBeenCalled();
+    expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
+    expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+    expect(softDeleteTranscriptMock).not.toHaveBeenCalled();
+    expect(setBatchTranscriptionPendingMock).toHaveBeenLastCalledWith(
+      "session-1",
+      false,
+    );
+  });
+
+  test("does not restart cancelled recovery after reattaching or reloading", async () => {
+    attachLiveSessionMock.mockResolvedValue("inactive");
+    const marker = {
+      version: 1 as const,
+      sessionId: "session-1",
+      transcriptId: "transcript-before-reload",
+      startedAt: 1_000,
+      createdAt: "2026-07-24T00:00:00.000Z",
+      audioOffsetMs: 10_000,
+      preserveExistingTranscript: true,
+      ownerUserId: "user-1",
+      memo: "Existing memo",
+    };
+    let pendingMarker: typeof marker | null = marker;
+    loadCaptureLifecycleMarkerMock.mockImplementation(
+      async () => pendingMarker,
+    );
+    clearCaptureLifecycleMarkerMock.mockImplementation(async () => {
+      pendingMarker = null;
+    });
+    runBatchMock.mockRejectedValueOnce(new Error("Transcription stopped."));
+    const recovery = renderHook(() => useResumeListeningLifecycle("session-1"));
+
+    await act(async () => {
+      await expect(recovery.result.current()).resolves.toBe("inactive");
+      await expect(recovery.result.current()).resolves.toBe("inactive");
+    });
+    recovery.unmount();
+    const reloaded = renderHook(() => useResumeListeningLifecycle("session-1"));
+    await act(async () => {
+      await expect(reloaded.result.current()).resolves.toBe("inactive");
+    });
+
+    expect(runBatchMock).toHaveBeenCalledOnce();
+    expect(clearCaptureLifecycleMarkerMock).toHaveBeenCalledWith(
+      "session-1",
+      marker.transcriptId,
+    );
+    expect(finishCaptureRecoveryFinalizationMock).toHaveBeenCalledOnce();
+    expect(requestCaptureRecoveryMock).not.toHaveBeenCalled();
+    expect(requestAutoEnhanceMock).not.toHaveBeenCalled();
+    expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
+    expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+    expect(softDeleteTranscriptMock).not.toHaveBeenCalled();
   });
 
   test("forwards auto-enhance to the main window when no enhancer service exists", async () => {


### PR DESCRIPTION
Clear pending capture recovery when batch transcription is stopped so it stays cancelled after reload. Preserve audio and saved transcripts, release capture ownership, and cover cancellation with regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-capture finalization and recovery persistence when users cancel batch transcription; incorrect handling could leave stale markers or retry unwanted repairs after reload.
> 
> **Overview**
> When post-stop **batch repair** is aborted with a stopped-transcription error (user cancel), capture finalization now **clears the lifecycle marker** and marks recovery as finished instead of calling **`requestCaptureRecovery`**.
> 
> That keeps cancellation durable across **reload and resume**: recovery does not re-run batch transcription, auto-enhance, or retention cleanup tied to a completed repair. The capture **CloudSync lease** still releases via the existing `finalizeStopped` `finally` path when recovery is no longer pending.
> 
> Tests distinguish **"Transcription stopped."** from other batch failures (marker clear, no recovery) and add a regression that **reattach/reload** does not restart cancelled recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d85f129196dc9fd1ee9e03095c77057eca6816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->