### PR TITLE
Keep Automations navigation visible across chat changes

### DIFF
--- a/apps/desktop/src/main/shell-frame.test.tsx
+++ b/apps/desktop/src/main/shell-frame.test.tsx
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   platform: "macos" as "linux" | "macos" | "windows",
   leftsidebar: {
     expanded: true,
+    setExpanded: vi.fn(),
+    setLocked: vi.fn(),
   },
 }));
 
@@ -84,6 +86,42 @@ describe("ClassicMainShellFrame", () => {
     mocks.currentTab = { type: "empty" };
     mocks.platform = "macos";
     mocks.leftsidebar.expanded = true;
+    mocks.leftsidebar.setExpanded.mockClear();
+    mocks.leftsidebar.setLocked.mockClear();
+  });
+
+  it.each([
+    "settings",
+    "calendar",
+    "contacts",
+    "templates",
+    "automations",
+    "folders",
+  ])("opens the %s sidebar and restores its previous state on exit", (type) => {
+    mocks.currentTab = { type };
+    mocks.leftsidebar.expanded = false;
+
+    const { rerender } = render(<ClassicMainShellFrame />);
+
+    expect(mocks.leftsidebar.setExpanded).toHaveBeenCalledWith(true);
+    expect(mocks.leftsidebar.setLocked).toHaveBeenCalledWith(true);
+
+    mocks.currentTab = { type: "empty" };
+    rerender(<ClassicMainShellFrame />);
+
+    expect(mocks.leftsidebar.setExpanded).toHaveBeenLastCalledWith(false);
+    expect(mocks.leftsidebar.setLocked).toHaveBeenLastCalledWith(false);
+  });
+
+  it("unlocks the custom sidebar when the shell unmounts", () => {
+    mocks.currentTab = { type: "calendar" };
+    mocks.leftsidebar.expanded = false;
+
+    const { unmount } = render(<ClassicMainShellFrame />);
+    unmount();
+
+    expect(mocks.leftsidebar.setExpanded).toHaveBeenLastCalledWith(false);
+    expect(mocks.leftsidebar.setLocked).toHaveBeenLastCalledWith(false);
   });
 
   it.each(["windows", "linux"] as const)(

--- a/apps/desktop/src/main/shell-frame.tsx
+++ b/apps/desktop/src/main/shell-frame.tsx
@@ -12,6 +12,7 @@ import { ToastNotifications } from "~/sidebar/toast";
 import {
   hasCustomSidebarTab,
   hasLeftSurfaceCustomSidebarTab,
+  useCustomSidebarEffect,
 } from "~/sidebar/use-custom-sidebar";
 import { useTabs } from "~/store/zustand/tabs";
 
@@ -22,6 +23,9 @@ export function ClassicMainShellFrame() {
   const isOnboarding = currentTab?.type === "onboarding";
   const isChangelog = currentTab?.type === "changelog";
   const hasCustomSidebar = hasCustomSidebarTab(currentTab);
+  // Chat session changes remount the body; sidebar ownership must survive them.
+  useCustomSidebarEffect(hasCustomSidebar, leftsidebar);
+
   const hasLeftSurfaceCustomSidebar =
     hasLeftSurfaceCustomSidebarTab(currentTab);
   const showSidebarTimelineChrome = !hasCustomSidebar && !isOnboarding;

--- a/apps/desktop/src/main/shell-sidebar-lifecycle.test.tsx
+++ b/apps/desktop/src/main/shell-sidebar-lifecycle.test.tsx
@@ -1,0 +1,121 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { Fragment, StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useChatContext } from "~/chat/state/chat-context";
+import { ShellProvider, useShell } from "~/contexts/shell";
+import { CustomSidebarHeader } from "~/sidebar/custom-sidebar-header";
+import { useTabs } from "~/store/zustand/tabs";
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => "macos",
+}));
+
+vi.mock("./body", async () => {
+  const { ClassicMainSidebar } = await import("./shell-sidebar");
+  return { ClassicMainBody: ClassicMainSidebar };
+});
+
+vi.mock("./windows-title-bar", () => ({ WindowsTitleBar: () => null }));
+vi.mock("~/devtools-bar", () => ({ DevtoolsStatusBar: () => null }));
+vi.mock("~/sidebar/toast", () => ({ ToastNotifications: () => null }));
+
+vi.mock("~/shared/main", () => ({
+  MainShellScaffold: ({ children }: { children: React.ReactNode }) => children,
+  MainShellBodyFrame: ({ children }: { children: React.ReactNode }) => {
+    const { chat } = useShell();
+    return <Fragment key={chat.sessionId}>{children}</Fragment>;
+  },
+}));
+
+vi.mock("~/sidebar", () => ({
+  LeftSidebar: () => {
+    const currentTab = useTabs((state) => state.currentTab);
+    return currentTab?.type === "empty" ? (
+      <div>Notes sidebar</div>
+    ) : (
+      <CustomSidebarHeader />
+    );
+  },
+}));
+
+import { ClassicMainShellFrame } from "./shell-frame";
+
+function SidebarToggle() {
+  const { leftsidebar } = useShell();
+  return (
+    <button onClick={leftsidebar.toggleExpanded}>
+      {leftsidebar.expanded ? "Hide sidebar" : "Show sidebar"}
+    </button>
+  );
+}
+
+describe("custom sidebar chat lifecycle", () => {
+  beforeEach(() => {
+    useTabs.setState(useTabs.getInitialState());
+    useChatContext.setState(useChatContext.getInitialState());
+    useTabs.getState().openCurrent({ type: "empty" });
+  });
+
+  afterEach(cleanup);
+
+  it.each([
+    { expanded: false, strict: false },
+    { expanded: true, strict: false },
+    { expanded: false, strict: true },
+    { expanded: true, strict: true },
+  ])(
+    "keeps Automations navigation usable across chat changes (expanded=$expanded, strict=$strict)",
+    ({ expanded, strict }) => {
+      const Wrapper = strict ? StrictMode : Fragment;
+      render(
+        <Wrapper>
+          <ShellProvider>
+            <SidebarToggle />
+            <ClassicMainShellFrame />
+          </ShellProvider>
+        </Wrapper>,
+      );
+
+      if (!expanded) {
+        fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+      }
+
+      act(() => useTabs.getState().openNew({ type: "settings" }));
+      expect(screen.getByRole("button", { name: "Go home" })).toBeTruthy();
+
+      act(() => useTabs.getState().openNew({ type: "automations" }));
+      expect(screen.getByRole("button", { name: "Go home" })).toBeTruthy();
+
+      act(() => useChatContext.getState().startNewChat("automations"));
+      expect(screen.getByRole("button", { name: "Go home" })).toBeTruthy();
+
+      act(() =>
+        useChatContext.getState().selectChat("automations", "saved-chat"),
+      );
+      expect(screen.getByRole("button", { name: "Go home" })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide sidebar" }));
+      expect(screen.getByRole("button", { name: "Go home" })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+      expect(useTabs.getState().currentTab?.type).toBe("settings");
+      fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+      expect(useTabs.getState().currentTab?.type).toBe("empty");
+      expect(screen.queryByText("Notes sidebar") !== null).toBe(expanded);
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: expanded ? "Hide sidebar" : "Show sidebar",
+        }),
+      );
+      expect(screen.queryByText("Notes sidebar") !== null).toBe(!expanded);
+    },
+  );
+});

