### PR TITLE
fix(api-cloud): add title annotations to Cloud MCP tools

### DIFF
--- a/crates/api-cloud/src/mcp.rs
+++ b/crates/api-cloud/src/mcp.rs
@@ -26,6 +26,7 @@ impl CloudMcpServer {
         output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingPage>(),
         meta = oauth_security_meta(),
         annotations(
+            title = "List meetings",
             read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,
@@ -61,6 +62,7 @@ impl CloudMcpServer {
         output_schema = rmcp::handler::server::tool::schema_for_type::<access::Meeting>(),
         meta = oauth_security_meta(),
         annotations(
+            title = "Get meeting",
             read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,
@@ -87,6 +89,7 @@ impl CloudMcpServer {
         output_schema = rmcp::handler::server::tool::schema_for_type::<access::TranscriptPage>(),
         meta = oauth_security_meta(),
         annotations(
+            title = "Get meeting transcript",
             read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,
@@ -118,6 +121,7 @@ impl CloudMcpServer {
         output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingPage>(),
         meta = oauth_security_meta(),
         annotations(
+            title = "Get recurring meeting history",
             read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,
@@ -152,6 +156,7 @@ impl CloudMcpServer {
         output_schema = rmcp::handler::server::tool::schema_for_type::<access::MeetingExport>(),
         meta = oauth_security_meta(),
         annotations(
+            title = "Export meeting",
             read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,


### PR DESCRIPTION
## Why

Claude's connector directory submission portal reads the live tool list and flags every Cloud MCP tool with "Missing annotations: title". Our tools set `title` only on the top-level `Tool` field (MCP 2025-06-18); Anthropic's pre-submission checklist expects it inside `ToolAnnotations`, which is what drives auto-permissions for read-only tools in Claude.

## Changes

- `crates/api-cloud/src/mcp.rs`: copy each tool's title into its `annotations(...)` block for all five tools (`list_meetings`, `get_meeting`, `get_meeting_transcript`, `get_recurring_meeting_history`, `export_meeting`). Both locations now agree.

Verified with `cargo check --locked -p api` and `cargo test --locked -p api-cloud` (12 passed). Deploy via the manual `api_cd.yaml` dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only MCP annotation updates; no runtime logic, auth, or data-path changes.
> 
> **Overview**
> **Adds `title` to each Cloud MCP tool’s `annotations(...)` block** so it matches the existing top-level `#[tool(title = ...)]` value for all five read-only tools (`list_meetings`, `get_meeting`, `get_meeting_transcript`, `get_recurring_meeting_history`, `export_meeting`).
> 
> This satisfies connector-directory checks that expect a title inside **ToolAnnotations** (used for display and read-only auto-permissions), without changing tool behavior, schemas, or OAuth metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6aca84d4640da85d622f4317ad1785fc2242a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->