### PR TITLE
Require a CloudSync restore in critical UX QA

### DIFF
--- a/.agents/skills/qa-critical-ux/SKILL.md
+++ b/.agents/skills/qa-critical-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-critical-ux
-description: QA Anarlog's critical Pro user journey on a signed staging candidate — onboarding, responsive launch, microphone and system-audio capture, and automated summaries.
+description: QA Anarlog's critical Pro user journey on a signed staging candidate — onboarding, responsive launch, microphone and system-audio capture, automated summaries, and cloud sync.
 ---
 
 # QA: Critical User Experience
@@ -13,6 +13,7 @@ Test only the signed staging artifact for the requested candidate:
 2. Onboarding completes from scratch: permissions, sign-in, and provider setup.
 3. A recording captures both microphone and system audio.
 4. Stopping the recording produces an automated summary.
+5. The note syncs to the account and comes back after a local wipe.
 
 Everything else is outside this skill's scope.
 
@@ -68,7 +69,7 @@ Leave the MacBook open on its built-in speakers and microphone with no external 
 
 Missing app data starts onboarding normally. Do not use `ONBOARDING=1`; resetting permissions asynchronously after initialization can suppress the microphone prompt. Do not edit permission databases.
 
-Complete onboarding for real: grant each permission, sign in with the Pro or trialing test account, and select Anarlog cloud (`anarlog`) in Settings → AI.
+Complete onboarding for real: grant each permission, sign in with the Pro or trialing test account, select Anarlog cloud (`anarlog`) in Settings → AI, and turn on encrypted cloud sync in Settings → Sync. Use that account's existing recovery key when prompted. Creating a new key on an account that already has sync fails this item.
 
 ## Checklist
 
@@ -82,6 +83,7 @@ Complete onboarding for real: grant each permission, sign in with the Pro or tri
 
 - Each permission prompt appears and the grant persists.
 - Sign-in completes and the app reaches the entitled state without feature-gate prompts.
+- Settings → Sync turns on with the account's existing recovery key.
 - A stalled, dead, or looping onboarding step fails this item.
 
 ### 3. Create a note and record
@@ -102,6 +104,19 @@ Complete onboarding for real: grant each permission, sign in with the Pro or tri
 - Stopping does not hang while settling.
 - An enhanced summary and title are generated automatically, reflect the fixture content, and remain attached with the transcript.
 - Restart the app and verify the note, transcript, and summary persist.
+
+### 5. Sync the note and restore it
+
+- After the summary exists, open Settings → Sync. Status must reach **Synced**, not stay on Connecting, Syncing, Saved locally, or Sync needs attention.
+- Record the note title shown in the app. Quit Anarlog Staging. Do not reset permissions again. Wipe staging data once more:
+
+  ```bash
+  rm -rf ~/Library/Application\ Support/com.hyprnote.staging
+  ```
+
+- Launch through LaunchServices, sign in with the same Pro or trialing account, and enter the same recovery key.
+- The same note, transcript, and summary reappear after restore. A missing note, empty transcript, or missing summary fails this item.
+- Mid-recording deferral, chat/enhance leases, and hash-stable transcript integrity stay informational under `ANLG-287`.
 
 Verify results programmatically where possible through the app's supported interfaces and logs. Do not query the app database directly.
 

--- a/.claude/skills/qa-critical-ux/SKILL.md
+++ b/.claude/skills/qa-critical-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-critical-ux
-description: QA the critical Pro user journey before a desktop release — onboards from scratch, launches without hanging, captures microphone and system audio, and produces an automated summary. Use before cutting a stable release or when asked to QA the app.
+description: QA the critical Pro user journey before a desktop release — onboards from scratch, launches without hanging, captures microphone and system audio, produces an automated summary, and restores the note from cloud sync. Use before cutting a stable release or when asked to QA the app.
 ---
 
 # QA: Critical User Experience

--- a/.cursor/skills/qa-critical-ux/SKILL.md
+++ b/.cursor/skills/qa-critical-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-critical-ux
-description: QA Anarlog's critical Pro user journey when explicitly asked — onboarding, responsive launch, microphone and system-audio capture, and automated summaries.
+description: QA Anarlog's critical Pro user journey when explicitly asked — onboarding, responsive launch, microphone and system-audio capture, automated summaries, and cloud sync.
 ---
 
 # QA: Critical User Experience


### PR DESCRIPTION
Add a wipe-and-restore check so Pro QA proves the recorded note, transcript, and summary leave the device and come back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only QA procedure updates; no application, auth, or sync runtime code changes.
> 
> **Overview**
> Extends the **critical Pro UX QA** skill so release QA must prove **encrypted cloud sync end-to-end**, not just local record/summary behavior.
> 
> The canonical `.agents/skills/qa-critical-ux/SKILL.md` now lists a fifth journey step and a new **§5 Sync the note and restore it**: after summary, sync must reach **Synced**; staging app data is wiped; the tester signs back in with the **same recovery key** and confirms the note, transcript, and summary return. Onboarding and Pro checklist **§2** require enabling sync in Settings → Sync with the account’s **existing** recovery key (creating a new key on an account that already has sync is a fail). Claude/Cursor skill stubs only update their front-matter descriptions to mention cloud sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de8ffdc5c187d0c50645398e62065d0fbdde375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->