--- a/apps/desktop/src/main/shell-sidebar.tsx
+++ b/apps/desktop/src/main/shell-sidebar.tsx
@@ -3,10 +3,6 @@ import { type ReactNode } from "react";
 import { useShell } from "~/contexts/shell";
 import { LeftSidebar } from "~/sidebar";
 import type { SidebarNoteFilter } from "~/sidebar/note-filter";
-import {
-  hasCustomSidebarTab,
-  useCustomSidebarEffect,
-} from "~/sidebar/use-custom-sidebar";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function ClassicMainSidebar({
@@ -25,10 +21,6 @@ export function ClassicMainSidebar({
   const { leftsidebar } = useShell();
   const currentTab = useTabs((state) => state.currentTab);
   const isOnboarding = currentTab?.type === "onboarding";
-
-  const hasCustomSidebar = hasCustomSidebarTab(currentTab);
-
-  useCustomSidebarEffect(hasCustomSidebar, leftsidebar);
 
   if (!leftsidebar.expanded || isOnboarding) {
     return null;

--- a/apps/desktop/src/shared/main/shell-sidebar.test.tsx
+++ b/apps/desktop/src/shared/main/shell-sidebar.test.tsx
@@ -1,20 +1,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const hoisted = vi.hoisted(() => ({
-  setExpanded: vi.fn(),
-  setLocked: vi.fn(),
-}));
-
-const { setExpanded, setLocked } = hoisted;
-
 let mockCurrentTab: {
   type: "settings" | "empty" | "onboarding" | "calendar" | "automations";
 } | null = { type: "empty" };
 const mockLeftSidebar = {
   expanded: false,
-  setExpanded,
-  setLocked,
 };
 
 vi.mock("~/contexts/shell", () => ({
@@ -40,47 +31,6 @@ describe("ClassicMainSidebar", () => {
     cleanup();
     mockCurrentTab = { type: "empty" };
     mockLeftSidebar.expanded = false;
-    setExpanded.mockClear();
-    setLocked.mockClear();
-  });
-
-  it("forces custom-sidebar tabs open and restores the previous sidebar state", async () => {
-    mockCurrentTab = { type: "settings" };
-
-    const { rerender } = render(<ClassicMainSidebar />);
-
-    expect(setExpanded).toHaveBeenCalledWith(true);
-    expect(setLocked).toHaveBeenCalledWith(true);
-
-    mockCurrentTab = { type: "empty" };
-
-    rerender(<ClassicMainSidebar />);
-
-    expect(setLocked).toHaveBeenLastCalledWith(false);
-    expect(setExpanded).toHaveBeenLastCalledWith(false);
-  });
-
-  it("unlocks the custom sidebar when unmounted while active", () => {
-    mockCurrentTab = { type: "calendar" };
-
-    const { unmount } = render(<ClassicMainSidebar />);
-
-    expect(setExpanded).toHaveBeenCalledWith(true);
-    expect(setLocked).toHaveBeenCalledWith(true);
-
-    unmount();
-
-    expect(setLocked).toHaveBeenLastCalledWith(false);
-    expect(setExpanded).toHaveBeenLastCalledWith(false);
-  });
-
-  it("forces the Automations navigator open", () => {
-    mockCurrentTab = { type: "automations" };
-
-    render(<ClassicMainSidebar />);
-
-    expect(setExpanded).toHaveBeenCalledWith(true);
-    expect(setLocked).toHaveBeenCalledWith(true);
   });
 
   it("renders the default timeline sidebar when expanded", () => {


### PR DESCRIPTION
## Summary

**Problem:** Starting or switching chats remounts the sidebar body, which could hide Automations navigation and lose the previous sidebar state.

**Fix:** Keep custom-sidebar ownership in the persistent shell frame so navigation stays visible across chat changes and the previous expansion state is restored on exit. Cover chat switching, navigation, cleanup, and Strict Mode with regression tests.

## Verification

- `pnpm -F @anlg/desktop exec vitest run src/main/shell-frame.test.tsx src/main/shell-sidebar-lifecycle.test.tsx src/shared/main/shell-sidebar.test.tsx src/settings/team/client.test.ts src/settings/team/index.test.tsx` — 74 tests passed in the combined workspace, including 34 sidebar tests.
- Full desktop checks and native UI QA were not rerun for PR creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI shell/sidebar behavior change with targeted regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Moves custom-sidebar expand/lock lifecycle from the remounting sidebar into `ClassicMainShellFrame`**, so settings, Automations, and other custom-sidebar tabs stay open and locked when chat sessions change remount the main body.
> 
> `ClassicMainSidebar` no longer runs `useCustomSidebarEffect`; the shell frame owns forcing the sidebar open on those tabs and restoring the prior expanded/locked state on exit or unmount. **Regression coverage** shifts to `shell-frame.test.tsx` (per-tab open/restore and unmount unlock) and a new **`shell-sidebar-lifecycle.test.tsx`** integration test that exercises tab switches, new/select chat, sidebar toggle, and “Go home” under collapsed/expanded and Strict Mode. **`shell-sidebar.test.tsx`** drops the moved unit tests and only checks render when expanded/collapsed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86758bbf577a2fcbe1216b8d5bbbf773dfa82880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->