### PR TITLE
Update the 1.4.24 changelog for Nightly, sync, and Meta Muse

### DIFF
--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -1,13 +1,13 @@
 ---
 date: "2026-09-09"
-summary: "Anarlog Nightly returns alongside more reliable recording, transcription, account, and meeting controls."
+summary: "Anarlog Nightly returns with shared notes, clearer sync status, Meta Muse, and more reliable recording."
 ---
 
 ## Anarlog Nightly is back
 
 [Try Anarlog Nightly](https://anarlog.so/download/nightly/) to use upcoming improvements before they reach stable and help us catch bugs earlier. Nightly installs as a separate app, updates more frequently, and may be less reliable. Your current Anarlog installation stays on stable.
 
-Nightly keeps its own local data. If you sign into the same account with sync enabled, changes can also reach your other devices. Use one app at a time for recording.
+Nightly opens the same local notes as stable. Sign-in and settings stay separate. Quit one app before opening the other. If Nightly updates the database format ahead of stable, keep using Nightly until stable includes that change.
 
 ## Transcription and meetings
 
@@ -18,10 +18,12 @@ Nightly keeps its own local data. If you sign into the same account with sync en
 - Use the actual default microphone on Linux instead of silently recording from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
 - Hide brief prompts after a meeting ends.
 
-## Accounts and teams
+## Accounts, sync, and teams
 
 - Connect additional sign-in methods from Connected accounts without merging separate accounts.
 - Let team owners automatically admit coworkers with a verified work email domain while respecting seats and previous removals.
+- See why cloud sync is stuck instead of retrying silently, including the failing step when restore or setup cannot continue.
+- Connect **Meta Muse** for transcription and intelligence in Settings → AI.
 
 ## Meeting controls
 


### PR DESCRIPTION
## Summary
- Correct the 1.4.24 Nightly note: it now opens the same local notes as stable.
- Add user-facing sync-status and Meta Muse entries that landed after the first changelog draft.

## Test plan
- [ ] Changelog preview reads correctly on the website index (`summary` is one plain sentence)
- [ ] Nightly wording matches #7499

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog copy only; no application or runtime behavior changes.
> 
> **Overview**
> Updates the **1.4.24** release notes so they match what shipped after the first draft.
> 
> The frontmatter **summary** now highlights shared Nightly notes, clearer sync status, and **Meta Muse**. The Nightly section no longer says Nightly keeps separate local data—it explains that Nightly uses the **same local notes as stable**, with separate sign-in/settings and guidance when the database format moves ahead of stable.
> 
> Under **Accounts, sync, and teams** (renamed from “Accounts and teams”), two bullets were added: visible reasons when cloud sync is stuck, and connecting **Meta Muse** in Settings → AI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809985134073427d458e6693c30db6a133900388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->