### PR TITLE
Hide the meeting info popover scrollbar

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -23,7 +23,7 @@ export function MetadataPopoverContent({ sessionId }: { sessionId: string }) {
 
 export function MetadataPanelContent({ sessionId }: { sessionId: string }) {
   return (
-    <AppFloatingPanel className="scrollbar-soft max-h-[80vh] min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain">
+    <AppFloatingPanel className="scrollbar-hide max-h-[80vh] min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain">
       <ContentInner sessionId={sessionId} />
     </AppFloatingPanel>
   );


### PR DESCRIPTION
Use the existing scrollbar-hide utility while preserving vertical scrolling for long meeting details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind utility change on a scroll container; no logic or data handling impact.
> 
> **Overview**
> The meeting info popover panel no longer shows a visible scrollbar when content exceeds **max-h-[80vh]**.
> 
> **`MetadataPanelContent`** swaps the **`AppFloatingPanel`** class from **`scrollbar-soft`** to **`scrollbar-hide`**, matching other scrollable areas in the desktop app. Vertical scrolling and overflow behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5977ee499e12cabe4d2ddc845ed346efe65199eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->