### PR TITLE
feat(db-app): sync tags, session tags, folders, and daily notes

### DIFF
--- a/crates/db-app/migrations/20260909160000_e2ee_dirty_tags_triggers.sql
+++ b/crates/db-app/migrations/20260909160000_e2ee_dirty_tags_triggers.sql
@@ -1,0 +1,109 @@
+-- tags rows sync as part of the encrypted workspace. Rows written without
+-- a workspace id take the device's workspace, as sessions do, so they publish.
+CREATE TRIGGER IF NOT EXISTS e2ee_workspace_stamp_tags
+AFTER INSERT ON tags
+WHEN NEW.workspace_id = ''
+BEGIN
+  UPDATE tags
+  SET workspace_id = COALESCE((
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ), '')
+  WHERE id = NEW.id AND workspace_id = '';
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_tags_insert
+AFTER INSERT ON tags
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = NEW.workspace_id
+    AND table_name = 'tags'
+    AND row_id = NEW.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (NEW.workspace_id, 'tags', NEW.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_tags_update
+AFTER UPDATE ON tags
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT OLD.workspace_id, 'tags', OLD.id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = OLD.workspace_id
+      AND table_name = 'tags'
+      AND row_id = OLD.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT NEW.workspace_id, 'tags', NEW.id
+  WHERE (NEW.workspace_id <> OLD.workspace_id OR NEW.id <> OLD.id)
+    AND NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = NEW.workspace_id
+      AND table_name = 'tags'
+      AND row_id = NEW.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_tags_delete
+AFTER DELETE ON tags
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = OLD.workspace_id
+    AND table_name = 'tags'
+    AND row_id = OLD.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (OLD.workspace_id, 'tags', OLD.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+-- Existing rows without a workspace take the device's workspace, and every row
+-- is queued so the first sync after this update publishes it.
+UPDATE tags
+SET workspace_id = (
+  SELECT json_extract(value_json, '$.workspace_id')
+  FROM app_settings
+  WHERE id = 'cloudsync_workspace_binding'
+)
+WHERE workspace_id = ''
+  AND (
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ) IS NOT NULL;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT workspace_id, 'tags', id
+FROM tags
+WHERE true
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT DISTINCT state.workspace_id, state.table_name, state.row_id
+FROM e2ee_local_state AS state
+WHERE state.table_name = 'tags'
+  AND state.field_name = '$row'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM tags AS domain
+    WHERE domain.workspace_id = state.workspace_id
+      AND domain.id = state.row_id
+  )
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;

--- a/crates/db-app/migrations/20260909160100_e2ee_dirty_session_tags_triggers.sql
+++ b/crates/db-app/migrations/20260909160100_e2ee_dirty_session_tags_triggers.sql
@@ -1,0 +1,109 @@
+-- session_tags rows sync as part of the encrypted workspace. Rows written without
+-- a workspace id take the device's workspace, as sessions do, so they publish.
+CREATE TRIGGER IF NOT EXISTS e2ee_workspace_stamp_session_tags
+AFTER INSERT ON session_tags
+WHEN NEW.workspace_id = ''
+BEGIN
+  UPDATE session_tags
+  SET workspace_id = COALESCE((
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ), '')
+  WHERE id = NEW.id AND workspace_id = '';
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_session_tags_insert
+AFTER INSERT ON session_tags
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = NEW.workspace_id
+    AND table_name = 'session_tags'
+    AND row_id = NEW.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (NEW.workspace_id, 'session_tags', NEW.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_session_tags_update
+AFTER UPDATE ON session_tags
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT OLD.workspace_id, 'session_tags', OLD.id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = OLD.workspace_id
+      AND table_name = 'session_tags'
+      AND row_id = OLD.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT NEW.workspace_id, 'session_tags', NEW.id
+  WHERE (NEW.workspace_id <> OLD.workspace_id OR NEW.id <> OLD.id)
+    AND NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = NEW.workspace_id
+      AND table_name = 'session_tags'
+      AND row_id = NEW.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_session_tags_delete
+AFTER DELETE ON session_tags
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = OLD.workspace_id
+    AND table_name = 'session_tags'
+    AND row_id = OLD.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (OLD.workspace_id, 'session_tags', OLD.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+-- Existing rows without a workspace take the device's workspace, and every row
+-- is queued so the first sync after this update publishes it.
+UPDATE session_tags
+SET workspace_id = (
+  SELECT json_extract(value_json, '$.workspace_id')
+  FROM app_settings
+  WHERE id = 'cloudsync_workspace_binding'
+)
+WHERE workspace_id = ''
+  AND (
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ) IS NOT NULL;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT workspace_id, 'session_tags', id
+FROM session_tags
+WHERE true
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT DISTINCT state.workspace_id, state.table_name, state.row_id
+FROM e2ee_local_state AS state
+WHERE state.table_name = 'session_tags'
+  AND state.field_name = '$row'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM session_tags AS domain
+    WHERE domain.workspace_id = state.workspace_id
+      AND domain.id = state.row_id
+  )
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;

--- a/crates/db-app/migrations/20260909160200_e2ee_dirty_folders_triggers.sql
+++ b/crates/db-app/migrations/20260909160200_e2ee_dirty_folders_triggers.sql
@@ -1,0 +1,109 @@
+-- folders rows sync as part of the encrypted workspace. Rows written without
+-- a workspace id take the device's workspace, as sessions do, so they publish.
+CREATE TRIGGER IF NOT EXISTS e2ee_workspace_stamp_folders
+AFTER INSERT ON folders
+WHEN NEW.workspace_id = ''
+BEGIN
+  UPDATE folders
+  SET workspace_id = COALESCE((
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ), '')
+  WHERE id = NEW.id AND workspace_id = '';
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_folders_insert
+AFTER INSERT ON folders
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = NEW.workspace_id
+    AND table_name = 'folders'
+    AND row_id = NEW.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (NEW.workspace_id, 'folders', NEW.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_folders_update
+AFTER UPDATE ON folders
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT OLD.workspace_id, 'folders', OLD.id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = OLD.workspace_id
+      AND table_name = 'folders'
+      AND row_id = OLD.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT NEW.workspace_id, 'folders', NEW.id
+  WHERE (NEW.workspace_id <> OLD.workspace_id OR NEW.id <> OLD.id)
+    AND NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = NEW.workspace_id
+      AND table_name = 'folders'
+      AND row_id = NEW.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_folders_delete
+AFTER DELETE ON folders
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = OLD.workspace_id
+    AND table_name = 'folders'
+    AND row_id = OLD.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (OLD.workspace_id, 'folders', OLD.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+-- Existing rows without a workspace take the device's workspace, and every row
+-- is queued so the first sync after this update publishes it.
+UPDATE folders
+SET workspace_id = (
+  SELECT json_extract(value_json, '$.workspace_id')
+  FROM app_settings
+  WHERE id = 'cloudsync_workspace_binding'
+)
+WHERE workspace_id = ''
+  AND (
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ) IS NOT NULL;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT workspace_id, 'folders', id
+FROM folders
+WHERE true
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT DISTINCT state.workspace_id, state.table_name, state.row_id
+FROM e2ee_local_state AS state
+WHERE state.table_name = 'folders'
+  AND state.field_name = '$row'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM folders AS domain
+    WHERE domain.workspace_id = state.workspace_id
+      AND domain.id = state.row_id
+  )
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;

--- a/crates/db-app/migrations/20260909160300_e2ee_dirty_daily_notes_triggers.sql
+++ b/crates/db-app/migrations/20260909160300_e2ee_dirty_daily_notes_triggers.sql
@@ -1,0 +1,109 @@
+-- daily_notes rows sync as part of the encrypted workspace. Rows written without
+-- a workspace id take the device's workspace, as sessions do, so they publish.
+CREATE TRIGGER IF NOT EXISTS e2ee_workspace_stamp_daily_notes
+AFTER INSERT ON daily_notes
+WHEN NEW.workspace_id = ''
+BEGIN
+  UPDATE daily_notes
+  SET workspace_id = COALESCE((
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ), '')
+  WHERE id = NEW.id AND workspace_id = '';
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_daily_notes_insert
+AFTER INSERT ON daily_notes
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = NEW.workspace_id
+    AND table_name = 'daily_notes'
+    AND row_id = NEW.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (NEW.workspace_id, 'daily_notes', NEW.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_daily_notes_update
+AFTER UPDATE ON daily_notes
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT OLD.workspace_id, 'daily_notes', OLD.id
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = OLD.workspace_id
+      AND table_name = 'daily_notes'
+      AND row_id = OLD.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  SELECT NEW.workspace_id, 'daily_notes', NEW.id
+  WHERE (NEW.workspace_id <> OLD.workspace_id OR NEW.id <> OLD.id)
+    AND NOT EXISTS (
+    SELECT 1
+    FROM e2ee_apply_guard
+    WHERE workspace_id = NEW.workspace_id
+      AND table_name = 'daily_notes'
+      AND row_id = NEW.id
+  )
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS e2ee_dirty_daily_notes_delete
+AFTER DELETE ON daily_notes
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM e2ee_apply_guard
+  WHERE workspace_id = OLD.workspace_id
+    AND table_name = 'daily_notes'
+    AND row_id = OLD.id
+)
+BEGIN
+  INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+  VALUES (OLD.workspace_id, 'daily_notes', OLD.id)
+  ON CONFLICT (workspace_id, table_name, row_id) DO UPDATE SET
+    generation = e2ee_dirty_rows.generation + 1;
+END;
+
+-- Existing rows without a workspace take the device's workspace, and every row
+-- is queued so the first sync after this update publishes it.
+UPDATE daily_notes
+SET workspace_id = (
+  SELECT json_extract(value_json, '$.workspace_id')
+  FROM app_settings
+  WHERE id = 'cloudsync_workspace_binding'
+)
+WHERE workspace_id = ''
+  AND (
+    SELECT json_extract(value_json, '$.workspace_id')
+    FROM app_settings
+    WHERE id = 'cloudsync_workspace_binding'
+  ) IS NOT NULL;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT workspace_id, 'daily_notes', id
+FROM daily_notes
+WHERE true
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;
+
+INSERT INTO e2ee_dirty_rows (workspace_id, table_name, row_id)
+SELECT DISTINCT state.workspace_id, state.table_name, state.row_id
+FROM e2ee_local_state AS state
+WHERE state.table_name = 'daily_notes'
+  AND state.field_name = '$row'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM daily_notes AS domain
+    WHERE domain.workspace_id = state.workspace_id
+      AND domain.id = state.row_id
+  )
+ON CONFLICT (workspace_id, table_name, row_id) DO NOTHING;

--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -24,13 +24,17 @@ pub use witness::{
 
 pub const E2EE_DOMAIN_TABLES: &[&str] = &[
     "action_items",
+    "daily_notes",
+    "folders",
     "humans",
     "organizations",
     "session_attachments",
     "session_documents",
     "session_participants",
+    "session_tags",
     "sessions",
     "synced_preferences",
+    "tags",
     "transcripts",
 ];
 

--- a/crates/db-app/src/e2ee/tests/mod.rs
+++ b/crates/db-app/src/e2ee/tests/mod.rs
@@ -47,4 +47,5 @@ mod revision_conflicts;
 mod roundtrip;
 mod session_deletion;
 mod snapshots;
+mod synced_tables;
 mod witness_queue;

--- a/crates/db-app/src/e2ee/tests/roundtrip.rs
+++ b/crates/db-app/src/e2ee/tests/roundtrip.rs
@@ -108,13 +108,17 @@ async fn reconstructs_every_protected_table_and_applies_deletions() {
     let source = test_db().await;
     for (table, id) in [
         ("action_items", "action-1"),
+        ("daily_notes", "daily-1"),
+        ("folders", "folder-1"),
         ("humans", "human-1"),
         ("organizations", "organization-1"),
         ("session_attachments", "attachment-1"),
         ("session_documents", "document-1"),
         ("session_participants", "participant-1"),
+        ("session_tags", "session-tag-1"),
         ("sessions", "session-1"),
         ("synced_preferences", "preference-1"),
+        ("tags", "tag-1"),
         ("transcripts", "transcript-1"),
     ] {
         let sql = format!("INSERT INTO {table} (id, workspace_id) VALUES (?, 'workspace-a')");

--- a/crates/db-app/src/e2ee/tests/synced_tables.rs
+++ b/crates/db-app/src/e2ee/tests/synced_tables.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+async fn binding_workspace(db: &anlg_db_core::Db) -> String {
+    sqlx::query_scalar(
+        "SELECT json_extract(value_json, '$.workspace_id')
+         FROM app_settings WHERE id = 'cloudsync_workspace_binding'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn tags_and_folders_written_without_a_workspace_take_the_device_workspace() {
+    let db = test_db().await;
+    let workspace = binding_workspace(&db).await;
+    assert!(!workspace.is_empty());
+
+    sqlx::query(
+        "INSERT INTO tags (id, owner_user_id, name) VALUES ('planning', 'user-a', 'planning')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO folders (id, path) VALUES ('folder-1', 'Work')")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO daily_notes (id, owner_user_id, note_date, body)
+         VALUES ('daily-1', 'user-a', '2026-09-09', 'today')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    for (table, id) in [
+        ("tags", "planning"),
+        ("folders", "folder-1"),
+        ("daily_notes", "daily-1"),
+    ] {
+        let sql = format!("SELECT workspace_id FROM {table} WHERE id = ?");
+        let stamped: String = sqlx::query_scalar(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(stamped, workspace, "{table} was not stamped");
+        let dirty: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM e2ee_dirty_rows
+             WHERE workspace_id = ? AND table_name = ? AND row_id = ?",
+        )
+        .bind(&workspace)
+        .bind(table)
+        .bind(id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(dirty, 1, "{table} was not queued for sync");
+    }
+}
+
+#[tokio::test]
+async fn tags_and_session_tags_sync_between_devices() {
+    let workspace_keys = keys("workspace-a");
+    let source = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-a', 'user-a', 'Tagged')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO tags (id, workspace_id, owner_user_id, name)
+         VALUES ('planning', 'workspace-a', 'user-a', 'planning')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO session_tags (id, workspace_id, owner_user_id, session_id, tag_id)
+         VALUES ('session-1:planning', 'workspace-a', 'user-a', 'session-1', 'planning')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO folders (id, workspace_id, path, instructions)
+         VALUES ('folder-1', 'workspace-a', 'Work', 'Be brief')",
+    )
+    .execute(source.pool())
+    .await
+    .unwrap();
+    encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    let target = test_db().await;
+    copy_replica(source.pool(), target.pool()).await;
+    apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    let tag: (String, String) =
+        sqlx::query_as("SELECT workspace_id, name FROM tags WHERE id = 'planning'")
+            .fetch_one(target.pool())
+            .await
+            .unwrap();
+    assert_eq!(tag, ("workspace-a".to_string(), "planning".to_string()));
+    let session_tag: (String, String) = sqlx::query_as(
+        "SELECT session_id, tag_id FROM session_tags WHERE id = 'session-1:planning'",
+    )
+    .fetch_one(target.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        session_tag,
+        ("session-1".to_string(), "planning".to_string())
+    );
+    let folder: (String, String) =
+        sqlx::query_as("SELECT path, instructions FROM folders WHERE id = 'folder-1'")
+            .fetch_one(target.pool())
+            .await
+            .unwrap();
+    assert_eq!(folder, ("Work".to_string(), "Be brief".to_string()));
+}

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -501,6 +501,32 @@ pub const APP_MIGRATION_STEPS: &[anlg_db_migrate::MigrationStep] = &[
         },
         sql: include_str!("../migrations/20260909150000_session_document_versions.sql"),
     },
+    anlg_db_migrate::MigrationStep {
+        id: "20260909160000_e2ee_dirty_tags_triggers",
+        scope: anlg_db_migrate::MigrationScope::CloudsyncAlter { table_name: "tags" },
+        sql: include_str!("../migrations/20260909160000_e2ee_dirty_tags_triggers.sql"),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260909160100_e2ee_dirty_session_tags_triggers",
+        scope: anlg_db_migrate::MigrationScope::CloudsyncAlter {
+            table_name: "session_tags",
+        },
+        sql: include_str!("../migrations/20260909160100_e2ee_dirty_session_tags_triggers.sql"),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260909160200_e2ee_dirty_folders_triggers",
+        scope: anlg_db_migrate::MigrationScope::CloudsyncAlter {
+            table_name: "folders",
+        },
+        sql: include_str!("../migrations/20260909160200_e2ee_dirty_folders_triggers.sql"),
+    },
+    anlg_db_migrate::MigrationStep {
+        id: "20260909160300_e2ee_dirty_daily_notes_triggers",
+        scope: anlg_db_migrate::MigrationScope::CloudsyncAlter {
+            table_name: "daily_notes",
+        },
+        sql: include_str!("../migrations/20260909160300_e2ee_dirty_daily_notes_triggers.sql"),
+    },
 ];
 
 pub fn schema() -> anlg_db_migrate::DbSchema {

--- a/crates/db-app/src/schema_tests/encrypted_replica.rs
+++ b/crates/db-app/src/schema_tests/encrypted_replica.rs
@@ -652,11 +652,12 @@ async fn e2ee_dirty_rows_migration_seeds_existing_domain_rows_and_tombstones() {
     .await
     .unwrap();
 
-    // Only the domain tables that predate the dirty-rows migration were backfilled.
+    // Only the domain tables that exist before the dirty-rows migration can be
+    // seeded here; later tables are backfilled by their own trigger migrations.
     let backfilled_tables: Vec<&str> = E2EE_DOMAIN_TABLES
         .iter()
         .copied()
-        .filter(|table_name| *table_name != "synced_preferences")
+        .filter(|table_name| !matches!(*table_name, "synced_preferences" | "folders"))
         .collect();
     for table_name in &backfilled_tables {
         let insert_sql = format!(
@@ -1021,10 +1022,11 @@ async fn e2ee_dirty_triggers_apply_to_initialized_cloudsync_tables() {
     )
     .await
     .unwrap();
-    // synced_preferences does not exist yet at this point in the migration history.
+    // Tables created after this point in the migration history cannot be
+    // initialized here; their migrations run below.
     for table_name in E2EE_DOMAIN_TABLES
         .iter()
-        .filter(|table_name| **table_name != "synced_preferences")
+        .filter(|table_name| !matches!(**table_name, "synced_preferences" | "folders"))
     {
         db.cloudsync_init(table_name, None, None).await.unwrap();
     }

--- a/crates/db-app/src/schema_tests/migrations.rs
+++ b/crates/db-app/src/schema_tests/migrations.rs
@@ -302,10 +302,11 @@ async fn search_index_migrations_apply_to_initialized_cloudsync_tables() {
     )
     .await
     .unwrap();
-    // synced_preferences does not exist yet at this point in the migration history.
+    // Tables created after this point in the migration history cannot be
+    // initialized here; their migrations run below.
     for table_name in E2EE_DOMAIN_TABLES
         .iter()
-        .filter(|table_name| **table_name != "synced_preferences")
+        .filter(|table_name| !matches!(**table_name, "synced_preferences" | "folders"))
     {
         db.cloudsync_init(table_name, None, None).await.unwrap();
     }

--- a/plugins/db/src/runtime/open.rs
+++ b/plugins/db/src/runtime/open.rs
@@ -85,6 +85,9 @@ pub(super) async fn open_app_db_without_cloudsync(
     Ok(db)
 }
 
+// App triggers may read the cloudsync_workspace_binding setting; only the
+// extension's own triggers, which reference cloudsync_ tables, mean the
+// database was initialized for sqlite-sync.
 pub(super) async fn database_uses_cloudsync_schema(
     db: &Db,
 ) -> std::result::Result<bool, sqlx::Error> {
@@ -93,7 +96,13 @@ pub(super) async fn database_uses_cloudsync_schema(
             SELECT 1
             FROM sqlite_master
             WHERE (type = 'table' AND name = 'cloudsync_table_settings')
-               OR (type = 'trigger' AND instr(lower(COALESCE(sql, '')), 'cloudsync_') > 0)
+               OR (
+                 type = 'trigger'
+                 AND instr(
+                   replace(lower(COALESCE(sql, '')), 'cloudsync_workspace_binding', ''),
+                   'cloudsync_'
+                 ) > 0
+               )
         )",
     )
     .fetch_one(db.pool())


### PR DESCRIPTION
Tags, folders, and daily notes never left the device, so users saw a different set on each device with nothing to explain why.

- The four tables join the encrypted domain with the same dirty-row triggers as the other synced tables.
- A workspace stamp trigger gives rows written without a workspace id (desktop and the CLI write tags that way) the device's binding workspace, as sessions do, so they publish. The migrations backfill existing rows and queue them.
- The desktop plugin's sqlite-sync detection now ignores app triggers that read the `cloudsync_workspace_binding` setting.

Older builds park records for these tables until they update, so this should ship in a release after the parked-records change at the bottom of this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the encrypted sync surface and runs data backfills that stamp workspace IDs and queue all rows on upgrade, which can drive a large first sync; pattern matches existing domain tables but affects user-visible metadata across devices.
> 
> **Overview**
> **Adds encrypted workspace sync for `tags`, `session_tags`, `folders`, and `daily_notes`** so they follow the same E2EE replica path as sessions and other domain tables.
> 
> Four **CloudsyncAlter** migrations install **workspace-stamp** triggers (empty `workspace_id` → device binding from `cloudsync_workspace_binding`), **insert/update/delete** triggers that enqueue `e2ee_dirty_rows` (with `e2ee_apply_guard` suppression), and a one-time **backfill** that stamps legacy rows, queues every row for the next publish, and queues orphan `$row` local state. **`E2EE_DOMAIN_TABLES`** and roundtrip coverage are updated accordingly; new tests assert stamping, dirty queuing, and encrypt/apply across devices.
> 
> **Desktop DB open:** `database_uses_cloudsync_schema` no longer treats app E2EE triggers that only read `cloudsync_workspace_binding` as proof of sqlite-sync, so local-only fallback still works after these migrations. Schema tests skip early cloudsync init for **`folders`** (created later in history), like **`synced_preferences`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217a0acd8bc90ce1ea0381d9d11c514fc5d4d2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->