### PR TITLE
Reset native QA permissions before launching onboarding

### DIFF
--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -80,29 +80,45 @@ helper's preflight enforces this.
 When Dev or staging QA is requested from first launch, reset that channel
 before the run:
 
-1. Quit the app, then delete its app data so `app.db` is gone:
+1. Fully quit the selected app, then reset its macOS permissions from outside
+   the app. Run only the command for the requested channel:
+
+   ```bash
+   .agents/skills/qa-critical-ux/scripts/reset-native-qa-permissions.sh dev
+   .agents/skills/qa-critical-ux/scripts/reset-native-qa-permissions.sh staging
+   ```
+
+   The helper refuses a running app or a stable channel and waits for every
+   `tccutil` reset to succeed. Do not continue if it fails.
+
+2. With the app still closed, back up any needed QA data, then delete that
+   channel's app data so `app.db`, auth, settings, and the store are gone:
 
    ```bash
    rm -rf ~/Library/Application\ Support/com.hyprnote.dev      # Dev
    rm -rf ~/Library/Application\ Support/com.hyprnote.staging  # staging
    ```
 
-2. Launch with the onboarding flag, which clears auth, settings, and the
-   store and resets microphone, system-audio, screen-recording,
-   accessibility, calendar, and reminders permission state (it does not
-   touch `app.db` — that is why step 1 deletes the directory):
+3. Launch normally through LaunchServices, without `--onboarding` or an
+   `ONBOARDING` value. Missing app data starts onboarding by default:
 
    ```bash
-   ONBOARDING=1 .agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh --launch-only
+   .agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh --launch-only
    ```
 
    For the installed staging app:
 
    ```bash
-   open -a "Anarlog Staging" --args --onboarding 1
+   open -a "Anarlog Staging" --env ONBOARDING=
    ```
 
-3. Complete onboarding for real: grant each permission when prompted, sign in
+   The old `--onboarding 1` / `ONBOARDING=1` path resets permissions
+   asynchronously after app initialization. Testing in that same process can
+   leave a missing microphone prompt and does not reproduce normal first
+   launch. Keep permission reset and onboarding in separate processes; do not
+   work around a failed grant by editing permission databases.
+
+4. Complete onboarding for real: grant each permission when prompted, sign in
    with the **Pro (or trialing)** test account, and select Anarlog cloud
    (`anarlog` provider) in Settings → AI.
 

--- a/.agents/skills/qa-critical-ux/scripts/launch-native-dev-qa.sh
+++ b/.agents/skills/qa-critical-ux/scripts/launch-native-dev-qa.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+[[ -z "${ONBOARDING:-}" ]] || {
+  echo "Reset QA permissions while the app is closed with reset-native-qa-permissions.sh dev, then launch without ONBOARDING. See the skill's Start from onboarding steps for the data reset." >&2
+  exit 2
+}
+
 [[ $# -eq 1 ]] || {
   echo "Usage: $0 <app-bundle>" >&2
   exit 2
@@ -14,10 +19,7 @@ qa_open_args=(
   --env AUDIO_SYNC_PROBE=1
   --env LISTENER_DEBUG=1
   --env NO_AEC=
+  --env ONBOARDING=
 )
-
-if [[ -n "${ONBOARDING+x}" ]]; then
-  qa_open_args+=(--env "ONBOARDING=$ONBOARDING")
-fi
 
 exec "$qa_open_executable" "${qa_open_args[@]}" "$qa_bundle_dir"

--- a/.agents/skills/qa-critical-ux/scripts/launch-native-dev-qa.test.mjs
+++ b/.agents/skills/qa-critical-ux/scripts/launch-native-dev-qa.test.mjs
@@ -9,6 +9,12 @@ import { fileURLToPath } from "node:url";
 const launcher = fileURLToPath(
   new URL("./launch-native-dev-qa.sh", import.meta.url),
 );
+const runner = fileURLToPath(
+  new URL("./run-native-dev-qa.sh", import.meta.url),
+);
+const resetter = fileURLToPath(
+  new URL("./reset-native-qa-permissions.sh", import.meta.url),
+);
 
 async function fixture() {
   const directory = await mkdtemp(path.join(tmpdir(), "anarlog-native-qa-"));
@@ -18,6 +24,27 @@ async function fixture() {
   await mkdir(appBundle);
   await writeFile(fakeOpen, "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\"\n");
   await chmod(fakeOpen, 0o755);
+
+  for (const command of ["uname", "pgrep", "tccutil"]) {
+    const executable = path.join(directory, command);
+    await writeFile(
+      executable,
+      `#!/usr/bin/env bash
+case "\${0##*/}" in
+  uname) printf '%s\\n' "\${ANARLOG_QA_TEST_OS:-Darwin}" ;;
+  pgrep)
+    [[ "$1" == "-x" && ( "$2" == "anarlog-dev" || "$2" == "anarlog-staging" ) ]] || exit 3
+    exit "\${ANARLOG_QA_TEST_PROCESS_STATUS:-1}"
+    ;;
+  tccutil)
+    printf 'tccutil %s %s %s\\n' "$1" "$2" "$3"
+    [[ "$2" != "\${ANARLOG_QA_TEST_FAILED_SERVICE:-}" ]] || exit 1
+    ;;
+esac
+`,
+    );
+    await chmod(executable, 0o755);
+  }
 
   return {
     appBundle,
@@ -35,6 +62,16 @@ async function fixture() {
       return spawnSync(launcher, [appBundle], {
         encoding: "utf8",
         env: childEnvironment,
+      });
+    },
+    reset(channel, environment = {}) {
+      return spawnSync(resetter, [channel], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+          ...environment,
+        },
       });
     },
   };
@@ -55,20 +92,102 @@ test("launches the app bundle through LaunchServices with QA probes", async (t) 
     "LISTENER_DEBUG=1",
     "--env",
     "NO_AEC=",
+    "--env",
+    "ONBOARDING=",
     harness.appBundle,
   ]);
 });
 
