### PR TITLE
fix(blog): format featured flag per dprint yaml rules

### DIFF
--- a/apps/web/content/articles/is-ai-notetaking-legal.mdx
+++ b/apps/web/content/articles/is-ai-notetaking-legal.mdx
@@ -3,7 +3,7 @@ meta_title: "Is AI note-taking legal? Everything You Need to Know"
 meta_description: "AI note-taking is legal, but selecting the wrong tool or missing compliance requirements can expose you to privacy and compliance risks. Learn more."
 author:
   - "John Jeong"
-featured: false
+featured: !!bool "false"
 category: "Guides"
 date: "2025-08-26"
 ---


### PR DESCRIPTION
Pre-existing dprint pretty_yaml formatting debt in `is-ai-notetaking-legal.mdx` frontmatter surfaced by the fmt check after PR #7170 merged (the file was part of that diff, and dprint validates changed files in full, not just the touched lines).

Only change: `featured: false` -> `featured: !!bool "false"` to match the repo's dprint config. No prose/copy changed, no llms.txt touched.

Fixes the currently-failing `fmt` check on `main` at 9785ac0ec9, and prevents the same false failure from blocking the still-queued Anarlog blog publish chain (#7172, #7171) when they touch this same hub file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter formatting only; no runtime, content, or behavioral changes.
> 
> **Overview**
> Updates the `is-ai-notetaking-legal.mdx` frontmatter so **`featured`** uses dprint’s YAML style: `featured: !!bool "false"` instead of `featured: false`.
> 
> **No article body or metadata meaning changes**—this only clears the **`fmt`** failure on that file so later blog PRs that touch the same hub article aren’t blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097318fe8b83b01ebac8992b9a4e202fae3b9cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->