### PR TITLE
feat(db-app): sync transcript words as chunks

### DIFF
--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -171,6 +171,8 @@ struct PreparedEncryptedField {
 struct PreparedDirtyRow {
     dirty: DirtyRow,
     fields: Vec<PreparedEncryptedField>,
+    /// Plain columns now synced as chunks; their old field state is dropped.
+    retired_fields: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -180,6 +182,7 @@ struct WitnessVersion {
     payload_hash: String,
 }
 
+mod chunks;
 mod conflicts;
 mod cooperative;
 mod merge;

--- a/crates/db-app/src/e2ee/chunks.rs
+++ b/crates/db-app/src/e2ee/chunks.rs
@@ -1,0 +1,121 @@
+//! Large JSON array columns sync as fixed-size chunks. An append then re-seals
+//! one small record instead of the whole array, edits to different parts of
+//! the array merge instead of replacing each other, and no single record has
+//! to carry a whole transcript.
+//!
+//! A chunked column never syncs as a plain field on current builds. Its
+//! records are the virtual fields `column#0`, `column#1`, ... holding one
+//! chunk each, plus `column#n` holding the chunk count. Older builds park the
+//! virtual fields as unknown until they update.
+
+use serde_json::{Value, json};
+
+const CHUNKED_ARRAY_COLUMNS: &[(&str, &str, usize)] = &[("transcripts", "words_json", 256)];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ChunkPart {
+    Count,
+    Index(usize),
+}
+
+pub(super) fn chunk_size_for(table: &str, column: &str) -> Option<usize> {
+    CHUNKED_ARRAY_COLUMNS
+        .iter()
+        .find(|(chunked_table, chunked_column, _)| {
+            *chunked_table == table && *chunked_column == column
+        })
+        .map(|(_, _, size)| *size)
+}
+
+pub(super) fn chunk_field(column: &str, index: usize) -> String {
+    format!("{column}#{index}")
+}
+
+pub(super) fn chunk_count_field(column: &str) -> String {
+    format!("{column}#n")
+}
+
+/// Splits a virtual field name into its column and part. Only columns that
+/// are chunked in `table` qualify, so a real column containing `#` is never
+/// mistaken for one.
+pub(super) fn parse_chunk_field<'a>(table: &str, field: &'a str) -> Option<(&'a str, ChunkPart)> {
+    let (column, part) = field.rsplit_once('#')?;
+    chunk_size_for(table, column)?;
+    let part = if part == "n" {
+        ChunkPart::Count
+    } else {
+        ChunkPart::Index(part.parse().ok()?)
+    };
+    Some((column, part))
+}
+
+/// The array stored in a chunked column, when the column holds one. Anything
+/// else falls back to whole-value sync.
+pub(super) fn parse_array(value: &Value) -> Option<Vec<Value>> {
+    match serde_json::from_str::<Value>(value.as_str()?).ok()? {
+        Value::Array(items) => Some(items),
+        _ => None,
+    }
+}
+
+pub(super) fn split_chunks(items: &[Value], chunk_size: usize) -> Vec<Vec<Value>> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+    items
+        .chunks(chunk_size.max(1))
+        .map(<[Value]>::to_vec)
+        .collect()
+}
+
+pub(super) fn join_chunks(chunks: &[Vec<Value>]) -> Value {
+    let items = chunks.iter().flatten().cloned().collect::<Vec<_>>();
+    Value::String(Value::Array(items).to_string())
+}
+
+pub(super) fn chunk_value(chunks: &[Vec<Value>], part: ChunkPart) -> Value {
+    match part {
+        ChunkPart::Count => json!(chunks.len()),
+        ChunkPart::Index(index) => chunks
+            .get(index)
+            .map(|chunk| Value::Array(chunk.clone()))
+            .unwrap_or(Value::Null),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_chunk_fields_only_for_chunked_columns() {
+        assert_eq!(
+            parse_chunk_field("transcripts", "words_json#12"),
+            Some(("words_json", ChunkPart::Index(12)))
+        );
+        assert_eq!(
+            parse_chunk_field("transcripts", "words_json#n"),
+            Some(("words_json", ChunkPart::Count))
+        );
+        assert_eq!(parse_chunk_field("transcripts", "memo#1"), None);
+        assert_eq!(parse_chunk_field("sessions", "words_json#1"), None);
+        assert_eq!(parse_chunk_field("transcripts", "words_json#x"), None);
+    }
+
+    #[test]
+    fn splits_and_joins_round_trip() {
+        let items = (0..10)
+            .map(|index| json!({ "id": index }))
+            .collect::<Vec<_>>();
+        let chunks = split_chunks(&items, 4);
+        assert_eq!(
+            chunks.iter().map(Vec::len).collect::<Vec<_>>(),
+            vec![4, 4, 2]
+        );
+        assert_eq!(chunk_value(&chunks, ChunkPart::Count), json!(3));
+        assert_eq!(chunk_value(&chunks, ChunkPart::Index(5)), Value::Null);
+        let joined = join_chunks(&chunks);
+        assert_eq!(parse_array(&joined).unwrap(), items);
+        assert!(split_chunks(&[], 4).is_empty());
+    }
+}

--- a/crates/db-app/src/e2ee/replica_apply.rs
+++ b/crates/db-app/src/e2ee/replica_apply.rs
@@ -5,16 +5,20 @@ use anlg_e2ee::WorkspaceKeyring;
 use serde_json::{Value, json};
 use sqlx::{QueryBuilder, Sqlite, SqlitePool, Transaction};
 
+use super::chunks::{
+    ChunkPart, chunk_count_field, chunk_field, chunk_size_for, join_chunks, parse_array,
+    parse_chunk_field, split_chunks,
+};
 use super::conflicts::{ConflictCopy, ConflictLoser, record_conflict};
 use super::cooperative::yield_once;
 use super::merge::merge_concurrent_field;
 use super::replica_storage::{
     E2eeParkReason, ParkedRecord, clear_stale_apply_guards, delete_row, dirty_row_edited_at_ms,
     insert_apply_guard, insert_row, load_or_create_writer_id, load_row_local_states,
-    mark_local_state_for_republish, normalize_replica_payload_hashes, park_records,
-    queue_dirty_row, read_field, record_version_order, remove_apply_guard,
-    replica_records_still_current, restore_local_payload, row_changed_since_snapshot, row_exists,
-    table_columns, update_field, upsert_local_state,
+    load_row_local_states_from_pool, mark_local_state_for_republish,
+    normalize_replica_payload_hashes, park_records, queue_dirty_row, read_column, read_field,
+    record_version_order, remove_apply_guard, replica_records_still_current, restore_local_payload,
+    row_changed_since_snapshot, row_exists, table_columns, update_field, upsert_local_state,
 };
 use super::witness::repair_e2ee_replica_from_witness_bounded_cancellable;
 use super::{
@@ -263,7 +267,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
     check_e2ee_apply_cancellation(is_cancelled)?;
     normalize_replica_payload_hashes(pool, keys, is_cancelled).await?;
     check_e2ee_apply_cancellation(is_cancelled)?;
-    let mut groups = BTreeSet::<(String, String, String)>::new();
+    let mut groups = BTreeMap::<(String, String, String), BTreeSet<String>>::new();
     let mut group_pending = BTreeMap::<(String, String, String), Vec<(String, i64)>>::new();
     let mut stats = E2eeReplicaStats::default();
     let metadata = load_changed_e2ee_record_metadata(pool, keys).await?;
@@ -337,10 +341,11 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
                     column_cache.insert(field.table.clone(), columns);
                 }
                 let columns = &column_cache[&field.table];
-                (field.field == "id"
-                    || field.field == "workspace_id"
-                    || !columns.contains(&field.field))
-                .then_some(E2eeParkReason::UnknownField)
+                let known = columns.contains(&field.field)
+                    || parse_chunk_field(&field.table, &field.field)
+                        .is_some_and(|(column, _)| columns.contains(column));
+                (field.field == "id" || field.field == "workspace_id" || !known)
+                    .then_some(E2eeParkReason::UnknownField)
             };
             if let Some(reason) = park_reason {
                 parked.push(ParkedRecord {
@@ -358,7 +363,10 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
                 .entry(group.clone())
                 .or_default()
                 .push((record.id.clone(), selected_generations[&record.id]));
-            groups.insert(group);
+            let chunk_fields = groups.entry(group).or_default();
+            if field.field.contains('#') {
+                chunk_fields.insert(field.field);
+            }
         }
         delete_reconciled_replica_entries(pool, &reconciled, is_cancelled).await?;
     }
@@ -372,7 +380,7 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
             }
         };
     }
