### PR TITLE
Keep saved transcripts when post-processing returns incomplete text

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-batch.ts
+++ b/apps/desktop/src/store/zustand/listener/general-batch.ts
@@ -83,6 +83,12 @@ export async function showBatchCompletedNotification(
   }
 }
 
+export async function notifyBatchCompleted(sessionId: string) {
+  await showBatchCompletedNotification(sessionId);
+  void playCompletionSound();
+  void requestAppAttention();
+}
+
 export const runBatchSession = async <T extends BatchStore>(
   get: StoreApi<T>["getState"],
   sessionId: string,
@@ -283,9 +289,7 @@ export const runBatchSession = async <T extends BatchStore>(
   });
 
   if (options?.notifyOnCompletion !== false) {
-    await showBatchCompletedNotification(sessionId);
-    void playCompletionSound();
-    void requestAppAttention();
+    await notifyBatchCompleted(sessionId);
   }
 };
 

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -54,6 +54,7 @@ import {
   createLiveTranscript,
   createTranscript,
   flushLiveTranscriptDeltasToDatabase,
+  getSessionTranscriptRecords,
   mergeTranscriptSegments,
   removeHumanSpeakerAssignments,
   updateTranscriptSegmentText,
@@ -115,7 +116,7 @@ describe("transcript SQLite queries", () => {
     );
   });
 
