### PR TITLE
Share the notes database between Nightly and stable, and give the Nightly page a blueprint theme

### DIFF
--- a/.agents/skills/product-update-newsletter/nightly-announcement.md
+++ b/.agents/skills/product-update-newsletter/nightly-announcement.md
@@ -11,6 +11,6 @@ Your current Anarlog installation stays on stable unless you choose to install N
 
 [Try Anarlog Nightly](https://anarlog.so/download/nightly/)
 
-Nightly keeps separate local data. If you use sync with the same account, changes
-can also reach your other devices. Please include your Nightly version and operating
-system when you reply with feedback.
+Nightly opens the same local notes as your stable Anarlog, while sign-in and settings
+stay separate. Quit one app before opening the other. Please include your Nightly
+version and operating system when you reply with feedback.

--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -16,7 +16,8 @@ Do not trigger a stable release from an unmerged branch. Complete the release su
 ## Nightly and Stable Operations
 
 - Existing users and the main download remain on stable. Nightly is an explicit
-  separate-app install, with its own updater feed, local data, and CLI command.
+  separate-app install, with its own updater feed and CLI command. It opens the
+  same local database as stable; settings, store, and sign-in stay per app.
 - The team uses Nightly for daily meetings. Volunteers can join through the
   announcement in the next stable changelog and product-update newsletter.
 - `.github/workflows/desktop_nightly.yaml` runs daily at 15:00 UTC (midnight KST)
@@ -48,8 +49,12 @@ Do not trigger a stable release from an unmerged branch. Complete the release su
   hotfix branch, supplying its exact SHA, then use the resulting Nightly tag
   for stable verification and publication. This preserves the minimal patch.
 - Shared APIs and synced data must stay compatible with existing stable clients.
-  Separate local storage does not isolate writes to a synced account. Use one
-  app at a time for recording, and never point Nightly at stable's local folder.
+  Nightly and stable write the same local database, and the apps refuse to run
+  at the same time. A `-- breaking` migration published in Nightly locks stable
+  users out of their notes until stable ships it: keep schema changes additive
+  (see the root `AGENTS.md`), and land a breaking migration only in the
+  candidate that becomes the next stable release, so the lockout ends when that
+  release publishes.
 
 ### Publish and verify Nightly
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Fix failures caused by the change before committing. If an existing unrelated fa
 - JavaScript/TypeScript formatting runs through `oxfmt` via dprint's exec plugin.
 - Use `useForm` (tanstack-form) and `useQuery`/`useMutation` (tanstack-query) for form/mutation state. Avoid manual state management (e.g. `setError`).
 - Keep schema creation, migrations, and DB initialization on the Rust side. TypeScript consumes the shared transport contracts; the Drizzle adapter uses `executeProxy` and must not parse SQL or remap named rows into positional rows.
-- New SQLite migrations must be downgrade-safe (older builds tolerate newer schemas): additive only, new columns nullable or with a DEFAULT. If a migration can't be downgrade-safe, add a `-- breaking` line to the leading comment block of its `.sql` file so older builds refuse the database with an update prompt.
+- New SQLite migrations must be downgrade-safe (older builds tolerate newer schemas): additive only, new columns nullable or with a DEFAULT. If a migration can't be downgrade-safe, add a `-- breaking` line to the leading comment block of its `.sql` file so older builds refuse the database with an update prompt. Nightly and stable desktop builds share one database, so a breaking migration published in Nightly locks stable out until stable ships it.
 - Branch naming: `fix/`, `chore/`, `refactor/` prefixes.
 
 ## Code Style

--- a/apps/cli/src/db.rs
+++ b/apps/cli/src/db.rs
@@ -51,10 +51,11 @@ fn resolve_default_path_for_command(data_dir: &Path, command_name: Option<&OsStr
         .and_then(OsStr::to_str)
         .and_then(|name| Path::new(name).file_stem())
         .and_then(OsStr::to_str);
+    // `anarlog-nightly` falls through: the Nightly desktop app opens the same
+    // database as stable.
     let channel_identifier = match command_name {
         Some("anarlog-dev") => Some("com.hyprnote.dev"),
         Some("anarlog-staging") => Some("com.hyprnote.staging"),
-        Some("anarlog-nightly") => Some("com.hyprnote.nightly"),
         _ => None,
     };
     if let Some(identifier) = channel_identifier {
@@ -122,14 +123,23 @@ mod tests {
     }
 
     #[test]
-    fn channel_commands_target_their_channel_database() {
+    fn nightly_command_targets_the_stable_database() {
         let dir = tempfile::tempdir().unwrap();
+        let stable = dir.path().join("anarlog/app.db");
+        std::fs::create_dir_all(stable.parent().unwrap()).unwrap();
+        std::fs::write(&stable, "").unwrap();
+
         for command in ["anarlog-nightly", "anarlog-nightly.exe"] {
             assert_eq!(
                 resolve_default_path_for_command(dir.path(), Some(OsStr::new(command))),
-                dir.path().join("com.hyprnote.nightly/app.db")
+                stable
             );
         }
+    }
+
+    #[test]
+    fn channel_commands_target_their_channel_database() {
+        let dir = tempfile::tempdir().unwrap();
         let stable = dir.path().join("anarlog/app.db");
         std::fs::create_dir_all(stable.parent().unwrap()).unwrap();
         std::fs::write(stable, "").unwrap();

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use anlg_db_core::Db;
 
 const DB_FILENAME: &str = "app.db";
+pub(crate) const STABLE_BUNDLE_ID: &str = "com.hyprnote.stable";
+pub(crate) const NIGHTLY_BUNDLE_ID: &str = "com.hyprnote.nightly";
 const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
 const DB_OPEN_LOCK_RETRIES: u32 = 12;
 const DB_OPEN_LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
@@ -132,7 +134,29 @@ fn parse_env_flag(value: String) -> Result<bool, String> {
     }
 }
 
+// Nightly previews run against the user's real notes, so it opens stable's
+// database while keeping its own settings, store, and sign-in. db-migrate keeps
+// the two builds compatible: stable tolerates the additive migrations a newer
+// Nightly applies and refuses the file after a "-- breaking" one until a stable
+// release includes that migration.
+pub(crate) fn shared_database_peer(identifier: &str) -> Option<&'static str> {
+    match identifier {
+        NIGHTLY_BUNDLE_ID => Some(STABLE_BUNDLE_ID),
+        STABLE_BUNDLE_ID => Some(NIGHTLY_BUNDLE_ID),
+        _ => None,
+    }
+}
+
+fn database_identifier(identifier: &str) -> &str {
+    if identifier == NIGHTLY_BUNDLE_ID {
+        STABLE_BUNDLE_ID
+    } else {
+        identifier
+    }
+}
+
 pub(crate) fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
+    let identifier = database_identifier(identifier);
     let data_dir = dirs::data_dir()?;
     let default_dir = anlg_storage::global::compute_default_base(identifier)?;
     let identifier_dir = data_dir.join(identifier);
@@ -179,6 +203,33 @@ mod tests {
         let db_dir = desktop_db_dir("com.hyprnote.dev").unwrap();
 
         assert!(db_dir.ends_with("com.hyprnote.dev"));
+    }
+
+    #[test]
+    fn nightly_opens_the_stable_database() {
+        assert_eq!(
+            desktop_db_dir(NIGHTLY_BUNDLE_ID),
+            desktop_db_dir(STABLE_BUNDLE_ID)
+        );
+        assert!(
+            !desktop_db_dir(NIGHTLY_BUNDLE_ID)
+                .unwrap()
+                .ends_with(NIGHTLY_BUNDLE_ID)
+        );
+    }
+
+    #[test]
+    fn only_nightly_and_stable_share_a_database() {
+        assert_eq!(
+            shared_database_peer(NIGHTLY_BUNDLE_ID),
+            Some(STABLE_BUNDLE_ID)
+        );
+        assert_eq!(
+            shared_database_peer(STABLE_BUNDLE_ID),
+            Some(NIGHTLY_BUNDLE_ID)
+        );
+        assert_eq!(shared_database_peer("com.hyprnote.staging"), None);
+        assert_eq!(shared_database_peer("com.hyprnote.dev"), None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -142,6 +142,18 @@ pub fn main() {
             None
         }
     };
+    // Held until run() returns so Nightly and stable never share the open
+    // database at the same time.
+    let _channel_lock = match startup::acquire_channel_lock(&identifier) {
+        startup::ChannelLockState::Acquired(lock) => lock,
+        startup::ChannelLockState::PeerRunning { peer } => {
+            startup::exit_for_running_peer_channel(&identifier, peer)
+        }
+        startup::ChannelLockState::Unavailable(reason) => {
+            eprintln!("starting without the channel lock: {reason}");
+            None
+        }
+    };
 
     let (root_supervisor_ctx, root_supervisor_handle, db, crash_reporting_enabled) = runtime
         .block_on(async {
@@ -574,7 +586,7 @@ fn exit_after_startup_failure(identifier: &str, error: &impl std::fmt::Display) 
         let alert = if db::is_transient_lock_error(error) {
             "display alert \"Anarlog is not ready yet\" message \"Another Anarlog process is still using your data, possibly finishing an update. Your existing data was left unchanged. Please wait a moment and open Anarlog again.\" as critical buttons {\"OK\"} default button \"OK\""
         } else if db::is_newer_schema_error(error) {
-            "display alert \"Anarlog needs an update\" message \"Your data was created by a newer version of Anarlog, and this older version cannot open it. Your existing data was left unchanged. Please install the latest version of Anarlog.\" as critical buttons {\"OK\"} default button \"OK\""
+            "display alert \"Anarlog needs an update\" message \"Your data was updated by a newer version of Anarlog, such as Anarlog Nightly, and this version cannot open it yet. Your existing data was left unchanged. Install the latest version of Anarlog, or keep using the newer app until this version catches up.\" as critical buttons {\"OK\"} default button \"OK\""
         } else {
             "display alert \"Anarlog could not start\" message \"Your existing data was left unchanged. Please restart the app. If the problem continues, contact support.\" as critical buttons {\"OK\"} default button \"OK\""
         };

--- a/apps/desktop/src-tauri/src/startup.rs
+++ b/apps/desktop/src-tauri/src/startup.rs
@@ -90,6 +90,87 @@ fn lock_launch_file(path: &Path) -> LaunchLockState {
     }
 }
 
+// Nightly and stable open the same database. SQLite serializes their writes,
+// but live queries and CloudSync only see their own process, so the two
+// channels exclude each other for the whole app lifetime. Each channel holds
+// its own lock file; the peer's lock being held means the peer is running.
+// Same-channel relaunches keep working: an own lock that is already held is
+// left to the single-instance plugin, as before.
+pub struct ChannelLock {
+    _file: std::fs::File,
+}
+
+pub enum ChannelLockState {
+    Acquired(Option<ChannelLock>),
+    PeerRunning { peer: &'static str },
+    Unavailable(String),
+}
+
+pub fn acquire_channel_lock(identifier: &str) -> ChannelLockState {
+    let Some(peer) = crate::db::shared_database_peer(identifier) else {
+        return ChannelLockState::Acquired(None);
+    };
+    let Some(dir) = crate::db::desktop_db_dir(identifier) else {
+        return ChannelLockState::Unavailable(
+            "application data directory is unavailable".to_string(),
+        );
+    };
+    lock_channel_files(
+        &dir.join(channel_lock_filename(identifier)),
+        &dir.join(channel_lock_filename(peer)),
+        peer,
+    )
+}
+
+fn channel_lock_filename(identifier: &str) -> String {
+    format!("{identifier}.running.lock")
+}
+
+// The peer is probed before our own lock is taken. Two channels starting at
+// the same instant can both slip through, which only preserves today's
+// behavior; the reverse order could make both of them exit.
+fn lock_channel_files(own_path: &Path, peer_path: &Path, peer: &'static str) -> ChannelLockState {
+    match lock_launch_file(peer_path) {
+        LaunchLockState::Acquired(probe) => drop(probe),
+        LaunchLockState::HeldByAnotherProcess => return ChannelLockState::PeerRunning { peer },
+        LaunchLockState::Unavailable(reason) => return ChannelLockState::Unavailable(reason),
+    }
+
+    match lock_launch_file(own_path) {
+        LaunchLockState::Acquired(LaunchLock { _file }) => {
+            ChannelLockState::Acquired(Some(ChannelLock { _file }))
+        }
+        LaunchLockState::HeldByAnotherProcess => ChannelLockState::Acquired(None),
+        LaunchLockState::Unavailable(reason) => ChannelLockState::Unavailable(reason),
+    }
+}
+
+pub fn exit_for_running_peer_channel(identifier: &str, peer: &str) -> ! {
+    let own_name = channel_product_name(identifier);
+    let peer_name = channel_product_name(peer);
+    eprintln!("{peer_name} is running on the shared database; exiting {own_name}");
+
+    #[cfg(target_os = "macos")]
+    {
+        let alert = format!(
+            "display alert \"{own_name} cannot open yet\" message \"{peer_name} is running, and both apps use the same notes. Quit {peer_name}, then open {own_name} again.\" as critical buttons {{\"OK\"}} default button \"OK\""
+        );
+        let _ = std::process::Command::new("/usr/bin/osascript")
+            .args(["-e", &alert])
+            .spawn();
+    }
+
+    std::process::exit(0);
+}
+
+fn channel_product_name(identifier: &str) -> &'static str {
+    if identifier == crate::db::NIGHTLY_BUNDLE_ID {
+        "Anarlog Nightly"
+    } else {
+        "Anarlog"
+    }
+}
+
 pub fn exit_for_already_running_instance() -> ! {
     eprintln!("another Anarlog process holds the launch lock; exiting");
 
@@ -213,6 +294,68 @@ mod tests {
             lock_launch_file(&path),
             LaunchLockState::Acquired(_)
         ));
+    }
+
+    #[test]
+    fn channel_lock_excludes_the_peer_channel_while_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let stable = dir
+            .path()
+            .join(channel_lock_filename("com.hyprnote.stable"));
+        let nightly = dir
+            .path()
+            .join(channel_lock_filename("com.hyprnote.nightly"));
+
+        let stable_lock = lock_channel_files(&stable, &nightly, "com.hyprnote.nightly");
+        assert!(matches!(stable_lock, ChannelLockState::Acquired(Some(_))));
+
+        assert!(matches!(
+            lock_channel_files(&nightly, &stable, "com.hyprnote.stable"),
+            ChannelLockState::PeerRunning {
+                peer: "com.hyprnote.stable"
+            }
+        ));
+
+        drop(stable_lock);
+        assert!(matches!(
+            lock_channel_files(&nightly, &stable, "com.hyprnote.stable"),
+            ChannelLockState::Acquired(Some(_))
+        ));
+    }
+
+    #[test]
+    fn channel_lock_defers_same_channel_relaunches_to_single_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let stable = dir
+            .path()
+            .join(channel_lock_filename("com.hyprnote.stable"));
+        let nightly = dir
+            .path()
+            .join(channel_lock_filename("com.hyprnote.nightly"));
+
+        let _running = lock_channel_files(&stable, &nightly, "com.hyprnote.nightly");
+
+        assert!(matches!(
+            lock_channel_files(&stable, &nightly, "com.hyprnote.nightly"),
+            ChannelLockState::Acquired(None)
+        ));
+    }
+
+    #[test]
+    fn channels_without_a_shared_database_skip_the_channel_lock() {
+        assert!(matches!(
+            acquire_channel_lock("com.hyprnote.staging"),
+            ChannelLockState::Acquired(None)
+        ));
+    }
+
+    #[test]
+    fn channel_product_names_follow_the_bundle_identifier() {
+        assert_eq!(
+            channel_product_name("com.hyprnote.nightly"),
+            "Anarlog Nightly"
+        );
+        assert_eq!(channel_product_name("com.hyprnote.stable"), "Anarlog");
     }
 
     #[test]

--- a/apps/desktop/src/shared/long-load-gate.tsx
+++ b/apps/desktop/src/shared/long-load-gate.tsx
@@ -131,7 +131,7 @@ function StartupErrorView({ error }: { error: Error }) {
         </h1>
         <p className="text-muted-foreground text-sm leading-relaxed">
           {needsUpdate
-            ? "Your data was created by a newer version of Anarlog, and this older version cannot open it. Your existing data was left unchanged. Please install the latest version of Anarlog."
+            ? "Your data was updated by a newer version of Anarlog, such as Anarlog Nightly, and this version cannot open it yet. Your existing data was left unchanged. Install the latest version of Anarlog, or keep using the newer app until this version catches up."
             : "Your existing data was left unchanged. Please restart the app. If the problem continues, contact support."}
         </p>
         {needsUpdate ? null : (

--- a/apps/web/src/lib/download.ts
+++ b/apps/web/src/lib/download.ts
@@ -19,6 +19,14 @@ export const windowsStoreDownloadUrl =
 
 export const comingSoonPlatforms = ["Apple Watch", "Galaxy Watch"] as const;
 
+export const platformIcons = {
+  macOS: "simple-icons:apple",
+  Windows: "simple-icons:windows",
+  Linux: "simple-icons:linux",
+  iOS: "simple-icons:apple",
+  Android: "simple-icons:android",
+} as const;
+
 export const mobileDownloadSections = [
   {
     platform: "ios",

--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -9,16 +9,9 @@ import {
   comingSoonPlatforms,
   desktopDownloadSections,
   mobileDownloadSections,
+  platformIcons,
 } from "@/lib/download";
 import { getCanonicalUrl } from "@/lib/seo";
-
-const platformIcons = {
-  macOS: "simple-icons:apple",
-  Windows: "simple-icons:windows",
-  Linux: "simple-icons:linux",
-  iOS: "simple-icons:apple",
-  Android: "simple-icons:android",
-} as const;
 
 const downloadSections = [
   ...desktopDownloadSections,

--- a/apps/web/src/routes/_view/download/nightly/index.tsx
+++ b/apps/web/src/routes/_view/download/nightly/index.tsx
@@ -38,7 +38,7 @@ function NightlyDownloads() {
           <h1 className="font-hand mt-5 text-6xl leading-[0.98] font-semibold md:text-7xl">
             Anarlog Nightly
           </h1>
-          <p className="text-blueprint-fg-muted mt-6 text-lg leading-7">
+          <p className="mt-6 text-lg leading-7">
             Try upcoming improvements before they reach stable and help us catch
             bugs earlier. Nightly installs as a separate app, updates
             frequently, and opens the same notes as your stable Anarlog.
@@ -53,7 +53,7 @@ function NightlyDownloads() {
               Quit one app before opening the other. Anarlog refuses to open
               while the other one is running.
             </p>
-            <p className="text-blueprint-fg-muted">
+            <p>
               Nightly can update the database format ahead of stable. Most
               changes stay compatible. When one is not, stable shows an update
               prompt and cannot open your notes until a stable release includes
@@ -87,11 +87,11 @@ function NightlyDownloads() {
               </section>
             ))}
           </div>
-          <p className="text-blueprint-fg-muted mt-9 text-sm leading-6">
+          <p className="mt-9 text-sm leading-6">
             Release notes are included in Nightly and on{" "}
             <a
               href="https://github.com/fastrepl/anarlog/releases"
-              className="text-blueprint-fg underline underline-offset-4"
+              className="underline underline-offset-4"
             >
               GitHub
             </a>

--- a/apps/web/src/routes/_view/download/nightly/index.tsx
+++ b/apps/web/src/routes/_view/download/nightly/index.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 
+import { DownloadSimple } from "@anlg/ui/components/icons";
+
 import { SiteFooter } from "@/components/site-footer";
 import { nightlyDownloadSections } from "@/lib/download";
 import { getCanonicalUrl } from "@/lib/seo";
@@ -13,7 +15,7 @@ export const Route = createFileRoute("/_view/download/nightly/")({
       {
         name: "description",
         content:
-          "Try upcoming Anarlog improvements in a separate app before they reach stable.",
+          "Try upcoming Anarlog improvements on your own notes before they reach stable.",
       },
     ],
   }),
@@ -21,72 +23,84 @@ export const Route = createFileRoute("/_view/download/nightly/")({
 
 function NightlyDownloads() {
   return (
-    <main className="surface text-color min-h-screen">
-      <div className="mx-auto w-full max-w-[700px] px-5 py-12 md:px-8">
-        <Link
-          to="/download/"
-          className="text-color-muted text-sm underline underline-offset-4"
-        >
-          Back to stable downloads
-        </Link>
-        <h1 className="font-hand mt-16 text-6xl font-semibold">
-          Anarlog Nightly
-        </h1>
-        <p className="mt-6 text-lg leading-7">
-          Try upcoming improvements before they reach stable and help us catch
-          bugs earlier. Nightly installs as a separate app and receives frequent
-          automatic updates.
-        </p>
-        <div className="border-color-subtle bg-surface-subtle my-8 rounded-xl border p-5 text-sm leading-6">
-          <p>
-            Nightly may be less reliable. Your existing Anarlog app stays on
-            stable.
-          </p>
-          <p className="mt-3">
-            Nightly keeps separate local data. Signing into the same account
-            with sync enabled can share changes with your other devices. Use one
-            app at a time for recording.
-          </p>
-        </div>
-        <div className="grid gap-9">
-          {nightlyDownloadSections.map((section) => (
-            <section key={section.name}>
-              <h2 className="font-hand mb-3 text-3xl font-semibold">
-                {section.name}
-              </h2>
-              <ul className="border-color-subtle divide-y divide-[var(--color-border-subtle)] border-y">
-                {section.downloads.map((download) => (
-                  <li
-                    key={download.name}
-                    className="flex items-center justify-between gap-5 py-4"
-                  >
-                    <span>{download.name}</span>
-                    <a
-                      href={download.url}
-                      aria-label={`Download Nightly for ${section.name}: ${download.name}`}
-                      className="bg-brand-dark rounded-full px-4 py-2 text-sm text-white"
-                    >
-                      Download Nightly
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
-        </div>
-        <p className="text-color-muted mt-9 text-sm leading-6">
-          Release notes are included in Nightly and on{" "}
-          <a
-            href="https://github.com/fastrepl/anarlog/releases"
-            className="text-color underline underline-offset-4"
+    <>
+      <main className="blueprint min-h-screen">
+        <div className="mx-auto w-full max-w-[700px] px-5 py-12 md:px-8">
+          <Link
+            to="/download/"
+            className="text-blueprint-fg-muted hover:text-blueprint-fg text-sm underline underline-offset-4"
           >
-            GitHub
-          </a>
-          . Please include your Nightly version and operating system when
-          reporting a problem.
-        </p>
-      </div>
+            Back to stable downloads
+          </Link>
+          <p className="border-blueprint-line-strong text-blueprint-fg-muted mt-16 flex w-fit rounded-full border px-3 py-1 font-mono text-[11px] tracking-[0.18em] uppercase">
+            Preview build
+          </p>
+          <h1 className="font-hand mt-5 text-6xl leading-[0.98] font-semibold md:text-7xl">
+            Anarlog Nightly
+          </h1>
+          <p className="text-blueprint-fg-muted mt-6 text-lg leading-7">
+            Try upcoming improvements before they reach stable and help us catch
+            bugs earlier. Nightly installs as a separate app, updates
+            frequently, and opens the same notes as your stable Anarlog.
+          </p>
+          <div className="border-blueprint-line-strong bg-blueprint-deep my-8 grid gap-3 rounded-xl border p-5 text-sm leading-6">
+            <p>
+              Nightly may be less reliable. Your existing Anarlog app stays on
+              stable, and both apps read and write one local notes database.
+              Sign-in and app settings stay separate.
+            </p>
+            <p>
+              Quit one app before opening the other. Anarlog refuses to open
+              while the other one is running.
+            </p>
+            <p className="text-blueprint-fg-muted">
+              Nightly can update the database format ahead of stable. Most
+              changes stay compatible. When one is not, stable shows an update
+              prompt and cannot open your notes until a stable release includes
+              that change. Keep using Nightly until then.
+            </p>
+          </div>
+          <div className="grid gap-9">
+            {nightlyDownloadSections.map((section) => (
+              <section key={section.name}>
+                <h2 className="font-hand mb-3 text-3xl font-semibold">
+                  {section.name}
+                </h2>
+                <ul className="border-blueprint-line-strong divide-blueprint-line-strong divide-y border-y">
+                  {section.downloads.map((download) => (
+                    <li
+                      key={download.name}
+                      className="flex items-center justify-between gap-5 py-4"
+                    >
+                      <span>{download.name}</span>
+                      <a
+                        href={download.url}
+                        aria-label={`Download Nightly for ${section.name}: ${download.name}`}
+                        className="bg-blueprint-fg text-blueprint inline-flex shrink-0 items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium"
+                      >
+                        Download Nightly
+                        <DownloadSimple size={16} aria-hidden="true" />
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
+          <p className="text-blueprint-fg-muted mt-9 text-sm leading-6">
+            Release notes are included in Nightly and on{" "}
+            <a
+              href="https://github.com/fastrepl/anarlog/releases"
+              className="text-blueprint-fg underline underline-offset-4"
+            >
+              GitHub
+            </a>
+            . Please include your Nightly version and operating system when
+            reporting a problem.
+          </p>
+        </div>
+      </main>
       <SiteFooter />
-    </main>
+    </>
   );
 }

--- a/apps/web/src/routes/_view/download/nightly/index.tsx
+++ b/apps/web/src/routes/_view/download/nightly/index.tsx
@@ -1,9 +1,10 @@
+import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { DownloadSimple } from "@anlg/ui/components/icons";
 
 import { SiteFooter } from "@/components/site-footer";
-import { nightlyDownloadSections } from "@/lib/download";
+import { nightlyDownloadSections, platformIcons } from "@/lib/download";
 import { getCanonicalUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/_view/download/nightly/")({
@@ -64,7 +65,12 @@ function NightlyDownloads() {
           <div className="grid gap-9">
             {nightlyDownloadSections.map((section) => (
               <section key={section.name}>
-                <h2 className="font-hand mb-3 text-3xl font-semibold">
+                <h2 className="font-hand mb-3 flex items-center gap-2.5 text-3xl leading-none font-semibold">
+                  <Icon
+                    icon={platformIcons[section.name]}
+                    className="text-2xl"
+                    aria-hidden="true"
+                  />
                   {section.name}
                 </h2>
                 <ul className="border-blueprint-line-strong divide-blueprint-line-strong divide-y border-y">

--- a/apps/web/src/routes/_view/download/nightly/index.tsx
+++ b/apps/web/src/routes/_view/download/nightly/index.tsx
@@ -25,6 +25,23 @@ function NightlyDownloads() {
   return (
     <>
       <main className="blueprint min-h-screen">
+        <aside
+          aria-label="Nightly notice"
+          className="border-blueprint-line-strong bg-blueprint-deep border-b"
+        >
+          <p className="mx-auto w-full max-w-[700px] px-5 py-3 text-sm leading-6 md:px-8">
+            Nightly may be less reliable. It opens the same notes as your stable
+            Anarlog, so quit one app before opening the other. If Nightly
+            updates the database format first, stable asks for an update until a
+            release includes it.{" "}
+            <a
+              href="https://docs.anarlog.so/desktop-installation#nightly"
+              className="whitespace-nowrap underline underline-offset-4"
+            >
+              Learn more
+            </a>
+          </p>
+        </aside>
         <div className="mx-auto w-full max-w-[700px] px-5 py-12 md:px-8">
           <Link
             to="/download/"
@@ -38,28 +55,12 @@ function NightlyDownloads() {
           <h1 className="font-hand mt-5 text-6xl leading-[0.98] font-semibold md:text-7xl">
             Anarlog Nightly
           </h1>
-          <p className="mt-6 text-lg leading-7">
+          <p className="mt-6 mb-10 text-lg leading-7">
             Try upcoming improvements before they reach stable and help us catch
-            bugs earlier. Nightly installs as a separate app, updates
-            frequently, and opens the same notes as your stable Anarlog.
+            bugs earlier. Nightly installs as a separate app with its own
+            sign-in and settings, updates frequently, and works on the notes you
+            already have.
           </p>
-          <div className="border-blueprint-line-strong bg-blueprint-deep my-8 grid gap-3 rounded-xl border p-5 text-sm leading-6">
-            <p>
-              Nightly may be less reliable. Your existing Anarlog app stays on
-              stable, and both apps read and write one local notes database.
-              Sign-in and app settings stay separate.
-            </p>
-            <p>
-              Quit one app before opening the other. Anarlog refuses to open
-              while the other one is running.
-            </p>
-            <p>
-              Nightly can update the database format ahead of stable. Most
-              changes stay compatible. When one is not, stable shows an update
-              prompt and cannot open your notes until a stable release includes
-              that change. Keep using Nightly until then.
-            </p>
-          </div>
           <div className="grid gap-9">
             {nightlyDownloadSections.map((section) => (
               <section key={section.name}>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -65,12 +65,15 @@
   --brand-yellow: oklch(0.9484 0.0672 90.6);
 
   /* ── Colors: blueprint (Nightly) ─────────────── */
-  --color-blueprint: oklch(0.36 0.11 262);
-  --color-blueprint-deep: oklch(0.31 0.1 262);
-  --color-blueprint-fg: oklch(0.985 0.005 260);
-  --color-blueprint-fg-muted: oklch(0.985 0.005 260 / 0.72);
-  --color-blueprint-line: oklch(1 0 0 / 0.1);
-  --color-blueprint-line-strong: oklch(1 0 0 / 0.22);
+  /* Hue and chroma follow the Blueprint app icon (#0091ff); lightness sits
+     at the brightest point that keeps white body text at WCAG AA (4.7:1).
+     The muted tone falls below AA, so it is for labels and links only. */
+  --color-blueprint: oklch(0.56 0.17 251.5);
+  --color-blueprint-deep: oklch(0.45 0.16 251.5);
+  --color-blueprint-fg: oklch(0.985 0.005 250);
+  --color-blueprint-fg-muted: oklch(0.985 0.005 250 / 0.9);
+  --color-blueprint-line: oklch(1 0 0 / 0.12);
+  --color-blueprint-line-strong: oklch(1 0 0 / 0.24);
 
   /* ── Shadows ─────────────────────────────────── */
   --shadow-ring: 0 0 0 1px var(--color-border);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -64,6 +64,14 @@
   --color-brand-dark: #57534e;
   --brand-yellow: oklch(0.9484 0.0672 90.6);
 
+  /* ── Colors: blueprint (Nightly) ─────────────── */
+  --color-blueprint: oklch(0.36 0.11 262);
+  --color-blueprint-deep: oklch(0.31 0.1 262);
+  --color-blueprint-fg: oklch(0.985 0.005 260);
+  --color-blueprint-fg-muted: oklch(0.985 0.005 260 / 0.72);
+  --color-blueprint-line: oklch(1 0 0 / 0.1);
+  --color-blueprint-line-strong: oklch(1 0 0 / 0.22);
+
   /* ── Shadows ─────────────────────────────────── */
   --shadow-ring: 0 0 0 1px var(--color-border);
   --shadow-ring-left: -1px 0 0 1px var(--color-border);
@@ -1006,6 +1014,28 @@
 
 .brand-yellow {
   background-color: var(--brand-yellow);
+}
+
+/* Drafting-paper grid: fine cells with a stronger line every fifth cell. */
+.blueprint {
+  color: var(--color-blueprint-fg);
+  background-color: var(--color-blueprint);
+  background-image:
+    radial-gradient(
+      ellipse 80% 55% at 50% 0%,
+      var(--color-blueprint-line) 0%,
+      transparent 70%
+    ),
+    linear-gradient(var(--color-blueprint-line-strong) 1px, transparent 1px),
+    linear-gradient(
+    90deg,
+    var(--color-blueprint-line-strong) 1px,
+    transparent 1px
+  ),
+    linear-gradient(var(--color-blueprint-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--color-blueprint-line) 1px, transparent 1px);
+  background-size: 100% 100%, 120px 120px, 120px 120px, 24px 24px, 24px 24px;
+  background-position: 0 0, -1px -1px, -1px -1px, -1px -1px, -1px -1px;
 }
 
 .text-color {

--- a/crates/db-app/AGENTS.md
+++ b/crates/db-app/AGENTS.md
@@ -16,6 +16,7 @@
 ## Hard Rules
 
 - Treat migration ids and shipped SQL as append-only. Add a new step instead of mutating an existing one.
+- Nightly and stable desktop builds open the same database. Keep new steps downgrade-safe so stable can still open a database that Nightly migrated. A `-- breaking` step raises the compat floor and locks stable out until stable includes it; add one only in the candidate that becomes the next stable release.
 - Migration scope is explicit. If DDL touches an enabled CloudSync table, declare `CloudsyncAlter`; never rely on SQL text inspection.
 - If a table may ever be synced, make the original DDL CloudSync-safe: one `TEXT NOT NULL` primary key and defaults on every non-PK `NOT NULL` column.
 - `cloudsync_table_registry()` is policy, not discovery. Adding or enabling a table here is a deliberate product/runtime decision.

--- a/crates/storage/src/global.rs
+++ b/crates/storage/src/global.rs
@@ -16,6 +16,8 @@ pub fn compute_default_base(bundle_id: &str) -> Option<PathBuf> {
     Some(data_dir.join(app_folder))
 }
 
+// This base holds settings, the store, and the vault config. Nightly keeps its
+// own; the desktop app maps only the database itself onto stable's folder.
 fn resolve_app_folder<'a>(data_dir: &Path, bundle_id: &'a str, is_debug: bool) -> &'a str {
     if is_debug || matches!(bundle_id, STAGING_BUNDLE_ID | NIGHTLY_BUNDLE_ID) {
         bundle_id
@@ -100,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn nightly_does_not_reuse_stable_or_legacy_data() {
+    fn nightly_keeps_its_own_settings_base() {
         let temp = tempfile::tempdir().unwrap();
         for folder in [RELEASE_APP_FOLDER, LEGACY_RELEASE_APP_FOLDER] {
             std::fs::create_dir(temp.path().join(folder)).unwrap();

--- a/docs/desktop-installation.mdx
+++ b/docs/desktop-installation.mdx
@@ -113,14 +113,20 @@ When installation is complete, continue to [Your first meeting](/quickstart). If
 
 ## Nightly
 
-Anarlog Nightly is returning as an optional separate desktop app. Check the
+Anarlog Nightly is an optional separate desktop app. Check the
 [Nightly download page](https://anarlog.so/download/nightly/) for availability.
 Your existing installation stays on stable; install Nightly only if you want
 frequent previews that may be less reliable.
 
-Nightly keeps separate local data. Signing into a synced account can share
-changes with your other devices. Use one app at a time for recording, and never
-select your stable app's local storage folder in Nightly.
+Nightly opens the same local notes database as stable, so your notes,
+transcripts, and meetings appear in both apps. Sign-in and app settings stay
+separate per app. Quit one app before opening the other: Anarlog does not open
+while the other app is running.
+
+Nightly can update the database format before stable does. Most changes stay
+compatible with stable. When a change is not, stable shows an update prompt and
+cannot open your notes until a stable release includes that change. Keep using
+Nightly until then. Your data is not modified by the older app.
 
 Nightly release notes are included in the app and its GitHub prerelease. Only
 stable changelogs appear on the Anarlog website. If you install the bundled CLI

--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -7,7 +7,7 @@ summary: "Anarlog Nightly returns alongside more reliable recording, transcripti
 
 [Try Anarlog Nightly](https://anarlog.so/download/nightly/) to use upcoming improvements before they reach stable and help us catch bugs earlier. Nightly installs as a separate app, updates more frequently, and may be less reliable. Your current Anarlog installation stays on stable.
 
-Nightly keeps its own local data. If you sign into the same account with sync enabled, changes can also reach your other devices. Use one app at a time for recording.
+Nightly opens the same local notes as your stable Anarlog, while sign-in and settings stay separate. Quit one app before opening the other. If Nightly updates the database format ahead of stable, stable asks for an update until a release includes that change; keep using Nightly until then.
 
 ## Transcription and meetings
 

--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -7,7 +7,7 @@ summary: "Anarlog Nightly returns alongside more reliable recording, transcripti
 
 [Try Anarlog Nightly](https://anarlog.so/download/nightly/) to use upcoming improvements before they reach stable and help us catch bugs earlier. Nightly installs as a separate app, updates more frequently, and may be less reliable. Your current Anarlog installation stays on stable.
 
-Nightly opens the same local notes as your stable Anarlog, while sign-in and settings stay separate. Quit one app before opening the other. If Nightly updates the database format ahead of stable, stable asks for an update until a release includes that change; keep using Nightly until then.
+Nightly keeps its own local data. If you sign into the same account with sync enabled, changes can also reach your other devices. Use one app at a time for recording.
 
 ## Transcription and meetings
 

--- a/packages/changelog/nightly.md
+++ b/packages/changelog/nightly.md
@@ -7,7 +7,7 @@ summary: "Nightly is back, with transcription recovery and meeting controls to t
 
 Nightly is a separate app for trying upcoming improvements before they reach stable. It updates more frequently and may be less reliable. Your existing Anarlog installation stays on stable.
 
-Nightly keeps its own local data. If you sign into the same account with sync enabled, synced changes can also reach your other devices. Use one app at a time for recording.
+Nightly opens the same local notes as your stable Anarlog, while sign-in and settings stay separate. Quit one app before opening the other. If Nightly updates the database format ahead of stable, stable asks for an update until a release includes that change; keep using Nightly until then.
 
 ## Try in your next meeting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** Nightly (restored in #7492) kept a separate local database, so trying it meant working in an empty app, and its download page looked like every other page.

**Fix:**

- Anarlog Nightly opens the same SQLite database as stable (`desktop_db_dir` maps the Nightly bundle id onto stable's folder; the `anarlog-nightly` CLI follows). Settings, store, vault config, and sign-in stay per app.
- Schema changes between the two builds rely on `db-migrate`'s existing compat floor: stable tolerates additive migrations applied by a newer Nightly and refuses the file after a `-- breaking` one until stable includes it. The newer-schema prompt (macOS alert and in-app gate) now names Nightly and says to keep using the newer app. The root and `db-app` guidelines require additive migrations and allow a breaking step only in the candidate that becomes the next stable release.
- A per-channel run lock (`<bundle-id>.running.lock` in the shared folder) keeps Nightly and stable from opening the shared database at the same time; the peer is probed before the own lock is taken so a simultaneous start fails open. Same-channel relaunches still go through the single-instance plugin.
- `/download/nightly/` gets a blueprint theme: `--color-blueprint-*` tokens with the hue and chroma of the Blueprint app icon (`#0091ff`) at the brightest lightness that keeps white body text at WCAG AA, a drafting-paper grid background class, white download pills, and the same Apple/Windows/Linux section icons as the stable page (the icon map now lives in `lib/download`). The reliability and shared-notes notice is a full-width banner at the top of the page, linking to the docs section on database format changes.
- Docs, release skill, `packages/changelog/nightly.md`, and the newsletter draft say the same. `1.4.24.md` is left as is because 1.4.24 is being prepared from the current Nightly; the shared-database note belongs to the stable release that carries this change.

## Verification

- `cargo test --locked -p desktop --lib` (53 passing, including new shared-DB and channel-lock tests); `cargo test --locked -p anarlog-cli db::`; `cargo test --locked -p storage global`; `cargo clippy --locked -p anarlog-cli --all-targets --no-deps -- -D warnings`; `cargo fmt --check`
- `pnpm -F @anlg/web typecheck`; `NODE_OPTIONS='--experimental-strip-types' pnpm -F @anlg/web test` (348 passing)
- `pnpm -F @anlg/desktop exec vitest run src/shared/long-load-gate.test.tsx`; `pnpm exec oxlint --quiet --format=github apps/desktop/src/`; `pnpm exec eslint` on the touched TSX
- `ci.yaml` node tests and license-boundary checks; dprint on all changed files
- Browser: `/download/nightly/` at desktop and 390px widths (banner alignment and wrapping, section icons, grid, contrast, footer on light background, azure matches the icon); `/download/` section icons unchanged

Not verified here: the macOS `osascript` alert paths and an end-to-end Nightly + stable run on one machine (no packaged builds in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b080629-ad14-4209-b055-2eb1fa60bfe0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b080629-ad14-4209-b055-2eb1fa60bfe0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

