### PR TITLE
chore(changelog): cover Sep 10 sync, Start fresh, and re-transcribe fixes in 1.4.24

### DIFF
--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -15,6 +15,8 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Honor cancellation of post-meeting transcription.
 - Keep saved transcripts when post-processing returns incomplete text.
 - Preserve all requested languages during mixed-language transcription instead of returning partial coverage.
+- Re-transcribe stereo recordings even when the available provider only accepts mono audio, and keep both languages when re-transcribing a mixed-language meeting.
+- Pass dictionary hints and speaker diarization through OpenRouter transcription, so custom terms are honored and multi-speaker transcripts no longer collapse into one speaker. Thanks [@ekapratama93](https://github.com/ekapratama93).
 - Use the actual default microphone on Linux instead of silently recording from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
 - Hide brief prompts after a meeting ends.
 
@@ -23,6 +25,12 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Connect additional sign-in methods from Connected accounts without merging separate accounts.
 - Let team owners automatically admit coworkers with a verified work email domain while respecting seats and previous removals.
 - See why cloud sync is stuck instead of retrying silently, including the failing step when restore or setup cannot continue.
+- Choose **Start fresh on this device** when the notes on a device belong to another Anarlog account. The existing database is kept as a timestamped backup and the signed-in account takes over; nothing from the old notes is uploaded.
+- Switch accounts on a device that never synced without reinstalling.
+- Sync tags, folders, and daily notes across devices.
+- Resolve concurrent edits by when they were made rather than which device published last, merge edits to different paragraphs of the same note, and keep the version that lost so nothing disappears.
+- Sync long transcripts in chunks, so recordings in progress sync incrementally and two devices no longer overwrite each other's transcript.
+- Keep syncing when a newer Anarlog build adds data this version cannot read yet; those records wait for an update instead of stopping sync.
 - Connect **Meta Muse** for transcription and intelligence in Settings → AI.
 
 ## Meeting controls
@@ -30,4 +38,5 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Find the folder picker beside the note header actions.
 - Keep Automations navigation visible when starting or switching chats.
 - Use more compact email and Slack sharing menus.
+- Confirm destructive actions with a click instead of press-and-hold.
 - Remove the scrollbar from the meeting details popover and simplify typography across the app.

--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-09-09"
+date: "2026-09-11"
 summary: "Anarlog Nightly returns with shared notes, clearer sync status, Meta Muse, and more reliable recording."
 ---
 
@@ -19,9 +19,12 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Pass dictionary hints and speaker diarization through OpenRouter transcription, so custom terms are honored and multi-speaker transcripts no longer collapse into one speaker. Thanks [@ekapratama93](https://github.com/ekapratama93).
 - Use the actual default microphone on Linux instead of silently recording from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
 - Hide brief prompts after a meeting ends.
+- Use Bluetooth microphones on macOS reliably by switching to the HFP/SCO profile when the mic opens.
+- Remember names for live one-on-one remote participants across restarts.
 
 ## Accounts, sync, and teams
 
+- Choose monthly or yearly billing for your Pro plan in your account.
 - Connect additional sign-in methods from Connected accounts without merging separate accounts.
 - Let team owners automatically admit coworkers with a verified work email domain while respecting seats and previous removals.
 - See why cloud sync is stuck instead of retrying silently, including the failing step when restore or setup cannot continue.


### PR DESCRIPTION
## Summary

Adds the desktop-facing changes merged after the last 1.4.24 changelog update (#7505):

- Start fresh on this device (#7521) and account takeover on never-synced devices (#7518)
- Tag, folder, and daily-note sync (#7522); edit-time conflict resolution with kept versions (#7520); chunked transcript sync (#7523); parked records instead of failed sync (#7517)
- Stereo and mixed-language re-transcription (#7513, b04e71e9); OpenRouter dictionary hints and diarization (#7515)
- Click-to-confirm destructive buttons (#7529)

#7515 is by outside contributor @ekapratama93 and is credited on its item; the rest are org members or bots. dprint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or deployment impact.
> 
> **Overview**
> **Extends the 1.4.24 release notes** with bullets that were missing after recent merges—no application code changes.
> 
> Under **Transcription and meetings**, it documents stereo/mixed-language re-transcription and OpenRouter dictionary hints plus speaker diarization (with contributor credit).
> 
> Under **Accounts, sync, and teams**, it adds **Start fresh on this device**, account switching on never-synced devices, tag/folder/daily-note sync, edit-time conflict handling with retained losing versions, chunked in-progress transcript sync, and forward-compatible sync when newer builds introduce unreadable records.
> 
> Under **Meeting controls**, it notes destructive actions now use click-to-confirm instead of press-and-hold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75aaafbb5a0ba8728cf758dcce423a97d5a323ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->