### PR TITLE
Allow cordoned API machines to finish stopping

### DIFF
--- a/.github/scripts/deploy_api_drain.py
+++ b/.github/scripts/deploy_api_drain.py
@@ -483,6 +483,11 @@ def drain_old_machines(app: str, machine_ids: list[str]) -> None:
                 )
             elif is_stopped(machine):
                 destroy_machine(app, machine_id)
+            elif machine.get("state") == "stopping" and is_cordoned(machine):
+                print(
+                    f"leaving cordoned machine {machine_id} to finish stopping",
+                    file=sys.stderr,
+                )
             else:
                 failures.append(f"{machine_id} is {machine.get('state')}")
         except Exception as error:

--- a/.github/scripts/test_deploy_api_drain.py
+++ b/.github/scripts/test_deploy_api_drain.py
@@ -540,6 +540,36 @@ def test_resume_only_signals_supported_draining_machines():
     assert signaled == ["supported"]
 
 
+def test_drain_leaves_already_stopping_cordoned_machines_alone():
+    with (
+        patch.object(
+            deploy_api_drain,
+            "get_machine",
+            return_value={"state": "stopping", "cordoned": True},
+        ),
+        patch.object(deploy_api_drain, "signal_machine") as signal,
+        patch.object(deploy_api_drain, "destroy_machine") as destroy,
+    ):
+        deploy_api_drain.drain_old_machines("anarlog-ai", ["old"])
+
+    signal.assert_not_called()
+    destroy.assert_not_called()
+
+
+def test_drain_rejects_unexpected_machine_states():
+    for machine in (
+        {"state": "stopping", "cordoned": False},
+        {"state": "starting", "cordoned": True},
+    ):
+        with patch.object(deploy_api_drain, "get_machine", return_value=machine):
+            try:
+                deploy_api_drain.drain_old_machines("anarlog-ai", ["old"])
+            except DeployError as error:
+                assert f"old is {machine['state']}" in str(error)
+            else:
+                raise AssertionError("expected the unexpected state to fail deployment")
+
+
 if __name__ == "__main__":
     test_classifies_serving_and_drained_machines()
     test_reads_cordon_from_metadata_when_top_level_flag_is_absent()
@@ -559,4 +589,6 @@ if __name__ == "__main__":
     test_partial_replacement_failure_destroys_created_machines()
     test_drain_only_signals_machines_with_protocol_support()
     test_resume_only_signals_supported_draining_machines()
+    test_drain_leaves_already_stopping_cordoned_machines_alone()
+    test_drain_rejects_unexpected_machine_states()
     print("ok")


### PR DESCRIPTION
API deployment could report failure after a healthy traffic cutover when Fly had already begun stopping an old, cordoned machine. Leave that machine to finish stopping; retain failures for unexpected states and keep active-session draining unchanged.

Validation: deployment regression tests, formatting, license boundary checks, and all 70 common Node tests passed. Authenticated Zizmor completed with 405 existing repository findings and none in the changed files.
