### PR TITLE
Prepare Android for public beta testing

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -187,6 +187,8 @@ jobs:
           assert apks, "No release APK was produced"
           for apk in apks:
               with ZipFile(apk) as package:
+                  dex = b"".join(package.read(name) for name in package.namelist() if name.endswith(".dex"))
+                  assert b"expo-audio:stream" in dex, f"{apk}: background recording patch is missing; build expo-audio from source"
                   supported_abis = {"arm64-v8a", "armeabi-v7a", "x86_64"}
                   packaged_abis = {
                       name.split("/")[1]

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -37,7 +37,8 @@
         "expo-audio",
         {
           "microphonePermission": "Anarlog uses the microphone to capture and transcribe your meetings.",
-          "enableBackgroundRecording": true
+          "enableBackgroundRecording": true,
+          "enableBackgroundPlayback": false
         }
       ],
       "expo-widgets",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -36,7 +36,7 @@
         "ascAppId": "6807350358"
       },
       "android": {
-        "track": "internal",
+        "track": "beta",
         "releaseStatus": "completed"
       }
     }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -69,6 +69,11 @@
     "react-native-worklets": "0.10.1"
   },
   "expo": {
+    "autolinking": {
+      "android": {
+        "buildFromSource": ["expo-audio"]
+      }
+    },
     "install": {
       "exclude": [
         "@sentry/react-native"


### PR DESCRIPTION
Target Play open testing and remove unused playback service permissions. Build patched expo-audio from source so background recording works, and reject native artifacts that omit the patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Android native linking, release verification, and background-audio permissions; mistakes could break CI releases or background meeting capture on Android.
> 
> **Overview**
> Prepares **stable Android releases for Play open testing** by changing EAS submit from the **internal** track to **beta**.
> 
> **Background recording** now relies on building **`expo-audio` from source** on Android (`expo.autolinking.android.buildFromSource`), so the existing native patch (wake lock / streaming) is compiled into release APKs instead of using prebuilt artifacts. **Mobile CI** fails the Android job if release APK dex does not contain the `expo-audio:stream` marker, alongside the existing CloudSync checks.
> 
> The **expo-audio** plugin config explicitly sets **`enableBackgroundPlayback` to `false`** while keeping background recording enabled, aligning native permissions with recording-only use and avoiding unused playback-service setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf279fea391e610c0809d6797173b86b5a620af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->