### PR TITLE
Credit outside contributors in the changelog

### DIFF
--- a/.agents/skills/new-changelog/SKILL.md
+++ b/.agents/skills/new-changelog/SKILL.md
@@ -56,3 +56,23 @@ summary: "One concise, user-facing sentence for the changelog index preview."
 Keep `summary` plain text. Do not use markdown or custom tags in it. The web
 changelog index renders this field directly, so it should describe the release
 at a glance without leaking implementation details.
+
+Follow the writing rules in `packages/changelog/content/AGENTS.md`, including
+[contributor credit](../../../packages/changelog/content/AGENTS.md#contributor-credit).
+
+## Contributor credit
+
+If a user-facing change came from a pull request by someone outside the
+Fastrepl org, acknowledge them on that changelog item. Do not credit org
+members, collaborators, owners, or bots.
+
+Look up each merged PR in the version range and credit the author when
+`author_association` is not `MEMBER`, `OWNER`, or `COLLABORATOR`, and the
+user is not a bot. Put the thanks at the end of the item, after the
+user-facing sentence, and link the GitHub username. Do not put credits in
+`summary`.
+
+```md
+- Use the actual default microphone on Linux instead of silently recording
+  from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
+```

--- a/.agents/skills/product-update-newsletter/SKILL.md
+++ b/.agents/skills/product-update-newsletter/SKILL.md
@@ -264,7 +264,8 @@ Run before sending and report pass or fail per item.
 Automated:
 
 - Version string consistent across subject and body, with no prior version anywhere.
-- Every changelog item is represented in the copy.
+- Every changelog item is represented in the copy, including contributor
+  thanks when a change came from someone outside the Fastrepl org.
 - All H3 sections match the `SP,IMG,SP` pattern.
 - All images report `complete && naturalWidth > 0`.
 - No stray artifacts: `/image`, orphan `/`, double spaces, duplicated greeting.

--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -254,7 +254,7 @@ The changelog is required alongside the release surface review. Before releasing
 3. Compare the file against the desktop user-facing changes since the latest `desktop_v*` tag.
 4. If the changelog is missing or incomplete, update it before release.
 
-Changelog entries should be worth reading for app users. Exclude internal-only refactors, CI changes, infra noise, and implementation details unless they explain a user-visible change.
+Changelog entries should be worth reading for app users. Exclude internal-only refactors, CI changes, infra noise, and implementation details unless they explain a user-visible change. If a user-facing change came from a pull request by someone outside the Fastrepl org, that item must credit them. See `packages/changelog/content/AGENTS.md`.
 
 Each changelog file must include:
 

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -80,6 +80,9 @@ jobs:
             Nightly notes must never be published in the website changelog.
             Changelog should be generated from commits between ${{ steps.version.outputs.prev }} ~ ${{ steps.version.outputs.current }}.
             Follow guidelines in packages/changelog/content/AGENTS.md.
+            Look up each merged PR author. If the PR came from someone
+            outside the Fastrepl org (not MEMBER, OWNER, COLLABORATOR, or a
+            bot), acknowledge them inline on that changelog item.
 
             2.
             Create a PR with title "Prepare Changelog for ${{ steps.version.outputs.version }}"

--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -15,7 +15,7 @@ Nightly keeps its own local data. If you sign into the same account with sync en
 - Honor cancellation of post-meeting transcription.
 - Keep saved transcripts when post-processing returns incomplete text.
 - Preserve all requested languages during mixed-language transcription instead of returning partial coverage.
-- Use the actual default microphone on Linux instead of silently recording from ALSA's null device.
+- Use the actual default microphone on Linux instead of silently recording from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
 - Hide brief prompts after a meeting ends.
 
 ## Accounts and teams

--- a/packages/changelog/content/AGENTS.md
+++ b/packages/changelog/content/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Read through the commits, and most of the diffs, but only keep the desktop-related thing to the changelog.
 - All changelogs should "worth reading" for app users. No internal changes or infra updates.
+- If a user-facing change came from a pull request by someone outside the Fastrepl org, acknowledge them on that item. See [Contributor credit](#contributor-credit).
 - Each changelog must include `date` and `summary` frontmatter. `summary` is shown on the web changelog index, so keep it to one concise, plain-text, user-facing sentence with no markdown or custom tags.
 
 ```md
@@ -45,6 +46,33 @@ done
 ```bash
 gh api repos/fastrepl/anarlog/compare/<>...<>  --jq '.commits'
 ```
+
+4. For each merged PR in that range, look up who opened it so outside
+   contributors can be credited:
+
+```bash
+gh api repos/fastrepl/anarlog/pulls/<number> --jq '{login: .user.login, type: .user.type, association: .author_association}'
+```
+
+# Contributor credit
+
+If a user-facing change came from a pull request by someone else — not a
+Fastrepl org member, collaborator, owner, or bot — acknowledge them on that
+changelog item. Team PRs need no credit line.
+
+Credit when `author_association` is not `MEMBER`, `OWNER`, or `COLLABORATOR`,
+and `user.type` is not `Bot`. Use the pull request author, not the merger.
+
+Put the thanks at the end of the item, after the user-facing sentence. Link
+the GitHub username. Do not put credits in `summary`. Skip credit when the
+change is internal-only and does not appear in the changelog.
+
+```md
+- Use the actual default microphone on Linux instead of silently recording
+  from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
+```
+
+If several people outside the org authored the same item, thank each of them.
 
 # Custom Tags
 

--- a/packages/changelog/nightly.md
+++ b/packages/changelog/nightly.md
@@ -15,4 +15,8 @@ Nightly opens the same local notes as your stable Anarlog, while sign-in and set
 - Canceling post-meeting transcription stops that work, and incomplete post-processing no longer replaces a saved transcript.
 - The folder picker sits beside the note header actions. Meeting details and sharing menus are more compact.
 
+## Providers
+
+- Connect Meta Muse for transcription and intelligence with your own API key. Thanks [@realtonypark](https://github.com/realtonypark).
+
 Please include the Nightly version and your operating system when reporting a problem.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Problem:** User-facing changes from outside pull requests were written as if they came from the team, so contributors were not acknowledged in stable or Nightly notes.

**Fix:** Changelog writing now credits the PR author when they are outside the Fastrepl org. The 1.4.24 Linux microphone fix thanks jacopone, and Nightly thanks realtonypark for Meta Muse.

## Verification

- `pnpm exec dprint fmt --allow-no-files` and `dprint check` on the changed files
- `python3 .github/scripts/test_check_license_boundary.py` and `check_license_boundary.py` passed
- `pnpm -F @anlg/changelog typecheck` passed
- `node --test` from `ci.yaml`: 75 passed; `scripts/changelog-bundle.test.mjs` failed here with `ERR_UNKNOWN_FILE_EXTENSION` for `apps/desktop/plugins/changelog.ts` on main as well, so this is an environment loader gap, not this change
- `uvx zizmor --format sarif .` with GitHub access completed; no new findings from the prompt-only `changelog.yaml` edit. Existing changelog.yaml findings remain: unpinned actions, missing `persist-credentials: false`, and `./` self-repository syntax
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a084dc-5260-7975-b6e8-ca406fbf2e58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a084dc-5260-7975-b6e8-ca406fbf2e58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