-test("forwards the onboarding reset through LaunchServices", async (t) => {
+test("refuses the old in-process reset before launching", async (t) => {
   const harness = await fixture();
   t.after(() => rm(harness.directory, { force: true, recursive: true }));
 
   const result = harness.launch({ ONBOARDING: "1" });
 
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(result.stdout.trim().split("\n").slice(-3), [
-    "--env",
-    "ONBOARDING=1",
-    harness.appBundle,
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /reset-native-qa-permissions.sh dev/);
+});
+
+test("rejects ONBOARDING before the Dev build or preflight", () => {
+  const result = spawnSync(runner, ["--launch-only"], {
+    encoding: "utf8",
+    env: { ...process.env, ONBOARDING: "1" },
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /reset-native-qa-permissions.sh dev/);
+});
+
+for (const channel of ["dev", "staging"]) {
+  test(`resets all requested permissions for the closed ${channel} app`, async (t) => {
+    const harness = await fixture();
+    t.after(() => rm(harness.directory, { force: true, recursive: true }));
+
+    const result = harness.reset(channel);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.stdout.trim().split("\n").slice(0, -1), [
+      `tccutil reset Microphone com.hyprnote.${channel}`,
+      `tccutil reset AudioCapture com.hyprnote.${channel}`,
+      `tccutil reset ScreenCapture com.hyprnote.${channel}`,
+      `tccutil reset Accessibility com.hyprnote.${channel}`,
+      `tccutil reset Calendar com.hyprnote.${channel}`,
+      `tccutil reset Reminders com.hyprnote.${channel}`,
+    ]);
+    assert.match(result.stdout, /Launch normally/);
+  });
+}
+
+for (const channel of ["stable", "com.hyprnote.staging", "", "staging extra"]) {
+  test(`refuses an unsupported reset target ${JSON.stringify(channel)}`, async (t) => {
+    const harness = await fixture();
+    t.after(() => rm(harness.directory, { force: true, recursive: true }));
+
+    const result = harness.reset(channel);
+
+    assert.equal(result.status, 2);
+    assert.equal(result.stdout, "");
+  });
+}
+
+for (const status of ["0", "2"]) {
+  test(`does not reset when process inspection returns ${status}`, async (t) => {
+    const harness = await fixture();
+    t.after(() => rm(harness.directory, { force: true, recursive: true }));
+
+    const result = harness.reset("staging", {
+      ANARLOG_QA_TEST_PROCESS_STATUS: status,
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+  });
+}
+
+test("does not reset on a non-macOS host", async (t) => {
+  const harness = await fixture();
+  t.after(() => rm(harness.directory, { force: true, recursive: true }));
+
+  const result = harness.reset("staging", { ANARLOG_QA_TEST_OS: "Linux" });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /requires macOS/);
+});
+
+test("a failed permission reset stops preparation without reporting success", async (t) => {
+  const harness = await fixture();
+  t.after(() => rm(harness.directory, { force: true, recursive: true }));
+
+  const result = harness.reset("staging", {
+    ANARLOG_QA_TEST_FAILED_SERVICE: "AudioCapture",
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.stdout.trim().split("\n"), [
+    "tccutil reset Microphone com.hyprnote.staging",
+    "tccutil reset AudioCapture com.hyprnote.staging",
   ]);
 });

--- a/.agents/skills/qa-critical-ux/scripts/reset-native-qa-permissions.sh
+++ b/.agents/skills/qa-critical-ux/scripts/reset-native-qa-permissions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[[ $# -eq 1 && ( "$1" == "dev" || "$1" == "staging" ) ]] || {
+  echo "Usage: $0 <dev|staging>" >&2
+  exit 2
+}
+
+[[ "$(uname -s)" == "Darwin" ]] || {
+  echo "Native QA permission reset requires macOS." >&2
+  exit 1
+}
+
+qa_channel="$1"
+qa_bundle_id="com.hyprnote.$qa_channel"
+qa_process_status=0
+pgrep -x "anarlog-$qa_channel" >/dev/null || qa_process_status=$?
+case "$qa_process_status" in
+  0)
+    echo "Quit Anarlog $qa_channel before resetting permissions." >&2
+    exit 1
+    ;;
+  1) ;;
+  *)
+    echo "Could not determine whether Anarlog $qa_channel is running." >&2
+    exit 1
+    ;;
+esac
+
+# Reset before LaunchServices starts the process that will request permission.
+for qa_service in Microphone AudioCapture ScreenCapture Accessibility Calendar Reminders; do
+  tccutil reset "$qa_service" "$qa_bundle_id"
+done
+
+echo "Permissions reset for $qa_bundle_id. Launch normally, without --onboarding or ONBOARDING."

--- a/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
+++ b/.agents/skills/qa-critical-ux/scripts/run-native-dev-qa.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 umask 077
 
+[[ -z "${ONBOARDING:-}" ]] || {
+  echo "Reset QA permissions while the app is closed with reset-native-qa-permissions.sh dev, then run without ONBOARDING. See the skill's Start from onboarding steps for the data reset." >&2
+  exit 2
+}
+
 qa_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 qa_target_dir="${ANARLOG_QA_TARGET_DIR:-$HOME/Library/Caches/anarlog/native-dev-qa-target-v2}"
 qa_target_parent="$(dirname "$qa_target_dir")"


### PR DESCRIPTION
## Summary

**Problem:** Resetting macOS permissions asynchronously inside the app can suppress onboarding prompts and produce an inaccurate first-launch QA run.

**Fix:** Reset permissions while the selected Dev or staging app is closed, then launch normally. Reject the old ONBOARDING path, unsupported channels, running apps, and failed resets, and update the QA instructions.

## Verification

- `node --test .agents/skills/qa-critical-ux/scripts/launch-native-dev-qa.test.mjs` — 13 tests passed.
- Native permission prompts were not manually exercised for PR creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to QA agent scripts, documentation, and tests; no production app or auth logic is modified.
> 
> **Overview**
> **First-launch native QA** now resets TCC permissions **outside** the app, then launches without in-process onboarding flags, so permission prompts match a real clean install.
> 
> Adds `reset-native-qa-permissions.sh` for **dev** and **staging** only: requires macOS, refuses a running process or unsupported channel, and runs `tccutil reset` for microphone, audio capture, screen capture, accessibility, calendar, and reminders before any launch.
> 
> `run-native-dev-qa.sh` and `launch-native-dev-qa.sh` **exit with guidance** if `ONBOARDING` is set and always pass `ONBOARDING=` through LaunchServices instead of forwarding `ONBOARDING=1`. The **qa-critical-ux** skill documents the new order (quit → reset permissions → wipe app support → launch normally; staging via `open` with empty `ONBOARDING`).
> 
> Tests cover the reset helper, launcher/runner rejection of the old path, and expanded fake `tccutil`/`pgrep` harness behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a6b364cf21a6a12aa4543a3723e53f4a14a002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->