### PR TITLE
fix: show disconnected copy after integration disconnect

### DIFF
--- a/apps/web/src/lib/integration-callback-copy.test.ts
+++ b/apps/web/src/lib/integration-callback-copy.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { integrationCallbackCopy } from "./integration-callback-copy.ts";
+
+test("connect success keeps the connected copy", () => {
+  assert.deepEqual(integrationCallbackCopy({ status: "success" }), {
+    title: "You’re connected",
+    description: "Return to Anarlog to keep going.",
+  });
+});
+
+test("disconnect success does not reuse the connected copy", () => {
+  assert.deepEqual(
+    integrationCallbackCopy({
+      status: "success",
+      disconnectedConnectionId: "conn_123",
+    }),
+    {
+      title: "You’re disconnected",
+      description: "Return to Anarlog to keep going.",
+    },
+  );
+});
+
+test("connect and disconnect failures keep their own copy", () => {
+  assert.deepEqual(integrationCallbackCopy({ status: "error" }), {
+    title: "Connection didn’t work",
+    description: "Something went wrong while connecting.",
+  });
+  assert.deepEqual(
+    integrationCallbackCopy({
+      status: "error",
+      disconnectedConnectionId: "conn_123",
+    }),
+    {
+      title: "Disconnect didn’t work",
+      description: "Something went wrong while disconnecting.",
+    },
+  );
+});

--- a/apps/web/src/lib/integration-callback-copy.ts
+++ b/apps/web/src/lib/integration-callback-copy.ts
@@ -1,0 +1,26 @@
+export function integrationCallbackCopy({
+  status,
+  disconnectedConnectionId,
+}: {
+  status: string;
+  disconnectedConnectionId?: string;
+}) {
+  const isDisconnect = Boolean(disconnectedConnectionId);
+  const isSuccess = status === "success";
+
+  if (isDisconnect) {
+    return {
+      title: isSuccess ? "You’re disconnected" : "Disconnect didn’t work",
+      description: isSuccess
+        ? "Return to Anarlog to keep going."
+        : "Something went wrong while disconnecting.",
+    };
+  }
+
+  return {
+    title: isSuccess ? "You’re connected" : "Connection didn’t work",
+    description: isSuccess
+      ? "Return to Anarlog to keep going."
+      : "Something went wrong while connecting.",
+  };
+}

--- a/apps/web/src/routes/_view/callback/integration.tsx
+++ b/apps/web/src/routes/_view/callback/integration.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_DESKTOP_SCHEME,
   flowSearchSchema,
 } from "@/functions/desktop-flow";
+import { integrationCallbackCopy } from "@/lib/integration-callback-copy";
 
 const commonSearch = {
   integration_id: z.string(),
@@ -121,17 +122,14 @@ function Component() {
   ]);
 
   const isSuccess = search.status === "success";
+  const copy = integrationCallbackCopy({
+    status: search.status,
+    disconnectedConnectionId: search.disconnected_connection_id,
+  });
 
   if (search.flow === "desktop") {
     return (
-      <AuthShell
-        title={isSuccess ? "You’re connected" : "Connection didn’t work"}
-        description={
-          isSuccess
-            ? "Return to Anarlog to keep going."
-            : "Something went wrong while connecting."
-        }
-      >
+      <AuthShell title={copy.title} description={copy.description}>
         {isSuccess ? (
           <div className="flex flex-col gap-3">
             <button


### PR DESCRIPTION
- Detect disconnect via disconnected_connection_id on the callback page
- Keep connect success as "You're connected"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy only on the integration callback page; behavior is covered by new unit tests.
> 
> **Overview**
> Fixes integration OAuth callback messaging so **disconnect** flows no longer show “You’re connected” when `disconnected_connection_id` is present on the URL.
> 
> Introduces `integrationCallbackCopy` to centralize title/description for connect vs disconnect and success vs error, with unit tests. The desktop integration callback route now uses that helper instead of inline copy that only distinguished success from failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2048cf80b739cab3f32a473d3117d9ff73211b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->