### PR TITLE
fix: let another account take over a never-synced device and make mobile sync opt-in

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -33,6 +33,7 @@ import { AppLock } from "@/settings/app-lock";
 import { createStyleHook, useColors } from "@/settings/theme-provider";
 import { ThemeProvider, useAppColorScheme } from "@/settings/theme-provider";
 import { MobileSyncLifecycle } from "@/sync/mobile-sync-lifecycle";
+import { useCloudSyncOptIn } from "@/sync/opt-in";
 import { initializeWatchConnectivity } from "@/watch-connectivity";
 
 void initializeErrorReporting().catch(() => {});
@@ -105,6 +106,7 @@ function Gate() {
     getMobileCaptureActive,
   );
   const [signingIn, setSigningIn] = useState(false);
+  const cloudSyncEnabled = useCloudSyncOptIn(auth.session?.user.id ?? null);
 
   const handleSignIn = async (method: SignInMethod) => {
     setSigningIn(true);
@@ -143,9 +145,10 @@ function Gate() {
     <>
       {session && auth.billing.isPro && (
         <MobileSyncLifecycle
-          key={`${session.user.id}:${session.access_token}`}
+          key={`${session.user.id}:${session.access_token}:${cloudSyncEnabled}`}
           accessToken={session.access_token}
           accountUserId={session.user.id}
+          syncEnabled={cloudSyncEnabled}
         />
       )}
       <Screens accountUserId={session?.user.id ?? null} />

--- a/apps/mobile/src/app/settings/sync.tsx
+++ b/apps/mobile/src/app/settings/sync.tsx
@@ -9,7 +9,7 @@ import {
   SettingsRow,
 } from "@/settings/components";
 import { FieldGroup } from "@/settings/field-group";
-import { Button, Text } from "@/settings/fields";
+import { Button, Switch, Text } from "@/settings/fields";
 import { formatStorageBytes, useRecordingStorage } from "@/settings/storage";
 import { requestSyncDeviceList } from "@/settings/sync-devices";
 import {
@@ -18,6 +18,7 @@ import {
   subscribeMobileSync,
   syncMobileNow,
 } from "@/sync/mobile-sync";
+import { setCloudSyncOptIn, useCloudSyncOptIn } from "@/sync/opt-in";
 import { syncStatusPresentation } from "@/sync/status-presentation";
 
 export default function SyncSettings() {
@@ -31,6 +32,10 @@ export default function SyncSettings() {
   const presentation = syncStatusPresentation(snapshot);
   const storage = useRecordingStorage();
   const data = storage.data?.[0];
+  const cloudSyncEnabled = useCloudSyncOptIn(auth.session?.user.id ?? null);
+  const showOptIn = !auth.bypass && auth.billing.isPro;
+  const optedOut = showOptIn && !cloudSyncEnabled;
+  const optIn = useMutation({ mutationFn: setCloudSyncOptIn });
   const sync = useMutation({ mutationFn: syncMobileNow });
   const refresh = useMutation({ mutationFn: auth.refreshBilling });
   const devices = useQuery({
@@ -46,16 +51,28 @@ export default function SyncSettings() {
           title={
             !auth.billing.isPro
               ? "Saved on this device"
-              : presentation.healthy
-                ? "Up to date"
-                : presentation.title
+              : optedOut
+                ? "Cloud sync is off"
+                : presentation.healthy
+                  ? "Up to date"
+                  : presentation.title
           }
           description={
             !auth.billing.isPro
               ? "Cloud sync is available during your Pro trial and with a Pro subscription. Your local notes and recordings are still available."
-              : presentation.description
+              : optedOut
+                ? "Your notes stay on this device. Turn on cloud sync to keep them end-to-end encrypted across your devices."
+                : presentation.description
           }
         />
+        {showOptIn && (
+          <Switch
+            label="Cloud sync"
+            value={cloudSyncEnabled}
+            disabled={optIn.isPending}
+            onValueChange={(value) => optIn.mutate(value)}
+          />
+        )}
         {!auth.bypass && !auth.billing.isPro && (
           <SettingsRow
             title="Explore Anarlog Pro"
@@ -103,7 +120,7 @@ export default function SyncSettings() {
             onPress={() => router.push("/settings/account")}
           />
         )}
-        <SettingsError error={sync.error || refresh.error} />
+        <SettingsError error={optIn.error || sync.error || refresh.error} />
       </FieldGroup.Section>
       <FieldGroup.Section title="Recordings">
         <SettingsRow

--- a/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
+++ b/apps/mobile/src/sync/mobile-sync-lifecycle.tsx
@@ -14,12 +14,18 @@ import {
 export function MobileSyncLifecycle({
   accessToken,
   accountUserId,
+  syncEnabled,
 }: {
   accessToken: string;
   accountUserId: string;
+  syncEnabled: boolean;
 }) {
   useMountEffect(() => {
-    const deactivate = activateMobileSync({ accessToken, accountUserId });
+    // Claiming the local database for an account is the user's call, so a
+    // signed-in Pro session alone never starts sync.
+    const deactivate = syncEnabled
+      ? activateMobileSync({ accessToken, accountUserId })
+      : () => {};
     const uploads = activateMobileAttachmentUploads({ accessToken });
     let transcriptionRetryTimer: ReturnType<typeof setInterval> | undefined;
     let syncWasReady = false;

--- a/apps/mobile/src/sync/opt-in-model.ts
+++ b/apps/mobile/src/sync/opt-in-model.ts
@@ -1,0 +1,41 @@
+export type CloudSyncOptInRow = {
+  account_user_id: string;
+  preference_json: string | null;
+  binding_json: string | null;
+};
+
+export const CLOUD_SYNC_OPT_IN_SQL = `
+SELECT
+  ? AS account_user_id,
+  (SELECT value_json FROM app_settings WHERE id = 'cloud_sync_enabled') AS preference_json,
+  (SELECT value_json FROM app_settings WHERE id = 'cloudsync_workspace_binding') AS binding_json
+`;
+
+function parseJson(value: string | null): unknown {
+  if (value === null) return undefined;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+// Sync is opt-in: signing in must not bind the local database to an account.
+// A device that already claimed its workspace for this account keeps syncing
+// so existing installs are not switched off by the upgrade.
+export function resolveCloudSyncOptIn(rows: CloudSyncOptInRow[]): boolean {
+  const row = rows[0];
+  if (!row) return false;
+  const preference = parseJson(row.preference_json);
+  if (typeof preference === "boolean") return preference;
+  const binding = parseJson(row.binding_json);
+  if (typeof binding !== "object" || binding === null) return false;
+  const { workspace_id, account_user_id } = binding as {
+    workspace_id?: unknown;
+    account_user_id?: unknown;
+  };
+  return (
+    workspace_id === row.account_user_id &&
+    account_user_id === row.account_user_id
+  );
+}

--- a/apps/mobile/src/sync/opt-in.test.mjs
+++ b/apps/mobile/src/sync/opt-in.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveCloudSyncOptIn } from "./opt-in-model.ts";
+
+const claimedBinding = JSON.stringify({
+  workspace_id: "user-a",
+  account_user_id: "user-a",
+});
+
+test("stays off until the user opts in", () => {
+  assert.equal(resolveCloudSyncOptIn([]), false);
+  assert.equal(
+    resolveCloudSyncOptIn([
+      { account_user_id: "user-a", preference_json: null, binding_json: null },
+    ]),
+    false,
+  );
+});
+
+test("keeps syncing on a device already claimed for the account", () => {
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-a",
+        preference_json: null,
+        binding_json: claimedBinding,
+      },
+    ]),
+    true,
+  );
+});
+
+test("does not claim a device bound to another account on sign-in", () => {
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-b",
+        preference_json: null,
+        binding_json: claimedBinding,
+      },
+    ]),
+    false,
+  );
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-b",
+        preference_json: null,
+        binding_json: JSON.stringify({
+          workspace_id: "local-workspace",
+          account_user_id: "user-b",
+        }),
+      },
+    ]),
+    false,
+  );
+});
+
+test("an explicit preference wins over the binding", () => {
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-a",
+        preference_json: "false",
+        binding_json: claimedBinding,
+      },
+    ]),
+    false,
+  );
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-b",
+        preference_json: "true",
+        binding_json: claimedBinding,
+      },
+    ]),
+    true,
+  );
+});
+
+test("ignores malformed stored values", () => {
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-a",
+        preference_json: "not-json",
+        binding_json: "not-json",
+      },
+    ]),
+    false,
+  );
+  assert.equal(
+    resolveCloudSyncOptIn([
+      {
+        account_user_id: "user-a",
+        preference_json: '"yes"',
+        binding_json: claimedBinding,
+      },
+    ]),
+    true,
+  );
+});

