### PR TITLE
Show Team on the website when the account is on a Team workspace.

### DIFF
--- a/apps/web/src/lib/account-plan.test.ts
+++ b/apps/web/src/lib/account-plan.test.ts
@@ -1,7 +1,9 @@
+import { createClient } from "@supabase/supabase-js";
 import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  fetchWorkspacePlan,
   formatAccountPlanDate,
   getAccountPlanCopy,
   getSubscriptionAccessEnd,
@@ -114,4 +116,147 @@ test("paid copy stays supportive when the subscription is not canceling", () => 
       planDetail: "Thanks for supporting Anarlog.",
     },
   );
+});
+
+test("a Team member with the shared Pro entitlement is shown as Team", () => {
+  assert.deepEqual(
+    getAccountPlanCopy({
+      isTrialing: false,
+      isPaid: true,
+      isPro: true,
+      trialDaysRemaining: null,
+      trialEnd: null,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: new Date("2026-09-17T00:00:00.000Z"),
+      workspacePlan: "team",
+    }),
+    {
+      planLabel: "Team",
+      planDetail: "Shared workspace with Pro for every member.",
+    },
+  );
+});
+
+test("Enterprise takes precedence over personal Pro and Team copy", () => {
+  assert.deepEqual(
+    getAccountPlanCopy({
+      isTrialing: true,
+      isPaid: true,
+      isPro: true,
+      trialDaysRemaining: 3,
+      trialEnd: new Date("2026-09-17T00:00:00.000Z"),
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
+      workspacePlan: "enterprise",
+    }),
+    {
+      planLabel: "Enterprise",
+      planDetail: "Organization-wide Team with security and policy controls.",
+    },
+  );
+});
+
+test("a free workspace does not upgrade an individual Pro subscription", () => {
+  assert.deepEqual(
+    getAccountPlanCopy({
+      isTrialing: false,
+      isPaid: true,
+      isPro: true,
+      trialDaysRemaining: null,
+      trialEnd: null,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: new Date("2026-09-17T00:00:00.000Z"),
+      workspacePlan: null,
+    }),
+    {
+      planLabel: "Pro",
+      planDetail: "Thanks for supporting Anarlog.",
+    },
+  );
+});
+
+function workspacePlanFixture(
+  workspaceTiers: string[],
+  failure?: { path: string },
+) {
+  const requests: Array<{ url: URL; init?: RequestInit }> = [];
+  const client = createClient(
+    "https://example.supabase.co",
+    "public-test-key",
+    {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: {
+        fetch: async (input, init) => {
+          const url = new URL(String(input));
+          requests.push({ url, init });
+          assert.equal(
+            new Headers(init?.headers).get("Authorization"),
+            "Bearer account-a-token",
+          );
+          if (failure?.path === url.pathname) {
+            return Response.json(
+              { message: "Plan lookup failed" },
+              { status: 403 },
+            );
+          }
+          if (url.pathname === "/rest/v1/workspaces") {
+            assert.equal(url.searchParams.get("kind"), "eq.shared");
+            assert.equal(url.searchParams.get("select"), "id");
+            return Response.json(
+              workspaceTiers.map((_, index) => ({ id: `workspace-${index}` })),
+            );
+          }
+          assert.equal(url.pathname, "/rest/v1/rpc/get_workspace_access");
+          const { p_workspace_id } = JSON.parse(String(init?.body));
+          const index = Number(p_workspace_id.replace("workspace-", ""));
+          return Response.json([{ workspace_tier: workspaceTiers[index] }]);
+        },
+      },
+    },
+  );
+  return {
+    requests,
+    load: () =>
+      fetchWorkspacePlan({
+        client,
+        accessToken: "account-a-token",
+        signal: new AbortController().signal,
+      }),
+  };
+}
+
+test("workspace plan lookup prefers Enterprise over Team", async () => {
+  for (const tiers of [
+    ["team", "enterprise"],
+    ["enterprise", "team"],
+  ]) {
+    const { load } = workspacePlanFixture(tiers);
+    assert.equal(await load(), "enterprise");
+  }
+});
+
+test("workspace plan lookup returns Team for a paid shared workspace", async () => {
+  const { load } = workspacePlanFixture(["free", "team"]);
+  assert.equal(await load(), "team");
+});
+
+test("an account with no shared workspaces keeps its individual plan", async () => {
+  const { load, requests } = workspacePlanFixture([]);
+  assert.equal(await load(), null);
+  assert.equal(requests.length, 1);
+});
+
+test("failed lookups do not silently mislabel a Team member as Pro", async () => {
+  for (const path of [
+    "/rest/v1/workspaces",
+    "/rest/v1/rpc/get_workspace_access",
+  ]) {
+    const { load } = workspacePlanFixture(["team"], { path });
+    await assert.rejects(load(), { message: "Plan lookup failed" });
+  }
+});
+
+test("an unknown workspace tier cannot silently fall back to Pro", async () => {
+  const { load } = workspacePlanFixture(["unknown"]);
+  await assert.rejects(load(), /Could not verify your plan/);
 });

