### PR TITLE
Give live 1:1 remotes a name even after restart.

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -311,7 +311,7 @@ describe("EventListeners notification events", () => {
     });
   });
 
-  test("live capture config sync waits for the transcript snapshot before pushing", async () => {
+  test("live capture config sync pushes remotes before the transcript snapshot", async () => {
     vi.useFakeTimers();
     useConfigValuesMock.mockReturnValue({
       ai_language: "ko",
@@ -319,7 +319,6 @@ describe("EventListeners notification events", () => {
       current_stt_provider: "soniox",
       current_stt_model: "stt-v4",
     });
-    // The transcript query answers later than the participant query here.
     liveQuerySubscribeMock.mockImplementation(
       async (sql, _params, handlers) => {
         if (!String(sql).includes("FROM transcripts")) {
@@ -343,18 +342,19 @@ describe("EventListeners notification events", () => {
     ]);
     await vi.runOnlyPendingTimersAsync();
 
-    expect(updateCaptureConfigMock).not.toHaveBeenCalled();
+    expect(updateCaptureConfigMock).toHaveBeenCalledTimes(1);
+    expect(updateCaptureConfigMock).toHaveBeenCalledWith({
+      session_id: "session-1",
+      languages: ["ko"],
+      participant_human_ids: ["human-remote"],
+      self_human_id: "human-self",
+      speaker_assignments: [],
+    });
 
     findLiveQueryHandlers("FROM transcripts").onData([]);
     await vi.runOnlyPendingTimersAsync();
 
     expect(updateCaptureConfigMock).toHaveBeenCalledTimes(1);
-    expect(updateCaptureConfigMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        session_id: "session-1",
-        speaker_assignments: [],
-      }),
-    );
   });
 
   test("live capture config sync runs without names when the transcript read fails", async () => {

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -56,6 +56,21 @@ const CAPTURE_IDENTITY_SQL = `
     AND participant.human_id <> ''
     AND participant.source <> 'excluded'
     AND participant.deleted_at IS NULL
+    AND participant.human_id <> session.owner_user_id
+    AND NOT EXISTS (
+      SELECT 1
+      FROM humans AS self_human
+      LEFT JOIN humans AS participant_human
+        ON participant_human.id = participant.human_id
+        AND participant_human.deleted_at IS NULL
+      WHERE self_human.id = session.owner_user_id
+        AND self_human.deleted_at IS NULL
+        AND NULLIF(lower(self_human.email), '') IS NOT NULL
+        AND lower(self_human.email) = lower(COALESCE(
+          NULLIF(participant_human.email, ''),
+          participant.email
+        ))
+    )
   WHERE session.deleted_at IS NULL
   ORDER BY session.id, participant.human_id
 `;
@@ -272,12 +287,6 @@ function LiveCaptureConfigSyncReady({
         return;
       }
 
-      // An empty assignment list is not a no-op: the engine drops the names it
-      // holds. Wait for the transcript query's first rows before pushing.
-      if (transcriptSessionId === live.sessionId && !hasTranscriptSnapshot) {
-        return;
-      }
-
       const languages = getLiveConfigLanguages(
         settingsValues.ai_language,
         settingsValues.spoken_languages,
@@ -302,7 +311,7 @@ function LiveCaptureConfigSyncReady({
         ),
         self_human_id: session?.owner_user_id || null,
         speaker_assignments:
-          transcriptSessionId === live.sessionId
+          transcriptSessionId === live.sessionId && hasTranscriptSnapshot
             ? getLiveSpeakerAssignments(transcriptRows)
             : [],
       };

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -69,17 +69,22 @@ const CAPTURE_IDENTITY_SQL = `
         AND owner_participant.deleted_at IS NULL
       WHERE self_human.id = session.owner_user_id
         AND self_human.deleted_at IS NULL
-        AND lower(COALESCE(
-          NULLIF(participant_human.email, ''),
-          participant.email
-        )) IN (
-          lower(self_human.email),
-          lower(owner_participant.email)
+        AND (
+          (
+            NULLIF(lower(self_human.email), '') IS NOT NULL
+            AND lower(self_human.email) = lower(COALESCE(
+              NULLIF(participant_human.email, ''),
+              participant.email
+            ))
+          )
+          OR (
+            NULLIF(lower(owner_participant.email), '') IS NOT NULL
+            AND lower(owner_participant.email) = lower(COALESCE(
+              NULLIF(participant_human.email, ''),
+              participant.email
+            ))
+          )
         )
-        AND NULLIF(lower(COALESCE(
-          NULLIF(self_human.email, ''),
-          owner_participant.email
-        )), '') IS NOT NULL
     )
   WHERE session.deleted_at IS NULL
   ORDER BY session.id, participant.human_id

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -63,13 +63,23 @@ const CAPTURE_IDENTITY_SQL = `
       LEFT JOIN humans AS participant_human
         ON participant_human.id = participant.human_id
         AND participant_human.deleted_at IS NULL
+      LEFT JOIN session_participants AS owner_participant
+        ON owner_participant.session_id = session.id
+        AND owner_participant.human_id = session.owner_user_id
+        AND owner_participant.deleted_at IS NULL
       WHERE self_human.id = session.owner_user_id
         AND self_human.deleted_at IS NULL
-        AND NULLIF(lower(self_human.email), '') IS NOT NULL
-        AND lower(self_human.email) = lower(COALESCE(
+        AND lower(COALESCE(
           NULLIF(participant_human.email, ''),
           participant.email
-        ))
+        )) IN (
+          lower(self_human.email),
+          lower(owner_participant.email)
+        )
+        AND NULLIF(lower(COALESCE(
+          NULLIF(self_human.email, ''),
+          owner_participant.email
+        )), '') IS NOT NULL
     )
   WHERE session.deleted_at IS NULL
   ORDER BY session.id, participant.human_id

--- a/apps/desktop/src/session/queries.test.ts
+++ b/apps/desktop/src/session/queries.test.ts
@@ -90,15 +90,29 @@ describe("session SQLite operations", () => {
     });
   });
 
-  it("returns the existing note for an event without writing", async () => {
+  it("attaches missing calendar participants to an existing event note", async () => {
     mocks.execute
       .mockResolvedValueOnce([event])
-      .mockResolvedValueOnce([{ id: "session-existing" }]);
+      .mockResolvedValueOnce([{ id: "session-existing" }])
+      .mockResolvedValueOnce([]);
 
     await expect(getOrCreateSessionForEventId("event-1")).resolves.toBe(
       "session-existing",
     );
-    expect(mocks.executeTransaction).not.toHaveBeenCalled();
+
+    const statements = mocks.executeTransaction.mock.calls[0][0] as Array<{
+      sql: string;
+      params: unknown[];
+    }>;
+    expect(
+      statements.some((statement) => statement.sql.includes("humans")),
+    ).toBe(true);
+    expect(
+      statements.some((statement) =>
+        statement.sql.includes("session_participants"),
+      ),
+    ).toBe(true);
+    expect(statements[0]?.params).toContain("alice@example.com");
   });
 
   it("commits title and raw note changes in one ordered transaction", async () => {

--- a/apps/desktop/src/session/queries.test.ts
+++ b/apps/desktop/src/session/queries.test.ts
@@ -115,6 +115,42 @@ describe("session SQLite operations", () => {
     expect(statements[0]?.params).toContain("alice@example.com");
   });
 
+  it("does not attach the calendar self copy to an existing event note", async () => {
+    mocks.execute
+      .mockResolvedValueOnce([
+        {
+          ...event,
+          participants_json: JSON.stringify([
+            {
+              name: "John",
+              email: "john@example.com",
+              is_current_user: true,
+            },
+            { name: "Artem", email: "artem@example.com" },
+          ]),
+        },
+      ])
+      .mockResolvedValueOnce([{ id: "session-existing" }])
+      .mockResolvedValueOnce([]);
+
+    await expect(getOrCreateSessionForEventId("event-1")).resolves.toBe(
+      "session-existing",
+    );
+
+    const statements = mocks.executeTransaction.mock.calls[0][0] as Array<{
+      sql: string;
+      params: unknown[];
+    }>;
+    const params = statements.flatMap((statement) => statement.params);
+    expect(params).toContain("artem@example.com");
+    expect(params).not.toContain("john@example.com");
+    expect(
+      statements.every((statement) =>
+        statement.sql.includes("? <> session.owner_user_id"),
+      ),
+    ).toBe(true);
+  });
+
   it("commits title and raw note changes in one ordered transaction", async () => {
     mocks.executeTransaction.mockResolvedValueOnce([1, 1]);
 

--- a/apps/desktop/src/session/queries/creation.ts
+++ b/apps/desktop/src/session/queries/creation.ts
@@ -147,6 +147,10 @@ export async function getOrCreateSessionForEventId(
 
   const existingSessionId = await findSessionForEvent(event);
   if (existingSessionId) {
+    await ensureEventParticipants(
+      existingSessionId,
+      parseEventParticipants(event.participants_json),
+    );
     return existingSessionId;
   }
 
@@ -203,7 +207,93 @@ export async function getOrCreateSessionForEventId(
     createEmptyNoteStatement(sessionId, now),
   ];
 
+  statements.push(
+    ...eventParticipantStatements(sessionId, participants, humansByEmail, now),
+  );
+
+  const rowsAffected = await executeTransaction(statements);
+
+  const createdSessionId = await findSessionForEvent(event, sessionId);
+  if (!createdSessionId) {
+    throw new Error(`Failed to create a session for event ${eventId}`);
+  }
+
+  if (rowsAffected[0] === 1) {
+    trackNoteCreated(true);
+  }
+  return createdSessionId;
+}
+
+function createEmptyNoteStatement(sessionId: string, now: string, body = "") {
+  return {
+    sql: `
+      INSERT INTO session_documents (
+        id, workspace_id, session_id, kind, body_format, body, created_by,
+        updated_by, created_at, updated_at, deleted_at
+      )
+      SELECT ?, workspace_id, id, 'note', 'prosemirror_json', ?,
+        owner_user_id, owner_user_id, ?, ?, NULL
+      FROM sessions
+      WHERE id = ? AND deleted_at IS NULL
+    `,
+    params: [sessionId, body, now, now, sessionId],
+  };
+}
+
+async function findSessionForEvent(
+  event: EventSqlRow,
+  preferredId?: string,
+): Promise<string | null> {
+  const rows = await liveQueryClient.execute<SessionIdentitySqlRow>(
+    `
+      SELECT id
+      FROM sessions
+      WHERE deleted_at IS NULL
+        AND (event_id = ? OR (? <> '' AND external_event_id = ?))
+      ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, created_at, id
+      LIMIT 1
+    `,
+    [
+      event.id,
+      event.tracking_id_event,
+      event.tracking_id_event,
+      preferredId ?? "",
+    ],
+  );
+  return rows[0]?.id ?? null;
+}
+
+async function ensureEventParticipants(
+  sessionId: string,
+  participants: EventParticipant[],
+): Promise<void> {
+  if (participants.length === 0) {
+    return;
+  }
+
+  const humansByEmail = await findHumansByEmail(participants);
+  const statements = eventParticipantStatements(
+    sessionId,
+    participants,
+    humansByEmail,
+    new Date().toISOString(),
+  );
+  if (statements.length === 0) {
+    return;
+  }
+
+  await executeTransaction(statements);
+}
+
+function eventParticipantStatements(
+  sessionId: string,
+  participants: EventParticipant[],
+  humansByEmail: Map<string, string>,
+  now: string,
+): Array<{ sql: string; params: string[] }> {
+  const statements: Array<{ sql: string; params: string[] }> = [];
   const seenEmails = new Set<string>();
+
   for (const participant of participants) {
     const email = participant.email?.trim();
     if (!email) continue;
@@ -269,56 +359,7 @@ export async function getOrCreateSessionForEventId(
     });
   }
 
-  const rowsAffected = await executeTransaction(statements);
-
-  const createdSessionId = await findSessionForEvent(event, sessionId);
-  if (!createdSessionId) {
-    throw new Error(`Failed to create a session for event ${eventId}`);
-  }
-
-  if (rowsAffected[0] === 1) {
-    trackNoteCreated(true);
-  }
-  return createdSessionId;
-}
-
-function createEmptyNoteStatement(sessionId: string, now: string, body = "") {
-  return {
-    sql: `
-      INSERT INTO session_documents (
-        id, workspace_id, session_id, kind, body_format, body, created_by,
-        updated_by, created_at, updated_at, deleted_at
-      )
-      SELECT ?, workspace_id, id, 'note', 'prosemirror_json', ?,
-        owner_user_id, owner_user_id, ?, ?, NULL
-      FROM sessions
-      WHERE id = ? AND deleted_at IS NULL
-    `,
-    params: [sessionId, body, now, now, sessionId],
-  };
-}
-
-async function findSessionForEvent(
-  event: EventSqlRow,
-  preferredId?: string,
-): Promise<string | null> {
-  const rows = await liveQueryClient.execute<SessionIdentitySqlRow>(
-    `
-      SELECT id
-      FROM sessions
-      WHERE deleted_at IS NULL
-        AND (event_id = ? OR (? <> '' AND external_event_id = ?))
-      ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, created_at, id
-      LIMIT 1
-    `,
-    [
-      event.id,
-      event.tracking_id_event,
-      event.tracking_id_event,
-      preferredId ?? "",
-    ],
-  );
-  return rows[0]?.id ?? null;
+  return statements;
 }
 
 async function findHumansByEmail(

--- a/apps/desktop/src/session/queries/creation.ts
+++ b/apps/desktop/src/session/queries/creation.ts
@@ -295,6 +295,7 @@ function eventParticipantStatements(
   const seenEmails = new Set<string>();
 
   for (const participant of participants) {
+    if (participant.is_current_user === true) continue;
     const email = participant.email?.trim();
     if (!email) continue;
     const emailKey = email.toLowerCase();
@@ -312,6 +313,7 @@ function eventParticipantStatements(
           SELECT ?, session.workspace_id, session.owner_user_id, ?, ?, ?, ?, NULL
           FROM sessions AS session
           WHERE session.id = ? AND session.deleted_at IS NULL
+            AND ? <> session.owner_user_id
             AND NOT EXISTS (
               SELECT 1
               FROM humans
@@ -325,6 +327,7 @@ function eventParticipantStatements(
           now,
           now,
           sessionId,
+          humanId,
           email,
         ],
       });
@@ -340,10 +343,32 @@ function eventParticipantStatements(
           ?, ?, ?, 'auto', ?, ?, NULL
         FROM sessions AS session
         WHERE session.id = ? AND session.deleted_at IS NULL
+          AND ? <> session.owner_user_id
           AND NOT EXISTS (
             SELECT 1
-            FROM session_participants
-            WHERE session_id = session.id AND human_id = ? AND deleted_at IS NULL
+            FROM humans AS owner
+            WHERE owner.id = session.owner_user_id
+              AND owner.deleted_at IS NULL
+              AND NULLIF(lower(owner.email), '') IS NOT NULL
+              AND lower(owner.email) = lower(?)
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM session_participants AS existing
+            WHERE existing.session_id = session.id
+              AND existing.deleted_at IS NULL
+              AND (
+                existing.human_id = ?
+                OR (
+                  existing.human_id = session.owner_user_id
+                  AND NULLIF(lower(existing.email), '') IS NOT NULL
+                  AND lower(existing.email) = lower(?)
+                )
+                OR (
+                  NULLIF(lower(existing.email), '') IS NOT NULL
+                  AND lower(existing.email) = lower(?)
+                )
+              )
           )
       `,
       params: [
@@ -355,6 +380,10 @@ function eventParticipantStatements(
         now,
         sessionId,
         humanId,
+        email,
+        humanId,
+        email,
+        email,
       ],
     });
   }

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -3,6 +3,7 @@ import type { StoreApi } from "zustand";
 
 import {
   commands as listenerCommands,
+  type CaptureConfigUpdate,
   type CaptureParams,
 } from "@anlg/plugin-transcription";
 import type { TranscriptionParams } from "@anlg/plugin-transcription";
@@ -56,12 +57,7 @@ export type GeneralActions = {
   setMuted: (value: boolean) => void;
   setBatchTranscriptionPending: (sessionId: string, pending: boolean) => void;
   setTriggerAppIds: (appIds: string[] | null) => void;
-  updateCaptureConfig: (
-    update: Pick<
-      CaptureParams,
-      "session_id" | "languages" | "participant_human_ids" | "self_human_id"
-    >,
-  ) => Promise<void>;
+  updateCaptureConfig: (update: CaptureConfigUpdate) => Promise<void>;
   startTranscription: (
     params: TranscriptionParams,
     options?: {
@@ -196,6 +192,7 @@ export const createGeneralSlice = <
       languages: update.languages,
       participant_human_ids: update.participant_human_ids ?? [],
       self_human_id: update.self_human_id ?? null,
+      speaker_assignments: update.speaker_assignments ?? [],
     });
   },
   startTranscription: async (params, options) => {

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -300,6 +300,12 @@ describe("transcript SQLite queries", () => {
     expect(mocks.queryOptions[0]?.sql).toContain("owner_user_id");
     expect(mocks.queryOptions[0]?.sql).toContain("owner_participant");
     expect(mocks.queryOptions[0]?.sql).toContain(
+      "NULLIF(lower(self_human.email), '') IS NOT NULL",
+    );
+    expect(mocks.queryOptions[0]?.sql).toContain(
+      "NULLIF(lower(owner_participant.email), '') IS NOT NULL",
+    );
+    expect(mocks.queryOptions[0]?.sql).toContain(
       "COALESCE(NULLIF(human.email, ''), participant.email)",
     );
   });

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -298,6 +298,7 @@ describe("transcript SQLite queries", () => {
     expect(mocks.queryOptions[0]?.sql).toContain("deleted_at IS NULL");
     expect(mocks.queryOptions[0]?.sql).toContain("source <> 'excluded'");
     expect(mocks.queryOptions[0]?.sql).toContain("owner_user_id");
+    expect(mocks.queryOptions[0]?.sql).toContain("owner_participant");
     expect(mocks.queryOptions[0]?.sql).toContain(
       "COALESCE(NULLIF(human.email, ''), participant.email)",
     );

--- a/apps/desktop/src/stt/queries.test.tsx
+++ b/apps/desktop/src/stt/queries.test.tsx
@@ -54,6 +54,7 @@ import {
   createLiveTranscript,
   createTranscript,
   flushLiveTranscriptDeltasToDatabase,
+  getSessionParticipantHumanIds,
   getSessionTranscriptRecords,
   mergeTranscriptSegments,
   removeHumanSpeakerAssignments,
@@ -299,6 +300,21 @@ describe("transcript SQLite queries", () => {
     expect(mocks.queryOptions[0]?.sql).toContain("owner_user_id");
     expect(mocks.queryOptions[0]?.sql).toContain(
       "COALESCE(NULLIF(human.email, ''), participant.email)",
+    );
+  });
+
+  it("loads remote participant ids without waiting for the live query", async () => {
+    mocks.execute.mockResolvedValueOnce([
+      { human_id: "human-artem" },
+      { human_id: "" },
+    ]);
+
+    await expect(getSessionParticipantHumanIds("session-1")).resolves.toEqual([
+      "human-artem",
+    ]);
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining("source <> 'excluded'"),
+      ["session-1"],
     );
   });
 

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -302,13 +302,23 @@ export const SESSION_REMOTE_PARTICIPANT_IDS_SQL = `
           NULLIF(lower(COALESCE(NULLIF(human.email, ''), participant.email)), '') IS NULL
           OR NOT EXISTS (
             SELECT 1
-            FROM humans AS self_human
-            JOIN sessions AS session
-              ON session.owner_user_id = self_human.id
-            WHERE session.id = participant.session_id
+            FROM sessions AS session
+            LEFT JOIN humans AS self_human
+              ON self_human.id = session.owner_user_id
               AND self_human.deleted_at IS NULL
-              AND NULLIF(lower(self_human.email), '') IS NOT NULL
-              AND lower(self_human.email) = lower(COALESCE(NULLIF(human.email, ''), participant.email))
+            LEFT JOIN session_participants AS owner_participant
+              ON owner_participant.session_id = session.id
+              AND owner_participant.human_id = session.owner_user_id
+              AND owner_participant.deleted_at IS NULL
+            WHERE session.id = participant.session_id
+              AND lower(COALESCE(NULLIF(human.email, ''), participant.email)) IN (
+                lower(self_human.email),
+                lower(owner_participant.email)
+              )
+              AND NULLIF(lower(COALESCE(
+                NULLIF(self_human.email, ''),
+                owner_participant.email
+              )), '') IS NOT NULL
           )
         )
       ORDER BY participant.human_id

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -311,14 +311,22 @@ export const SESSION_REMOTE_PARTICIPANT_IDS_SQL = `
               AND owner_participant.human_id = session.owner_user_id
               AND owner_participant.deleted_at IS NULL
             WHERE session.id = participant.session_id
-              AND lower(COALESCE(NULLIF(human.email, ''), participant.email)) IN (
-                lower(self_human.email),
-                lower(owner_participant.email)
+              AND (
+                (
+                  NULLIF(lower(self_human.email), '') IS NOT NULL
+                  AND lower(self_human.email) = lower(COALESCE(
+                    NULLIF(human.email, ''),
+                    participant.email
+                  ))
+                )
+                OR (
+                  NULLIF(lower(owner_participant.email), '') IS NOT NULL
+                  AND lower(owner_participant.email) = lower(COALESCE(
+                    NULLIF(human.email, ''),
+                    participant.email
+                  ))
+                )
               )
-              AND NULLIF(lower(COALESCE(
-                NULLIF(self_human.email, ''),
-                owner_participant.email
-              )), '') IS NOT NULL
           )
         )
       ORDER BY participant.human_id

--- a/apps/desktop/src/stt/queries.ts
+++ b/apps/desktop/src/stt/queries.ts
@@ -281,11 +281,9 @@ export async function getSessionTranscriptRecords(
   return rows.map(mapTranscriptRow);
 }
 
-export function useSessionParticipantHumanIds(sessionId: string): string[] {
-  const { data = EMPTY_IDS } = useLiveQuery<ParticipantHumanSqlRow, string[]>({
-    // Drop excluded people and any contact that is the current user (or a
-    // calendar copy with the same email) so a 1:1 meeting still has one remote.
-    sql: `
+// Drop excluded people and any contact that is the current user (or a
+// calendar copy with the same email) so a 1:1 meeting still has one remote.
+export const SESSION_REMOTE_PARTICIPANT_IDS_SQL = `
       SELECT DISTINCT participant.human_id
       FROM session_participants AS participant
       LEFT JOIN humans AS human
@@ -314,7 +312,25 @@ export function useSessionParticipantHumanIds(sessionId: string): string[] {
           )
         )
       ORDER BY participant.human_id
-    `,
+    `;
+
+export async function getSessionParticipantHumanIds(
+  sessionId: string,
+): Promise<string[]> {
+  if (!sessionId) {
+    return [];
+  }
+
+  const rows = await liveQueryClient.execute<ParticipantHumanSqlRow>(
+    SESSION_REMOTE_PARTICIPANT_IDS_SQL,
+    [sessionId],
+  );
+  return rows.map((row) => row.human_id).filter(Boolean);
+}
+
+export function useSessionParticipantHumanIds(sessionId: string): string[] {
+  const { data = EMPTY_IDS } = useLiveQuery<ParticipantHumanSqlRow, string[]>({
+    sql: SESSION_REMOTE_PARTICIPANT_IDS_SQL,
     params: [sessionId],
     enabled: Boolean(sessionId),
     mapRows: (rows) => rows.map((row) => row.human_id),

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -37,6 +37,7 @@ const {
   useSessionMock,
   useSessionHasTranscriptMock,
   useSessionParticipantHumanIdsMock,
+  getSessionParticipantHumanIdsMock,
   createLiveTranscriptMock,
   applyLiveTranscriptDeltaToDatabaseMock,
   flushLiveTranscriptDeltasToDatabaseMock,
@@ -92,6 +93,7 @@ const {
   useSessionMock: vi.fn(),
   useSessionHasTranscriptMock: vi.fn(),
   useSessionParticipantHumanIdsMock: vi.fn(),
+  getSessionParticipantHumanIdsMock: vi.fn(),
   createLiveTranscriptMock: vi.fn(),
   applyLiveTranscriptDeltaToDatabaseMock: vi.fn(),
   flushLiveTranscriptDeltasToDatabaseMock: vi.fn(),
@@ -289,6 +291,7 @@ vi.mock("~/stt/queries", () => ({
   softDeleteTranscript: softDeleteTranscriptMock,
   transcriptExists: transcriptExistsMock,
   useSessionParticipantHumanIds: useSessionParticipantHumanIdsMock,
+  getSessionParticipantHumanIds: getSessionParticipantHumanIdsMock,
 }));
 
 let disclosureSessionSequence = 0;
@@ -489,6 +492,9 @@ describe("useStartListening", () => {
     });
     useSessionHasTranscriptMock.mockReturnValue(false);
     useSessionParticipantHumanIdsMock.mockReturnValue([]);
+    getSessionParticipantHumanIdsMock.mockImplementation(async () =>
+      useSessionParticipantHumanIdsMock(),
+    );
     createLiveTranscriptMock.mockResolvedValue(undefined);
     applyLiveTranscriptDeltaToDatabaseMock.mockResolvedValue(undefined);
     flushLiveTranscriptDeltasToDatabaseMock.mockResolvedValue(undefined);
@@ -907,6 +913,23 @@ describe("useStartListening", () => {
       saveCaptureLifecycleMarkerMock,
     );
     expect(saveCaptureLifecycleMarkerMock).toHaveBeenCalledBefore(startMock);
+  });
+
+  test("reads remote participants from sqlite before starting capture", async () => {
+    useSessionParticipantHumanIdsMock.mockReturnValue([]);
+    getSessionParticipantHumanIdsMock.mockResolvedValue(["human-artem"]);
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(getSessionParticipantHumanIdsMock).toHaveBeenCalledWith("session-1");
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      participant_human_ids: ["human-artem"],
+      self_human_id: "user-1",
+    });
   });
 
   test("manual recording stays manual while a scheduled start is waiting for the same note", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -21,7 +21,10 @@ import {
   getLiveTranscriptionConfig,
   getTranscriptionLanguages,
 } from "~/stt/capabilities";
-import { useSessionParticipantHumanIds } from "~/stt/queries";
+import {
+  getSessionParticipantHumanIds,
+  useSessionParticipantHumanIds,
+} from "~/stt/queries";
 
 export {
   CLOUDSYNC_CAPTURE_LEASE_ATTEMPTS,
@@ -89,17 +92,25 @@ export function useStartListeningState(
         );
       }
     };
-    const [keywords, liveTranscriptionConfig] = await Promise.all([
-      import("./useKeywords").then(({ getSessionKeywords }) =>
-        getSessionKeywords({ sessionId, dictionaryTerms }),
-      ),
-      getLiveTranscriptionConfig({
-        provider: conn?.provider,
-        model: conn?.model,
-        languages: getTranscriptionLanguages(aiLanguage, spokenLanguages),
-      }),
-      lifecycle.ready,
-    ]);
+    const [keywords, liveTranscriptionConfig, remoteParticipantHumanIds] =
+      await Promise.all([
+        import("./useKeywords").then(({ getSessionKeywords }) =>
+          getSessionKeywords({ sessionId, dictionaryTerms }),
+        ),
+        getLiveTranscriptionConfig({
+          provider: conn?.provider,
+          model: conn?.model,
+          languages: getTranscriptionLanguages(aiLanguage, spokenLanguages),
+        }),
+        getSessionParticipantHumanIds(sessionId).catch((error) => {
+          console.error(
+            "[listener] failed to read session participants before capture",
+            error,
+          );
+          return participantHumanIds;
+        }),
+        lifecycle.ready,
+      ]);
     if (!canStartLiveSession(sessionId)) {
       await releaseCloudsyncDeferral();
       return;
@@ -144,7 +155,7 @@ export function useStartListeningState(
           keywords,
           mic_device: microphoneDevice || null,
           transcription_mode: liveTranscriptionConfig.transcriptionMode,
-          participant_human_ids: participantHumanIds,
+          participant_human_ids: remoteParticipantHumanIds,
           self_human_id: session?.user_id || null,
         },
         {


### PR DESCRIPTION
Fetch participants from SQLite at start, push remotes before the transcript snapshot, attach missing calendar attendees on existing event notes, and exclude owner/self copies so a unique remote can become Speaker 1's name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live capture participant resolution and when config is pushed to the transcription engine; incorrect filtering could mis-label speakers or omit remotes in 1:1 meetings.
> 
> **Overview**
> Improves **live 1:1 speaker naming** by treating calendar/event remotes as the real capture participants and syncing them to the engine earlier, including after app restart.
> 
> **Capture start** now loads remote `participant_human_ids` from SQLite via `getSessionParticipantHumanIds` (shared `SESSION_REMOTE_PARTICIPANT_IDS_SQL`) instead of relying only on the React live-query hook, so recording starts with the correct remotes even before subscriptions settle.
> 
> **Live config sync** pushes participant IDs (and languages) as soon as session participants are known; **speaker assignments** are added only after the transcript snapshot is available. The listener forwards full `CaptureConfigUpdate` including `speaker_assignments`. Participant queries exclude the session owner and anyone whose email matches the owner (including an owner’s calendar participant row).
> 
> **Event notes**: opening an existing calendar session runs `ensureEventParticipants` to insert missing attendees from `participants_json`, while skipping `is_current_user` and deduping owner/self email copies in SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef70017d6639558d17eb2d41930af0bb307f46a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->