### PR TITLE
Fix Linux recordings opening ALSA's null device instead of the default microphone

### DIFF
--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -366,6 +366,14 @@ impl MicInput {
                     continue;
                 };
 
+                if is_unusable_input_device_with_id(
+                    get_device_id(&device).as_deref(),
+                    &get_device_name(&device),
+                ) {
+                    drop_quietly(device);
+                    continue;
+                }
+
                 match device.default_input_config() {
                     Ok(config) => {
                         opened = Some((device, config, name));

--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -25,12 +25,28 @@ fn is_tap_device(name: &str) -> bool {
 }
 
 pub(crate) fn is_unusable_input_device(name: &str) -> bool {
+    is_unusable_input_device_with_id(None, name)
+}
+
+/// Like `is_unusable_input_device`, but also rejects the ALSA `null` pcm by its stable device id
+/// (`cpal::Device::id()`) when the caller has one. `null` accepts writes and produces silence
+/// with no real clock, so a capture stream opened on it free-spins the audio callback instead of
+/// blocking on hardware timing (see `new_locked`). The id check is the primary signal; the
+/// description check below is a defensive fallback for callers that only have a name, such as a
+/// device_name string loaded from settings.
+pub(crate) fn is_unusable_input_device_with_id(id: Option<&str>, name: &str) -> bool {
     if is_tap_device(name) {
         return true;
     }
 
+    if id.is_some_and(|id| id.eq_ignore_ascii_case("null")) {
+        return true;
+    }
+
     let lower = name.to_ascii_lowercase();
-    lower.contains(".monitor") || lower.contains("monitor of ")
+    lower.contains(".monitor")
+        || lower.contains("monitor of ")
+        || lower.starts_with("discard all samples")
 }
 
 fn rank_input_devices(
@@ -59,6 +75,36 @@ fn rank_input_devices(
         push(name);
     }
     ordered
+}
+
+/// Finds the index in `listed_names` that a ranked candidate should open.
+///
+/// Candidates are normally matched by description (`name`). The default device is a special
+/// case on ALSA: `host.default_input_device()` returns a synthetic device whose description
+/// (e.g. "Default Audio Device") never matches the real ALSA hint description carried by its
+/// entry in the listed devices, so a plain name match misses it even though `rank_input_devices`
+/// ranked it correctly. When `is_default` is set, fall back to matching by stable device id
+/// (`cpal::Device::id()`) against `listed_ids` — on ALSA the "default" pcm id also shows up as
+/// its own listed hint, with the real description, whenever the system defines one.
+fn resolve_ranked_candidate(
+    name: &str,
+    is_default: bool,
+    default_id: Option<&str>,
+    listed_names: &[String],
+    listed_ids: &[Option<String>],
+) -> Option<usize> {
+    listed_names
+        .iter()
+        .position(|listed_name| listed_name == name)
+        .or_else(|| {
+            if !is_default {
+                return None;
+            }
+            let id = default_id?;
+            listed_ids
+                .iter()
+                .position(|listed_id| listed_id.as_deref() == Some(id))
+        })
 }
 
 fn with_cpal_host_lock<T>(f: impl FnOnce() -> T) -> T {
@@ -218,11 +264,12 @@ impl MicInput {
                 .into_iter()
                 .flatten()
                 .filter_map(|d| {
+                    let id = d.id().ok().map(|id| id.1);
                     let name = d
                         .description()
                         .map(|desc| desc.name().to_string())
                         .unwrap_or("Unknown Microphone".to_string());
-                    let keep = !is_unusable_input_device(&name);
+                    let keep = !is_unusable_input_device_with_id(id.as_deref(), &name);
                     drop_quietly(d);
                     keep.then_some(name)
                 })
@@ -238,12 +285,14 @@ impl MicInput {
             let name = host
                 .default_input_device()
                 .and_then(|device| {
+                    let id = device.id().ok().map(|id| id.1);
                     let name = device
                         .description()
                         .map(|d| d.name().to_string())
                         .unwrap_or_default();
                     drop_quietly(device);
-                    (!name.is_empty() && !is_unusable_input_device(&name)).then_some(name)
+                    (!name.is_empty() && !is_unusable_input_device_with_id(id.as_deref(), &name))
+                        .then_some(name)
                 })
                 .unwrap_or_else(|| "Unknown Microphone".to_string());
             drop_quietly(host);
@@ -263,13 +312,17 @@ impl MicInput {
                 .map(|desc| desc.name().to_string())
                 .unwrap_or_default()
         };
+        let get_device_id = |d: &cpal::Device| d.id().ok().map(|id| id.1);
 
         let listed: Vec<cpal::Device> = host
             .input_devices()
             .map(|devices| devices.collect())
             .unwrap_or_else(|_| Vec::new());
         let listed_names: Vec<String> = listed.iter().map(get_device_name).collect();
-        let default_name = host.default_input_device().map(|d| {
+        let listed_ids: Vec<Option<String>> = listed.iter().map(get_device_id).collect();
+        let default_device = host.default_input_device();
+        let default_id = default_device.as_ref().and_then(get_device_id);
+        let default_name = default_device.map(|d| {
             let name = get_device_name(&d);
             drop_quietly(d);
             name
@@ -285,16 +338,31 @@ impl MicInput {
         } else {
             let mut opened = None;
             for name in ranked {
-                let Some(device) = listed
-                    .iter()
-                    .find(|d| get_device_name(d) == name)
-                    .cloned()
-                    .or_else(|| {
-                        host.input_devices()
-                            .ok()
-                            .and_then(|devices| take_named_device(devices, &name, get_device_name))
-                    })
-                else {
+                let is_default = default_name.as_deref() == Some(name.as_str());
+
+                let device = resolve_ranked_candidate(
+                    &name,
+                    is_default,
+                    default_id.as_deref(),
+                    &listed_names,
+                    &listed_ids,
+                )
+                .map(|index| listed[index].clone())
+                .or_else(|| {
+                    host.input_devices()
+                        .ok()
+                        .and_then(|devices| take_named_device(devices, &name, get_device_name))
+                })
+                .or_else(|| {
+                    // Nothing in `listed` matches this candidate by name or id. For the default
+                    // candidate, open the live default device directly rather than silently
+                    // skipping the user's actual default input device — see
+                    // `resolve_ranked_candidate` for why name matching alone misses it.
+                    is_default.then(|| host.default_input_device()).flatten()
+                });
+
+                let Some(device) = device else {
+                    tracing::warn!(device_name = name, "mic_candidate_device_unresolved");
                     continue;
                 };
 
@@ -609,6 +677,46 @@ mod tests {
     }
 
     #[test]
+    fn alsa_null_device_is_unusable_by_id_even_with_an_innocuous_description() {
+        // The id is the primary signal: it is authoritative and does not depend on locale or
+        // wording of the ALSA hint description.
+        assert!(is_unusable_input_device_with_id(
+            Some("null"),
+            "Some Innocuous Description"
+        ));
+        assert!(is_unusable_input_device_with_id(
+            Some("NULL"),
+            "Some Innocuous Description"
+        ));
+    }
+
+    #[test]
+    fn alsa_null_device_is_unusable_by_description_when_no_id_is_available() {
+        // Defensive fallback for callers that only have a name, such as a device_name string
+        // loaded from settings, or a host that does not report device ids.
+        assert!(is_unusable_input_device(
+            "Discard all samples (playback) or generate zero samples (capture)"
+        ));
+        assert!(is_unusable_input_device_with_id(
+            None,
+            "Discard all samples (playback) or generate zero samples (capture)"
+        ));
+    }
+
+    #[test]
+    fn ordinary_devices_are_not_rejected_by_id_or_description() {
+        assert!(!is_unusable_input_device_with_id(
+            Some("hw:CARD=0,DEV=0"),
+            "USB Microphone"
+        ));
+        // A non-null id must not be enough on its own to reject a device.
+        assert!(!is_unusable_input_device_with_id(
+            Some("default"),
+            "Default ALSA Output (currently PipeWire Media Server)"
+        ));
+    }
+
+    #[test]
     fn rank_input_devices_prefers_named_then_default_and_skips_monitors() {
         let ranked = rank_input_devices(
             Some("USB Microphone"),
@@ -680,6 +788,126 @@ mod tests {
         );
 
         assert_eq!(ranked, vec!["Built-in Audio".to_string()]);
+    }
+
+    #[test]
+    fn rank_input_devices_excludes_the_null_device_like_a_monitor() {
+        let ranked = rank_input_devices(
+            None,
+            Some("Built-in Audio"),
+            &[
+                "Discard all samples (playback) or generate zero samples (capture)".to_string(),
+                "Built-in Audio".to_string(),
+                "USB Microphone".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            ranked,
+            vec!["Built-in Audio".to_string(), "USB Microphone".to_string()]
+        );
+    }
+
+    #[test]
+    fn rank_input_devices_ranks_default_even_when_its_description_is_not_listed() {
+        // On ALSA, `host.default_input_device()` returns a synthetic device described as
+        // "Default Audio Device" — a string that never appears among the listed hints, whose
+        // own "default" entry carries the real ALSA hint description instead. Ranking must still
+        // surface the default's own description so `resolve_ranked_candidate` has a candidate to
+        // resolve by id.
+        let ranked = rank_input_devices(
+            None,
+            Some("Default Audio Device"),
+            &[
+                "Default ALSA Output (currently PipeWire Media Server)".to_string(),
+                "USB Microphone".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            ranked,
+            vec![
+                "Default Audio Device".to_string(),
+                "Default ALSA Output (currently PipeWire Media Server)".to_string(),
+                "USB Microphone".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_ranked_candidate_matches_default_by_id_when_description_differs() {
+        let listed_names = vec![
+            "Discard all samples (playback) or generate zero samples (capture)".to_string(),
+            "Default ALSA Output (currently PipeWire Media Server)".to_string(),
+            "USB Microphone".to_string(),
+        ];
+        let listed_ids = vec![
+            Some("null".to_string()),
+            Some("default".to_string()),
+            Some("hw:CARD=1,DEV=0".to_string()),
+        ];
+
+        // The synthetic default's description matches nothing in `listed_names`, but its id
+        // ("default") matches the second listed device's id.
+        let resolved = resolve_ranked_candidate(
+            "Default Audio Device",
+            true,
+            Some("default"),
+            &listed_names,
+            &listed_ids,
+        );
+        assert_eq!(resolved, Some(1));
+    }
+
+    #[test]
+    fn resolve_ranked_candidate_prefers_name_match_over_id_match() {
+        let listed_names = vec!["USB Microphone".to_string(), "Built-in Audio".to_string()];
+        let listed_ids = vec![
+            Some("hw:CARD=1,DEV=0".to_string()),
+            Some("default".to_string()),
+        ];
+
+        let resolved = resolve_ranked_candidate(
+            "USB Microphone",
+            false,
+            Some("default"),
+            &listed_names,
+            &listed_ids,
+        );
+        assert_eq!(resolved, Some(0));
+    }
+
+    #[test]
+    fn resolve_ranked_candidate_does_not_id_match_non_default_candidates() {
+        let listed_names = vec!["Default ALSA Output".to_string()];
+        let listed_ids = vec![Some("default".to_string())];
+
+        // Even though the id would match, this candidate is not the default, so it must not be
+        // resolved by id — only the caller's explicit preferred/listed name matching applies.
+        let resolved = resolve_ranked_candidate(
+            "Some Other Name",
+            false,
+            Some("default"),
+            &listed_names,
+            &listed_ids,
+        );
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_ranked_candidate_returns_none_when_default_id_is_unavailable() {
+        let listed_names = vec!["USB Microphone".to_string()];
+        let listed_ids = vec![Some("hw:CARD=1,DEV=0".to_string())];
+
+        // Falls through to the caller's own "open the live default directly" fallback.
+        let resolved = resolve_ranked_candidate(
+            "Default Audio Device",
+            true,
+            None,
+            &listed_names,
+            &listed_ids,
+        );
+        assert_eq!(resolved, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Problem:** On Linux, `MicInput::new` silently fails to resolve the default microphone and opens ALSA's `null` pcm instead. `null` opens successfully and generates silence with no clock, so the capture callback free-spins at CPU speed: every affected session logs `mic_input_initialized` with `device_name="Discard all samples (playback) or generate zero samples (capture)"`, `mic_samples_dropped` climbs to roughly 790,000,000 per second, the mic/speaker joiner starves the speaker side, and the recording is written far faster than realtime (a 15 s recording produced a 19:54 file of silence, over which batch STT hallucinates filler). Reproduced on 7 of 7 recordings on NixOS 25.11, PipeWire 1.6.8, alsa-lib 1.2.16, with no microphone selected in settings, i.e. the default-device path.

**Root cause:** cpal's ALSA host returns a synthetic device for `host.default_input_device()` whose description is the literal `"Default Audio Device"`. That string never matches any listed device's ALSA hint description (the listed `default` entry carries e.g. `"Default ALSA Output (currently PipeWire Media Server)"`). The resolution loop in `crates/audio-actual/src/mic.rs` matched devices by description only, found nothing for the default candidate, and silently `continue`d past it, landing on the first listed device that opened. alsa-lib defines `null` everywhere and lists it first, and `is_unusable_input_device` rejected only `.monitor` / `monitor of` names.

**Fix:** Resolve the actual default microphone and reject unusable devices before opening capture.

- Resolve the default candidate by its stable device id (`cpal::Device::id()`, the pcm id on ALSA) against the listed devices when its description matches nothing. On ALSA the `default` pcm id also appears as its own listed hint carrying the real description, so this is the common-case match.
- If that still finds nothing, open `host.default_input_device()` directly instead of skipping the candidate.
- Reject `null` explicitly, by id (primary) and by its ALSA hint description (defensive fallback for callers that only have a name), everywhere a device is considered: capture, the settings device list, and the reported default name.
- Log `mic_candidate_device_unresolved` at WARN when a ranked candidate resolves to no device at all. This was silent before, for every candidate.

The user-selected microphone setting stores the description string, so description matching stays the primary path for that value; the id fallback applies to the default candidate only.

## Verification

Contributor verification on real hardware, NixOS 25.11, PipeWire 1.6.8, alsa-lib 1.2.16, AMD Ryzen HD Audio digital microphone, stock ALSA configuration, running the crate's hardware-gated test `cargo test -p audio-actual test_mic_stream_with_resampling -- --ignored --nocapture`:

| | `mic device:` | resampled chunk stream |
|---|---|---|
| upstream `main` (8a39c78) | `Discard all samples (playback) or generate zero samples (capture)` | finished in 0.01 s (no clock) |
| this branch | `Default ALSA Output (currently PipeWire Media Server)`, 44100 Hz | 1.26 s of real time |

- `cargo test -p audio-actual`: 42 passed, 0 failed, 3 ignored (the pre-existing hardware-only tests).
- `cargo clippy -p audio-actual --all-targets`: no new warnings (the pre-existing ones are in `speaker/linux.rs` and `norm.rs`, untouched).
- `cargo fmt -p audio-actual -- --check`: clean.
- New unit tests: `null` rejected by id and by description; monitors still rejected; ordinary devices and the real `default` entry not rejected; the default's description still ranks when absent from the listed names; the id-based resolver matches the default when its description differs, prefers a direct name match, never id-matches a non-default candidate, and returns nothing when no id is available.

### Independent validation

- The original PR head restores clocked default capture on Ubuntu with a real PulseAudio virtual input: 89,561 nonzero samples, peak 0.50. Explicit input also captures the tone, and an absent audio backend returns `mic_open_failed` instead of opening the standard null device.
- Follow-up commit `01a3349` applies the ID-aware filter to every resolved capture device before querying its input configuration, retaining guarded CPAL cleanup. Native before/after validation passes: a renamed `null` device previously opened and produced 43.8 million silent samples in 3 seconds; the guard returns `mic_open_failed` in 0.01 seconds. After restoring PulseAudio, default and explicit capture produce 88,537 and 88,025 nonzero samples respectively. Desktop UI recovery verification is in progress.
- On macOS with the follow-up: `cargo test --locked -p audio-actual` passes (37 passed, 3 hardware tests ignored); the complete CI script suite passes (64 tests), as do 9 license-boundary tests, the license-boundary check, and formatting of `mic.rs`.
- Desktop CI passes on `01a3349`, including 4,244 frontend tests across 451 files, typecheck, i18n, formatting, lint, and general CI. Automated review passes with no unresolved review threads. Native desktop jobs are not part of the PR trigger.
- The filter identifies the standard ALSA `null` PCM by ID or description. User-defined null-backed aliases with different IDs, including an intentionally null-backed `default`, remain outside this fix.
- Strict Clippy remains blocked by existing warnings in untouched `rt_ring.rs`, `speaker/`, and `norm.rs`. The authenticated workflow audit reports 410 existing findings; no workflow files changed.

## Notes

- The repository has issues disabled, so this PR doubles as the bug report.
- Unrelated, noticed while running the suite: a test in `norm.rs` leaves an untracked 11 MB `crates/audio-actual/normalized_output.wav` behind and it is not gitignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core microphone selection on Linux (device open path and defaults); wrong matching could still pick a bad input, but scope is limited to `mic.rs` with extensive new tests.
> 
> **Overview**
> Fixes Linux recordings that opened ALSA’s **`null`** pcm instead of the real default microphone when no device was selected in settings.
> 
> **Unusable devices:** `is_unusable_input_device` now delegates to **`is_unusable_input_device_with_id`**, which treats the ALSA **`null`** pcm as unusable by stable **`cpal::Device::id()`** (case-insensitive) and by the “Discard all samples…” description when only a name is available. Listing devices, reporting the default name, and opening capture all use the id-aware check so **`null`** is filtered like monitor sources.
> 
> **Default resolution:** **`resolve_ranked_candidate`** matches ranked devices by description first; for the **default** candidate only, it falls back to matching **`default_id`** against listed device ids (ALSA’s synthetic “Default Audio Device” label vs. the listed **`default`** hint). **`MicInput::new_locked`** tracks **`listed_ids`**, uses that resolver, opens **`host.default_input_device()`** when the default still cannot be mapped, skips opened devices that are unusable by id/name, and logs **`mic_candidate_device_unresolved`** at WARN when a ranked candidate cannot be opened.
> 
> Unit tests cover **`null`** rejection, default ranking/resolution by id, and resolver edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a3349a066361ce9221fdca7af6c634ee0bd0a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->