### PR TITLE
fix(supabase): grant Cloud API access to workspace-seat Pro members

### DIFF
--- a/supabase/migrations/20260910040000_cloud_api_pro_via_workspace_seat.sql
+++ b/supabase/migrations/20260910040000_cloud_api_pro_via_workspace_seat.sql
@@ -1,0 +1,63 @@
+-- Cloud API access checked only the user's own Stripe customer, so members
+-- whose Pro comes from a paid workspace seat were refused with
+-- subscription_required even though the access token hook already grants them
+-- the hyprnote_pro entitlement. Mirror the hook: a personal entitlement or
+-- trial, or an entitlement or trial on any workspace the user belongs to.
+CREATE OR REPLACE FUNCTION private.cloud_api_user_has_pro(p_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM public.profiles AS profile
+      JOIN stripe.active_entitlements AS entitlement
+        ON entitlement.customer = profile.stripe_customer_id
+      WHERE profile.id = p_user_id
+        AND entitlement.lookup_key = 'hyprnote_pro'
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles AS profile
+      JOIN stripe.subscriptions AS subscription
+        ON subscription.customer = profile.stripe_customer_id
+      WHERE profile.id = p_user_id
+        AND subscription.status = 'trialing'
+        AND (subscription.trial_end #>> '{}')::bigint
+          > extract(epoch FROM now())::bigint
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.workspace_memberships AS membership
+      JOIN public.workspaces AS workspace
+        ON workspace.id = membership.workspace_id
+      JOIN stripe.active_entitlements AS entitlement
+        ON entitlement.customer = workspace.stripe_customer_id
+      WHERE membership.user_id = p_user_id
+        AND membership.deleted_at IS NULL
+        AND workspace.deleted_at IS NULL
+        AND workspace.stripe_customer_id IS NOT NULL
+        AND entitlement.lookup_key = 'hyprnote_pro'
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.workspace_memberships AS membership
+      JOIN public.workspaces AS workspace
+        ON workspace.id = membership.workspace_id
+      JOIN stripe.subscriptions AS subscription
+        ON subscription.customer = workspace.stripe_customer_id
+      WHERE membership.user_id = p_user_id
+        AND membership.deleted_at IS NULL
+        AND workspace.deleted_at IS NULL
+        AND workspace.stripe_customer_id IS NOT NULL
+        AND subscription.status = 'trialing'
+        AND (subscription.trial_end #>> '{}')::bigint
+          > extract(epoch FROM now())::bigint
+    );
+$$;
+
+REVOKE ALL ON FUNCTION private.cloud_api_user_has_pro(uuid)
+  FROM PUBLIC, anon, authenticated;

--- a/supabase/tests/040-cloud-api-workspace-seat.sql
+++ b/supabase/tests/040-cloud-api-workspace-seat.sql
@@ -1,0 +1,135 @@
+begin;
+select plan(7);
+
+select tests.create_supabase_user('seat_cloud_owner', 'seat-cloud-owner@example.com');
+select tests.create_supabase_user('seat_cloud_member', 'seat-cloud-member@example.com');
+
+create temporary table cloud_seat_test_state (
+  name text primary key,
+  workspace_id uuid,
+  invitation_id uuid,
+  invite_token text
+);
+
+grant all on cloud_seat_test_state to authenticated, service_role;
+
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('seat_cloud_owner'),
+  tests.get_supabase_uid('seat_cloud_member')
+);
+
+select tests.authenticate_as('seat_cloud_owner');
+
+select lives_ok(
+  $$
+    insert into cloud_seat_test_state (name, workspace_id)
+    select 'hq', workspace_id from public.create_workspace('Cloud seat HQ')
+  $$,
+  'The owner creates a workspace'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select tests.enable_workspace_plan(
+  (select workspace_id from cloud_seat_test_state where name = 'hq')
+);
+
+select tests.authenticate_as('seat_cloud_owner');
+
+select lives_ok(
+  $$
+    insert into cloud_seat_test_state (name, invitation_id, invite_token)
+    select 'member_invite', invitation_id, invite_token
+    from public.create_workspace_invitation(
+      (select workspace_id from cloud_seat_test_state where name = 'hq'),
+      'seat-cloud-member@example.com'
+    )
+  $$,
+  'The paid workspace invites a member'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('seat_cloud_member');
+
+select lives_ok(
+  $$
+    select *
+    from public.accept_workspace_invitation(
+      (select invitation_id from cloud_seat_test_state where name = 'member_invite'),
+      (select invite_token from cloud_seat_test_state where name = 'member_invite')
+    )
+  $$,
+  'A free account joins the paid workspace'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  format(
+    $$
+      select status
+      from public.verify_cloud_api_user(%L::uuid)
+    $$,
+    tests.get_supabase_uid('seat_cloud_member')
+  ),
+  array['cloud_api_not_enabled'::text],
+  'A member covered by a workspace seat has Pro for the Cloud API before opting in'
+);
+
+select results_eq(
+  format(
+    $$
+      select enabled
+      from public.set_cloud_api_enabled(%L::uuid, true)
+    $$,
+    tests.get_supabase_uid('seat_cloud_member')
+  ),
+  array[true],
+  'A member covered by a workspace seat can enable Cloud API & Connectors'
+);
+
+select results_eq(
+  format(
+    $$
+      select status
+      from public.verify_cloud_api_user(%L::uuid)
+    $$,
+    tests.get_supabase_uid('seat_cloud_member')
+  ),
+  array['ok'::text],
+  'An opted-in member covered by a workspace seat verifies for OAuth access'
+);
+
+select tests.clear_authentication();
+reset role;
+
+delete from stripe.active_entitlements
+where lookup_key = 'hyprnote_pro'
+  and customer = (
+    select stripe_customer_id
+    from public.workspaces
+    where id = (select workspace_id from cloud_seat_test_state where name = 'hq')
+  );
+
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  format(
+    $$
+      select status
+      from public.verify_cloud_api_user(%L::uuid)
+    $$,
+    tests.get_supabase_uid('seat_cloud_member')
+  ),
+  array['subscription_required'::text],
+  'Losing the workspace Pro entitlement revokes Cloud API access'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Why

`private.cloud_api_user_has_pro` only looked at the user's own Stripe customer, so members whose Pro comes from a paid workspace seat were refused with `subscription_required` by `verify_cloud_api_user`, `verify_cloud_api_key`, and `set_cloud_api_enabled`, even though `custom_access_token_hook` already grants them the `hyprnote_pro` entitlement. Claude's connector directory surfaced this as "Authorization with the MCP server failed" right after a successful OAuth flow: the token was valid on every claim and `POST /mcp` still returned 403.

## Changes

- Migration `20260910040000_cloud_api_pro_via_workspace_seat.sql` mirrors the hook's workspace paths in `cloud_api_user_has_pro`: an active `hyprnote_pro` entitlement or an in-trial subscription on any non-deleted workspace the user belongs to now counts alongside the personal entitlement and trial.
- New pgTAP test `040-cloud-api-workspace-seat.sql` walks a free account through a paid-workspace invitation and checks `verify_cloud_api_user` before opt-in, after opt-in, and after the workspace entitlement is removed.

Verified locally with `supabase db reset` + `supabase test db`: 54 files, 1,323 tests, all passing. Hosted deploy is the manual `db_cd.yaml` dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription gating for Cloud API OAuth and API keys; scope is limited to aligning DB checks with existing token entitlements rather than new product rules.
> 
> **Overview**
> **Fixes a mismatch** where OAuth tokens already included `hyprnote_pro` for workspace-seat members, but Cloud API verification still returned `subscription_required`.
> 
> `private.cloud_api_user_has_pro` is **replaced** to match the access-token hook: Pro still counts from a personal `hyprnote_pro` entitlement or active trial, and now also from **any non-deleted workspace** the user belongs to (workspace entitlement or in-trial subscription on the workspace Stripe customer).
> 
> A new pgTAP suite exercises a free user joining a paid workspace—`verify_cloud_api_user` / `set_cloud_api_enabled` before and after opt-in, and **`subscription_required`** after the workspace entitlement is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57325f4275414b2c53769bcdb84001698437c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->