-    for (attempted_rows, group) in groups.into_iter().enumerate() {
+    for (attempted_rows, (group, pending_chunk_fields)) in groups.into_iter().enumerate() {
         if attempted_rows >= max_rows {
             stats.remaining_replica_changes = true;
             break;
@@ -399,11 +407,28 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
         };
 
         check_e2ee_apply_cancellation(is_cancelled)?;
+        let mut chunk_fields = pending_chunk_fields;
+        for column in columns
+            .iter()
+            .filter(|column| chunk_size_for(&table, column).is_some())
+        {
+            chunk_fields.insert(chunk_count_field(column));
+        }
+        for state in load_row_local_states_from_pool(pool, &workspace_id, &table, &row_id)
+            .await?
+            .into_values()
+        {
+            if parse_chunk_field(&table, &state.field_name).is_some() {
+                chunk_fields.insert(state.field_name);
+            }
+        }
+        check_e2ee_apply_cancellation(is_cancelled)?;
         let Some(encrypted_records) = load_encrypted_row_group(
             pool,
             keyring,
             (&workspace_id, &table, &row_id),
             &columns,
+            &chunk_fields,
             max_bytes,
             is_cancelled,
         )
@@ -445,11 +470,10 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
             if field.table != table || field.row_id != row_id {
                 return Err(E2eeReplicaError::InvalidField);
             }
+            let known =
+                columns.contains(&field.field) || parse_chunk_field(&table, &field.field).is_some();
             if field.field != ROW_MANIFEST_FIELD
-                && (field.field == "id"
-                    || field.field == "workspace_id"
-                    || !columns.contains(&field.field)
-                    || field.deleted)
+                && (field.field == "id" || field.field == "workspace_id" || !known || field.deleted)
             {
                 return Err(E2eeReplicaError::InvalidField);
             }
@@ -475,6 +499,15 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
                 records_by_field.insert(field_name, candidate);
             }
         }
+        load_remaining_chunk_records(
+            pool,
+            keyring,
+            (&workspace_id, &table, &row_id),
+            &columns,
+            require_witness,
+            &mut records_by_field,
+        )
+        .await?;
         let mut records = records_by_field.into_values().collect::<Vec<_>>();
 
         check_e2ee_apply_cancellation(is_cancelled)?;
@@ -657,7 +690,24 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
 
         let mut deferred_pending_ids = HashSet::new();
         let mut republish_merged_row = false;
+        let mut chunk_columns = BTreeMap::<String, ChunkedColumnRecords>::new();
+        let mut plain_records = Vec::with_capacity(records.len());
         for record in records {
+            match parse_chunk_field(&table, &record.field.field) {
+                Some((column, part)) => {
+                    let column = column.to_string();
+                    let entry = chunk_columns.entry(column).or_default();
+                    match part {
+                        ChunkPart::Count => entry.count = Some(record),
+                        ChunkPart::Index(index) => {
+                            entry.chunks.insert(index, record);
+                        }
+                    }
+                }
+                None => plain_records.push(record),
+            }
+        }
+        for record in plain_records {
             rollback_if_cancelled!(transaction, is_cancelled);
             let record_key = keyring
                 .get(&record.field.key_id)
@@ -842,6 +892,11 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
                 republish_merged_row = true;
                 stats.merged_fields += 1;
             }
