### PR TITLE
Send mobile website visitors to public beta signup

### DIFF
--- a/apps/web/src/components/home-page/hero-section.tsx
+++ b/apps/web/src/components/home-page/hero-section.tsx
@@ -11,9 +11,9 @@ import { AnarlogLogo } from "@/components/anarlog-logo";
 import { useAnalytics } from "@/hooks/use-posthog";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import {
-  type DesktopPlatform,
-  detectDesktopPlatform,
-  getOrderedDesktopDownloadSections,
+  type DownloadPlatform,
+  detectDownloadPlatform,
+  getOrderedDownloadSections,
 } from "@/lib/download";
 import { getResizedImageUrl } from "@/lib/image-cdn";
 import { runWhenIdle } from "@/lib/run-when-idle";
@@ -340,18 +340,23 @@ function DownloadButton() {
   const { track } = useAnalytics();
   const [open, setOpen] = useState(false);
   const [preferredPlatform, setPreferredPlatform] =
-    useState<DesktopPlatform>("macos");
+    useState<DownloadPlatform>("macos");
   const containerRef = useRef<HTMLDivElement>(null);
-  const orderedSections = getOrderedDesktopDownloadSections(preferredPlatform);
+  const orderedSections = getOrderedDownloadSections(preferredPlatform);
   const preferredSection = orderedSections[0];
   const preferredDownload = preferredSection.downloads[0];
   const preferredLabel =
-    preferredSection.platform === "macos"
-      ? `Download for ${preferredDownload.name}`
-      : `Download for ${preferredSection.name}`;
+    preferredSection.platform === "ios" ||
+    preferredSection.platform === "android"
+      ? `Join ${preferredSection.name} beta`
+      : preferredSection.platform === "macos"
+        ? `Download for ${preferredDownload.name}`
+        : `Download for ${preferredSection.name}`;
 
   useMountEffect(() => {
-    setPreferredPlatform(detectDesktopPlatform(navigator.userAgent));
+    setPreferredPlatform(
+      detectDownloadPlatform(navigator.userAgent, navigator.maxTouchPoints),
+    );
 
     const onPointerDown = (event: MouseEvent | TouchEvent) => {
       if (
@@ -407,7 +412,7 @@ function DownloadButton() {
       {open && (
         <div
           role="menu"
-          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-0 z-10 w-72 max-w-[calc(100vw-2.5rem)] rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
+          className="surface border-color-brand absolute top-[calc(100%+0.5rem)] left-1/2 z-10 w-72 max-w-[calc(100vw-2.5rem)] -translate-x-1/2 rounded-2xl border p-2 text-left shadow-[0_14px_40px_rgba(24,22,19,0.12)]"
         >
           {orderedSections.map((section) =>
             section.downloads.map((download) => {
@@ -459,13 +464,15 @@ function DownloadButton() {
   );
 }
 
-function getPlatformIcon(platform: DesktopPlatform, size: number) {
+function getPlatformIcon(platform: DownloadPlatform, size: number) {
   const icon =
     platform === "windows"
       ? "simple-icons:windows11"
       : platform === "linux"
         ? "simple-icons:linux"
-        : "simple-icons:apple";
+        : platform === "android"
+          ? "simple-icons:android"
+          : "simple-icons:apple";
   return (
     <Icon
       icon={icon}
@@ -478,9 +485,11 @@ function getPlatformIcon(platform: DesktopPlatform, size: number) {
 }
 
 function getDownloadOptionLabel(
-  platform: DesktopPlatform,
+  platform: DownloadPlatform,
   downloadName: string,
 ) {
+  if (platform === "ios") return "iOS";
+  if (platform === "android") return "Android";
   if (platform === "macos" && downloadName === "Intel") return "Apple Intel";
   const label = downloadName.replace(/ x64$/, "");
   if (platform === "linux") return `Linux ${label}`;

--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -4,8 +4,9 @@ import test from "node:test";
 import {
   comingSoonPlatforms,
   desktopDownloadSections,
-  detectDesktopPlatform,
-  getOrderedDesktopDownloadSections,
+  detectDownloadPlatform,
+  getOrderedDownloadSections,
+  mobileDownloadSections,
   windowsStoreDownloadUrl,
 } from "./download.ts";
 
@@ -14,12 +15,7 @@ test("offers macOS, Windows, and Linux downloads", () => {
     desktopDownloadSections.map((section) => section.platform),
     ["macos", "windows", "linux"],
   );
-  assert.deepEqual(comingSoonPlatforms, [
-    "iOS",
-    "Android",
-    "Apple Watch",
-    "Galaxy Watch",
-  ]);
+  assert.deepEqual(comingSoonPlatforms, ["Apple Watch", "Galaxy Watch"]);
 
   const macosDownloads = desktopDownloadSections.find(
     (section) => section.platform === "macos",
@@ -61,42 +57,77 @@ test("offers macOS, Windows, and Linux downloads", () => {
 
 test("detects supported desktop platforms from browser user agents", () => {
   assert.equal(
-    detectDesktopPlatform(
+    detectDownloadPlatform(
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
     ),
     "windows",
   );
   assert.equal(
-    detectDesktopPlatform(
+    detectDownloadPlatform(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
     ),
     "macos",
   );
   assert.equal(
-    detectDesktopPlatform("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"),
+    detectDownloadPlatform(
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+    ),
     "linux",
   );
 });
 
+test("routes phones and tablets to the matching public beta", () => {
+  for (const userAgent of [
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15",
+    "Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X) AppleWebKit/605.1.15",
+    "Mozilla/5.0 (iPod touch; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15",
+  ]) {
+    const platform = detectDownloadPlatform(userAgent);
+    assert.equal(platform, "ios");
+    assert.equal(
+      getOrderedDownloadSections(platform)[0].downloads[0].url,
+      "https://testflight.apple.com/join/y7WJCXvG",
+    );
+  }
+
+  const android = detectDownloadPlatform(
+    "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36",
+  );
+  assert.equal(android, "android");
+  assert.equal(
+    getOrderedDownloadSections(android)[0].downloads[0].url,
+    "https://play.google.com/apps/testing/so.anarlog.mobile",
+  );
+  assert.deepEqual(
+    mobileDownloadSections.map((section) => section.platform),
+    ["ios", "android"],
+  );
+});
+
+test("recognizes iPad desktop browsing without treating Macs as iPads", () => {
+  const userAgent =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15";
+  assert.equal(detectDownloadPlatform(userAgent, 5), "ios");
+  assert.equal(detectDownloadPlatform(userAgent, 0), "macos");
+  assert.equal(detectDownloadPlatform(userAgent, 1), "macos");
+});
+
 test("falls back to macOS for unsupported and unknown platforms", () => {
   assert.equal(
-    detectDesktopPlatform(
-      "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36",
-    ),
+    detectDownloadPlatform("Mozilla/5.0 (X11; CrOS x86_64)"),
     "macos",
   );
-  assert.equal(detectDesktopPlatform("unknown"), "macos");
+  assert.equal(detectDownloadPlatform("unknown"), "macos");
+  assert.equal(detectDownloadPlatform(""), "macos");
 });
 
 test("orders the detected platform first", () => {
   assert.deepEqual(
-    getOrderedDesktopDownloadSections("windows").map(
-      (section) => section.platform,
-    ),
-    ["windows", "macos", "linux"],
+    getOrderedDownloadSections("windows").map((section) => section.platform),
+    ["windows", "macos", "linux", "ios", "android"],
   );
   assert.equal(
-    getOrderedDesktopDownloadSections("macos")[0].downloads[0].name,
+    getOrderedDownloadSections("macos")[0].downloads[0].name,
     "Apple Silicon",
   );
 });

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -5,18 +5,51 @@ function getStableDownloadUrl(platform: string) {
   return `${latestStableDownloadUrl}/${platform}?channel=stable`;
 }
 
-export type DesktopPlatform = "linux" | "macos" | "windows";
+export type DownloadPlatform =
+  | "android"
+  | "ios"
+  | "linux"
+  | "macos"
+  | "windows";
 
 export const appleSiliconDownloadUrl = getStableDownloadUrl("dmg-aarch64");
 export const appleIntelDownloadUrl = getStableDownloadUrl("dmg-x86_64");
 export const windowsStoreDownloadUrl =
   "https://apps.microsoft.com/detail/XPDLN196NKSW10";
 
-export const comingSoonPlatforms = [
-  "iOS",
-  "Android",
-  "Apple Watch",
-  "Galaxy Watch",
+export const comingSoonPlatforms = ["Apple Watch", "Galaxy Watch"] as const;
+
+export const mobileDownloadSections = [
+  {
+    platform: "ios",
+    name: "iOS",
+    status: "Beta",
+    description: "Join the public beta on your iPhone or iPad with TestFlight.",
+    downloads: [
+      {
+        name: "TestFlight",
+        detail: "iPhone and iPad · Public beta",
+        url: "https://testflight.apple.com/join/y7WJCXvG",
+        actionLabel: "Join TestFlight",
+        showInMenu: true,
+      },
+    ],
+  },
+  {
+    platform: "android",
+    name: "Android",
+    status: "Beta",
+    description: "Join the open beta on Google Play.",
+    downloads: [
+      {
+        name: "Google Play",
+        detail: "Android · Open beta",
+        url: "https://play.google.com/apps/testing/so.anarlog.mobile",
+        actionLabel: "Join open beta",
+        showInMenu: true,
+      },
+    ],
+  },
 ] as const;
 
 export const desktopDownloadSections = [
@@ -110,9 +143,19 @@ export const desktopDownloadSections = [
   },
 ] as const;
 
-export function detectDesktopPlatform(userAgent: string): DesktopPlatform {
+export function detectDownloadPlatform(
+  userAgent: string,
+  maxTouchPoints = 0,
+): DownloadPlatform {
+  if (/Android/i.test(userAgent)) return "android";
+  if (
+    /iPhone|iPad|iPod/i.test(userAgent) ||
+    (/Macintosh/i.test(userAgent) && maxTouchPoints > 1)
+  ) {
+    return "ios";
+  }
   if (/Windows/i.test(userAgent)) return "windows";
-  if (/Macintosh|Mac OS X|iPhone|iPad|iPod/i.test(userAgent)) return "macos";
+  if (/Macintosh|Mac OS X/i.test(userAgent)) return "macos";
   if (!/Android|CrOS/i.test(userAgent) && /Linux|X11/i.test(userAgent)) {
     return "linux";
   }
@@ -120,15 +163,12 @@ export function detectDesktopPlatform(userAgent: string): DesktopPlatform {
   return "macos";
 }
 
-export function getOrderedDesktopDownloadSections(
-  preferredPlatform: DesktopPlatform,
+export function getOrderedDownloadSections(
+  preferredPlatform: DownloadPlatform,
 ) {
+  const sections = [...desktopDownloadSections, ...mobileDownloadSections];
   return [
-    ...desktopDownloadSections.filter(
-      (section) => section.platform === preferredPlatform,
-    ),
-    ...desktopDownloadSections.filter(
-      (section) => section.platform !== preferredPlatform,
-    ),
+    ...sections.filter((section) => section.platform === preferredPlatform),
+    ...sections.filter((section) => section.platform !== preferredPlatform),
   ];
 }

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -5,14 +5,25 @@ import { ArrowSquareOut, DownloadSimple } from "@anlg/ui/components/icons";
 
 import { SiteFooter } from "@/components/site-footer";
 import { useAnalytics } from "@/hooks/use-posthog";
-import { comingSoonPlatforms, desktopDownloadSections } from "@/lib/download";
+import {
+  comingSoonPlatforms,
+  desktopDownloadSections,
+  mobileDownloadSections,
+} from "@/lib/download";
 import { getCanonicalUrl } from "@/lib/seo";
 
 const platformIcons = {
   macOS: "simple-icons:apple",
   Windows: "simple-icons:windows",
   Linux: "simple-icons:linux",
+  iOS: "simple-icons:apple",
+  Android: "simple-icons:android",
 } as const;
+
+const downloadSections = [
+  ...desktopDownloadSections,
+  ...mobileDownloadSections,
+];
 
 export const Route = createFileRoute("/_view/download/")({
   component: Component,
@@ -23,7 +34,7 @@ export const Route = createFileRoute("/_view/download/")({
       {
         name: "description",
         content:
-          "Download Anarlog for macOS, Windows, or Linux. Every desktop build uses the same release version.",
+          "Download Anarlog for macOS, Windows, or Linux. Join the iOS beta on TestFlight or the Android open beta on Google Play.",
       },
       { property: "og:title", content: "Download Anarlog" },
       { property: "og:url", content: getCanonicalUrl("/download") },
@@ -50,7 +61,7 @@ function Component() {
         </section>
 
         <div className="grid gap-14 pb-12">
-          {desktopDownloadSections.map((section) => {
+          {downloadSections.map((section) => {
             const headingId = `${section.name.toLowerCase()}-downloads`;
 
             return (
@@ -71,6 +82,13 @@ function Component() {
                     </span>
                   )}
                 </h2>
+
+                {(section.platform === "ios" ||
+                  section.platform === "android") && (
+                  <p className="text-color-muted mb-4 text-sm leading-6">
+                    {section.description}
+                  </p>
+                )}
 
                 <ul className="border-color-subtle divide-y divide-[var(--color-border-subtle)] border-y">
                   {section.downloads.map((download) => (


### PR DESCRIPTION
Add TestFlight and Google Play beta links to the homepage and downloads page. Detect iPads in desktop mode and keep the platform menu within the viewport.

Resume the paused Android open-testing track before publishing these links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing and download-routing UI with external beta URLs; no auth, payments, or server-side behavior changes.
> 
> **Overview**
> **Mobile visitors** on the homepage and `/download` now get **TestFlight** and **Google Play open beta** links instead of treating iOS/Android as “coming soon.”
> 
> `detectDownloadPlatform` replaces desktop-only detection: it classifies Android and Apple mobile UAs, and uses **`navigator.maxTouchPoints > 1`** with a Mac-like UA so **iPad desktop browsing** maps to iOS without misclassifying Macs. Ordered download sections merge desktop and new `mobileDownloadSections`; the hero CTA label becomes **“Join … beta”** on iOS/Android, with Android icons/labels in the menu and a **centered** platform dropdown. The download page lists iOS/Android beta sections (with descriptions) and updates page meta copy; **coming soon** is limited to watch platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a553c536899a15ea1b5b559d1ad1223b790363d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->