### PR TITLE
Document retirement of the Anarlog Netlify project

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -48,8 +48,14 @@ existing job leases and delivery idempotency remain in place.
    secret, so there is no dependency on a provider-assigned project hostname.
 4. Disable the old Netlify scheduled jobs, then set `CRON_JOBS_ENABLED=true` in
    Vercel and redeploy. Verify each job before retiring the old web deployment.
-   Keep the old deployment and DNS values available for rollback; if rolling
-   back, disable Vercel jobs before re-enabling the old scheduler.
+   After retirement, use a previous Vercel deployment for web rollback.
+
+The old Netlify `anarlog` project was deleted on 2026-09-08 after its final
+`hyprnote.com` redirect dependency moved to Vercel. The apex uses the existing
+host-specific routes; `www.hyprnote.com` redirects to the apex. Both use the
+Vercel CNAME target in Cloudflare with proxying disabled. The desktop download
+and update aliases remain on Vercel for installed-client compatibility.
+Netlify is no longer a deployment, scheduler, or rollback target for Anarlog.
 
 Local development still uses `pnpm exec turbo dev:web`. Local image requests
 redirect to their original assets; Vercel performs width-based image


### PR DESCRIPTION
Record the legacy domain migration to Vercel and keep rollback instructions on the current host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, DNS automation, or application code impact.
> 
> **Overview**
> Updates **`apps/web/README.md`** cutover guidance to match the completed migration off Netlify.
> 
> Rollback instructions now point to **previous Vercel deployments** instead of keeping the old Netlify stack and re-enabling its scheduler. A new section records that the legacy Netlify `anarlog` project was removed on **2026-09-08**, that **`hyprnote.com`** redirects now live on Vercel (apex host routes, `www` → apex, Cloudflare CNAME to Vercel with proxying off), and that desktop download/update aliases stay on Vercel for client compatibility. **Netlify is explicitly no longer** a deployment, cron, or rollback option for Anarlog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5176f8c36e0ee0458328293c9ce4bd79ceb619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->