-  it("materializes ordered live journal chunks on read", () => {
+  it("materializes ordered live journal chunks on read", async () => {
     mocks.transcriptRows = [
       {
         id: "transcript-1",
@@ -168,6 +169,19 @@ describe("transcript SQLite queries", () => {
       "word-final",
       "word-next",
     ]);
+
+    mocks.execute.mockResolvedValueOnce(mocks.transcriptRows);
+    const records = await getSessionTranscriptRecords("session-1");
+    expect(records[0]?.words.map((word) => word.id)).toEqual([
+      "word-final",
+      "word-next",
+    ]);
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "transcript.session_id = ? AND transcript.deleted_at IS NULL",
+      ),
+      ["session-1"],
+    );
   });
 
   it("skips live journal replay for an active renderer baseline", () => {

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -265,6 +265,22 @@ export async function getTranscriptRecord(
   return rows[0] ? mapTranscriptRow(rows[0]) : null;
 }
 
+export async function getSessionTranscriptRecords(
+  sessionId: string,
+): Promise<TranscriptRecord[]> {
+  const rows = await liveQueryClient.execute<TranscriptSqlRow>(
+    `
+      SELECT ${TRANSCRIPT_COLUMNS}
+      FROM transcripts AS transcript
+      WHERE transcript.session_id = ? AND transcript.deleted_at IS NULL
+      ORDER BY transcript.started_at_ms, transcript.created_at, transcript.id
+    `,
+    [sessionId],
+  );
+
+  return rows.map(mapTranscriptRow);
+}
+
 export function useSessionParticipantHumanIds(sessionId: string): string[] {
   const { data = EMPTY_IDS } = useLiveQuery<ParticipantHumanSqlRow, string[]>({
     // Drop excluded people and any contact that is the current user (or a

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -32,6 +32,8 @@ const {
   markSessionAudioTranscriptionCompleteMock,
   createTranscriptMock,
   getTranscriptRecordMock,
+  getSessionTranscriptRecordsMock,
+  notifyBatchCompletedMock,
   idMock,
   archMock,
   platformMock,
@@ -52,6 +54,8 @@ const {
   markSessionAudioTranscriptionCompleteMock: vi.fn(),
   createTranscriptMock: vi.fn(),
   getTranscriptRecordMock: vi.fn(),
+  getSessionTranscriptRecordsMock: vi.fn(),
+  notifyBatchCompletedMock: vi.fn(),
   idMock: vi.fn(),
   archMock: vi.fn(),
   platformMock: vi.fn(),
@@ -173,6 +177,11 @@ vi.mock("~/stt/capabilities", () => {
 vi.mock("~/stt/queries", () => ({
   createTranscript: createTranscriptMock,
   getTranscriptRecord: getTranscriptRecordMock,
+  getSessionTranscriptRecords: getSessionTranscriptRecordsMock,
+}));
+
+vi.mock("~/store/zustand/listener/general-batch", () => ({
+  notifyBatchCompleted: notifyBatchCompletedMock,
 }));
 
 describe("getBatchProvider", () => {
@@ -596,6 +605,8 @@ describe("useRunBatch", () => {
     idMock.mockImplementation(() => `generated-${++nextId}`);
     createTranscriptMock.mockResolvedValue(undefined);
     getTranscriptRecordMock.mockResolvedValue(null);
+    getSessionTranscriptRecordsMock.mockResolvedValue([]);
+    notifyBatchCompletedMock.mockResolvedValue(undefined);
     deleteProcessedAudioForRetentionMock.mockResolvedValue(undefined);
     markSessionAudioTranscriptionCompleteMock.mockResolvedValue(undefined);
     isSupportedLanguagesBatchMock.mockResolvedValue(true);
@@ -659,6 +670,8 @@ describe("useRunBatch", () => {
 
     expect(createTranscriptMock).not.toHaveBeenCalled();
     expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+    expect(getSessionTranscriptRecordsMock).not.toHaveBeenCalled();
+    expect(notifyBatchCompletedMock).not.toHaveBeenCalled();
 
     finishTranscription?.();
     await act(async () => await run);
@@ -681,6 +694,13 @@ describe("useRunBatch", () => {
       "session-1",
     );
     expect(deleteProcessedAudioForRetentionMock).toHaveBeenCalledTimes(1);
+    expect(startTranscriptionMock.mock.calls[0]?.[1]?.notifyOnCompletion).toBe(
+      false,
+    );
+    expect(notifyBatchCompletedMock).toHaveBeenCalledWith("session-1");
+    expect(createTranscriptMock.mock.invocationCallOrder[0]).toBeLessThan(
+      notifyBatchCompletedMock.mock.invocationCallOrder[0],
+    );
     expect(
       markSessionAudioTranscriptionCompleteMock.mock.invocationCallOrder[0],
     ).toBeLessThan(
@@ -902,6 +922,212 @@ describe("useRunBatch", () => {
     });
   });
 
+  test.each(["current_capture", "whole_session"] as const)(
+    "keeps the saved transcript and audio when %s processing returns only a few lines",
+    async (scope) => {
+      const saved = {
+        id: "transcript-current-live",
+        sessionId: "session-1",
+        ownerUserId: "user-1",
+        startedAt: 123_000,
+        words: Array.from({ length: 300 }, (_, index) => ({
+          id: `live-${index}`,
+          text: index % 2 ? "megbeszélés" : "meeting",
+          start_ms: index * 6_000,
+          end_ms: index * 6_000 + 500,
+          channel: 0,
+        })),
+        speakerHints: [],
+      };
+      getTranscriptRecordMock.mockResolvedValue(saved);
+      getSessionTranscriptRecordsMock.mockResolvedValue([saved]);
+      startTranscriptionMock.mockImplementation(async (_params, options) => {
+        options.handlePersist(
+          [
+            ...(scope === "current_capture"
+              ? [
+                  {
+                    text: "earlier capture ".repeat(1_000),
+                    start_ms: 0,
+                    end_ms: 59_000,
+                    channel: 0,
+                  },
+                ]
+              : []),
+            {
+              text: "Thank you for the meeting.",
+              start_ms: 60_100,
+              end_ms: 61_000,
+              channel: 0,
+            },
+          ],
+          [],
+          { mode: "replace" },
+        );
+      });
+
+      const { result } = renderHook(() => useRunBatch("session-1"));
+      let error: unknown;
+      await act(async () => {
+        try {
+          await result.current("/tmp/session.wav", {
+            promotion:
+              scope === "current_capture"
+                ? {
+                    scope,
+                    audioOffsetMs: 60_000,
+                    replaceTranscriptId: saved.id,
+                    startedAt: saved.startedAt,
+                  }
+                : { scope },
+          });
+        } catch (caught) {
+          error = caught;
+        }
+      });
+
+      expect(error).toMatchObject({
+        message:
+          "The new transcription returned much less text. Your saved transcript and recording were kept. Try transcribing again.",
+      });
+      expect(isTerminalTranscriptionError(error)).toBe(true);
+      expect(createTranscriptMock).not.toHaveBeenCalled();
+      expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
+      expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+      expect(notifyBatchCompletedMock).not.toHaveBeenCalled();
+      expect(startTranscriptionMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  test.each([
+    {
+      name: "provider tokenization changes",
+      previousText: "meeting ".repeat(100),
+      replacementText: "meeting ".repeat(100),
+    },
+    {
+      name: "languages without spaces",
+      previousText: "会议记录".repeat(100),
+      replacementText: "会议记录".repeat(100),
+    },
+    {
+      name: "ordinary corrections",
+      previousText: "meeting ".repeat(100),
+      replacementText: "meeting ".repeat(70),
+    },
+    {
+      name: "small captures",
+      previousText: "meeting ".repeat(10),
+      replacementText: "hello",
+    },
+  ])(
+    "accepts $name without comparing earlier captures",
+    async ({ previousText, replacementText }) => {
+      getTranscriptRecordMock.mockResolvedValue({
+        id: "live-current",
+        sessionId: "session-1",
+        ownerUserId: "user-1",
+        startedAt: 123_000,
+        words: [
+          { id: "empty", channel: 0, start_ms: 0, end_ms: 0 },
+          ...previousText.split("").map((text, index) => ({
+            id: `live-${index}`,
+            text,
+            channel: 0,
+            start_ms: 0,
+            end_ms: 100,
+          })),
+        ],
+        speakerHints: [],
+      });
+      startTranscriptionMock.mockImplementation(async (_params, options) => {
+        options.handlePersist(
+          [
+            {
+              text: "An earlier capture ".repeat(1_000),
+              start_ms: 0,
+              end_ms: 59_000,
+              channel: 0,
+            },
+            {
+              text: replacementText,
+              start_ms: 60_000,
+              end_ms: 61_000,
+              channel: 0,
+            },
+          ],
+          [],
+          { mode: "replace" },
+        );
+      });
+
+      const { result } = renderHook(() => useRunBatch("session-1"));
+      await act(async () => {
+        await result.current("/tmp/session.wav", {
+          promotion: {
+            scope: "current_capture",
+            audioOffsetMs: 60_000,
+            replaceTranscriptId: "live-current",
+            startedAt: 123_000,
+          },
+        });
+      });
+
+      expect(getSessionTranscriptRecordsMock).not.toHaveBeenCalled();
+      expect(createTranscriptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replaceTranscriptId: "live-current",
+          words: [
+            expect.objectContaining({
+              text: replacementText,
+              start_ms: 0,
+              end_ms: 1_000,
+            }),
+          ],
+        }),
+      );
+      expect(markSessionAudioTranscriptionCompleteMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  test.each(["current_capture", "whole_session"] as const)(
+    "keeps existing data when the %s transcript cannot be checked",
+    async (scope) => {
+      getTranscriptRecordMock.mockRejectedValue(new Error("read failed"));
+      getSessionTranscriptRecordsMock.mockRejectedValue(
+        new Error("read failed"),
+      );
+      startTranscriptionMock.mockImplementation(async (_params, options) => {
+        options.handlePersist(
+          [{ text: "replacement", start_ms: 0, end_ms: 100, channel: 0 }],
+          [],
+        );
+      });
+      const { result } = renderHook(() => useRunBatch("session-1"));
+
+      await expect(
+        act(async () => {
+          await result.current("/tmp/session.wav", {
+            promotion:
+              scope === "current_capture"
+                ? {
+                    scope,
+                    audioOffsetMs: 0,
+                    replaceTranscriptId: "live-current",
+                    startedAt: 123_000,
+                  }
+                : { scope },
+          });
+        }),
+      ).rejects.toBeInstanceOf(BatchResponseProcessingError);
+
+      expect(createTranscriptMock).not.toHaveBeenCalled();
+      expect(markSessionAudioTranscriptionCompleteMock).not.toHaveBeenCalled();
+      expect(deleteProcessedAudioForRetentionMock).not.toHaveBeenCalled();
+      expect(notifyBatchCompletedMock).not.toHaveBeenCalled();
+    },
+  );
+
   test("retains recovery audio when the batch has no current-capture words", async () => {
     startTranscriptionMock.mockImplementation(async (_params, options) => {
       options.handlePersist(
@@ -1030,6 +1256,7 @@ describe("useRunBatch", () => {
       expect.objectContaining({ notifyOnCompletion: false }),
     );
     expect(sonnerToastWarningMock).not.toHaveBeenCalled();
+    expect(notifyBatchCompletedMock).not.toHaveBeenCalled();
   });
 
   test("uses custom Deepgram-compatible endpoints for batch transcription", async () => {

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -23,6 +23,7 @@ import { markSessionAudioTranscriptionComplete } from "~/session/attachments";
 import { useSession, useSessionParticipants } from "~/session/queries";
 import { useConfigValue } from "~/shared/config";
 import { id } from "~/shared/utils";
+import { notifyBatchCompleted } from "~/store/zustand/listener/general-batch";
 import type { BatchPersistCallback } from "~/store/zustand/listener/transcript";
 import {
   getTranscriptionLanguages,
@@ -33,6 +34,7 @@ import {
 } from "~/stt/capabilities";
 import {
   createTranscript,
+  getSessionTranscriptRecords,
   getTranscriptRecord,
   type TranscriptRecord,
 } from "~/stt/queries";
@@ -100,6 +102,10 @@ const DIRECT_BATCH_PROVIDERS: Set<TranscriptionParams["provider"]> = new Set([
 export const STOPPED_TRANSCRIPTION_ERROR_MESSAGE = "Transcription stopped.";
 export const EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE =
   "Batch transcription did not include the current recording.";
+export const INCOMPLETE_BATCH_TRANSCRIPT_ERROR_MESSAGE =
+  "The new transcription returned much less text. Your saved transcript and recording were kept. Try transcribing again.";
+const MIN_TRANSCRIPT_CHARACTER_LOSS = 200;
+const MIN_TRANSCRIPT_RETAINED_RATIO = 0.5;
 const MIN_REFINED_SPEAKER_OVERLAP_RATIO = 0.6;
 const LOCAL_SONIQO_BATCH_TARGET = {
   provider: "soniqo",
@@ -242,6 +248,28 @@ function prepareTranscriptPromotion(
     replaceTranscriptId: promotion.replaceTranscriptId,
     startedAt: promotion.startedAt,
   };
+}
+
+function assertTranscriptNotTruncated(
+  previous: WordWithId[],
+  replacement: WordWithId[],
+) {
+  // Character counts tolerate provider tokenization differences and languages
+  // without spaces; the absolute margin allows small transcription corrections.
+  const characterCount = (words: WordWithId[]) =>
+    words.reduce(
+      (count, word) =>
+        count + (word.text ?? "").replace(/[^\p{L}\p{N}]/gu, "").length,
+      0,
+    );
+  const previousLength = characterCount(previous);
+  const replacementLength = characterCount(replacement);
+  if (
+    previousLength - replacementLength >= MIN_TRANSCRIPT_CHARACTER_LOSS &&
+    replacementLength < previousLength * MIN_TRANSCRIPT_RETAINED_RATIO
+  ) {
+    throw new Error(INCOMPLETE_BATCH_TRANSCRIPT_ERROR_MESSAGE);
+  }
 }
 
 function parseHintValue(value: string): Record<string, unknown> | null {
@@ -508,6 +536,7 @@ export function isTerminalTranscriptionError(error: unknown) {
   return (
     error instanceof BatchResponseProcessingError ||
     message === EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE ||
+    message === INCOMPLETE_BATCH_TRANSCRIPT_ERROR_MESSAGE ||
     isTranscriptionAuthenticationError(error) ||
     /corrupt or unsupported|unsupported (?:audio|data)|invalid audio|no speech|empty transcript/i.test(
       message,
@@ -638,20 +667,6 @@ export const useRunBatch = (sessionId: string) => {
         });
       }
 
-      let refinedTranscriptSource: TranscriptRecord | null = null;
-      const replaceTranscriptId =
-        options?.promotion?.scope === "current_capture"
-          ? options.promotion.replaceTranscriptId
-          : undefined;
-      if (replaceTranscriptId) {
-        try {
-          refinedTranscriptSource =
-            await getTranscriptRecord(replaceTranscriptId);
-        } catch (error) {
-          console.warn("[runBatch] failed to load refined transcript", error);
-        }
-      }
-
       const createdAt = new Date().toISOString();
       const startedAt = Date.now();
       const memoMd = session?.raw_md ?? "";
@@ -770,7 +785,7 @@ export const useRunBatch = (sessionId: string) => {
           try {
             await startTranscription(params, {
               handlePersist: persist,
-              notifyOnCompletion: options?.notifyOnCompletion,
+              notifyOnCompletion: false,
             });
           } catch (error) {
             if (
@@ -793,7 +808,7 @@ export const useRunBatch = (sessionId: string) => {
               { ...params, api_key: refreshedSession.access_token },
               {
                 handlePersist: persist,
-                notifyOnCompletion: options?.notifyOnCompletion,
+                notifyOnCompletion: false,
               },
             );
           }
@@ -811,6 +826,18 @@ export const useRunBatch = (sessionId: string) => {
               ) {
                 throw new Error(EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE);
               }
+              const refinedTranscriptSource = promoted.replaceTranscriptId
+                ? await getTranscriptRecord(promoted.replaceTranscriptId)
+                : null;
+              const previousTranscripts = promoted.replaceSession
+                ? await getSessionTranscriptRecords(sessionId)
+                : refinedTranscriptSource
+                  ? [refinedTranscriptSource]
+                  : [];
+              assertTranscriptNotTruncated(
+                previousTranscripts.flatMap((transcript) => transcript.words),
+                promoted.words,
+              );
               if (transcriptId) {
                 const completedTranscriptId = transcriptId;
                 if (promoted.words.length > 0) {
@@ -866,12 +893,16 @@ export const useRunBatch = (sessionId: string) => {
             if (
               error instanceof BatchResponseProcessingError ||
               (error instanceof Error &&
-                error.message ===
-                  EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE)
+                (error.message ===
+                  EMPTY_CURRENT_CAPTURE_TRANSCRIPT_ERROR_MESSAGE ||
+                  error.message === INCOMPLETE_BATCH_TRANSCRIPT_ERROR_MESSAGE))
             ) {
               throw error;
             }
             throw new BatchResponseProcessingError(error);
+          }
+          if (options?.notifyOnCompletion !== false) {
+            await notifyBatchCompleted(sessionId);
           }
         },
       );


### PR DESCRIPTION
Reject severely shortened replacements and retain recovery audio. Compare the latest saved capture and notify completion only after validation and persistence; cover multilingual, resumed-capture, and read-failure cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core batch persistence and retention paths; incorrect truncation heuristics could block valid refinements, but failures are conservative (keep existing data).
> 
> **Overview**
> Batch post-processing now **refuses to replace** saved transcripts when the new result is drastically shorter than what’s already stored, so users keep their live transcript and recovery audio instead of losing content to a bad provider run.
> 
> Before `createTranscript`, the flow loads the prior transcript(s) via `getSessionTranscriptRecords` (whole session) or `getTranscriptRecord` (current capture) and runs `assertTranscriptNotTruncated` using Unicode letter/digit counts with a 200-character loss floor and 50% retention threshold. Failures surface `INCOMPLETE_BATCH_TRANSCRIPT_ERROR_MESSAGE` as a **terminal** error—no persist, no audio cleanup, no completion notification.
> 
> **Completion UX** is reordered: `startTranscription` always gets `notifyOnCompletion: false`, and shared `notifyBatchCompleted` runs only after validation and successful persistence (extracted from `general-batch` for reuse in `useRunBatch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220359d4e3ed69ba4011bdfbc6315dc409c3a9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->