### PR TITLE
feat(db-app): park records a build cannot apply instead of failing sync

### DIFF
--- a/crates/db-app/migrations/20260909130000_e2ee_parked_records.sql
+++ b/crates/db-app/migrations/20260909130000_e2ee_parked_records.sql
@@ -1,0 +1,15 @@
+-- Encrypted records this build cannot apply yet (a table or column only a newer
+-- client knows, or a record above the apply size limit) wait here instead of
+-- failing the whole sync round. Startup requeues them so an upgraded build
+-- gets another chance to apply them.
+CREATE TABLE IF NOT EXISTS e2ee_parked_records (
+  record_id    TEXT PRIMARY KEY NOT NULL,
+  workspace_id TEXT NOT NULL DEFAULT '',
+  reason       TEXT NOT NULL DEFAULT '',
+  table_name   TEXT NOT NULL DEFAULT '',
+  field_name   TEXT NOT NULL DEFAULT '',
+  created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_e2ee_parked_records_workspace
+ON e2ee_parked_records(workspace_id, record_id);

--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -101,6 +101,7 @@ pub struct E2eeReplicaStats {
     pub skipped_local_changes: u64,
     pub rejected_rollbacks: u64,
     pub rejected_unwitnessed: u64,
+    pub parked_records: u64,
     pub remaining_replica_changes: bool,
 }
 
@@ -129,6 +130,7 @@ struct EncryptedRecord {
 #[derive(sqlx::FromRow)]
 struct EncryptedRecordMetadata {
     id: String,
+    workspace_id: String,
     generation: i64,
     record_bytes: i64,
     witnessed: bool,
@@ -203,6 +205,10 @@ use replica_encrypt::{
 #[cfg(test)]
 use replica_storage::load_or_create_writer_id;
 use replica_storage::reconcile_e2ee_witness_pending;
+pub use replica_storage::{
+    E2eeParkReason, E2eeParkedRecordSummary, parked_e2ee_record_summary,
+    requeue_parked_e2ee_records,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/db-app/src/e2ee/replica_apply.rs
+++ b/crates/db-app/src/e2ee/replica_apply.rs
@@ -9,9 +9,8 @@ use super::cooperative::yield_once;
 use super::replica_storage::{
     E2eeParkReason, ParkedRecord, clear_stale_apply_guards, delete_row, insert_apply_guard,
     insert_row, load_row_local_states, normalize_replica_payload_hashes, park_records, read_field,
-    record_version_order, remove_apply_guard, replica_records_still_current,
-    restore_local_payload, row_changed_since_snapshot, row_exists, table_columns, update_field,
-    upsert_local_state,
+    record_version_order, remove_apply_guard, replica_records_still_current, restore_local_payload,
+    row_changed_since_snapshot, row_exists, table_columns, update_field, upsert_local_state,
 };
 use super::witness::repair_e2ee_replica_from_witness_bounded_cancellable;
 use super::{

--- a/crates/db-app/src/e2ee/replica_apply.rs
+++ b/crates/db-app/src/e2ee/replica_apply.rs
@@ -7,10 +7,11 @@ use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
 
 use super::cooperative::yield_once;
 use super::replica_storage::{
-    clear_stale_apply_guards, delete_row, insert_apply_guard, insert_row, load_row_local_states,
-    normalize_replica_payload_hashes, read_field, record_version_order, remove_apply_guard,
-    replica_records_still_current, restore_local_payload, row_changed_since_snapshot, row_exists,
-    table_columns, update_field, upsert_local_state,
+    E2eeParkReason, ParkedRecord, clear_stale_apply_guards, delete_row, insert_apply_guard,
+    insert_row, load_row_local_states, normalize_replica_payload_hashes, park_records, read_field,
+    record_version_order, remove_apply_guard, replica_records_still_current,
+    restore_local_payload, row_changed_since_snapshot, row_exists, table_columns, update_field,
+    upsert_local_state,
 };
 use super::witness::repair_e2ee_replica_from_witness_bounded_cancellable;
 use super::{
@@ -171,6 +172,7 @@ pub(super) async fn load_changed_e2ee_record_metadata(
          )
          SELECT
            page.id,
+           page.workspace_id,
            page.generation,
            COALESCE(
              LENGTH(CAST(replica.id AS BLOB))
@@ -258,7 +260,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
     check_e2ee_apply_cancellation(is_cancelled)?;
     normalize_replica_payload_hashes(pool, keys, is_cancelled).await?;
     check_e2ee_apply_cancellation(is_cancelled)?;
-    let mut groups = BTreeMap::<(String, String, String), BTreeSet<String>>::new();
+    let mut groups = BTreeSet::<(String, String, String)>::new();
     let mut group_pending = BTreeMap::<(String, String, String), Vec<(String, i64)>>::new();
     let mut stats = E2eeReplicaStats::default();
     let metadata = load_changed_e2ee_record_metadata(pool, keys).await?;
@@ -266,6 +268,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
     let mut selected_ids = Vec::new();
     let mut selected_generations = HashMap::new();
     let mut reconciled = Vec::new();
+    let mut parked = Vec::new();
     let mut selected_bytes = 0_usize;
     for record in &metadata {
         check_e2ee_apply_cancellation(is_cancelled)?;
@@ -279,7 +282,15 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
         let record_bytes =
             usize::try_from(record.record_bytes).map_err(|_| E2eeReplicaError::InvalidRow)?;
         if record_bytes > max_bytes {
-            return Err(E2eeReplicaError::ReplicaApplyTooLarge);
+            parked.push(ParkedRecord {
+                record_id: record.id.clone(),
+                workspace_id: record.workspace_id.clone(),
+                generation: record.generation,
+                reason: E2eeParkReason::TooLarge,
+                table_name: String::new(),
+                field_name: String::new(),
+            });
+            continue;
         }
         if !selected_ids.is_empty() && selected_bytes.saturating_add(record_bytes) > max_bytes {
             stats.remaining_replica_changes = true;
@@ -291,6 +302,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
     }
     delete_reconciled_replica_entries(pool, &reconciled, is_cancelled).await?;
 
+    let mut column_cache = HashMap::<String, HashSet<String>>::new();
     if !selected_ids.is_empty() {
         check_e2ee_apply_cancellation(is_cancelled)?;
         let records = load_encrypted_records_by_id(pool, &selected_ids).await?;
@@ -307,20 +319,48 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
             }
             let field = key.open_field(&record.workspace_id, &record.id, &record.payload)?;
             check_e2ee_apply_cancellation(is_cancelled)?;
-            if !E2EE_DOMAIN_TABLES.contains(&field.table.as_str()) {
-                return Err(E2eeReplicaError::InvalidField);
+            // A newer client may sync tables or columns this build does not
+            // have yet. Park those records instead of failing the round; the
+            // rest of the row still applies.
+            let park_reason = if !E2EE_DOMAIN_TABLES.contains(&field.table.as_str()) {
+                Some(E2eeParkReason::UnknownTable)
+            } else if field.field == ROW_MANIFEST_FIELD {
+                None
+            } else {
+                if !column_cache.contains_key(&field.table) {
+                    check_e2ee_apply_cancellation(is_cancelled)?;
+                    let columns = table_columns(pool, &field.table).await?;
+                    check_e2ee_apply_cancellation(is_cancelled)?;
+                    column_cache.insert(field.table.clone(), columns);
+                }
+                let columns = &column_cache[&field.table];
+                (field.field == "id"
+                    || field.field == "workspace_id"
+                    || !columns.contains(&field.field))
+                .then_some(E2eeParkReason::UnknownField)
+            };
+            if let Some(reason) = park_reason {
+                parked.push(ParkedRecord {
+                    record_id: record.id.clone(),
+                    workspace_id: record.workspace_id.clone(),
+                    generation: selected_generations[&record.id],
+                    reason,
+                    table_name: field.table,
+                    field_name: field.field,
+                });
+                continue;
             }
             let group = (record.workspace_id, field.table, field.row_id);
             group_pending
                 .entry(group.clone())
                 .or_default()
                 .push((record.id.clone(), selected_generations[&record.id]));
-            groups.entry(group).or_default().insert(field.field);
+            groups.insert(group);
         }
         delete_reconciled_replica_entries(pool, &reconciled, is_cancelled).await?;
     }
+    stats.parked_records += park_replica_records(pool, &parked, is_cancelled).await?;
 
-    let mut column_cache = HashMap::<String, HashSet<String>>::new();
     let mut attempted_bytes = 0_usize;
     macro_rules! rollback_if_cancelled {
         ($transaction:ident, $is_cancelled:expr) => {
@@ -329,7 +369,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
             }
         };
     }
-    for (attempted_rows, (group, changed_fields)) in groups.into_iter().enumerate() {
+    for (attempted_rows, group) in groups.into_iter().enumerate() {
         if attempted_rows >= max_rows {
             stats.remaining_replica_changes = true;
             break;
@@ -354,15 +394,9 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
                 columns
             }
         };
-        if changed_fields.iter().any(|field| {
-            field != ROW_MANIFEST_FIELD
-                && (field == "id" || field == "workspace_id" || !columns.contains(field))
-        }) {
-            return Err(E2eeReplicaError::InvalidField);
-        }
 
         check_e2ee_apply_cancellation(is_cancelled)?;
-        let encrypted_records = load_encrypted_row_group(
+        let Some(encrypted_records) = load_encrypted_row_group(
             pool,
             keyring,
             (&workspace_id, &table, &row_id),
@@ -370,7 +404,12 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
             max_bytes,
             is_cancelled,
         )
-        .await?;
+        .await?
+        else {
+            stats.parked_records +=
+                park_oversized_row(pool, &workspace_id, &table, &pending, is_cancelled).await?;
+            continue;
+        };
         check_e2ee_apply_cancellation(is_cancelled)?;
         let row_bytes = encrypted_records
             .iter()
@@ -383,7 +422,9 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
                     .ok_or(E2eeReplicaError::InvalidRow)
             })?;
         if row_bytes > max_bytes {
-            return Err(E2eeReplicaError::ReplicaApplyTooLarge);
+            stats.parked_records +=
+                park_oversized_row(pool, &workspace_id, &table, &pending, is_cancelled).await?;
+            continue;
         }
         if attempted_rows > 0 && attempted_bytes.saturating_add(row_bytes) > max_bytes {
             stats.remaining_replica_changes = true;
@@ -761,7 +802,7 @@ async fn load_encrypted_row_group(
     columns: &HashSet<String>,
     max_bytes: usize,
     is_cancelled: &(impl Fn() -> bool + Sync),
-) -> E2eeReplicaResult<Vec<EncryptedRecord>> {
+) -> E2eeReplicaResult<Option<Vec<EncryptedRecord>>> {
     let (workspace_id, table, row_id) = row;
     let mut record_ids = keyring
         .generations()
@@ -783,6 +824,7 @@ async fn load_encrypted_row_group(
     let mut query = QueryBuilder::<Sqlite>::new(
         "SELECT
            replica.id,
+           replica.workspace_id,
            0 AS generation,
            LENGTH(CAST(replica.id AS BLOB))
              + LENGTH(CAST(replica.workspace_id AS BLOB))
@@ -819,13 +861,57 @@ async fn load_encrypted_row_group(
             .ok_or(E2eeReplicaError::InvalidRow)
     })?;
     if row_bytes > max_bytes {
-        return Err(E2eeReplicaError::ReplicaApplyTooLarge);
+        return Ok(None);
     }
     check_e2ee_apply_cancellation(is_cancelled)?;
     let records = load_encrypted_records_by_id(pool, &record_ids).await?;
     check_e2ee_apply_cancellation(is_cancelled)?;
-    Ok(records
-        .into_iter()
-        .filter(|record| record.workspace_id == workspace_id)
-        .collect())
+    Ok(Some(
+        records
+            .into_iter()
+            .filter(|record| record.workspace_id == workspace_id)
+            .collect(),
+    ))
+}
+
+async fn park_replica_records(
+    pool: &SqlitePool,
+    records: &[ParkedRecord],
+    is_cancelled: &(impl Fn() -> bool + Sync),
+) -> E2eeReplicaResult<u64> {
+    if records.is_empty() {
+        return Ok(0);
+    }
+    check_e2ee_apply_cancellation(is_cancelled)?;
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    if let Err(error) = check_e2ee_apply_cancellation(is_cancelled) {
+        transaction.rollback().await?;
+        return Err(error);
+    }
+    park_records(&mut transaction, records).await?;
+    commit_e2ee_apply_transaction(transaction, is_cancelled).await?;
+    Ok(records.len() as u64)
+}
+
+// A row whose ciphertext exceeds the apply budget waits as a unit so a partial
+// row never lands; startup requeues it once a build can take it.
+async fn park_oversized_row(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    table: &str,
+    pending: &[(String, i64)],
+    is_cancelled: &(impl Fn() -> bool + Sync),
+) -> E2eeReplicaResult<u64> {
+    let records = pending
+        .iter()
+        .map(|(record_id, generation)| ParkedRecord {
+            record_id: record_id.clone(),
+            workspace_id: workspace_id.to_string(),
+            generation: *generation,
+            reason: E2eeParkReason::TooLarge,
+            table_name: table.to_string(),
+            field_name: String::new(),
+        })
+        .collect::<Vec<_>>();
+    park_replica_records(pool, &records, is_cancelled).await
 }

--- a/crates/db-app/src/e2ee/replica_storage.rs
+++ b/crates/db-app/src/e2ee/replica_storage.rs
@@ -425,6 +425,114 @@ pub(super) async fn load_or_create_writer_id(
     Ok(writer_id)
 }
 
+/// Why a received record is waiting for a more capable build instead of
+/// blocking the sync round.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum E2eeParkReason {
+    UnknownTable,
+    UnknownField,
+    TooLarge,
+}
+
+impl E2eeParkReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UnknownTable => "unknown_table",
+            Self::UnknownField => "unknown_field",
+            Self::TooLarge => "too_large",
+        }
+    }
+}
+
+pub(super) struct ParkedRecord {
+    pub record_id: String,
+    pub workspace_id: String,
+    pub generation: i64,
+    pub reason: E2eeParkReason,
+    pub table_name: String,
+    pub field_name: String,
+}
+
+pub(super) async fn park_records(
+    transaction: &mut Transaction<'_, Sqlite>,
+    records: &[ParkedRecord],
+) -> E2eeReplicaResult<()> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "INSERT INTO e2ee_parked_records (record_id, workspace_id, reason, table_name, field_name) ",
+    );
+    query.push_values(records, |mut row, record| {
+        row.push_bind(&record.record_id)
+            .push_bind(&record.workspace_id)
+            .push_bind(record.reason.as_str())
+            .push_bind(&record.table_name)
+            .push_bind(&record.field_name);
+    });
+    query.push(
+        " ON CONFLICT(record_id) DO UPDATE SET
+           workspace_id = excluded.workspace_id,
+           reason = excluded.reason,
+           table_name = excluded.table_name,
+           field_name = excluded.field_name",
+    );
+    query.build().execute(&mut **transaction).await?;
+
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "DELETE FROM e2ee_replica_pending WHERE (record_id, generation) IN (",
+    );
+    query.push_values(records, |mut row, record| {
+        row.push_bind(&record.record_id)
+            .push_bind(record.generation);
+    });
+    query.push(")").build().execute(&mut **transaction).await?;
+    Ok(())
+}
+
+/// Moves every parked record back into the apply queue. Runs at startup, after
+/// migrations, so a build that gained a table, a column, or a larger limit
+/// retries what an older build had to skip.
+pub async fn requeue_parked_e2ee_records(pool: &SqlitePool) -> sqlx::Result<u64> {
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let requeued = sqlx::query(
+        "INSERT INTO e2ee_replica_pending (record_id, workspace_id)
+         SELECT record_id, workspace_id FROM e2ee_parked_records
+         WHERE true
+         ON CONFLICT(record_id) DO UPDATE SET
+           workspace_id = excluded.workspace_id,
+           generation = e2ee_replica_pending.generation + 1",
+    )
+    .execute(&mut *transaction)
+    .await?
+    .rows_affected();
+    sqlx::query("DELETE FROM e2ee_parked_records")
+        .execute(&mut *transaction)
+        .await?;
+    transaction.commit().await?;
+    Ok(requeued)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, sqlx::FromRow)]
+pub struct E2eeParkedRecordSummary {
+    pub reason: String,
+    pub table_name: String,
+    pub count: i64,
+}
+
+pub async fn parked_e2ee_record_summary(
+    pool: &SqlitePool,
+) -> sqlx::Result<Vec<E2eeParkedRecordSummary>> {
+    sqlx::query_as(
+        "SELECT reason, table_name, COUNT(*) AS count
+         FROM e2ee_parked_records
+         GROUP BY reason, table_name
+         ORDER BY reason, table_name",
+    )
+    .fetch_all(pool)
+    .await
+}
+
 pub(super) fn record_version_order(
     state: &LocalState,
     record: &DecryptedRecord,

--- a/crates/db-app/src/e2ee/tests/replica_apply.rs
+++ b/crates/db-app/src/e2ee/tests/replica_apply.rs
@@ -988,3 +988,226 @@ async fn replica_apply_scan_bounds_payload_comparisons_before_filtering() {
     assert_eq!(changed[0].id, "record-255");
     assert!(changed[0].changed);
 }
+
+async fn seeded_target_with_session() -> (
+    anlg_db_core::Db,
+    HashMap<String, anlg_e2ee::WorkspaceKeyring>,
+) {
+    let workspace_keys = keys("workspace-a");
+    let source = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-a', 'user-a', 'Ready')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+    encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    let target = test_db().await;
+    copy_replica(source.pool(), target.pool()).await;
+    (target, workspace_keys)
+}
+
+async fn parked_record(pool: &SqlitePool, record_id: &str) -> Option<(String, String, String)> {
+    sqlx::query_as(
+        "SELECT reason, table_name, field_name FROM e2ee_parked_records WHERE record_id = ?",
+    )
+    .bind(record_id)
+    .fetch_optional(pool)
+    .await
+    .unwrap()
+}
+
+async fn pending_count(pool: &SqlitePool, record_id: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM e2ee_replica_pending WHERE record_id = ?")
+        .bind(record_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn records_for_unknown_tables_are_parked_and_requeued_at_startup() {
+    let (target, workspace_keys) = seeded_target_with_session().await;
+    let key = &workspace_keys["workspace-a"];
+    let future = key
+        .seal_field(
+            "workspace-a",
+            "templates",
+            "template-1",
+            "title",
+            "ffffffffffffffffffffffffffffffff",
+            1,
+            false,
+            json!("Inbox"),
+        )
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO e2ee_records (id, workspace_id, payload) VALUES (?, 'workspace-a', ?)",
+    )
+    .bind(&future.record_id)
+    .bind(&future.payload)
+    .execute(target.pool())
+    .await
+    .unwrap();
+
+    let stats = apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.parked_records, 1);
+    assert!(!stats.remaining_replica_changes);
+    let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+        .fetch_one(target.pool())
+        .await
+        .unwrap();
+    assert_eq!(title, "Ready");
+    assert_eq!(
+        parked_record(target.pool(), &future.record_id).await,
+        Some((
+            "unknown_table".to_string(),
+            "templates".to_string(),
+            "title".to_string()
+        ))
+    );
+    assert_eq!(pending_count(target.pool(), &future.record_id).await, 0);
+
+    let stats = apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(stats, E2eeReplicaStats::default());
+
+    assert_eq!(requeue_parked_e2ee_records(target.pool()).await.unwrap(), 1);
+    assert_eq!(parked_record(target.pool(), &future.record_id).await, None);
+    assert_eq!(pending_count(target.pool(), &future.record_id).await, 1);
+
+    let stats = apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(stats.parked_records, 1);
+    assert_eq!(
+        parked_e2ee_record_summary(target.pool()).await.unwrap(),
+        vec![E2eeParkedRecordSummary {
+            reason: "unknown_table".to_string(),
+            table_name: "templates".to_string(),
+            count: 1,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn records_for_unknown_columns_are_parked_while_the_row_still_applies() {
+    let (target, workspace_keys) = seeded_target_with_session().await;
+    let key = &workspace_keys["workspace-a"];
+    let future = key
+        .seal_field(
+            "workspace-a",
+            "sessions",
+            "session-1",
+            "future_column",
+            "ffffffffffffffffffffffffffffffff",
+            5,
+            false,
+            json!("later"),
+        )
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO e2ee_records (id, workspace_id, payload) VALUES (?, 'workspace-a', ?)",
+    )
+    .bind(&future.record_id)
+    .bind(&future.payload)
+    .execute(target.pool())
+    .await
+    .unwrap();
+
+    let stats = apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.parked_records, 1);
+    let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+        .fetch_one(target.pool())
+        .await
+        .unwrap();
+    assert_eq!(title, "Ready");
+    assert_eq!(
+        parked_record(target.pool(), &future.record_id).await,
+        Some((
+            "unknown_field".to_string(),
+            "sessions".to_string(),
+            "future_column".to_string()
+        ))
+    );
+}
+
+#[tokio::test]
+async fn oversized_rows_are_parked_instead_of_failing_the_round() {
+    let workspace_keys = keys("workspace-a");
+    let source = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-big', 'workspace-a', 'user-a', ?),
+                ('session-small', 'workspace-a', 'user-a', 'Small')",
+    )
+    .bind("x".repeat(60_000))
+    .execute(source.pool())
+    .await
+    .unwrap();
+    encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    let target = test_db().await;
+    copy_replica(source.pool(), target.pool()).await;
+    let big_title_id =
+        workspace_keys["workspace-a"].blind_field_id("sessions", "session-big", "title");
+
+    let mut parked_records = 0;
+    for _ in 0..8 {
+        let stats = apply_e2ee_replica_changes_inner(
+            target.pool(),
+            &workspace_keys,
+            false,
+            E2EE_APPLY_ROW_LIMIT,
+            20_000,
+            &|| false,
+        )
+        .await
+        .unwrap();
+        parked_records += stats.parked_records;
+        if !stats.remaining_replica_changes {
+            break;
+        }
+    }
+
+    assert!(parked_records >= 1);
+    let small: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-small'")
+        .fetch_one(target.pool())
+        .await
+        .unwrap();
+    assert_eq!(small, "Small");
+    let big_present: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM sessions WHERE id = 'session-big')")
+            .fetch_one(target.pool())
+            .await
+            .unwrap();
+    assert!(!big_present);
+    let (reason, _, _) = parked_record(target.pool(), &big_title_id)
+        .await
+        .expect("oversized title record is parked");
+    assert_eq!(reason, "too_large");
+
+    // A build with a larger budget applies the row after startup requeues it.
+    assert!(requeue_parked_e2ee_records(target.pool()).await.unwrap() >= 1);
+    let stats = apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(stats.parked_records, 0);
+    let big_length: i64 =
+        sqlx::query_scalar("SELECT LENGTH(title) FROM sessions WHERE id = 'session-big'")
+            .fetch_one(target.pool())
+            .await
+            .unwrap();
+    assert_eq!(big_length, 60_000);
+}

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -484,6 +484,11 @@ pub const APP_MIGRATION_STEPS: &[anlg_db_migrate::MigrationStep] = &[
         },
         sql: include_str!("../migrations/20260907120800_sessions_local_restoration.sql"),
     },
+    anlg_db_migrate::MigrationStep {
+        id: "20260909130000_e2ee_parked_records",
+        scope: anlg_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260909130000_e2ee_parked_records.sql"),
+    },
 ];
 
 pub fn schema() -> anlg_db_migrate::DbSchema {
@@ -577,6 +582,8 @@ pub async fn prepare_schema_with_progress(
     apply_net_zero_e2ee_payload_hash_alters(db, &mut on_migration_progress).await?;
     anlg_db_migrate::migrate_with_progress(db, schema(), on_migration_progress).await?;
     repair_missing_core_tables(db.pool(), templates_missing_before_migration).await?;
+    // A build that just migrated may now understand records an older build parked.
+    requeue_parked_e2ee_records(db.pool()).await?;
     backfill_session_share_activation(db.pool()).await?;
     ensure_cloudsync_workspace_binding(db.pool()).await?;
     Ok(())

--- a/crates/db-app/src/schema_tests/migrations.rs
+++ b/crates/db-app/src/schema_tests/migrations.rs
@@ -99,6 +99,7 @@ async fn migrations_apply_cleanly() {
             "e2ee_dirty_rows",
             "e2ee_local_device",
             "e2ee_local_state",
+            "e2ee_parked_records",
             "e2ee_records",
             "e2ee_replica_payload_hashes",
             "e2ee_replica_pending",

--- a/crates/db-sync/src/e2ee_sync.rs
+++ b/crates/db-sync/src/e2ee_sync.rs
@@ -48,6 +48,15 @@ pub enum ReplicaSyncOutcome {
     Paused,
 }
 
+fn warn_parked_records(stats: &anlg_db_app::E2eeReplicaStats) {
+    if stats.parked_records > 0 {
+        tracing::warn!(
+            parked_records = stats.parked_records,
+            "parked encrypted records this build cannot apply yet; they retry after an update"
+        );
+    }
+}
+
 fn ordered_witness_workspace_ids(
     keys: &HashMap<String, anlg_e2ee::WorkspaceKeyring>,
     witnesses: &HashMap<String, E2eeWitnessClient>,
@@ -515,6 +524,7 @@ impl E2eeSyncHook {
                 std::io::Error::other(format!("E2EE replica application failed: {error}"))
             })?;
             cancellation.check()?;
+            warn_parked_records(&stats);
             if stats.remaining_replica_changes {
                 self.request_reconciliation();
             }
@@ -710,11 +720,13 @@ impl anlg_db_core::CloudsyncSyncHook for E2eeSyncHook {
                 } else {
                     anlg_db_app::E2eeReplicaStats::default()
                 };
+                warn_parked_records(&stats);
                 tracing::debug!(
                     applied_fields = stats.applied_fields,
                     skipped_local_changes = stats.skipped_local_changes,
                     rejected_rollbacks = stats.rejected_rollbacks,
                     rejected_unwitnessed = stats.rejected_unwitnessed,
+                    parked_records = stats.parked_records,
                     snapshot_complete,
                     "applied encrypted CloudSync replica"
                 );


### PR DESCRIPTION
A record for a table or column only a newer client knows, or a record above the apply size budget, used to fail the whole apply round with `InvalidField` or `ReplicaApplyTooLarge`. One such record stalled every other change on the device until the app was updated, and every later schema addition would have hit the same wall on un-updated clients.

- Add `e2ee_parked_records`. Unknown tables and columns are parked per record while the rest of the row still applies; an oversized row is parked as a unit so a partial row never lands.
- Startup requeues parked records after migrations so an upgraded build retries them.
- Sync logs a warning with the parked count and exposes a per-reason summary for status surfaces.

This is the base of the sync stack and should ship in a release before the branches that add synced tables, since clients without it stall on unknown tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core E2EE replica apply and pending-queue semantics; incorrect parking or requeue could delay or mishandle encrypted sync until an app update, though the design avoids partial-row application.
> 
> **Overview**
> **E2EE replica apply** no longer aborts the whole sync round when it hits unknown tables/columns (from newer clients) or records/rows over the byte budget. Those cases **park** ciphertext in a new `e2ee_parked_records` table, remove them from `e2ee_replica_pending`, and let other changes apply; oversized rows are parked as a unit so partial rows are not written.
> 
> **Startup** runs `requeue_parked_e2ee_records` after migrations so upgraded builds retry previously parked work. **Observability**: `E2eeReplicaStats` adds `parked_records`, `parked_e2ee_record_summary` groups parked rows by reason/table, and `db-sync` logs a warning when any records were parked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a263f5b51d3a9b83ea97993b0c4bc3dccae351c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->