### PR TITLE
Narrow the email and Slack sharing menu

### DIFF
--- a/apps/desktop/src/session-sharing/delivery-panel.tsx
+++ b/apps/desktop/src/session-sharing/delivery-panel.tsx
@@ -72,7 +72,7 @@ export function ShareRecapOverflowMenu({
           <DotsThree className="size-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent variant="app" align="end" className="w-44">
+      <DropdownMenuContent variant="app" align="end">
         <AppFloatingPanel className={appFloatingMenuPanelClassName}>
           <DropdownMenuItem
             onSelect={() => onValueChange("email")}


### PR DESCRIPTION
Use the shared menu minimum width instead of a fixed 176px width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single className removal on a sharing overflow menu; no logic or data changes.
> 
> **Overview**
> The **Email / Slack** overflow menu in session sharing no longer forces a fixed `w-44` (176px) width on `DropdownMenuContent`.
> 
> It now follows the same **app** dropdown sizing as other menus—content-driven width with the shared `min-w-32` minimum—so the menu appears narrower when the labels fit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a04737e2a667a939b880773a961eb51bf8a18ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->