--- a/apps/mobile/src/sync/opt-in.ts
+++ b/apps/mobile/src/sync/opt-in.ts
@@ -1,0 +1,24 @@
+import { execute, useLiveQuery } from "@/db";
+import {
+  CLOUD_SYNC_OPT_IN_SQL,
+  type CloudSyncOptInRow,
+  resolveCloudSyncOptIn,
+} from "@/sync/opt-in-model";
+
+export function useCloudSyncOptIn(accountUserId: string | null): boolean {
+  const { data } = useLiveQuery<CloudSyncOptInRow, boolean>({
+    sql: CLOUD_SYNC_OPT_IN_SQL,
+    params: [accountUserId ?? ""],
+    mapRows: resolveCloudSyncOptIn,
+    enabled: accountUserId !== null,
+  });
+  return data ?? false;
+}
+
+export async function setCloudSyncOptIn(enabled: boolean): Promise<void> {
+  await execute(
+    `INSERT INTO app_settings (id, value_json, updated_at) VALUES ('cloud_sync_enabled', ?, ?)
+     ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, updated_at = excluded.updated_at`,
+    [JSON.stringify(enabled), new Date().toISOString()],
+  );
+}

--- a/crates/db-app/src/cloudsync/binding.rs
+++ b/crates/db-app/src/cloudsync/binding.rs
@@ -69,14 +69,7 @@ pub async fn bind_cloudsync_account(
     let account_user_id = validated_account_user_id(account_user_id)?;
     let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
     let binding = load_or_create_binding(&mut transaction).await?;
-
-    if binding
-        .account_user_id
-        .as_deref()
-        .is_some_and(|id| id != account_user_id)
-    {
-        return Err(CloudsyncWorkspaceError::AccountMismatch);
-    }
+    let binding = release_vestigial_binding(&mut transaction, binding, account_user_id).await?;
 
     if binding.account_user_id.is_none() {
         save_binding(
@@ -134,13 +127,7 @@ async fn claim_cloudsync_workspace_in_transaction(
     check_workspace_claim_cancellation(is_cancelled)?;
     let binding = load_or_create_binding(transaction).await?;
     check_workspace_claim_cancellation(is_cancelled)?;
-    if binding
-        .account_user_id
-        .as_deref()
-        .is_some_and(|id| id != account_user_id)
-    {
-        return Err(CloudsyncWorkspaceError::AccountMismatch);
-    }
+    let binding = release_vestigial_binding(transaction, binding, account_user_id).await?;
     if binding.workspace_id == account_user_id
         && binding.account_user_id.as_deref() == Some(account_user_id)
     {
@@ -201,6 +188,62 @@ async fn claim_cloudsync_workspace_in_transaction(
     }
     check_workspace_claim_cancellation(is_cancelled)?;
     Ok(())
+}
+
+/// Signing in binds the device before anything syncs, so a binding whose account
+/// never left rows behind is vestigial: releasing it lets the next account take
+/// over without touching anyone's data. Once the bound account owns local or
+/// replica rows, the device belongs to it and other accounts are rejected.
+async fn release_vestigial_binding(
+    transaction: &mut Transaction<'_, Sqlite>,
+    binding: CloudsyncWorkspaceBinding,
+    account_user_id: &str,
+) -> Result<CloudsyncWorkspaceBinding, CloudsyncWorkspaceError> {
+    let Some(bound_account_user_id) = binding.account_user_id.as_deref() else {
+        return Ok(binding);
+    };
+    if bound_account_user_id == account_user_id {
+        return Ok(binding);
+    }
+    if workspace_owns_local_rows(transaction, bound_account_user_id).await? {
+        return Err(CloudsyncWorkspaceError::AccountMismatch);
+    }
+
+    // A claimed binding uses the account id as the local workspace id. Starting
+    // from a fresh id keeps the claim from treating the previous account as a
+    // local identity to merge into the next one.
+    let workspace_id = if binding.workspace_id == bound_account_user_id {
+        uuid::Uuid::new_v4().to_string()
+    } else {
+        binding.workspace_id
+    };
+    Ok(CloudsyncWorkspaceBinding {
+        workspace_id,
+        account_user_id: None,
+    })
+}
+
+async fn workspace_owns_local_rows(
+    transaction: &mut Transaction<'_, Sqlite>,
+    workspace_id: &str,
+) -> Result<bool, CloudsyncWorkspaceError> {
+    for table_name in crate::E2EE_DOMAIN_TABLES
+        .iter()
+        .chain(std::iter::once(&"e2ee_records"))
+    {
+        let mut query = QueryBuilder::<Sqlite>::new(format!(
+            "SELECT EXISTS(SELECT 1 FROM {table_name} WHERE workspace_id = "
+        ));
+        query.push_bind(workspace_id).push(")");
+        let owns_rows: bool = query
+            .build_query_scalar()
+            .fetch_one(&mut **transaction)
+            .await?;
+        if owns_rows {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn check_workspace_claim_cancellation(

--- a/crates/db-app/src/cloudsync/tests/binding.rs
+++ b/crates/db-app/src/cloudsync/tests/binding.rs
@@ -76,23 +76,131 @@ async fn account_binding_is_durable_without_rekeying_rows() {
 }
 
 #[tokio::test]
-async fn account_binding_rejects_switching_before_and_after_claim() {
+async fn account_binding_switches_until_the_bound_account_owns_rows() {
     let db = test_db().await;
+    let local_workspace = ensure_cloudsync_workspace_binding(db.pool()).await.unwrap();
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('local-session', ?, ?, 'Local note')",
+    )
+    .bind(&local_workspace)
+    .bind(&local_workspace)
+    .execute(db.pool())
+    .await
+    .unwrap();
 
     bind_cloudsync_account(db.pool(), "user-a").await.unwrap();
-    let error = bind_cloudsync_account(db.pool(), "user-b")
+    bind_cloudsync_account(db.pool(), "user-b").await.unwrap();
+
+    assert_eq!(
+        read_binding(db.pool()).await,
+        (local_workspace.clone(), Some("user-b".to_string()))
+    );
+
+    claim_cloudsync_workspace(db.pool(), "user-b")
+        .await
+        .unwrap();
+    let session_workspace: String =
+        sqlx::query_scalar("SELECT workspace_id FROM sessions WHERE id = 'local-session'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(session_workspace, "user-b");
+
+    bind_cloudsync_account(db.pool(), "user-b").await.unwrap();
+    let error = bind_cloudsync_account(db.pool(), "user-a")
         .await
         .unwrap_err();
     assert!(matches!(error, CloudsyncWorkspaceError::AccountMismatch));
+    let error = claim_cloudsync_workspace(db.pool(), "user-a")
+        .await
+        .unwrap_err();
+    assert!(matches!(error, CloudsyncWorkspaceError::AccountMismatch));
+    assert_eq!(
+        read_binding(db.pool()).await,
+        ("user-b".to_string(), Some("user-b".to_string()))
+    );
+}
 
+#[tokio::test]
+async fn claimed_binding_without_rows_is_released_to_the_next_account() {
+    let db = test_db().await;
     claim_cloudsync_workspace(db.pool(), "user-a")
         .await
         .unwrap();
-    bind_cloudsync_account(db.pool(), "user-a").await.unwrap();
+    assert_eq!(
+        read_binding(db.pool()).await,
+        ("user-a".to_string(), Some("user-a".to_string()))
+    );
+    sqlx::query("INSERT INTO sessions (id, workspace_id, title) VALUES ('unowned', '', 'Draft')")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    claim_cloudsync_workspace(db.pool(), "user-b")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        read_binding(db.pool()).await,
+        ("user-b".to_string(), Some("user-b".to_string()))
+    );
+    assert!(
+        cloudsync_workspace_is_claimed_by(db.pool(), "user-b")
+            .await
+            .unwrap()
+    );
+    let session_workspace: String =
+        sqlx::query_scalar("SELECT workspace_id FROM sessions WHERE id = 'unowned'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(session_workspace, "user-b");
+    let previous_account_humans: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM humans WHERE id = 'user-a'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(previous_account_humans, 0);
+}
+
+#[tokio::test]
+async fn encrypted_replica_rows_keep_the_binding_with_their_account() {
+    let db = test_db().await;
+    claim_cloudsync_workspace(db.pool(), "user-a")
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO e2ee_records (id, workspace_id, payload)
+         VALUES ('record', 'user-a', 'ciphertext')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
     let error = bind_cloudsync_account(db.pool(), "user-b")
         .await
         .unwrap_err();
     assert!(matches!(error, CloudsyncWorkspaceError::AccountMismatch));
+    let error = claim_cloudsync_workspace(db.pool(), "user-b")
+        .await
+        .unwrap_err();
+    assert!(matches!(error, CloudsyncWorkspaceError::AccountMismatch));
+    assert_eq!(
+        read_binding(db.pool()).await,
+        ("user-a".to_string(), Some("user-a".to_string()))
+    );
+}
+
+async fn read_binding(pool: &SqlitePool) -> (String, Option<String>) {
+    sqlx::query_as(
+        "SELECT json_extract(value_json, '$.workspace_id'),
+                json_extract(value_json, '$.account_user_id')
+         FROM app_settings WHERE id = 'cloudsync_workspace_binding'",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }
 
 #[tokio::test]
@@ -598,8 +706,12 @@ async fn claim_tombstones_duplicate_self_participants_before_rekeying() {
 }
 
 #[tokio::test]
-async fn claim_rejects_account_switching() {
+async fn claim_rejects_account_switching_once_the_workspace_owns_rows() {
     let db = test_db().await;
+    sqlx::query("INSERT INTO sessions (id, workspace_id, title) VALUES ('session', '', 'Note')")
+        .execute(db.pool())
+        .await
+        .unwrap();
     claim_cloudsync_workspace(db.pool(), "user-a")
         .await
         .unwrap();
@@ -609,6 +721,12 @@ async fn claim_rejects_account_switching() {
         .unwrap_err();
 
     assert!(matches!(error, CloudsyncWorkspaceError::AccountMismatch));
+    let session_workspace: String =
+        sqlx::query_scalar("SELECT workspace_id FROM sessions WHERE id = 'session'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(session_workspace, "user-a");
 }
 
 #[tokio::test]

--- a/crates/mobile-bridge/src/lib.rs
+++ b/crates/mobile-bridge/src/lib.rs
@@ -1241,6 +1241,14 @@ mod tests {
                 r#"["{\"workspace_id\":\"user-a\",\"account_user_id\":\"user-a\"}"]"#.to_string(),
             )
             .unwrap();
+        bridge
+            .execute(
+                "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+                 VALUES ('session', 'user-a', 'user-a', 'Note')"
+                    .to_string(),
+                "[]".to_string(),
+            )
+            .unwrap();
         let recovery_key = anlg_e2ee::RecoveryKey::generate().unwrap();
 
         let result = bridge
@@ -1253,6 +1261,42 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, "account_mismatch");
+    }
+
+    #[test]
+    fn configure_e2ee_replica_releases_a_binding_whose_account_owns_no_rows() {
+        let (_dir, bridge) = new_bridge(None);
+        bridge
+            .execute(
+                "UPDATE app_settings SET value_json = ? WHERE id = 'cloudsync_workspace_binding'"
+                    .to_string(),
+                r#"["{\"workspace_id\":\"user-a\",\"account_user_id\":\"user-a\"}"]"#.to_string(),
+            )
+            .unwrap();
+        let recovery_key = anlg_e2ee::RecoveryKey::generate().unwrap();
+
+        let result = bridge
+            .configure_e2ee_replica(
+                "user-b".to_string(),
+                "http://127.0.0.1:9/sync/e2ee/witness/user-b".to_string(),
+                "access-token".to_string(),
+                recovery_key.expose_code().to_string(),
+            )
+            .unwrap();
+
+        assert_eq!(result, "configured");
+        let binding = bridge
+            .execute(
+                "SELECT json_extract(value_json, '$.workspace_id') AS workspace_id,
+                        json_extract(value_json, '$.account_user_id') AS account_user_id
+                 FROM app_settings WHERE id = 'cloudsync_workspace_binding'"
+                    .to_string(),
+                "[]".to_string(),
+            )
+            .unwrap();
+        let binding: serde_json::Value = serde_json::from_str(&binding).unwrap();
+        assert_eq!(binding[0]["workspace_id"], "user-b");
+        assert_eq!(binding[0]["account_user_id"], "user-b");
     }
 
     #[test]

--- a/plugins/db/src/runtime/tests/activity.rs
+++ b/plugins/db/src/runtime/tests/activity.rs
@@ -411,7 +411,7 @@ async fn local_account_binding_is_not_deferred_by_cloudsync_activity() {
 async fn local_account_binding_times_out_before_mutation_and_remains_fail_closed() {
     let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
     anlg_db_app::prepare_schema(db.as_ref()).await.unwrap();
-    let runtime = PluginDbRuntime::new(db);
+    let runtime = PluginDbRuntime::new(std::sync::Arc::clone(&db));
     let control = runtime.cloudsync_control_operation.lock().await;
 
     let error = runtime
@@ -439,9 +439,23 @@ async fn local_account_binding_times_out_before_mutation_and_remains_fail_closed
             .await
             .unwrap()
     );
+    // Only an account that owns local rows keeps the device bound.
+    assert!(
+        runtime
+            .bind_cloudsync_account("user-b".to_string())
+            .await
+            .unwrap()
+    );
+    anlg_db_app::claim_cloudsync_workspace(db.pool(), "user-b")
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO sessions (id, workspace_id, title) VALUES ('note', 'user-b', 'Note')")
+        .execute(db.pool())
+        .await
+        .unwrap();
     assert!(
         !runtime
-            .bind_cloudsync_account("user-b".to_string())
+            .bind_cloudsync_account("user-a".to_string())
             .await
             .unwrap()
     );

--- a/plugins/db/src/tests/cloudsync_credentials.rs
+++ b/plugins/db/src/tests/cloudsync_credentials.rs
@@ -67,6 +67,13 @@ async fn account_binding_is_durable_without_rekeying_local_rows() {
         )
     );
     assert_eq!(session, (local_workspace.clone(), local_workspace));
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('owned', 'user-a', 'user-a', 'Synced note')",
+    )
+    .execute(runtime.pool())
+    .await
+    .unwrap();
     assert!(
         !runtime
             .bind_cloudsync_account("user-b".to_string())
@@ -603,6 +610,14 @@ async fn account_switch_is_rejected_and_leaves_cloudsync_suspended() {
             .await
             .unwrap()
     );
+    // The device only stays bound once the account owns rows on it.
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('owned', 'user-a', 'user-a', 'Synced note')",
+    )
+    .execute(runtime.pool())
+    .await
+    .unwrap();
 
     let bound = runtime
         .bind_cloudsync_account("user-b".to_string())


### PR DESCRIPTION
Signing in bound the local database to an account before anything synced, so switching accounts (Apple, then Google) stranded a device in "belongs to another account" with no way out short of reinstalling. Fixes ANLG-325's short-term items.

- `db-app`: a binding whose account owns no rows in the E2EE domain tables or `e2ee_records` is released, so both the sign-in bind and the workspace claim rebind to the signing-in account. A binding backed by local or replica rows is still rejected, and a released claimed binding starts from a fresh local workspace id so the previous account is never merged as a local identity.
- Mobile: cloud sync is an explicit opt-in (`cloud_sync_enabled`, switch in Settings > Sync & storage). When unset, sync stays on only for devices already claimed by the signed-in account, so existing installs keep syncing; new sign-ins stay local until the user turns sync on.

Note: desktop's `cloud_sync_enabled` defaults to on, so mobile is now stricter than desktop by design of the issue; flip the resolver default if parity is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cloudsync workspace binding, account switching, and when mobile starts E2EE sync—security- and data-ownership sensitive paths with broad test coverage but real user-data implications.
> 
> **Overview**
> **Makes mobile cloud sync opt-in** and **lets another account take over a device that never actually synced data**, fixing stranded “wrong account” bindings after sign-in switches.
> 
> On **mobile**, Pro users get a **Cloud sync** toggle in Settings → Sync & storage (`cloud_sync_enabled` in `app_settings`). `resolveCloudSyncOptIn` defaults sync **off** until the user opts in, but **keeps sync on** when the signed-in account already has a claimed workspace binding (upgrade-safe). `MobileSyncLifecycle` only calls `activateMobileSync` when opt-in resolves true; signing in alone no longer starts sync.
> 
> In **`db-app`**, `bind_cloudsync_account` and workspace **claim** no longer fail immediately on a different bound account. **`release_vestigial_binding`** clears bindings whose account owns **no** rows in E2EE domain tables or `e2ee_records`; a released claimed binding gets a **new local workspace id** so the next account is not merged as the old identity. Bindings backed by local or replica rows still return **`AccountMismatch`**.
> 
> Tests cover vestigial release, opt-in resolution, mobile-bridge replica configure, and updated account-switch expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002e43c1dbaeafa4342eefbfaa3d9f6c3d0e8023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->