### PR TITLE
Hide brief prompts after meetings end

### DIFF
--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -709,7 +709,7 @@ describe("RawEditor", () => {
     expect(hoisted.createBrief).toHaveBeenCalledOnce();
   });
 
-  it("still offers a brief after the meeting when templates hide", () => {
+  it("hides the brief suggestion once the meeting has a recording or transcript", () => {
     hoisted.briefVisible = true;
     hoisted.canShowTranscript = true;
     hoisted.userTemplates = [
@@ -725,10 +725,10 @@ describe("RawEditor", () => {
     render(<RawEditor sessionId="session-1" />);
 
     expect(
-      screen.getByRole("button", {
+      screen.queryByRole("button", {
         name: "Create a brief to prepare this meeting",
       }),
-    ).not.toBeNull();
+    ).toBeNull();
     expect(screen.queryByText("Suggested templates")).toBeNull();
     expect(screen.queryByRole("button", { name: "Daily Standup" })).toBeNull();
   });

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -316,7 +316,7 @@ export const RawEditor = forwardRef<
             />
             {isMemoEmpty && !isGenerating ? (
               <div className="pointer-events-none absolute inset-x-0 top-8 z-10 flex flex-col">
-                {briefVisible ? (
+                {briefVisible && audioExistsResolved && !canShowTranscript ? (
                   <CreateBriefSuggestion onCreate={createBrief} />
                 ) : null}
                 {audioExistsResolved && !canShowTranscript ? (

--- a/apps/desktop/src/session/hooks/useCreatePreMeetingBrief.test.tsx
+++ b/apps/desktop/src/session/hooks/useCreatePreMeetingBrief.test.tsx
@@ -172,6 +172,27 @@ describe("useCreatePreMeetingBrief", () => {
     expect(result.current.visible).toBe(true);
   });
 
+  it("hides and disables create brief when the meeting ends even with participants", () => {
+    mocks.participants = [
+      {
+        humanId: "ada",
+        source: "manual",
+        name: "Ada",
+        email: "ada@example.com",
+      },
+    ];
+    mocks.now = new Date("2026-08-21T09:59:00.000Z");
+    const { result, rerender } = renderBriefHook();
+    expect(result.current.visible).toBe(true);
+
+    mocks.now = new Date("2026-08-21T10:00:00.000Z");
+    rerender();
+    expect(result.current.visible).toBe(false);
+
+    act(() => result.current.createBrief());
+    expect(mocks.streamPreMeetingBrief).not.toHaveBeenCalled();
+  });
+
   it("hides after the memo has content and returns when the memo is cleared", () => {
     const { result, rerender } = renderBriefHook();
 

--- a/apps/desktop/src/session/insights/pre-meeting.test.ts
+++ b/apps/desktop/src/session/insights/pre-meeting.test.ts
@@ -120,7 +120,38 @@ describe("pre-meeting brief visibility", () => {
     ).toBe(true);
   });
 
-  it("requires an upcoming event or added participants, plus usable prior meetings", () => {
+  it.each(["2026-08-21T07:59:00.000Z", "2026-08-21T08:00:00.000Z"])(
+    "hides short meetings at or after their end time %s",
+    (ended_at) => {
+      expect(
+        shouldShowPreMeetingBrief(
+          {
+            started_at: "2026-08-21T07:58:00.000Z",
+            ended_at,
+            is_all_day: false,
+          },
+          nowMs,
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("does not let added participants make an ended meeting eligible", () => {
+    expect(
+      canCreatePreMeetingBrief({
+        event: {
+          started_at: "2026-08-21T07:00:00.000Z",
+          ended_at: "2026-08-21T07:30:00.000Z",
+          is_all_day: false,
+        },
+        nowMs,
+        notes: [makeNote({ sessionId: "previous" })],
+        hasParticipants: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires an upcoming event or participants without an event, plus usable prior meetings", () => {
     const event = {
       started_at: "2026-08-21T09:00:00.000Z",
       ended_at: "2026-08-21T10:00:00.000Z",

--- a/apps/desktop/src/session/insights/pre-meeting.ts
+++ b/apps/desktop/src/session/insights/pre-meeting.ts
@@ -72,10 +72,7 @@ export function shouldShowPreMeetingBrief(
   }
 
   const endMs = parseEventInstant(event.ended_at)?.getTime();
-  const hideAfterMs =
-    endMs == null
-      ? startMs + AFTER_START_GRACE_MS
-      : Math.max(endMs, startMs + AFTER_START_GRACE_MS);
+  const hideAfterMs = endMs ?? startMs + AFTER_START_GRACE_MS;
   return hideAfterMs > nowMs;
 }
 
@@ -99,7 +96,7 @@ export function canCreatePreMeetingBrief({
   hasParticipants?: boolean;
 }): boolean {
   return (
-    (shouldShowPreMeetingBrief(event, nowMs) || hasParticipants) &&
+    (event ? shouldShowPreMeetingBrief(event, nowMs) : hasParticipants) &&
     selectBriefSourceNotes(notes).length > 0
   );
 }


### PR DESCRIPTION
Hide suggestions for recorded meetings and respect calendar end times even when participants are present. Cover completed meetings and short-event boundaries with regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and timing/eligibility rules for pre-meeting briefs with broad test coverage; no auth, data migration, or payment paths.
> 
> **Overview**
> **Pre-meeting brief prompts no longer appear once a meeting is over or once recording/transcript UI is available.**
> 
> Eligibility now respects the calendar **end time** (no extra post-end grace when `ended_at` is set), and **manually added participants no longer keep brief creation enabled** after a linked event has ended—participant-only sessions without a calendar event still work.
> 
> In the empty memo UI, **Create brief** is gated like template suggestions: it only shows when audio state is resolved and **transcript is not yet shown** (`!canShowTranscript`). Regression tests cover ended meetings, short events at end boundary, disabled `createBrief` after end, and the raw editor hiding the brief button when a transcript exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c25884c2561074665ee20edf0a7ba4ef647055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->