### PR TITLE
chore(release): number Nightly builds sequentially per base version

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -24,7 +24,9 @@ Do not trigger a stable release from an unmerged branch. Complete the release su
   and can be dispatched manually from `main`. It runs desktop JS/i18n and native
   CI, including source CloudSync rebuilds, before building and publishing all
   desktop platforms through `desktop_cd.yaml` with `channel=nightly`.
-- Nightly versions are `<shared-version>-nightly.<workflow-run-id>`. Each build
+- Nightly versions are `<shared-version>-nightly.<n>`, where `<n>` counts up
+  from 1 for each base version (`1.4.24-nightly.1`, `1.4.24-nightly.2`, ...)
+  and resets when `release-version.json` moves to the next stable. Each build
   snapshots `packages/changelog/nightly.md` into the app and a GitHub prerelease
   tagged `desktop_nightly_v<nightly-version>`. Maintain that file as curated,
   user-facing changes since the previous stable release; do not generate a raw

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -104,7 +104,13 @@ jobs:
             fi
           elif [[ "$RELEASE_CHANNEL" == "nightly" ]]; then
             BASE=$(node -p 'require("./release-version.json").version')
-            VERSION="$BASE-nightly.$GITHUB_RUN_ID"
+            # Sequential per base version: 1.4.24-nightly.1, 1.4.24-nightly.2, ... until
+            # stable 1.4.24 ships. The first restored Nightly used the workflow run ID
+            # as the number; digits beyond six are that legacy scheme and are ignored.
+            LAST=$(git tag --list "desktop_nightly_v${BASE}-nightly.*" \
+              | sed -E "s/^desktop_nightly_v${BASE//./\\.}-nightly\.//" \
+              | grep -Ex '[0-9]{1,6}' | sort -n | tail -1)
+            VERSION="${BASE}-nightly.$(( ${LAST:-0} + 1 ))"
           elif [[ -n "$INPUT_VERSION" ]]; then
             VERSION="$INPUT_VERSION"
           elif [[ "$RELEASE_CHANNEL" == "staging" ]]; then


### PR DESCRIPTION
## Summary

- `desktop_cd.yaml` `compute-version` now derives the Nightly version as `<release-version.json>-nightly.<n>`, where `<n>` is one more than the highest existing `desktop_nightly_v<base>-nightly.<n>` tag (starting at 1). Stable stays `<base>` (1.4.24).
- The one legacy tag that used the workflow run ID (`desktop_nightly_v1.4.24-nightly.34447628579`) is ignored by the counter (digits beyond six).
- `.agents/skills/release-new-version/SKILL.md` describes the new scheme.

## Notes

- Semver orders `1.4.24-nightly.1` below `1.4.24-nightly.34447628579`, so devices on today's run-ID Nightly will not be offered the first sequential build by the updater. Retract that GitHub prerelease and CrabNebula nightly release so new installs do not pick it up; those devices reinstall once.
- Verified locally: with the current tag list the next version is `1.4.24-nightly.1`; with `.1`, `.2`, `.10` present it is `.11`. dprint clean; zizmor shows no new findings for the edited block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release versioning and updater ordering for the Nightly channel; mistaken tag handling could produce duplicate versions or skip numbers, and legacy nightly installs need a one-time migration path.
> 
> **Overview**
> **Nightly desktop builds** no longer use the GitHub workflow run ID in the version string. `desktop_cd.yaml` `compute-version` now assigns `<release-version.json>-nightly.<n>`, where `<n>` is one greater than the highest existing `desktop_nightly_v<base>-nightly.<n>` tag for that base (starting at 1). Tags whose suffix has more than six digits are ignored so the one legacy run-ID prerelease does not affect the counter.
> 
> The release skill doc is updated to match: `<n>` increments per stable base and resets when `release-version.json` bumps. Stable versioning is unchanged.
> 
> **Operational note:** semver treats `1.4.24-nightly.1` as older than the legacy `…-nightly.<run-id>` build, so clients on that legacy nightly may not auto-update to the first sequential build until the old prerelease is retracted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7f7117370ee6ee50c1c57b750ffec688dea783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->