### PR TITLE
fix(deepgram): allow batch language detection fallback for unsupported multi-language pairs

### DIFF
--- a/crates/owhisper-client/src/adapter/deepgram/mod.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/mod.rs
@@ -143,7 +143,13 @@ impl DeepgramAdapter {
             return LanguageSupport::NotSupported;
         }
 
-        Self::language_support_impl(languages, model)
+        match Self::language_support_impl(languages, model) {
+            support @ LanguageSupport::Supported { .. } => support,
+            LanguageSupport::NotSupported if Self::supports_batch_language_detection(languages) => {
+                LanguageSupport::min(languages.iter().map(Self::single_language_support))
+            }
+            LanguageSupport::NotSupported => LanguageSupport::NotSupported,
+        }
     }
 
     fn language_support_impl(
@@ -406,6 +412,12 @@ mod tests {
             &languages,
             Some("nova-3-general")
         ));
+    }
+
+    #[test]
+    fn batch_supports_language_detection_fallback_for_unsupported_multi_languages() {
+        let en_pl: Vec<Language> = vec![ISO639::En.into(), ISO639::Pl.into()];
+        assert!(DeepgramAdapter::is_supported_languages_batch(&en_pl, None));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrows batch eligibility logic in the Deepgram adapter only; live paths and Flux batch rejection are unchanged.
> 
> **Overview**
> **Batch** Deepgram language eligibility no longer stops at “no multi-model match” when every requested language supports batch language detection.
> 
> `language_support_batch` still uses the existing model/multi-language checks first, but if that returns `NotSupported` and `supports_batch_language_detection` passes, support is derived from the **minimum** per-language quality via `single_language_support` (same pattern as the happy path). **Live** behavior is unchanged; Flux models remain batch-unsupported.
> 
> Adds a test that **en + pl** is accepted for batch with no explicit model—pairs that live/multi-model logic would reject but detection fallback allows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839374fe040c37fb52258accda184fbea6d159a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->