### PR TITLE
Stop labeling Windows and Linux downloads as beta

### DIFF
--- a/apps/web/src/lib/download.test.ts
+++ b/apps/web/src/lib/download.test.ts
@@ -16,6 +16,14 @@ test("offers macOS, Windows, and Linux downloads", () => {
     desktopDownloadSections.map((section) => section.platform),
     ["macos", "windows", "linux"],
   );
+  assert.deepEqual(
+    desktopDownloadSections.map((section) => section.status),
+    [null, null, null],
+  );
+  assert.deepEqual(
+    mobileDownloadSections.map((section) => section.status),
+    ["Beta", "Beta"],
+  );
   assert.deepEqual(comingSoonPlatforms, ["Apple Watch", "Galaxy Watch"]);
 
   const macosDownloads = desktopDownloadSections.find(

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -76,7 +76,7 @@ export const desktopDownloadSections = [
   {
     platform: "windows",
     name: "Windows",
-    status: "Beta",
+    status: null,
     description: "Choose a direct download or install from Microsoft Store.",
     downloads: [
       {
@@ -97,7 +97,7 @@ export const desktopDownloadSections = [
   {
     platform: "linux",
     name: "Linux",
-    status: "Beta",
+    status: null,
     description:
       "APT, AppImage, and Debian packages for x64 and ARM64, plus a PKGBUILD for Arch.",
     downloads: [

--- a/apps/web/src/lib/trust-center.ts
+++ b/apps/web/src/lib/trust-center.ts
@@ -176,7 +176,7 @@ export const contractualDocs = [
 ];
 
 export const shipsToday = [
-  "Desktop app on macOS, with Windows and Linux in beta",
+  "Desktop app on macOS, Windows, and Linux",
   "Bot-free local capture from microphone and system audio",
   "Local SQLite as the source of truth, plus Markdown and other exports",
   "On-device transcription and local models, or bring-your-own API keys",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** The website still marked Windows and Linux as beta on the homepage download menu and the download page, even though those desktop builds now ship as stable.

**Fix:** Treat Windows and Linux like macOS: no Beta badge on those platforms. iOS and Android stay labeled as public beta. Trust Center copy now lists the desktop app on macOS, Windows, and Linux.

## Verification

- Formatted and checked the changed files with dprint
- `pnpm -F @anlg/web typecheck`
- `NODE_OPTIONS='--experimental-strip-types' pnpm -F @anlg/web test` (348 passing)
- License-boundary Python checks from `ci.yaml`
- Browser: homepage download menu, `/download/`, and `/enterprise/` — Windows/Linux have no Beta badge; iOS/Android still do; Ships today reads "Desktop app on macOS, Windows, and Linux"

Note: the Nightly shared-database and blueprint-theme work that was briefly described here moved to its own PR after this one merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b080629-ad14-4209-b055-2eb1fa60bfe0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b080629-ad14-4209-b055-2eb1fa60bfe0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

