### PR TITLE
Move folder picker beside note header actions

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -2279,7 +2279,6 @@ msgstr "Flags"
 msgid "Float chat"
 msgstr "Float chat"
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -2279,7 +2279,6 @@ msgstr ""
 msgid "Float chat"
 msgstr ""
 
-#: src/session/components/folder-picker.tsx
 #: src/settings/appearance/sidebar-item-fields.tsx
 #: src/sidebar/note-filter-menu.tsx
 msgid "Folder"

--- a/apps/desktop/src/session/components/folder-picker.test.tsx
+++ b/apps/desktop/src/session/components/folder-picker.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { FolderPicker, FolderPickerSubmenu } from "./folder-picker";
+import { FolderPicker } from "./folder-picker";
 
 const mocks = vi.hoisted(() => ({
   createNamedFolder: vi.fn(() => Promise.resolve("clients")),
@@ -41,27 +41,6 @@ vi.mock("~/session/queries", () => ({
   useFolderPaths: () => mocks.folderPaths,
   useSession: () => ({ folder_id: mocks.folderId }),
   useUpdateSession: () => mocks.updateSession,
-}));
-
-vi.mock("@anlg/ui/components/ui/dropdown-menu", () => ({
-  DropdownMenuPortal: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
-  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DropdownMenuSubTrigger: ({
-    children,
-    ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>
-      {children}
-      <span aria-hidden>›</span>
-    </button>
-  ),
 }));
 
 describe("FolderPicker", () => {
@@ -113,25 +92,6 @@ describe("FolderPicker", () => {
     expect(label?.className).toContain("truncate");
     expect(label?.className).toContain("@max-[480px]:sr-only");
     expect(trigger.querySelectorAll("svg")).toHaveLength(1);
-  });
-
-  it("shows the current folder in the overflow submenu", () => {
-    mocks.folderId = "work";
-    const onClose = vi.fn();
-
-    render(<FolderPickerSubmenu sessionId="session-1" onClose={onClose} />);
-
-    const trigger = screen.getByRole("button", { name: "Folder: work" });
-
-    expect(trigger.textContent).toContain("Folder");
-    expect(trigger.textContent).toContain("work");
-
-    fireEvent.click(screen.getByRole("option", { name: "personal" }));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(mocks.updateSession).toHaveBeenCalledWith({
-      folder_id: "personal",
-    });
   });
 
   it("uses the same floating chrome as note metadata", () => {

--- a/apps/desktop/src/session/components/folder-picker.tsx
+++ b/apps/desktop/src/session/components/folder-picker.tsx
@@ -1,7 +1,7 @@
 import { useLingui } from "@lingui/react/macro";
 import { useCallback, useMemo, useState } from "react";
 
-import { CaretRight, Check, Plus } from "@anlg/ui/components/icons";
+import { CaretRight, Check, Folder, Plus } from "@anlg/ui/components/icons";
 import {
   Command,
   CommandEmpty,
@@ -10,12 +10,6 @@ import {
   CommandItem,
   CommandList,
 } from "@anlg/ui/components/ui/command";
-import {
-  DropdownMenuPortal,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-} from "@anlg/ui/components/ui/dropdown-menu";
 import {
   AppFloatingPanel,
   Popover,
@@ -83,10 +77,14 @@ export function FolderPicker({
             open && "bg-accent text-foreground",
           ])}
         >
-          <TemplateIconGlyph
-            icon={resolvedFolderIcon(currentPath ?? "", folderIcons)}
-            className="size-4 shrink-0"
-          />
+          {currentPath ? (
+            <TemplateIconGlyph
+              icon={resolvedFolderIcon(currentPath, folderIcons)}
+              className="size-4 shrink-0"
+            />
+          ) : (
+            <Folder className="size-4 shrink-0" />
+          )}
           {currentPath ? (
             <span className="min-w-0 truncate text-xs text-neutral-600 @max-[480px]:sr-only dark:text-neutral-300">
               {currentPath}
@@ -105,49 +103,6 @@ export function FolderPicker({
         />
       </PopoverContent>
     </Popover>
-  );
-}
-
-export function FolderPickerSubmenu({
-  sessionId,
-  onClose,
-}: {
-  sessionId: string;
-  onClose: () => void;
-}) {
-  const { t } = useLingui();
-  const [open, setOpen] = useState(false);
-  const currentPath = normalizeFolderPath(
-    useSession(sessionId)?.folder_id ?? "",
-  );
-  const folderIcons = useFolderIcons();
-
-  return (
-    <DropdownMenuSub open={open} onOpenChange={setOpen}>
-      <DropdownMenuSubTrigger
-        aria-label={currentPath ? t`Folder: ${currentPath}` : t`Select folder`}
-        className="cursor-pointer"
-      >
-        <TemplateIconGlyph
-          icon={resolvedFolderIcon(currentPath ?? "", folderIcons)}
-          className="size-4 opacity-70"
-        />
-        <span className="flex-1">{t`Folder`}</span>
-        {currentPath ? (
-          <span className="text-muted-foreground max-w-24 truncate">
-            {currentPath}
-          </span>
-        ) : null}
-      </DropdownMenuSubTrigger>
-      <DropdownMenuPortal>
-        <DropdownMenuSubContent
-          variant="app"
-          className="w-56 overflow-hidden pb-0"
-        >
-          <FolderPickerContent sessionId={sessionId} onClose={onClose} />
-        </DropdownMenuSubContent>
-      </DropdownMenuPortal>
-    </DropdownMenuSub>
   );
 }
 

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -47,6 +47,13 @@ vi.mock("../title-input", () => ({
   TitleInput: () => <input aria-label="Session title" placeholder="Untitled" />,
 }));
 
+vi.mock("~/session/queries", () => ({
+  useSession: () => ({ folder_id: "" }),
+  useFolderIcons: () => ({}),
+  useFolderPaths: () => [],
+  useUpdateSession: () => vi.fn(),
+}));
+
 vi.mock("./overflow", () => ({
   OverflowButton: (props: {
     allowListening?: boolean;
@@ -393,7 +400,7 @@ describe("OuterHeader", () => {
     expect(actionStrip?.hasAttribute("data-tauri-drag-region")).toBe(true);
   });
 
-  it("places the record and overflow controls in order", () => {
+  it("places folder selection before the record and overflow controls", () => {
     const { container } = render(
       <OuterHeader
         sessionId="session-1"
@@ -409,6 +416,7 @@ describe("OuterHeader", () => {
     const header = container.firstElementChild;
     const views = screen.getByRole("group", { name: "Session note views" });
     const record = screen.getByRole("button", { name: "Record" });
+    const folder = screen.getByRole("combobox", { name: "Select folder" });
     const more = screen.getByRole("button", { name: "More" });
     const actionStrip = header?.lastElementChild;
     const actionChildren = [...(actionStrip?.children ?? [])];
@@ -416,12 +424,13 @@ describe("OuterHeader", () => {
     expect(header?.firstElementChild).toBe(views);
     expect(actionStrip?.contains(record)).toBe(true);
     expect(actionStrip?.contains(more)).toBe(true);
+    expect(actionStrip?.contains(folder)).toBe(true);
+    expect(
+      actionChildren.findIndex((child) => child.contains(folder)),
+    ).toBeLessThan(actionChildren.findIndex((child) => child.contains(record)));
     expect(
       actionChildren.findIndex((child) => child.contains(record)),
     ).toBeLessThan(actionChildren.findIndex((child) => child.contains(more)));
-    expect(
-      screen.queryByRole("combobox", { name: "Select folder" }),
-    ).toBeNull();
   });
 
   it("shows an editable title in the header on the summary tab", () => {
@@ -756,6 +765,11 @@ describe("OuterHeader", () => {
     const joinButton = screen.getByRole("button", { name: "Join & record" });
     const moreButton = screen.getByRole("button", { name: "More" });
 
+    expect(
+      screen
+        .getByRole("combobox", { name: "Select folder" })
+        .compareDocumentPosition(joinButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(joinButton.className).toContain("border-border");
     expect(joinButton.className).toContain("bg-transparent");
     expect(joinButton.className).toContain("text-foreground");
@@ -1238,6 +1252,13 @@ describe("OuterHeader", () => {
 
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
     expect(screen.getByRole("button", { name: "Share note" })).not.toBeNull();
+    expect(
+      screen
+        .getByRole("combobox", { name: "Select folder" })
+        .compareDocumentPosition(
+          screen.getByRole("button", { name: "Share note" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: "More" })).not.toBeNull();
     expect(mocks.startListening).not.toHaveBeenCalled();
   });
@@ -1278,8 +1299,10 @@ describe("OuterHeader", () => {
       stop.compareDocumentPosition(more) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      screen.queryByRole("combobox", { name: "Select folder" }),
-    ).toBeNull();
+      screen
+        .getByRole("combobox", { name: "Select folder" })
+        .compareDocumentPosition(stop) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("keeps stop available for an active ad hoc session", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "@anlg/ui/components/ui/popover";
 import { cn, parseEventInstant, safeParseDate } from "@anlg/utils";
 
+import { FolderPicker } from "../folder-picker";
 import { RecordingIcon, useHasTranscript } from "../shared";
 import { TitleInput } from "../title-input";
 import { OverflowButton } from "./overflow";
@@ -102,6 +103,7 @@ export function OuterHeader({
         data-tauri-drag-region
         className="relative z-10 flex shrink-0 items-center pr-1"
       >
+        <FolderPicker sessionId={sessionId} align="end" />
         <HeaderMeetingControl
           sessionId={sessionId}
           sessionMode={sessionMode}

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -128,14 +128,6 @@ vi.mock("../metadata", () => ({
   ),
 }));
 
-vi.mock("../../folder-picker", () => ({
-  FolderPickerSubmenu: ({ sessionId }: { sessionId: string }) => (
-    <button type="button" aria-label="Select folder">
-      Folder {sessionId}
-    </button>
-  ),
-}));
-
 vi.mock("~/meeting-float/host", () => ({
   openFloatingMeetingPanel: vi.fn(),
 }));
@@ -355,7 +347,7 @@ describe("OverflowButton", () => {
     );
   });
 
-  it("nests folder selection in the overflow menu", () => {
+  it("keeps folder selection out of the overflow menu", () => {
     render(
       <OverflowButton
         sessionId="session-1"
@@ -363,9 +355,8 @@ describe("OverflowButton", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("button", { name: "Select folder" }).textContent,
-    ).toContain("session-1");
+    expect(screen.queryByRole("combobox", { name: /folder/i })).toBeNull();
+    expect(screen.queryByText("Folder")).toBeNull();
   });
 
   it("keeps the overflow trigger out of the header drag region", () => {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -26,7 +26,6 @@ import {
   DropdownMenuTrigger,
 } from "@anlg/ui/components/ui/dropdown-menu";
 
-import { FolderPickerSubmenu } from "../../folder-picker";
 import { MetadataPanelContent } from "../metadata";
 import { DeleteNote } from "./delete";
 import { ExportModal } from "./export-modal";
@@ -139,10 +138,6 @@ export function OverflowButton({
         </DropdownMenuTrigger>
         <DropdownMenuContent variant="app" align="end" className="w-56">
           <AppFloatingPanel className={appFloatingMenuPanelClassName}>
-            <FolderPickerSubmenu
-              sessionId={sessionId}
-              onClose={() => setOpen(false)}
-            />
             <DropdownMenuSub>
               <DropdownMenuSubTrigger className="cursor-pointer">
                 <CalendarBlank />


### PR DESCRIPTION
Move folder selection from the note's overflow menu to the header, immediately before Share or the recording action. Reuse the existing picker, match the unassigned folder icon to the header controls, and remove the unused submenu and its translation references.

Validation: all 4,232 desktop tests, desktop typecheck, shared UI build, formatting, lint, i18n, license-boundary checks, and common Node tests passed. Native visual verification was not run. Zizmor completed with 405 existing workflow findings; no workflows changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI placement and component removal only; folder assignment behavior stays in the same picker content with no auth or data-model changes.
> 
> **Overview**
> **Folder selection** moves out of the note overflow menu and into the **session outer header**, placed before record/share and the “More” menu so it’s always one click away.
> 
> The header reuses the existing **`FolderPicker`** popover (`align="end"`). When a note has **no folder**, the trigger now shows the generic **`Folder`** icon instead of a folder template glyph. **`FolderPickerSubmenu`** and its dropdown nesting are removed; Lingui catalogs drop the obsolete `folder-picker.tsx` source reference on the shared **“Folder”** string.
> 
> Tests are updated to assert the combobox lives in the header action strip and is absent from overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c278c0c3f8ed9ae8db89a40cf27cb21bab43a7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->