### PR TITLE
Use official Discord, GitHub, and X marks instead of Hugeicons.

### DIFF
--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -54,7 +54,6 @@ import {
   CrownIcon,
   Cursor01Icon,
   DatabaseIcon,
-  DiscordIcon,
   DollarSignIcon,
   Download01Icon,
   ElectricPlugsIcon,
@@ -74,7 +73,6 @@ import {
   FolderOpenIcon,
   GitMergeIcon,
   GitPullRequestIcon,
-  GithubIcon,
   GlobeIcon,
   GraduationCapIcon,
   GripVerticalIcon,
@@ -123,7 +121,6 @@ import {
   MoreHorizontalIcon,
   MoreVerticalIcon,
   MusicNote01Icon,
-  NewTwitterIcon,
   NoteEditIcon,
   NoteIcon,
   NotebookIcon,
@@ -261,6 +258,44 @@ function createIcon(icon: IconSvgElement, displayName: string): Icon {
             : style
         }
       />
+    ),
+  );
+
+  Component.displayName = displayName;
+  return Component;
+}
+
+function createBrandIcon(
+  path: string,
+  displayName: string,
+  viewBox = "0 0 24 24",
+): Icon {
+  const Component = forwardRef<SVGSVGElement, IconProps>(
+    (
+      {
+        mirrored: _mirrored,
+        strokeWidth: _strokeWidth,
+        weight: _weight,
+        size = 24,
+        className,
+        style,
+        color = "currentColor",
+        ...props
+      },
+      ref,
+    ) => (
+      <svg
+        ref={ref}
+        width={size}
+        height={size}
+        viewBox={viewBox}
+        fill={color}
+        className={className}
+        style={style}
+        {...props}
+      >
+        <path d={path} />
+      </svg>
     ),
   );
 
@@ -443,8 +478,8 @@ export const DeviceMobile = /* @__PURE__ */ createIcon(
   SmartphoneIcon,
   "DeviceMobile",
 );
-export const DiscordLogo = /* @__PURE__ */ createIcon(
-  DiscordIcon,
+export const DiscordLogo = /* @__PURE__ */ createBrandIcon(
+  "M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03ZM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418Zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418Z",
   "DiscordLogo",
 );
 export const DotsSixVertical = /* @__PURE__ */ createIcon(
@@ -505,7 +540,10 @@ export const FunnelSimple = /* @__PURE__ */ createIcon(
 );
 export const Gear = /* @__PURE__ */ createIcon(Settings02Icon, "Gear");
 export const GearSix = /* @__PURE__ */ createIcon(Settings01Icon, "GearSix");
-export const GithubLogo = /* @__PURE__ */ createIcon(GithubIcon, "GithubLogo");
+export const GithubLogo = /* @__PURE__ */ createBrandIcon(
+  "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12",
+  "GithubLogo",
+);
 export const GitMerge = /* @__PURE__ */ createIcon(GitMergeIcon, "GitMerge");
 export const GitPullRequest = /* @__PURE__ */ createIcon(
   GitPullRequestIcon,
@@ -767,4 +805,7 @@ export const Waveform = /* @__PURE__ */ createIcon(
 export const Wrench = /* @__PURE__ */ createIcon(Wrench01Icon, "Wrench");
 export const X = /* @__PURE__ */ createIcon(XIcon, "X");
 export const XCircle = /* @__PURE__ */ createIcon(CancelCircleIcon, "XCircle");
-export const XLogo = /* @__PURE__ */ createIcon(NewTwitterIcon, "XLogo");
+export const XLogo = /* @__PURE__ */ createBrandIcon(
+  "M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.727-8.822L1.254 2.25H8.08l4.253 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z",
+  "XLogo",
+);


### PR DESCRIPTION
Hugeicons rendered generic outlines on onboarding and other brand surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only icon swap in the shared UI package; API surface stays the same with minor prop behavior change on brand logos.
> 
> **Overview**
> Replaces **Discord**, **GitHub**, and **X** logo exports in `icons.tsx` with inline **official brand SVG paths** instead of Hugeicons outline glyphs, so onboarding and other brand surfaces show recognizable marks.
> 
> Adds a **`createBrandIcon`** helper (filled `svg` + `path`, `color`/`size` props) and drops unused Hugeicons imports (`DiscordIcon`, `GithubIcon`, `NewTwitterIcon`). Public export names (`DiscordLogo`, `GithubLogo`, `XLogo`) are unchanged; **`weight` / `strokeWidth` / `mirrored` are ignored** on these three icons where callers still pass them (e.g. desktop onboarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4dbf405b525182eb040f3b81936c1328b54253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->