--- a/apps/web/src/lib/account-plan.ts
+++ b/apps/web/src/lib/account-plan.ts
@@ -1,3 +1,9 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type WorkspacePlan = "team" | "enterprise";
+
+export const accountWorkspacePlanQueryKey = ["account-workspace-plan"] as const;
+
 export function getSubscriptionAccessEnd(subscription: {
   cancel_at?: number | null;
   current_period_end?: number | null;
@@ -28,6 +34,55 @@ export function formatAccountPlanDate(date: Date) {
   });
 }
 
+export async function fetchWorkspacePlan({
+  client,
+  accessToken,
+  signal,
+}: {
+  client: SupabaseClient;
+  accessToken: string;
+  signal: AbortSignal;
+}): Promise<WorkspacePlan | null> {
+  const authorization = `Bearer ${accessToken}`;
+  const workspaces = await client
+    .from("workspaces")
+    .select("id")
+    .eq("kind", "shared")
+    .setHeader("Authorization", authorization)
+    .abortSignal(signal);
+  if (workspaces.error) throw workspaces.error;
+  if (!Array.isArray(workspaces.data)) {
+    throw new Error("Could not verify your plan. Try refreshing it.");
+  }
+
+  const tiers = await Promise.all(
+    workspaces.data.map(async (workspace) => {
+      if (typeof workspace.id !== "string") {
+        throw new Error("Could not verify your plan. Try refreshing it.");
+      }
+      const access = await client
+        .rpc("get_workspace_access", { p_workspace_id: workspace.id })
+        .setHeader("Authorization", authorization)
+        .abortSignal(signal);
+      if (access.error) throw access.error;
+      const row = Array.isArray(access.data) ? access.data[0] : access.data;
+      const tier =
+        row && typeof row === "object" && "workspace_tier" in row
+          ? row.workspace_tier
+          : undefined;
+      if (tier !== "free" && tier !== "team" && tier !== "enterprise") {
+        throw new Error("Could not verify your plan. Try refreshing it.");
+      }
+      return tier;
+    }),
+  );
+  return tiers.includes("enterprise")
+    ? "enterprise"
+    : tiers.includes("team")
+      ? "team"
+      : null;
+}
+
 export function getAccountPlanCopy({
   isTrialing,
   isPaused = false,
@@ -39,6 +94,7 @@ export function getAccountPlanCopy({
   cancelAtPeriodEnd,
   currentPeriodEnd,
   hasYcPerk = false,
+  workspacePlan = null,
 }: {
   isTrialing: boolean;
   isPaused?: boolean;
@@ -50,7 +106,22 @@ export function getAccountPlanCopy({
   cancelAtPeriodEnd: boolean;
   currentPeriodEnd: Date | null;
   hasYcPerk?: boolean;
+  workspacePlan?: WorkspacePlan | null;
 }): { planLabel: string; planDetail: string } {
+  if (workspacePlan === "enterprise") {
+    return {
+      planLabel: "Enterprise",
+      planDetail: "Organization-wide Team with security and policy controls.",
+    };
+  }
+
+  if (workspacePlan === "team") {
+    return {
+      planLabel: "Team",
+      planDetail: "Shared workspace with Pro for every member.",
+    };
+  }
+
   const planLabel = isTrialing
     ? "Pro trial"
     : isPaid

--- a/apps/web/src/routes/_view/app/-account-plan.tsx
+++ b/apps/web/src/routes/_view/app/-account-plan.tsx
@@ -6,8 +6,13 @@ import { cn } from "@anlg/utils";
 
 import { authInputClassName } from "@/components/auth-shell";
 import { getAccountSubscription } from "@/functions/billing";
+import { getSupabaseBrowserClient } from "@/functions/supabase";
 import { applyYcPerk } from "@/functions/yc-perk";
-import { getAccountPlanCopy } from "@/lib/account-plan";
+import {
+  accountWorkspacePlanQueryKey,
+  fetchWorkspacePlan,
+  getAccountPlanCopy,
+} from "@/lib/account-plan";
 import { validateYcPerkApplyValue } from "@/lib/yc-perk";
 
 import { useAccountSession } from "./-account-session";
@@ -33,10 +38,30 @@ export function PlanSection({
 }) {
   const { data, isPending } = useAccountSession();
   const billing = data?.billing;
+  const workspacePlanQuery = useQuery({
+    queryKey: accountWorkspacePlanQueryKey,
+    enabled: typeof window !== "undefined",
+    retry: 1,
+    queryFn: async ({ signal }) => {
+      const supabase = getSupabaseBrowserClient();
+      const { data: sessionData, error } = await supabase.auth.getSession();
+      const session = sessionData.session;
+      if (error || !session) {
+        throw new Error("Sign in again to refresh your plan.");
+      }
+      return fetchWorkspacePlan({
+        client: supabase,
+        accessToken: session.access_token,
+        signal,
+      });
+    },
+  });
   const subscriptionQuery = useQuery({
     queryKey: accountSubscriptionQueryKey,
     enabled:
       typeof window !== "undefined" &&
+      workspacePlanQuery.isSuccess &&
+      workspacePlanQuery.data == null &&
       (billing?.isPaid === true ||
         billing?.isTrialing === true ||
         billing?.isPaused === true),
@@ -53,6 +78,8 @@ export function PlanSection({
       : (billing?.currentPeriodEnd ?? null);
   const hasYcPerk =
     subscriptionQuery.data?.hasYcPerk === true || perk === "applied";
+  const workspacePlan = workspacePlanQuery.data ?? null;
+  const isWorkspacePlan = workspacePlan != null;
 
   const { planLabel, planDetail } = getAccountPlanCopy({
     isTrialing: billing?.isTrialing === true,
@@ -65,13 +92,20 @@ export function PlanSection({
     cancelAtPeriodEnd,
     currentPeriodEnd,
     hasYcPerk,
+    workspacePlan,
   });
 
   const isCheckingPlan =
     isPending ||
-    (billing?.isPaid === true &&
+    workspacePlanQuery.isPending ||
+    (workspacePlanQuery.isSuccess &&
+      workspacePlanQuery.data == null &&
+      billing?.isPaid === true &&
       billing.isTrialing !== true &&
       subscriptionQuery.isPending);
+  const couldNotVerifyPlan =
+    !isCheckingPlan &&
+    (workspacePlanQuery.isError || !workspacePlanQuery.isSuccess);
 
   return (
     <div className={accountCardClassName}>
@@ -79,6 +113,10 @@ export function PlanSection({
         {isCheckingPlan ? (
           <p className="text-sm leading-6 text-[#756b5d]">
             Checking your plan...
+          </p>
+        ) : couldNotVerifyPlan ? (
+          <p className="text-sm leading-6 text-[#756b5d]">
+            Couldn't verify your plan. Refresh to try again.
           </p>
         ) : (
           <>
@@ -93,7 +131,7 @@ export function PlanSection({
                 {planDetail}
               </p>
             </div>
-            {billing?.isPaid || billing?.isTrialing ? (
+            {isWorkspacePlan ? null : billing?.isPaid || billing?.isTrialing ? (
               <Link to="/app/portal/" className={accountPillSecondaryClassName}>
                 Manage billing
               </Link>
@@ -113,7 +151,12 @@ export function PlanSection({
           </>
         )}
       </div>
-      {!isCheckingPlan && !hasYcPerk ? <YcPerkApplyForm perk={perk} /> : null}
+      {!isCheckingPlan &&
+      !couldNotVerifyPlan &&
+      !isWorkspacePlan &&
+      !hasYcPerk ? (
+        <YcPerkApplyForm perk={perk} />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/routes/_view/app/account.tsx
+++ b/apps/web/src/routes/_view/app/account.tsx
@@ -10,6 +10,7 @@ import {
   type IdentityLinkStatus,
 } from "@/functions/identity-link";
 import { getSupabaseBrowserClient } from "@/functions/supabase";
+import { accountWorkspacePlanQueryKey } from "@/lib/account-plan";
 import {
   ACCOUNT_SECTIONS,
   type AccountSectionId,
@@ -176,6 +177,9 @@ function Component() {
       // The refreshed JWT carries the post-checkout billing claims; cached
       // account-session data is stale until it re-reads the session.
       void queryClient.invalidateQueries({ queryKey: accountSessionQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: accountWorkspacePlanQueryKey,
+      });
     };
 
     void syncBillingAnalytics();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Plan labeling now depends on live Supabase workspace access; misconfiguration or RPC errors affect account UI copy and billing CTAs, though failures are surfaced rather than silently defaulting to Pro.
> 
> **Overview**
> The account **Plan** section now resolves **Team** and **Enterprise** from shared workspaces (via Supabase `workspaces` + `get_workspace_access`) before falling back to personal billing, so members with workspace Pro entitlements are not shown as individual **Pro**.
> 
> `fetchWorkspacePlan` and `accountWorkspacePlanQueryKey` drive a new React Query load in `PlanSection`; subscription details load only when no workspace plan applies. **Enterprise** wins over **Team** across workspaces; lookup failures surface “Couldn’t verify your plan” instead of defaulting to Pro. Workspace plans hide **Manage billing** / upgrade CTAs and the YC perk form; post-checkout session refresh also invalidates the workspace plan cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7276ddbbaec10522a5a0c770b5247faf1ce6f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->