### PR TITLE
Allow brand logos to be filled icons in tests

### DIFF
--- a/apps/desktop/src/shared/icons.test.tsx
+++ b/apps/desktop/src/shared/icons.test.tsx
@@ -3,8 +3,13 @@ import { describe, expect, it } from "vitest";
 
 import * as icons from "@anlg/ui/components/icons";
 
+const brandIconNames = new Set(["DiscordLogo", "GithubLogo", "XLogo"]);
+const outlineIcons = Object.entries(icons).filter(
+  ([name]) => !brandIconNames.has(name),
+);
+
 describe("outline icons", () => {
-  it.each(Object.entries(icons))(
+  it.each(outlineIcons)(
     "renders %s without filled shapes at every supported weight",
     (_, Icon) => {
       for (const weight of ["thin", "light", "regular", "bold"] as const) {
@@ -27,5 +32,19 @@ describe("outline icons", () => {
     );
 
     expect(container.querySelector("svg")?.getAttribute("fill")).toBe("none");
+  });
+});
+
+describe("brand icons", () => {
+  it.each([
+    ["DiscordLogo", icons.DiscordLogo],
+    ["GithubLogo", icons.GithubLogo],
+    ["XLogo", icons.XLogo],
+  ] as const)("renders %s as a filled brand logo", (_, Icon) => {
+    const { container } = render(<Icon size={16} />);
+    const svg = container.querySelector("svg");
+
+    expect(svg?.getAttribute("fill")).toBe("currentColor");
+    expect(svg?.querySelector("path")).not.toBeNull();
   });
 });


### PR DESCRIPTION
The outline-icon test was asserting that every exported icon renders
without fill and with a currentColor stroke. Brand logos (Discord,
GitHub, X) are intentionally filled shapes, so they now have their own
assertions. This fixes the desktop test failures blocking Nightly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Updates desktop icon tests so **outline** and **brand** icons are validated separately instead of one rule for every export.
> 
> The existing parameterized test now runs only on non-brand icons (`DiscordLogo`, `GithubLogo`, `XLogo` are filtered out), still checking `fill="none"`, no filled child shapes, and `currentColor` stroke across weights. A new **brand icons** block asserts those three logos render with `fill="currentColor"` and include a `path`, matching filled `createBrandIcon` behavior and unblocking Nightly failures from the old “all icons must be outline” assumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342bc6e8d80f7f8514eb0d4460da9cab079c0812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->