### PR TITLE
Let signed-in users request access to shared notes they can't open

### DIFF
--- a/apps/web/src/components/shared-note-access-gate.tsx
+++ b/apps/web/src/components/shared-note-access-gate.tsx
@@ -1,0 +1,190 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  CheckCircle,
+  Clock,
+  LockSimple,
+  SignIn,
+} from "@anlg/ui/components/icons";
+
+import {
+  SharedNoteLoading,
+  SharedNotePrompt,
+  sharedPrimaryButtonClassName,
+  sharedSecondaryButtonClassName,
+} from "@/components/shared-note-viewer";
+import {
+  cancelMySharedNoteAccessRequest,
+  getMySharedNoteAccessRequest,
+  requestSharedNoteAccess,
+} from "@/functions/shared-notes";
+import { getSharedNoteAccessGate } from "@/lib/shared-note-route-state";
+
+const accessRequestQueryKey = (shareId: string) => [
+  "shared-note-access-request",
+  shareId,
+];
+
+export function SharedNoteAccessGate({
+  returnPath,
+  shareId,
+  signedIn,
+}: {
+  returnPath: string;
+  shareId: string;
+  signedIn: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const accessRequestQuery = useQuery({
+    queryKey: accessRequestQueryKey(shareId),
+    queryFn: async () => {
+      const result = await getMySharedNoteAccessRequest({ data: shareId });
+      if (result.status !== "ready") {
+        throw new Error("access request unavailable");
+      }
+      return result.request;
+    },
+    enabled: signedIn,
+    retry: false,
+  });
+  const requestMutation = useMutation({
+    mutationFn: async () => {
+      const result = await requestSharedNoteAccess({
+        data: { shareId, capability: "viewer" },
+      });
+      if (result.status !== "ready") {
+        throw new Error(result.status);
+      }
+      return result.request;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: accessRequestQueryKey(shareId),
+      });
+    },
+  });
+  const cancelMutation = useMutation({
+    mutationFn: async (requestId: string) => {
+      const result = await cancelMySharedNoteAccessRequest({ data: requestId });
+      if (result.status !== "ready") {
+        throw new Error(result.status);
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: accessRequestQueryKey(shareId),
+      });
+    },
+  });
+
+  const request = accessRequestQuery.data ?? null;
+  const gate = getSharedNoteAccessGate({
+    requestStatus: request?.status ?? null,
+    signedIn,
+  });
+
+  if (signedIn && accessRequestQuery.isPending) {
+    return <SharedNoteLoading />;
+  }
+
+  if (gate === "sign-in") {
+    const search = new URLSearchParams({ flow: "web", redirect: returnPath });
+    return (
+      <SharedNotePrompt
+        icon={<SignIn className="size-6" aria-hidden="true" />}
+        title="Sign in to view this note"
+        description="This note is private. Sign in with the account it was shared with, or request access from the note owner after signing in."
+        actions={
+          <a
+            href={`/auth/?${search.toString()}`}
+            className={sharedPrimaryButtonClassName}
+          >
+            Sign in to Anarlog
+          </a>
+        }
+      />
+    );
+  }
+
+  if (gate === "pending" && request) {
+    return (
+      <SharedNotePrompt
+        icon={<Clock className="size-6" aria-hidden="true" />}
+        title="Access requested"
+        description="The note owner can approve or decline your request. You’ll be able to open the note once it’s approved."
+        actions={
+          <>
+            <button
+              type="button"
+              className={sharedSecondaryButtonClassName}
+              disabled={cancelMutation.isPending}
+              onClick={() => cancelMutation.mutate(request.requestId)}
+            >
+              {cancelMutation.isPending ? "Cancelling…" : "Cancel request"}
+            </button>
+            {cancelMutation.isError && (
+              <p className="basis-full text-sm text-red-700" role="status">
+                We couldn’t cancel this request. Please try again.
+              </p>
+            )}
+          </>
+        }
+      />
+    );
+  }
+
+  if (gate === "approved") {
+    return (
+      <SharedNotePrompt
+        icon={<CheckCircle className="size-6" aria-hidden="true" />}
+        title="Access approved"
+        description="Your request was approved. Reload this page to open the note."
+        actions={
+          <button
+            type="button"
+            className={sharedPrimaryButtonClassName}
+            onClick={() => window.location.reload()}
+          >
+            Reload note
+          </button>
+        }
+      />
+    );
+  }
+
+  const requestError =
+    requestMutation.error instanceof Error
+      ? requestMutation.error.message
+      : null;
+
+  return (
+    <SharedNotePrompt
+      icon={<LockSimple className="size-6" aria-hidden="true" />}
+      title="You don’t have access to this note"
+      description={
+        request?.status === "denied"
+          ? "Your previous request was declined. You can send a new request if you still need access."
+          : "Ask the note owner for access. Once they approve your request, the note will open here."
+      }
+      actions={
+        <>
+          <button
+            type="button"
+            className={sharedPrimaryButtonClassName}
+            disabled={requestMutation.isPending}
+            onClick={() => requestMutation.mutate()}
+          >
+            {requestMutation.isPending ? "Requesting…" : "Request access"}
+          </button>
+          {requestError && (
+            <p className="basis-full text-sm text-red-700" role="status">
+              {requestError === "unavailable"
+                ? "Access can’t be requested for this note right now. It may no longer be shared, or you cancelled a request too recently."
+                : "We couldn’t send your request. Please try again."}
+            </p>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -22,7 +22,7 @@ import {
   cancelMySharedNoteAccessRequest,
   getMySharedNoteAccessRequest,
   listSharedNoteManagerAccess,
-  requestSharedNoteCommentAccess,
+  requestSharedNoteAccess,
   reviewSharedNoteAccessRequest,
 } from "@/functions/shared-notes";
 import { formatSharedNoteAccessRequestDescription } from "@/lib/shared-note-collaboration";
@@ -92,7 +92,9 @@ export function SharedNoteCollaboration({
   });
   const requestMutation = useMutation({
     mutationFn: async () => {
-      const result = await requestSharedNoteCommentAccess({ data: shareId });
+      const result = await requestSharedNoteAccess({
+        data: { shareId, capability: "commenter" },
+      });
       if (result.status !== "ready") {
         throw new Error("access request unavailable");
       }
@@ -162,7 +164,7 @@ export function SharedNoteCollaboration({
 
   return (
     <section
-      aria-label="Comment access"
+      aria-label={manageAccess ? "Access requests" : "Comment access"}
       className="surface-subtle border-color-subtle mt-8 rounded-2xl border px-4 py-4 sm:px-5"
     >
       {!signedIn ? (
@@ -353,9 +355,7 @@ function ManagerRequests({
 
   return (
     <div>
-      <h2 className="text-color text-sm font-medium">
-        Comment access requests
-      </h2>
+      <h2 className="text-color text-sm font-medium">Access requests</h2>
       {requests.length > 0 && (
         <ul className="mt-3 space-y-2">
           {requests.map((request) => {

--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -25,7 +25,10 @@ import {
   requestSharedNoteAccess,
   reviewSharedNoteAccessRequest,
 } from "@/functions/shared-notes";
-import { formatSharedNoteAccessRequestDescription } from "@/lib/shared-note-collaboration";
+import {
+  formatSharedNoteAccessRequestDescription,
+  selectSharedNoteCommentAccessRequest,
+} from "@/lib/shared-note-collaboration";
 import type {
   SessionAccessRequestState,
   SessionShareAccessCursor,
@@ -192,7 +195,9 @@ export function SharedNoteCollaboration({
         />
       ) : (
         <AccessRequestPanel
-          request={accessRequestQuery.data ?? null}
+          request={selectSharedNoteCommentAccessRequest(
+            accessRequestQuery.data ?? null,
+          )}
           error={
             accessRequestQuery.isError ||
             requestMutation.isError ||

--- a/apps/web/src/functions/shared-notes.ts
+++ b/apps/web/src/functions/shared-notes.ts
@@ -121,10 +121,17 @@ const invitationActionInputSchema = z
   })
   .strict();
 
+const requestSharedNoteAccessInputSchema = z
+  .object({
+    shareId: shareIdSchema,
+    capability: z.enum(["viewer", "commenter"]),
+  })
+  .strict();
+
 const requestSessionAccessRowSchema = z
   .object({
     request_id: shareIdSchema,
-    requested_capability: z.literal("commenter"),
+    requested_capability: z.enum(["viewer", "commenter"]),
     was_created: z.boolean(),
   })
   .strict();
@@ -177,6 +184,7 @@ type SharedNoteOperationStatus =
 
 type SharedNoteAccessRequestResult =
   | { status: "ready"; request: SessionAccessRequestState | null }
+  | { status: "unavailable" }
   | { status: "error" };
 
 export const readAuthenticatedSharedNote = createServerFn({ method: "GET" })
@@ -336,38 +344,39 @@ export const getMySharedNoteAccessRequest = createServerFn({ method: "GET" })
     },
   );
 
-export const requestSharedNoteCommentAccess = createServerFn({ method: "POST" })
-  .inputValidator(shareIdSchema)
-  .handler(
-    async ({ data: shareId }): Promise<SharedNoteAccessRequestResult> => {
-      setPrivateShareResponseHeaders();
+export const requestSharedNoteAccess = createServerFn({ method: "POST" })
+  .inputValidator(requestSharedNoteAccessInputSchema)
+  .handler(async ({ data }): Promise<SharedNoteAccessRequestResult> => {
+    setPrivateShareResponseHeaders();
 
-      const supabase = getSupabaseServerClient();
-      const { data, error } = await supabase.rpc("request_session_access", {
-        p_share_id: shareId,
-        p_requested_capability: "commenter",
-      });
-      if (error || !Array.isArray(data) || data.length !== 1) {
+    const supabase = getSupabaseServerClient();
+    const { data: rows, error } = await supabase.rpc("request_session_access", {
+      p_share_id: data.shareId,
+      p_requested_capability: data.capability,
+    });
+    if (error) return unavailableOrError(error.code);
+    if (!Array.isArray(rows) || rows.length !== 1) {
+      return { status: "error" };
+    }
+
+    try {
+      const requested = requestSessionAccessRowSchema.parse(rows[0]);
+      const result = await loadMySharedNoteAccessRequest(data.shareId);
+      // An existing pending request is reused as-is, so compare against what
+      // the database returned rather than the capability we asked for.
+      if (
+        result.status !== "ready" ||
+        result.request?.requestId !== requested.request_id ||
+        result.request.requestedCapability !== requested.requested_capability ||
+        result.request.status !== "pending"
+      ) {
         return { status: "error" };
       }
-
-      try {
-        const requested = requestSessionAccessRowSchema.parse(data[0]);
-        const result = await loadMySharedNoteAccessRequest(shareId);
-        if (
-          result.status !== "ready" ||
-          result.request?.requestId !== requested.request_id ||
-          result.request.requestedCapability !== "commenter" ||
-          result.request.status !== "pending"
-        ) {
-          return { status: "error" };
-        }
-        return result;
-      } catch {
-        return { status: "error" };
-      }
-    },
-  );
+      return result;
+    } catch {
+      return { status: "error" };
+    }
+  });
 
 export const cancelMySharedNoteAccessRequest = createServerFn({
   method: "POST",

--- a/apps/web/src/lib/shared-note-collaboration.test.ts
+++ b/apps/web/src/lib/shared-note-collaboration.test.ts
@@ -6,6 +6,7 @@ import {
   formatAuthenticatedSharedNoteAccessLabel,
   formatSharedNoteAccessRequestDescription,
   hasSharedNoteCollaborationAccess,
+  selectSharedNoteCommentAccessRequest,
   MAX_SHARED_NOTE_COMMENT_ANCHOR_CONTEXT_BYTES,
   MAX_SHARED_NOTE_COMMENT_ANCHOR_EXACT_BYTES,
   MAX_SHARED_NOTE_COMMENT_BYTES,
@@ -244,4 +245,31 @@ test("access request descriptions preserve the requested capability", () => {
     formatSharedNoteAccessRequestDescription("editor"),
     "Requested permission to edit",
   );
+});
+
+test("comment panel ignores viewer requests made from the access gate", () => {
+  const base = {
+    requestId: "00000000-0000-4000-8000-000000000001",
+    createdAt: "2026-09-09T09:00:00Z",
+    reviewedAt: "2026-09-09T09:05:00Z",
+  } as const;
+  assert.equal(
+    selectSharedNoteCommentAccessRequest({
+      ...base,
+      requestedCapability: "viewer",
+      status: "approved",
+    }),
+    null,
+  );
+  const commentRequest = {
+    ...base,
+    requestedCapability: "commenter",
+    status: "pending",
+    reviewedAt: null,
+  } as const;
+  assert.equal(
+    selectSharedNoteCommentAccessRequest(commentRequest),
+    commentRequest,
+  );
+  assert.equal(selectSharedNoteCommentAccessRequest(null), null);
 });

--- a/apps/web/src/lib/shared-note-collaboration.ts
+++ b/apps/web/src/lib/shared-note-collaboration.ts
@@ -1,4 +1,5 @@
 import type {
+  SessionAccessRequestState,
   SharedNoteCapability,
   SharedNoteCommentAnchor,
 } from "@/lib/shared-notes";
@@ -93,6 +94,14 @@ export function hasSharedNoteCollaborationAccess(
     | undefined,
 ) {
   return result?.status === "ready";
+}
+
+// The latest request may be a viewer request made from the access gate; the
+// comment panel must not present it as a comment-access outcome.
+export function selectSharedNoteCommentAccessRequest(
+  request: SessionAccessRequestState | null,
+): SessionAccessRequestState | null {
+  return request && request.requestedCapability !== "viewer" ? request : null;
 }
 
 export function formatSharedNoteAccessRequestDescription(

--- a/apps/web/src/lib/shared-note-route-state.test.ts
+++ b/apps/web/src/lib/shared-note-route-state.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getInvitationRouteFailure,
   getLinkSharedNoteRouteGate,
+  getSharedNoteAccessGate,
 } from "./shared-note-route-state.ts";
 
 test("keeps failed invitation acceptance retryable", () => {
@@ -63,5 +64,39 @@ test("authenticated access outranks continuation failures", () => {
       linkSnapshotPending: false,
     }),
     "continuation-error",
+  );
+});
+
+test("signed-out visitors sign in before they can request access", () => {
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: null, signedIn: false }),
+    "sign-in",
+  );
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: "pending", signedIn: false }),
+    "sign-in",
+  );
+});
+
+test("signed-in visitors see their latest access request state", () => {
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: null, signedIn: true }),
+    "request",
+  );
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: "pending", signedIn: true }),
+    "pending",
+  );
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: "approved", signedIn: true }),
+    "approved",
+  );
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: "denied", signedIn: true }),
+    "request",
+  );
+  assert.equal(
+    getSharedNoteAccessGate({ requestStatus: "cancelled", signedIn: true }),
+    "request",
   );
 });

--- a/apps/web/src/lib/shared-note-route-state.ts
+++ b/apps/web/src/lib/shared-note-route-state.ts
@@ -13,6 +13,22 @@ export function getInvitationRouteFailure({
   return acceptanceFailed ? "accept-retry" : null;
 }
 
+export function getSharedNoteAccessGate({
+  requestStatus,
+  signedIn,
+}: {
+  requestStatus: "pending" | "approved" | "denied" | "cancelled" | null;
+  signedIn: boolean;
+}): "sign-in" | "pending" | "approved" | "request" {
+  if (!signedIn) {
+    return "sign-in";
+  }
+  if (requestStatus === "pending" || requestStatus === "approved") {
+    return requestStatus;
+  }
+  return "request";
+}
+
 export function getLinkSharedNoteRouteGate({
   authenticatedNotePending,
   continuationFailed,

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback } from "react";
 
+import { SharedNoteAccessGate } from "@/components/shared-note-access-gate";
 import {
   AccountSharedNoteActions,
   StableSharedNoteActions,
@@ -102,6 +103,7 @@ export const Route = createFileRoute("/share/$shareId")({
 
 function Component() {
   const { authenticatedResult, preview, stableResult } = Route.useLoaderData();
+  const { shareId } = Route.useParams();
   const { user } = Route.useRouteContext();
   const { scheme } = Route.useSearch();
   const authenticatedNote =
@@ -136,7 +138,20 @@ function Component() {
     return <SharedNoteTransientError />;
   }
   if (!snapshot) {
-    return <SharedNoteUnavailable />;
+    const validShareId = shareIdSchema.safeParse(shareId);
+    if (!validShareId.success) {
+      return <SharedNoteUnavailable />;
+    }
+    return (
+      <SharedNoteAccessGate
+        returnPath={buildSharedNoteWebPath(
+          `/share/${encodeURIComponent(validShareId.data)}/`,
+          scheme,
+        )}
+        shareId={validShareId.data}
+        signedIn={user !== null}
+      />
+    );
   }
 
   const returnPath = buildSharedNoteWebPath(

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -3,6 +3,7 @@ import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { useShareRouteContinuation } from "@/components/share-route-continuation";
+import { SharedNoteAccessGate } from "@/components/shared-note-access-gate";
 import { LinkSharedNoteActions } from "@/components/shared-note-actions";
 import { SharedNoteChatPanel } from "@/components/shared-note-chat-panel";
 import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
@@ -206,10 +207,16 @@ export function LinkSharedNoteClient({
   const linkSnapshot =
     snapshotQuery.data?.status === "ready" ? snapshotQuery.data.snapshot : null;
   const snapshot = authenticatedNote?.snapshot ?? linkSnapshot;
-  if (!snapshot) {
-    return <SharedNoteUnavailable />;
-  }
   const returnPath = buildSharedNoteWebPath(pathname, scheme);
+  if (!snapshot) {
+    return (
+      <SharedNoteAccessGate
+        returnPath={returnPath}
+        shareId={validShareId.data}
+        signedIn={currentUserId !== null}
+      />
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
When a shared note is unavailable, the web viewer showed a dead-end
"isn't available" card. Now signed-out visitors on link/short-link routes
get a sign-in prompt that returns them to the note, and signed-in users
without a grant can request viewer access, see the pending state, and
cancel it.

- Add SharedNoteAccessGate and wire it into /share/$shareId and
  /share/link/$shareId (also used by /t/$linkId)
- Generalize requestSharedNoteCommentAccess into requestSharedNoteAccess
  with a viewer|commenter capability and surface the DB's "unavailable"
  outcome
- Rename the manager panel header to "Access requests" since viewer
  requests now appear there
- Add getSharedNoteAccessGate route-state helper with tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends shared-note authorization and access-request RPC behavior across primary share entry routes; mistakes could block legitimate viewers or mis-route request state.
> 
> **Overview**
> Replaces the dead-end **“isn’t available”** state on share routes with an **access gate** when the note snapshot can’t be loaded but the share ID is valid.
> 
> **SharedNoteAccessGate** guides visitors through sign-in (with return URL), **request viewer access**, pending/cancel, and reload after approval. It’s wired into **`/share/$shareId`** and **`/share/link/$shareId`** instead of **`SharedNoteUnavailable`**.
> 
> Access requests are unified: **`requestSharedNoteCommentAccess`** becomes **`requestSharedNoteAccess`** with **`viewer` | `commenter`**, including DB **`unavailable`** handling and reuse of an existing pending request. The comment collaboration panel filters out viewer-only requests via **`selectSharedNoteCommentAccessRequest`**, and the manager UI is labeled **“Access requests”** so viewer requests show up there. **`getSharedNoteAccessGate`** centralizes gate state with tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf002107deab708411d0f3a205aac229897a92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->