+            // A whole-column record from an older build was honoured; this
+            // build re-seals the column as chunks so current builds converge.
+            if chunk_size_for(&table, field_name).is_some() {
+                republish_merged_row = true;
+            }
             let value_tag =
                 record_key.value_tag(&table, &row_id, field_name, false, &record.field.value);
             let state = LocalState {
@@ -863,6 +918,33 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
             rollback_if_cancelled!(transaction, is_cancelled);
             states.insert(state.record_id.clone(), state);
             stats.applied_fields += 1;
+        }
+        for (column, column_records) in chunk_columns {
+            rollback_if_cancelled!(transaction, is_cancelled);
+            let outcome = apply_chunked_column(
+                &mut transaction,
+                keyring,
+                (&workspace_id, &table, &row_id),
+                &column,
+                column_records,
+                &mut states,
+                row_materialized,
+            )
+            .await?;
+            rollback_if_cancelled!(transaction, is_cancelled);
+            match outcome {
+                ChunkedColumnOutcome::Deferred(record_ids) => {
+                    stats.skipped_local_changes += record_ids.len() as u64;
+                    deferred_pending_ids.extend(record_ids);
+                }
+                ChunkedColumnOutcome::Applied {
+                    applied_fields,
+                    kept_local,
+                } => {
+                    stats.applied_fields += applied_fields;
+                    republish_merged_row |= kept_local;
+                }
+            }
         }
         if republish_merged_row {
             // A merged document differs from the incoming record, so the next
@@ -897,15 +979,306 @@ pub(super) async fn apply_e2ee_replica_changes_inner(
 // Bookkeeping columns still resolve by edit time, but their values mean
 // nothing to the user, so they never produce conflict copies.
 fn field_keeps_conflict_copies(field_name: &str) -> bool {
-    !matches!(
-        field_name,
-        "updated_at"
-            | "created_at"
-            | "updated_by"
-            | "created_by"
-            | "content_version"
-            | "deleted_at"
+    !field_name.contains('#')
+        && !matches!(
+            field_name,
+            "updated_at"
+                | "created_at"
+                | "updated_by"
+                | "created_by"
+                | "content_version"
+                | "deleted_at"
+        )
+}
+
+#[derive(Default)]
+struct ChunkedColumnRecords {
+    count: Option<DecryptedRecord>,
+    chunks: BTreeMap<usize, DecryptedRecord>,
+}
+
+enum ChunkedColumnOutcome {
+    Deferred(Vec<String>),
+    Applied {
+        applied_fields: u64,
+        kept_local: bool,
+    },
+}
+
+// The chunk count record says how many chunk records the column has; fetch
+// any this row group did not already load so the column can be rebuilt whole.
+async fn load_remaining_chunk_records(
+    pool: &SqlitePool,
+    keyring: &WorkspaceKeyring,
+    row: (&str, &str, &str),
+    columns: &HashSet<String>,
+    require_witness: bool,
+    records_by_field: &mut BTreeMap<String, DecryptedRecord>,
+) -> E2eeReplicaResult<()> {
+    let (workspace_id, table, row_id) = row;
+    let mut missing = Vec::new();
+    for column in columns
+        .iter()
+        .filter(|column| chunk_size_for(table, column).is_some())
+    {
+        let Some(count) = records_by_field
+            .get(&chunk_count_field(column))
+            .and_then(|record| record.field.value.as_u64())
+        else {
+            continue;
+        };
+        for index in 0..usize::try_from(count).unwrap_or(usize::MAX).min(1 << 20) {
+            let field = chunk_field(column, index);
+            if !records_by_field.contains_key(&field) {
+                missing.extend(
+                    keyring
+                        .generations()
+                        .map(|key| key.blind_field_id(table, row_id, &field)),
+                );
+            }
+        }
+    }
+    if missing.is_empty() {
+        return Ok(());
+    }
+    missing.sort_unstable();
+    missing.dedup();
+    for record in load_encrypted_records_by_id(pool, &missing).await? {
+        if record.workspace_id != workspace_id || (require_witness && !record.witnessed) {
+            continue;
+        }
+        let Ok(field) = keyring.open_field(&record.workspace_id, &record.id, &record.payload)
+        else {
+            continue;
+        };
+        if field.table != table || field.row_id != row_id {
+            continue;
+        }
+        let payload_hash = anlg_e2ee::payload_hash(&record.payload);
+        records_by_field
+            .entry(field.field.clone())
+            .or_insert(DecryptedRecord {
+                record_id: record.id,
+                workspace_id: record.workspace_id,
+                payload_hash,
+                payload: record.payload,
+                field,
+            });
+    }
+    Ok(())
+}
+
+/// Rebuilds a chunked column from its chunk records, chunk by chunk: a chunk
+/// this device changed since it last synced is kept when its edit is later
+/// (or when edit times are unknown), otherwise the incoming chunk wins. The
+/// column is only written once every chunk the count names is available, so a
+/// partly received transcript never lands.
+async fn apply_chunked_column(
+    transaction: &mut Transaction<'_, Sqlite>,
+    keyring: &WorkspaceKeyring,
+    row: (&str, &str, &str),
+    column: &str,
+    column_records: ChunkedColumnRecords,
+    states: &mut HashMap<String, LocalState>,
+    row_materialized: bool,
+) -> E2eeReplicaResult<ChunkedColumnOutcome> {
+    let (workspace_id, table, row_id) = row;
+    let all_record_ids = || {
+        column_records
+            .count
+            .iter()
+            .chain(column_records.chunks.values())
+            .map(|record| record.record_id.clone())
+            .collect::<Vec<_>>()
+    };
+    let Some(count_record) = column_records.count.as_ref() else {
+        return Ok(ChunkedColumnOutcome::Deferred(all_record_ids()));
+    };
+    let Some(count) = count_record
+        .field
+        .value
+        .as_u64()
+        .and_then(|count| usize::try_from(count).ok())
+    else {
+        return Err(E2eeReplicaError::InvalidField);
+    };
+    if (0..count).any(|index| !column_records.chunks.contains_key(&index)) {
+        return Ok(ChunkedColumnOutcome::Deferred(all_record_ids()));
+    }
+
+    let chunk_size = chunk_size_for(table, column).unwrap_or(1);
+    let current = read_column(transaction, table, workspace_id, row_id, column).await?;
+    let local_chunks = current
+        .as_ref()
+        .and_then(parse_array)
+        .map(|items| split_chunks(&items, chunk_size))
+        .unwrap_or_default();
+    let mut local_edit: Option<(Option<i64>, String)> = None;
+    let mut merged = Vec::with_capacity(count);
+    let mut applied_fields = 0;
+    let mut kept_local = false;
+    let mut applied_states = Vec::new();
+    for index in 0..count {
+        let record = &column_records.chunks[&index];
+        let remote_chunk = record.field.value.as_array().cloned().unwrap_or_default();
+        let local_chunk = local_chunks.get(index).cloned();
+        let state = states.get(&record.record_id);
+        let keep_local = match (state, local_chunk.as_ref()) {
+            (Some(state), Some(local_chunk)) if !row_materialized => {
+                let local_value = Value::Array(local_chunk.clone());
+                let matches_snapshot = keyring.generations().any(|key| {
+                    key.value_tag(table, row_id, &record.field.field, false, &local_value)
+                        == state.value_tag
+                });
+                if matches_snapshot {
+                    // Unchanged here; take the record unless it is an older
+                    // edit that merely won the revision race.
+                    match (record.field.edited_at_ms, state.edited_at_ms) {
+                        (Some(incoming), Some(local))
+                            if state.payload_hash != record.payload_hash
+                                && incoming_edit_is_older(
+                                    i64::try_from(incoming).unwrap_or(i64::MAX),
+                                    &record.field.writer_id,
+                                    local,
+                                    &state.writer_id,
+                                ) =>
+                        {
+                            mark_local_state_for_republish(
+                                transaction,
+                                &record.record_id,
+                                i64::try_from(record.field.revision)
+                                    .map_err(|_| E2eeReplicaError::InvalidRow)?,
+                            )
+                            .await?;
+                            true
+                        }
+                        _ => false,
+                    }
+                } else if state.payload_hash == record.payload_hash {
+                    true
+                } else {
+                    if local_edit.is_none() {
+                        local_edit = Some((
+                            dirty_row_edited_at_ms(transaction, workspace_id, table, row_id)
+                                .await?,
+                            load_or_create_writer_id(transaction).await?,
+                        ));
+                    }
+                    let (local_edited_at_ms, local_writer_id) =
+                        local_edit.as_ref().expect("local edit loaded");
+                    let incoming_wins = match (record.field.edited_at_ms, local_edited_at_ms) {
+                        (Some(incoming), Some(local)) => {
+                            let incoming = i64::try_from(incoming).unwrap_or(i64::MAX);
+                            incoming > *local
+                                || (incoming == *local && record.field.writer_id > *local_writer_id)
+                        }
+                        _ => false,
+                    };
+                    !incoming_wins
+                }
+            }
+            _ => false,
+        };
+        if keep_local {
+            kept_local = true;
+            merged.push(local_chunk.unwrap_or_default());
+            continue;
+        }
+        merged.push(remote_chunk);
+        if state.is_none_or(|state| state.payload_hash != record.payload_hash) {
+            applied_states.push(record);
+        }
+    }
+
+    let joined = join_chunks(&merged);
+    if current.as_ref() != Some(&joined) {
+        update_field(transaction, table, workspace_id, row_id, column, &joined).await?;
+    }
+    for record in applied_states {
+        let key = keyring
+            .get(&record.field.key_id)
+            .ok_or(E2eeReplicaError::InvalidRow)?;
+        let state = local_state_for_record(key, table, row_id, record);
+        upsert_local_state(transaction, &state).await?;
+        states.insert(state.record_id.clone(), state);
+        applied_fields += 1;
+    }
+    if states
+        .get(&count_record.record_id)
+        .is_none_or(|state| state.payload_hash != count_record.payload_hash)
+    {
+        let key = keyring
+            .get(&count_record.field.key_id)
+            .ok_or(E2eeReplicaError::InvalidRow)?;
+        let state = local_state_for_record(key, table, row_id, count_record);
+        upsert_local_state(transaction, &state).await?;
+        states.insert(state.record_id.clone(), state);
+        applied_fields += 1;
+    }
+    // Chunk state beyond the new count is stale; drop it so a later shrink or
+    // regrowth compares against nothing.
+    let stale_ids = states
+        .values()
+        .filter(|state| {
+            matches!(
+                parse_chunk_field(table, &state.field_name),
+                Some((state_column, ChunkPart::Index(index)))
+                    if state_column == column && index >= count
+            )
+        })
+        .map(|state| state.record_id.clone())
+        .collect::<Vec<_>>();
+    for record_id in stale_ids {
+        sqlx::query("DELETE FROM e2ee_local_state WHERE record_id = ?")
+            .bind(&record_id)
+            .execute(&mut **transaction)
+            .await?;
+        states.remove(&record_id);
+    }
+    // The plain column's own state belongs to the legacy format.
+    sqlx::query(
+        "DELETE FROM e2ee_local_state
+         WHERE workspace_id = ? AND table_name = ? AND row_id = ? AND field_name = ?",
     )
+    .bind(workspace_id)
+    .bind(table)
+    .bind(row_id)
+    .bind(column)
+    .execute(&mut **transaction)
+    .await?;
+    states.retain(|_, state| !(state.field_name == column && state.row_id == row_id));
+    Ok(ChunkedColumnOutcome::Applied {
+        applied_fields,
+        kept_local,
+    })
+}
+
+fn local_state_for_record(
+    key: &anlg_e2ee::WorkspaceKey,
+    table: &str,
+    row_id: &str,
+    record: &DecryptedRecord,
+) -> LocalState {
+    LocalState {
+        record_id: record.record_id.clone(),
+        workspace_id: record.workspace_id.clone(),
+        table_name: table.to_string(),
+        row_id: row_id.to_string(),
+        field_name: record.field.field.clone(),
+        revision: i64::try_from(record.field.revision).unwrap_or(i64::MAX),
+        writer_id: record.field.writer_id.clone(),
+        value_tag: key.value_tag(
+            table,
+            row_id,
+            &record.field.field,
+            record.field.deleted,
+            &record.field.value,
+        ),
+        payload_hash: record.payload_hash.clone(),
+        payload: record.payload.clone(),
+        edited_at_ms: edited_at_ms_i64(record.field.edited_at_ms),
+        republish: false,
+    }
 }
 
 fn edited_at_ms_i64(edited_at_ms: Option<u64>) -> Option<i64> {
@@ -997,6 +1370,7 @@ async fn load_encrypted_row_group(
     keyring: &WorkspaceKeyring,
     row: (&str, &str, &str),
     columns: &HashSet<String>,
+    chunk_fields: &BTreeSet<String>,
     max_bytes: usize,
     is_cancelled: &(impl Fn() -> bool + Sync),
 ) -> E2eeReplicaResult<Option<Vec<EncryptedRecord>>> {
@@ -1007,6 +1381,7 @@ async fn load_encrypted_row_group(
             columns
                 .iter()
                 .filter(|field| !matches!(field.as_str(), "id" | "workspace_id"))
+                .chain(chunk_fields.iter())
                 .map(|field| key.blind_field_id(table, row_id, field))
                 .chain(std::iter::once(key.blind_field_id(
                     table,
@@ -1016,6 +1391,7 @@ async fn load_encrypted_row_group(
         })
         .collect::<Vec<_>>();
     record_ids.sort_unstable();
+    record_ids.dedup();
 
     check_e2ee_apply_cancellation(is_cancelled)?;
     let mut query = QueryBuilder::<Sqlite>::new(

--- a/crates/db-app/src/e2ee/replica_encrypt.rs
+++ b/crates/db-app/src/e2ee/replica_encrypt.rs
@@ -4,6 +4,10 @@ use anlg_e2ee::{WorkspaceKey, WorkspaceKeyring};
 use serde_json::{Value, json};
 use sqlx::{Column, QueryBuilder, Row, Sqlite, SqlitePool, Transaction};
 
+use super::chunks::{
+    ChunkPart, chunk_count_field, chunk_field, chunk_size_for, parse_array, parse_chunk_field,
+    split_chunks,
+};
 use super::cooperative::yield_once;
 use super::replica_storage::{
     load_or_create_writer_id, load_row_local_states_from_pool, sqlite_value, upsert_local_state,
@@ -405,7 +409,7 @@ async fn prepare_dirty_row_cancellable(
             .get(&manifest_id)
             .is_some_and(|state| state.value_tag == tombstone_tag);
     let mut values = Vec::new();
-    let mut record_ids = vec![manifest_id.clone()];
+    let mut retired_fields = Vec::new();
     if let Some(row) = row.as_ref() {
         for (index, column) in row.columns().iter().enumerate() {
             check_e2ee_cancellation(is_cancelled)?;
@@ -413,10 +417,47 @@ async fn prepare_dirty_row_cancellable(
             if matches!(field_name, "id" | "workspace_id") {
                 continue;
             }
-            values.push((field_name.to_string(), sqlite_value(row, index)?));
-            record_ids.push(key.blind_field_id(&dirty.table_name, &dirty.row_id, field_name));
+            let value = sqlite_value(row, index)?;
+            if let Some(chunk_size) = chunk_size_for(&dirty.table_name, field_name)
+                && let Some(items) = parse_array(&value)
+            {
+                let chunks = split_chunks(&items, chunk_size);
+                for (chunk_index, chunk) in chunks.iter().enumerate() {
+                    values.push((
+                        chunk_field(field_name, chunk_index),
+                        Value::Array(chunk.clone()),
+                    ));
+                }
+                values.push((chunk_count_field(field_name), json!(chunks.len())));
+                // Chunks the array no longer reaches are sealed as null so
+                // every replica drops them.
+                let previous_count = states
+                    .values()
+                    .filter_map(|state| {
+                        match parse_chunk_field(&dirty.table_name, &state.field_name) {
+                            Some((column, ChunkPart::Index(index))) if column == field_name => {
+                                Some(index + 1)
+                            }
+                            _ => None,
+                        }
+                    })
+                    .max()
+                    .unwrap_or(0);
+                for chunk_index in chunks.len()..previous_count {
+                    values.push((chunk_field(field_name, chunk_index), Value::Null));
+                }
+                retired_fields.push(field_name.to_string());
+                continue;
+            }
+            values.push((field_name.to_string(), value));
         }
     }
+    let mut record_ids = vec![manifest_id.clone()];
+    record_ids.extend(
+        values.iter().map(|(field_name, _)| {
+            key.blind_field_id(&dirty.table_name, &dirty.row_id, field_name)
+        }),
+    );
     check_e2ee_cancellation(is_cancelled)?;
     let witness_versions = load_witness_versions(pool, &dirty.workspace_id, &record_ids).await?;
     check_e2ee_cancellation(is_cancelled)?;
@@ -484,7 +525,11 @@ async fn prepare_dirty_row_cancellable(
     }
 
     check_e2ee_cancellation(is_cancelled)?;
-    Ok(PreparedDirtyRow { dirty, fields })
+    Ok(PreparedDirtyRow {
+        dirty,
+        fields,
+        retired_fields,
+    })
 }
 
 async fn load_witness_versions(
@@ -701,6 +746,23 @@ pub(super) async fn persist_prepared_dirty_row_cancellable(
             check_e2ee_cancellation(is_cancelled)?;
             return Ok(0);
         }
+    }
+
+    for field_name in &prepared.retired_fields {
+        if let Err(error) = check_e2ee_cancellation(is_cancelled) {
+            transaction.rollback().await?;
+            return Err(error);
+        }
+        sqlx::query(
+            "DELETE FROM e2ee_local_state
+             WHERE workspace_id = ? AND table_name = ? AND row_id = ? AND field_name = ?",
+        )
+        .bind(&prepared.dirty.workspace_id)
+        .bind(&prepared.dirty.table_name)
+        .bind(&prepared.dirty.row_id)
+        .bind(field_name)
+        .execute(&mut *transaction)
+        .await?;
     }
 
     for field in &prepared.fields {

--- a/crates/db-app/src/e2ee/replica_storage.rs
+++ b/crates/db-app/src/e2ee/replica_storage.rs
@@ -8,6 +8,7 @@ use serde_json::{Value, json};
 use sqlx::sqlite::SqliteRow;
 use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool, Transaction, TypeInfo, ValueRef};
 
+use super::chunks::{chunk_size_for, chunk_value, parse_array, parse_chunk_field, split_chunks};
 use super::{
     DecryptedRecord, E2EE_DOMAIN_TABLES, E2eeReplicaError, E2eeReplicaResult, LocalState,
     ROW_MANIFEST_FIELD, check_e2ee_cancellation, yield_once,
@@ -701,7 +702,28 @@ pub(super) async fn delete_row(
     Ok(())
 }
 
+/// Reads a field as it would be sealed: a real column's value, or for a
+/// virtual chunk field the chunk (or chunk count) cut from its column.
 pub(super) async fn read_field(
+    transaction: &mut Transaction<'_, Sqlite>,
+    table: &str,
+    workspace_id: &str,
+    row_id: &str,
+    field: &str,
+) -> E2eeReplicaResult<Option<Value>> {
+    if let Some((column, part)) = parse_chunk_field(table, field) {
+        let Some(value) = read_column(transaction, table, workspace_id, row_id, column).await?
+        else {
+            return Ok(None);
+        };
+        let chunk_size = chunk_size_for(table, column).unwrap_or(1);
+        let items = parse_array(&value).unwrap_or_default();
+        return Ok(Some(chunk_value(&split_chunks(&items, chunk_size), part)));
+    }
+    read_column(transaction, table, workspace_id, row_id, field).await
+}
+
+pub(super) async fn read_column(
     transaction: &mut Transaction<'_, Sqlite>,
     table: &str,
     workspace_id: &str,

--- a/crates/db-app/src/e2ee/tests/chunked_fields.rs
+++ b/crates/db-app/src/e2ee/tests/chunked_fields.rs
@@ -1,0 +1,260 @@
+use super::*;
+
+const EIGHT_AM: i64 = 1_700_000_000_000;
+const NINE_AM: i64 = EIGHT_AM + 3_600_000;
+
+fn words(range: std::ops::Range<usize>) -> Vec<Value> {
+    range
+        .map(|index| json!({ "id": format!("w{index}"), "text": format!("word{index}"), "start_ms": index * 500, "end_ms": index * 500 + 400, "channel": 0 }))
+        .collect()
+}
+
+fn words_json(items: &[Value]) -> String {
+    Value::Array(items.to_vec()).to_string()
+}
+
+async fn seed_transcript(
+    workspace_keys: &HashMap<String, anlg_e2ee::WorkspaceKeyring>,
+    items: &[Value],
+) -> (anlg_db_core::Db, anlg_db_core::Db) {
+    let a = test_db().await;
+    let b = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-a', 'user-a', 'Meeting')",
+    )
+    .execute(a.pool())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO transcripts (id, workspace_id, owner_user_id, session_id, words_json)
+         VALUES ('transcript-1', 'workspace-a', 'user-a', 'session-1', ?)",
+    )
+    .bind(words_json(items))
+    .execute(a.pool())
+    .await
+    .unwrap();
+    // Later edits use fixed times, so the seed must predate them.
+    sqlx::query("UPDATE e2ee_dirty_rows SET dirtied_at_ms = ?")
+        .bind(EIGHT_AM - 3_600_000)
+        .execute(a.pool())
+        .await
+        .unwrap();
+    encrypt_e2ee_replica_changes(a.pool(), workspace_keys)
+        .await
+        .unwrap();
+    copy_replica(a.pool(), b.pool()).await;
+    apply_e2ee_replica_changes(b.pool(), workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(read_words(&b).await, items);
+    (a, b)
+}
+
+async fn read_words(db: &anlg_db_core::Db) -> Vec<Value> {
+    let json: String =
+        sqlx::query_scalar("SELECT words_json FROM transcripts WHERE id = 'transcript-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    serde_json::from_str::<Value>(&json)
+        .unwrap()
+        .as_array()
+        .cloned()
+        .unwrap()
+}
+
+async fn write_words(db: &anlg_db_core::Db, items: &[Value], edited_at_ms: i64) {
+    sqlx::query("UPDATE transcripts SET words_json = ? WHERE id = 'transcript-1'")
+        .bind(words_json(items))
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE e2ee_dirty_rows SET dirtied_at_ms = ?
+         WHERE table_name = 'transcripts' AND row_id = 'transcript-1'",
+    )
+    .bind(edited_at_ms)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
+async fn chunk_state_revisions(db: &anlg_db_core::Db) -> HashMap<String, i64> {
+    sqlx::query_as::<_, (String, i64)>(
+        "SELECT field_name, revision FROM e2ee_local_state
+         WHERE table_name = 'transcripts' AND row_id = 'transcript-1' AND field_name LIKE 'words_json%'",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap()
+    .into_iter()
+    .collect()
+}
+
+async fn chunk_state_fields(db: &anlg_db_core::Db) -> Vec<String> {
+    sqlx::query_scalar(
+        "SELECT field_name FROM e2ee_local_state
+         WHERE table_name = 'transcripts' AND row_id = 'transcript-1' AND field_name LIKE 'words_json%'
+         ORDER BY field_name",
+    )
+    .fetch_all(db.pool())
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn transcripts_sync_as_chunks_and_an_append_reseals_only_the_tail() {
+    let workspace_keys = keys("workspace-a");
+    let items = words(0..600);
+    let (a, b) = seed_transcript(&workspace_keys, &items).await;
+
+    let fields = chunk_state_fields(&a).await;
+    assert_eq!(
+        fields,
+        vec![
+            "words_json#0",
+            "words_json#1",
+            "words_json#2",
+            "words_json#n"
+        ]
+    );
+    assert_eq!(chunk_state_fields(&b).await, fields);
+
+    let revisions_before = chunk_state_revisions(&a).await;
+    let appended = words(0..610);
+    write_words(&a, &appended, NINE_AM).await;
+    let stats = encrypt_e2ee_replica_changes(a.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    // The last chunk, the row manifest, and bookkeeping columns; the earlier
+    // chunks and the count are untouched.
+    assert!(stats.encrypted_fields <= 4, "{stats:?}");
+    let revisions_after = chunk_state_revisions(&a).await;
+    assert_eq!(
+        revisions_after["words_json#0"],
+        revisions_before["words_json#0"]
+    );
+    assert_eq!(
+        revisions_after["words_json#1"],
+        revisions_before["words_json#1"]
+    );
+    assert_eq!(
+        revisions_after["words_json#n"],
+        revisions_before["words_json#n"]
+    );
+    assert!(revisions_after["words_json#2"] > revisions_before["words_json#2"]);
+
+    copy_replica(a.pool(), b.pool()).await;
+    apply_e2ee_replica_changes(b.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(read_words(&b).await, appended);
+}
+
+#[tokio::test]
+async fn edits_to_different_chunks_merge_on_both_devices() {
+    let workspace_keys = keys("workspace-a");
+    let items = words(0..300);
+    let (a, b) = seed_transcript(&workspace_keys, &items).await;
+
+    // Phone corrects a word in the first chunk while offline; desktop keeps
+    // recording and appends to the second chunk.
+    let mut phone = items.clone();
+    phone[3]["text"] = json!("corrected");
+    write_words(&b, &phone, EIGHT_AM).await;
+    let mut desktop = items.clone();
+    desktop.extend(words(300..320));
+    write_words(&a, &desktop, NINE_AM).await;
+    encrypt_e2ee_replica_changes(a.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    copy_replica(a.pool(), b.pool()).await;
+    let stats = apply_e2ee_replica_changes(b.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(stats.recorded_conflicts, 0);
+    let mut expected = desktop.clone();
+    expected[3]["text"] = json!("corrected");
+    assert_eq!(read_words(&b).await, expected);
+
+    encrypt_e2ee_replica_changes(b.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    copy_replica(b.pool(), a.pool()).await;
+    apply_e2ee_replica_changes(a.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    assert_eq!(read_words(&a).await, expected);
+}
+
+#[tokio::test]
+async fn shrinking_a_transcript_drops_trailing_chunks_everywhere() {
+    let workspace_keys = keys("workspace-a");
+    let items = words(0..600);
+    let (a, b) = seed_transcript(&workspace_keys, &items).await;
+
+    let trimmed = words(0..100);
+    write_words(&a, &trimmed, NINE_AM).await;
+    encrypt_e2ee_replica_changes(a.pool(), &workspace_keys)
+        .await
+        .unwrap();
+    copy_replica(a.pool(), b.pool()).await;
+    apply_e2ee_replica_changes(b.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    assert_eq!(read_words(&b).await, trimmed);
+    assert_eq!(
+        chunk_state_fields(&b).await,
+        vec!["words_json#0", "words_json#n"]
+    );
+}
+
+#[tokio::test]
+async fn a_legacy_whole_column_record_still_applies() {
+    let workspace_keys = keys("workspace-a");
+    let key = &workspace_keys["workspace-a"];
+    let db = test_db().await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+         VALUES ('session-1', 'workspace-a', 'user-a', 'Meeting')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    let items = words(0..5);
+    for (field, value) in [
+        (ROW_MANIFEST_FIELD, json!(true)),
+        ("session_id", json!("session-1")),
+        ("words_json", Value::String(words_json(&items))),
+    ] {
+        let sealed = key
+            .seal_field(
+                "workspace-a",
+                "transcripts",
+                "transcript-1",
+                field,
+                "ffffffffffffffffffffffffffffffff",
+                1,
+                false,
+                value,
+            )
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO e2ee_records (id, workspace_id, payload) VALUES (?, 'workspace-a', ?)",
+        )
+        .bind(&sealed.record_id)
+        .bind(&sealed.payload)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    }
+
+    apply_e2ee_replica_changes(db.pool(), &workspace_keys)
+        .await
+        .unwrap();
+
+    assert_eq!(read_words(&db).await, items);
+}

--- a/crates/db-app/src/e2ee/tests/convergence.rs
+++ b/crates/db-app/src/e2ee/tests/convergence.rs
@@ -275,9 +275,12 @@ async fn local_transcript_edit_rebases_above_witnessed_field_and_tombstone() {
         .await
         .unwrap();
 
-    let local_words_payload: String =
+    // Transcript words sync as chunks; the local edit publishes as chunk
+    // records while the row manifest rebases above the witnessed tombstone.
+    let chunk_id = key.blind_field_id("transcripts", "transcript-1", "words_json#0");
+    let local_chunk_payload: String =
         sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
-            .bind(&words_id)
+            .bind(&chunk_id)
             .fetch_one(db.pool())
             .await
             .unwrap();
@@ -287,14 +290,16 @@ async fn local_transcript_edit_rebases_above_witnessed_field_and_tombstone() {
             .fetch_one(db.pool())
             .await
             .unwrap();
-    let rebased_words = key
-        .open_field("workspace-a", &words_id, &local_words_payload)
+    let rebased_chunk = key
+        .open_field("workspace-a", &chunk_id, &local_chunk_payload)
         .unwrap();
     let rebased_manifest = key
         .open_field("workspace-a", &manifest_id, &local_manifest_payload)
         .unwrap();
-    assert_eq!(rebased_words.value, json!(local_words));
-    assert!(rebased_words.revision > 7);
+    assert_eq!(
+        rebased_chunk.value,
+        serde_json::from_str::<Value>(local_words).unwrap()
+    );
     assert!(!rebased_manifest.deleted);
     assert!(rebased_manifest.revision > 8);
 
@@ -410,17 +415,26 @@ async fn chunked_recreation_materializes_late_transcript_and_summary_fields() {
         .await
         .unwrap();
 
-    let words_id = key.blind_field_id("transcripts", "transcript-1", "words_json");
+    // Transcript words sync as chunk records plus a chunk count.
+    let words_chunk_id = key.blind_field_id("transcripts", "transcript-1", "words_json#0");
+    let words_count_id = key.blind_field_id("transcripts", "transcript-1", "words_json#n");
     let body_id = key.blind_field_id("session_documents", "summary-1", "body");
     let transcript_manifest_id =
         key.blind_field_id("transcripts", "transcript-1", ROW_MANIFEST_FIELD);
     let summary_manifest_id =
         key.blind_field_id("session_documents", "summary-1", ROW_MANIFEST_FIELD);
-    let words_payload: String = sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
-        .bind(&words_id)
-        .fetch_one(source.pool())
-        .await
-        .unwrap();
+    let words_chunk_payload: String =
+        sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+            .bind(&words_chunk_id)
+            .fetch_one(source.pool())
+            .await
+            .unwrap();
+    let words_count_payload: String =
+        sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+            .bind(&words_count_id)
+            .fetch_one(source.pool())
+            .await
+            .unwrap();
     let body_payload: String = sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
         .bind(&body_id)
         .fetch_one(source.pool())
@@ -528,7 +542,11 @@ async fn chunked_recreation_materializes_late_transcript_and_summary_fields() {
     );
     assert_eq!(defaults, ("[]".to_string(), String::new()));
 
-    for (id, payload) in [(&words_id, &words_payload), (&body_id, &body_payload)] {
+    for (id, payload) in [
+        (&words_chunk_id, &words_chunk_payload),
+        (&words_count_id, &words_count_payload),
+        (&body_id, &body_payload),
+    ] {
         sqlx::query(
             "INSERT INTO e2ee_records (id, workspace_id, payload)
                  VALUES (?, 'workspace-a', ?)",

--- a/crates/db-app/src/e2ee/tests/mod.rs
+++ b/crates/db-app/src/e2ee/tests/mod.rs
@@ -37,6 +37,7 @@ async fn copy_replica(source: &SqlitePool, target: &SqlitePool) {
 }
 
 mod block_merge;
+mod chunked_fields;
 mod convergence;
 mod convergence_fuzz;
 mod dirty_rows;


### PR DESCRIPTION
A transcript synced as one `words_json` record, so every append during a recording re-sealed the whole array, two devices editing different parts of a transcript replaced each other, and a long meeting could exceed the per-record apply budget.

- `transcripts.words_json` syncs as fixed-size chunks: virtual fields `words_json#0`, `words_json#1`, ... hold 256 words each and `words_json#n` the chunk count.
- An append re-seals only the last chunk, chunks merge independently with the same edit-time rules as other fields, and the column is rebuilt only once every chunk the count names has arrived, so a partly received transcript never lands.
- Whole-column records from older builds still apply and are then republished as chunks; older builds park the chunk records until they update.

The capture-time deferral from #6226 is unchanged; lifting it to show a transcript growing on another device is a follow-up that needs the capture pipeline exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes E2EE replica encrypt/apply and merge behavior for transcript data; logic is substantial but covered by new integration tests.
> 
> **Overview**
> **Transcript `words_json` no longer syncs as a single E2EE field.** Current builds split the JSON word array into 256-word virtual records (`words_json#0`, `words_json#1`, …) plus a count field (`words_json#n`), wired through a new `chunks` module and the encrypt/apply/storage paths.
> 
> **Encrypt** re-seals chunked columns as those virtual fields (and nulls dropped trailing chunks), tracks `retired_fields` on `PreparedDirtyRow`, and deletes legacy plain-column `e2ee_local_state` when persisting.
> 
> **Apply** treats chunk virtual fields as known, loads full row groups including chunk IDs, fetches missing chunks from the count, and rebuilds the column in `apply_chunked_column` with per-chunk edit-time wins—deferring until every indexed chunk is present so partial transcripts never materialize. Whole-column records from older clients still apply and trigger republish as chunks; chunk fields skip conflict copies.
> 
> **Tests** cover append-only tail reseal, concurrent edits in different chunks, shrink, and legacy whole-column apply; existing convergence tests expect chunk record IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de18c99a248972b8f7354132fe0f164cbe4a0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->