### PR TITLE
fix: trigger HFP/SCO when opening a Bluetooth mic on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "aec",
  "anyhow",
  "audio",
+ "audio-device",
  "audio-interface",
  "audio-sync",
  "audio-utils",

--- a/apps/mobile/src/settings/provider-model-catalog.ts
+++ b/apps/mobile/src/settings/provider-model-catalog.ts
@@ -23,6 +23,7 @@ const TRANSCRIPTION_MODELS: Record<string, readonly string[]> = {
     "fish-audio/transcribe-1",
     "x-ai/grok-stt-1.0",
     "deepgram/nova-3",
+    "microsoft/mai-transcribe-2",
     "microsoft/mai-transcribe-1.5",
     "nvidia/parakeet-tdt-0.6b-v3",
     "qwen/qwen3-asr-flash-2026-02-10",

--- a/crates/audio-actual/Cargo.toml
+++ b/crates/audio-actual/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anlg-aec = { workspace = true }
 anlg-audio = { workspace = true }
+anlg-audio-device = { workspace = true }
 anlg-audio-interface = { workspace = true }
 anlg-audio-sync = { workspace = true }
 anlg-audio-utils = { workspace = true }

--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -219,6 +219,7 @@ impl Drop for CpalHandles {
 pub struct MicInput {
     handles: CpalHandles,
     config: cpal::SupportedStreamConfig,
+    bluetooth: Option<Arc<anlg_audio_device::BluetoothInputActivation>>,
 }
 
 const MIC_READ_CHUNK_SIZE: usize = 256;
@@ -305,6 +306,18 @@ impl MicInput {
     }
 
     fn new_locked(device_name: Option<String>) -> Result<Self, crate::Error> {
+        let bluetooth = device_name
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+            .or_else(anlg_audio_device::default_input_device_name)
+            .and_then(|name| anlg_audio_device::prepare_bluetooth_input_for_capture(&name))
+            .map(Arc::new);
+        let preferred = bluetooth
+            .as_ref()
+            .map(|activation| activation.name.clone())
+            .or(device_name);
+
         let host = cpal::default_host();
 
         let get_device_name = |d: &cpal::Device| {
@@ -327,11 +340,8 @@ impl MicInput {
             drop_quietly(d);
             name
         });
-        let ranked = rank_input_devices(
-            device_name.as_deref(),
-            default_name.as_deref(),
-            &listed_names,
-        );
+        let ranked =
+            rank_input_devices(preferred.as_deref(), default_name.as_deref(), &listed_names);
 
         let opened = if ranked.is_empty() {
             None
@@ -407,6 +417,7 @@ impl MicInput {
                 Ok(Self {
                     handles: CpalHandles::new(host, device),
                     config,
+                    bluetooth,
                 })
             }
             None => {
@@ -601,6 +612,7 @@ impl MicInput {
         Ok(MicStream {
             drop_tx,
             config: self.config.clone(),
+            _bluetooth: self.bluetooth.clone(),
             reader: RingbufAsyncReader::new(
                 consumer,
                 waker,
@@ -616,6 +628,7 @@ impl MicInput {
 pub struct MicStream {
     drop_tx: std::sync::mpsc::Sender<()>,
     config: cpal::SupportedStreamConfig,
+    _bluetooth: Option<Arc<anlg_audio_device::BluetoothInputActivation>>,
     reader: RingbufAsyncReader<HeapCons<f32>>,
 }
 

--- a/crates/audio-actual/src/mic.rs
+++ b/crates/audio-actual/src/mic.rs
@@ -313,10 +313,10 @@ impl MicInput {
             .or_else(anlg_audio_device::default_input_device_name)
             .and_then(|name| anlg_audio_device::prepare_bluetooth_input_for_capture(&name))
             .map(Arc::new);
-        let preferred = bluetooth
-            .as_ref()
-            .map(|activation| activation.name.clone())
-            .or(device_name);
+        let preferred = match bluetooth.as_ref() {
+            Some(activation) => activation.name.clone(),
+            None => device_name,
+        };
 
         let host = cpal::default_host();
 

--- a/crates/audio-device/src/device.rs
+++ b/crates/audio-device/src/device.rs
@@ -93,6 +93,14 @@ pub(crate) fn name_suggests_microphone(name: &str) -> bool {
     name.to_lowercase().contains("mic")
 }
 
+/// Hands-Free / HFP capture endpoints created after an A2DP→SCO handoff.
+pub(crate) fn name_suggests_hands_free(name: &str) -> bool {
+    let name_lower = name.to_lowercase();
+    name_lower.contains("hands-free")
+        || name_lower.contains("handsfree")
+        || name_lower.contains("hands free")
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 pub struct AudioDevice {
     pub id: DeviceId,
@@ -142,7 +150,10 @@ impl AudioDevice {
 
 #[cfg(test)]
 mod tests {
-    use super::{name_suggests_microphone, name_suggests_non_microphone, name_suggests_speaker};
+    use super::{
+        name_suggests_hands_free, name_suggests_microphone, name_suggests_non_microphone,
+        name_suggests_speaker,
+    };
 
     #[test]
     fn loopbacks_and_jacks_are_not_microphones() {
@@ -192,6 +203,26 @@ mod tests {
     fn bluetooth_headphones_without_keywords_are_not_speakers() {
         for name in ["WH-1000XM5", "Bose QC45", "AirPods Pro", "Jabra Elite 85t"] {
             assert!(!name_suggests_speaker(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn hands_free_capture_names_are_recognized() {
+        for name in [
+            "AirPods Hands-Free",
+            "AirPods Handsfree",
+            "WH-1000XM5 Hands Free",
+            "Headset (Jabra Elite 85t Hands-Free AG Audio)",
+        ] {
+            assert!(name_suggests_hands_free(name), "{name}");
+        }
+        for name in [
+            "AirPods",
+            "AirPods Pro",
+            "WH-1000XM5",
+            "MacBook Pro Microphone",
+        ] {
+            assert!(!name_suggests_hands_free(name), "{name}");
         }
     }
 }

--- a/crates/audio-device/src/lib.rs
+++ b/crates/audio-device/src/lib.rs
@@ -73,11 +73,11 @@ fn resolve_headphone_only_output(
 
 /// When the default input is a Bluetooth device, returns a wired microphone to use instead.
 ///
-/// Opening a Bluetooth headset's mic forces it into the HFP call profile: the headset gates the
-/// mic to silence between words and the wearer's audio drops to 8–16 kHz. Any wired input avoids
-/// both, so built-in mics are preferred, then USB. Linux reports onboard mics as PCI rather than
-/// built-in, so PCI ranks with built-in. Line-in jacks and output loopbacks are capture endpoints
-/// too but never microphones, so they are skipped.
+/// Opening a Bluetooth headset's mic on Windows forces the HFP call profile: the headset gates
+/// the mic to silence between words and the wearer's audio drops to 8–16 kHz. Any wired input
+/// avoids both, so built-in mics are preferred, then USB. Linux reports onboard mics as PCI
+/// rather than built-in, so PCI ranks with built-in. Line-in jacks and output loopbacks are
+/// capture endpoints too but never microphones, so they are skipped.
 pub fn wired_input_replacing_bluetooth_default() -> Option<AudioDevice> {
     let backend = backend();
     let default = backend.get_default_input_device().ok().flatten()?;
@@ -112,6 +112,127 @@ fn wired_input_rank(transport: TransportType) -> Option<u8> {
         TransportType::Unknown => Some(3),
         TransportType::Bluetooth | TransportType::Virtual => None,
     }
+}
+
+fn bluetooth_input_named<'a>(name: &str, inputs: &'a [AudioDevice]) -> Option<&'a AudioDevice> {
+    inputs.iter().find(|device| {
+        device.direction == AudioDirection::Input
+            && device.transport_type == TransportType::Bluetooth
+            && device.name == name
+    })
+}
+
+fn resolved_capture_name(requested: &AudioDevice, default_after: Option<&AudioDevice>) -> String {
+    default_after
+        .filter(|device| device.transport_type == TransportType::Bluetooth)
+        .map(|device| device.name.clone())
+        .unwrap_or_else(|| requested.name.clone())
+}
+
+/// Keeps a Bluetooth headset in HFP/SCO for the life of a capture stream.
+///
+/// Restores the previous default input when dropped if this activation changed it.
+pub struct BluetoothInputActivation {
+    pub name: String,
+    previous_default: Option<DeviceId>,
+}
+
+impl Drop for BluetoothInputActivation {
+    fn drop(&mut self) {
+        let Some(previous) = self.previous_default.take() else {
+            return;
+        };
+        if let Err(error) = backend().set_default_input_device(&previous) {
+            tracing::warn!(
+                error = %error,
+                device_id = %previous,
+                "bluetooth_input_restore_default_failed"
+            );
+        }
+    }
+}
+
+pub fn default_input_device_name() -> Option<String> {
+    backend()
+        .get_default_input_device()
+        .ok()
+        .flatten()
+        .map(|device| device.name)
+}
+
+/// Prepares a Bluetooth headset so opening it actually receives microphone frames.
+///
+/// On macOS, a Core Audio HAL open against AirPods (and other BT headsets) does not trigger
+/// A2DP→HFP/SCO. Setting the device as the system default input does. After that handoff the
+/// live default may be a different HAL endpoint than the A2DP-named device, so callers should
+/// open the returned name — preferably via the system default input.
+///
+/// Returns `None` when `name` is not a Bluetooth input, or on platforms where opening the
+/// device already negotiates the call profile.
+pub fn prepare_bluetooth_input_for_capture(name: &str) -> Option<BluetoothInputActivation> {
+    #[cfg(target_os = "macos")]
+    {
+        prepare_macos_bluetooth_input(name)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = name;
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn prepare_macos_bluetooth_input(name: &str) -> Option<BluetoothInputActivation> {
+    use std::time::{Duration, Instant};
+
+    const HANDOFF_TIMEOUT: Duration = Duration::from_millis(1000);
+    const HANDOFF_POLL: Duration = Duration::from_millis(50);
+
+    let backend = backend();
+    let inputs = backend.list_input_devices().ok()?;
+    let requested = bluetooth_input_named(name, &inputs)?.clone();
+    let previous = backend.get_default_input_device().ok().flatten();
+    let previous_default = previous
+        .as_ref()
+        .filter(|device| device.id != requested.id)
+        .map(|device| device.id.clone());
+
+    if let Err(error) = backend.set_default_input_device(&requested.id) {
+        tracing::warn!(
+            error = %error,
+            device = %requested.name,
+            "bluetooth_input_set_default_failed"
+        );
+        return Some(BluetoothInputActivation {
+            name: requested.name,
+            previous_default: None,
+        });
+    }
+
+    let started = Instant::now();
+    let mut default_after = previous.filter(|device| device.id == requested.id);
+    while started.elapsed() < HANDOFF_TIMEOUT {
+        match backend.get_default_input_device() {
+            Ok(Some(device)) if device.transport_type == TransportType::Bluetooth => {
+                default_after = Some(device);
+                break;
+            }
+            _ => std::thread::sleep(HANDOFF_POLL),
+        }
+    }
+
+    let name = resolved_capture_name(&requested, default_after.as_ref());
+    tracing::info!(
+        requested = %requested.name,
+        opened = %name,
+        restored_default = previous_default.is_some(),
+        "bluetooth_input_prepared"
+    );
+
+    Some(BluetoothInputActivation {
+        name,
+        previous_default,
+    })
 }
 
 pub trait AudioDeviceBackend {
@@ -331,6 +452,34 @@ mod tests {
         let result =
             resolve_wired_input_replacement(&input("headset", TransportType::Bluetooth), inputs);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn bluetooth_input_named_requires_bluetooth_transport() {
+        let inputs = vec![
+            named_input("usb", "AirPods", TransportType::Usb),
+            named_input("bt", "AirPods", TransportType::Bluetooth),
+            named_input("other", "WH-1000XM5", TransportType::Bluetooth),
+        ];
+        assert_eq!(
+            bluetooth_input_named("AirPods", &inputs).map(|device| device.id.0.as_str()),
+            Some("bt")
+        );
+        assert!(bluetooth_input_named("MacBook Pro Microphone", &inputs).is_none());
+    }
+
+    #[test]
+    fn capture_name_follows_the_live_bluetooth_default_after_handoff() {
+        let requested = named_input("a2dp", "AirPods", TransportType::Bluetooth);
+        let handsfree = named_input("tsco", "AirPods Hands-Free", TransportType::Bluetooth);
+        assert_eq!(
+            resolved_capture_name(&requested, Some(&handsfree)),
+            "AirPods Hands-Free"
+        );
+
+        let builtin = named_input("mic", "MacBook Pro Microphone", TransportType::BuiltIn);
+        assert_eq!(resolved_capture_name(&requested, Some(&builtin)), "AirPods");
+        assert_eq!(resolved_capture_name(&requested, None), "AirPods");
     }
 
     #[test]

--- a/crates/audio-device/src/lib.rs
+++ b/crates/audio-device/src/lib.rs
@@ -122,32 +122,109 @@ fn bluetooth_input_named<'a>(name: &str, inputs: &'a [AudioDevice]) -> Option<&'
     })
 }
 
-fn resolved_capture_name(requested: &AudioDevice, default_after: Option<&AudioDevice>) -> String {
+fn related_bluetooth_endpoint(requested: &AudioDevice, other: &AudioDevice) -> bool {
+    other.direction == AudioDirection::Input
+        && other.transport_type == TransportType::Bluetooth
+        && (other.id == requested.id || bluetooth_names_share_headset(&requested.name, &other.name))
+}
+
+fn bluetooth_base_name(name: &str) -> String {
+    let lower = name.to_lowercase();
+    for suffix in [
+        " hands-free ag audio",
+        " hands-free",
+        " handsfree",
+        " hands free",
+    ] {
+        if let Some(stripped) = lower.strip_suffix(suffix) {
+            return stripped.trim().to_string();
+        }
+    }
+    lower
+}
+
+fn bluetooth_names_share_headset(left: &str, right: &str) -> bool {
+    bluetooth_base_name(left) == bluetooth_base_name(right)
+}
+
+fn bluetooth_handoff_ready(requested: &AudioDevice, default: &AudioDevice) -> bool {
+    related_bluetooth_endpoint(requested, default)
+        && (default.id != requested.id || device::name_suggests_hands_free(&default.name))
+}
+
+fn listed_hands_free_capture<'a>(
+    requested: &AudioDevice,
+    inputs: &'a [AudioDevice],
+) -> Option<&'a AudioDevice> {
+    inputs.iter().find(|device| {
+        related_bluetooth_endpoint(requested, device)
+            && device::name_suggests_hands_free(&device.name)
+    })
+}
+
+fn resolved_capture_name(
+    requested: &AudioDevice,
+    default_after: Option<&AudioDevice>,
+    listed_after: Option<&[AudioDevice]>,
+) -> Option<String> {
     default_after
-        .filter(|device| device.transport_type == TransportType::Bluetooth)
+        .filter(|device| bluetooth_handoff_ready(requested, device))
         .map(|device| device.name.clone())
-        .unwrap_or_else(|| requested.name.clone())
+        .or_else(|| {
+            listed_after.and_then(|inputs| {
+                listed_hands_free_capture(requested, inputs).map(|device| device.name.clone())
+            })
+        })
+}
+
+static BLUETOOTH_DEFAULT_OWNERS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// True while a macOS Bluetooth capture is holding the system default input for HFP/SCO.
+///
+/// Setting that default (and the A2DP→HFP profile switch) looks like a user device change
+/// to Core Audio. Capture must not restart itself on those events.
+pub fn bluetooth_input_owns_system_defaults() -> bool {
+    BLUETOOTH_DEFAULT_OWNERS.load(std::sync::atomic::Ordering::Acquire) > 0
+}
+
+#[cfg(target_os = "macos")]
+fn retain_bluetooth_system_defaults() {
+    BLUETOOTH_DEFAULT_OWNERS.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+}
+
+fn release_bluetooth_system_defaults() {
+    let _ = BLUETOOTH_DEFAULT_OWNERS.fetch_update(
+        std::sync::atomic::Ordering::AcqRel,
+        std::sync::atomic::Ordering::Acquire,
+        |n| Some(n.saturating_sub(1)),
+    );
 }
 
 /// Keeps a Bluetooth headset in HFP/SCO for the life of a capture stream.
 ///
 /// Restores the previous default input when dropped if this activation changed it.
 pub struct BluetoothInputActivation {
-    pub name: String,
+    /// Post-handoff CPAL name to open. `None` means use the live system default.
+    pub name: Option<String>,
     previous_default: Option<DeviceId>,
+    owns_system_defaults: bool,
 }
 
 impl Drop for BluetoothInputActivation {
     fn drop(&mut self) {
-        let Some(previous) = self.previous_default.take() else {
-            return;
-        };
-        if let Err(error) = backend().set_default_input_device(&previous) {
-            tracing::warn!(
-                error = %error,
-                device_id = %previous,
-                "bluetooth_input_restore_default_failed"
-            );
+        if let Some(previous) = self.previous_default.take() {
+            if let Err(error) = backend().set_default_input_device(&previous) {
+                tracing::warn!(
+                    error = %error,
+                    device_id = %previous,
+                    "bluetooth_input_restore_default_failed"
+                );
+            }
+        }
+        if self.owns_system_defaults {
+            self.owns_system_defaults = false;
+            release_bluetooth_system_defaults();
         }
     }
 }
@@ -164,8 +241,9 @@ pub fn default_input_device_name() -> Option<String> {
 ///
 /// On macOS, a Core Audio HAL open against AirPods (and other BT headsets) does not trigger
 /// A2DP→HFP/SCO. Setting the device as the system default input does. After that handoff the
-/// live default may be a different HAL endpoint than the A2DP-named device, so callers should
-/// open the returned name — preferably via the system default input.
+/// live default may be a different HAL endpoint than the A2DP-named device. `name` is that
+/// endpoint when handoff is visible; `None` means open the live system default instead of the
+/// A2DP-named device, which is usually still silent.
 ///
 /// Returns `None` when `name` is not a Bluetooth input, or on platforms where opening the
 /// device already negotiates the call profile.
@@ -204,16 +282,19 @@ fn prepare_macos_bluetooth_input(name: &str) -> Option<BluetoothInputActivation>
             "bluetooth_input_set_default_failed"
         );
         return Some(BluetoothInputActivation {
-            name: requested.name,
+            name: Some(requested.name),
             previous_default: None,
+            owns_system_defaults: false,
         });
     }
 
+    retain_bluetooth_system_defaults();
+
     let started = Instant::now();
-    let mut default_after = previous.filter(|device| device.id == requested.id);
+    let mut default_after = previous.filter(|device| bluetooth_handoff_ready(&requested, device));
     while started.elapsed() < HANDOFF_TIMEOUT {
         match backend.get_default_input_device() {
-            Ok(Some(device)) if device.transport_type == TransportType::Bluetooth => {
+            Ok(Some(device)) if bluetooth_handoff_ready(&requested, &device) => {
                 default_after = Some(device);
                 break;
             }
@@ -221,10 +302,11 @@ fn prepare_macos_bluetooth_input(name: &str) -> Option<BluetoothInputActivation>
         }
     }
 
-    let name = resolved_capture_name(&requested, default_after.as_ref());
+    let listed_after = backend.list_input_devices().ok();
+    let name = resolved_capture_name(&requested, default_after.as_ref(), listed_after.as_deref());
     tracing::info!(
         requested = %requested.name,
-        opened = %name,
+        opened = %name.as_deref().unwrap_or("default"),
         restored_default = previous_default.is_some(),
         "bluetooth_input_prepared"
     );
@@ -232,6 +314,7 @@ fn prepare_macos_bluetooth_input(name: &str) -> Option<BluetoothInputActivation>
     Some(BluetoothInputActivation {
         name,
         previous_default,
+        owns_system_defaults: true,
     })
 }
 
@@ -473,13 +556,78 @@ mod tests {
         let requested = named_input("a2dp", "AirPods", TransportType::Bluetooth);
         let handsfree = named_input("tsco", "AirPods Hands-Free", TransportType::Bluetooth);
         assert_eq!(
-            resolved_capture_name(&requested, Some(&handsfree)),
-            "AirPods Hands-Free"
+            resolved_capture_name(&requested, Some(&handsfree), None).as_deref(),
+            Some("AirPods Hands-Free")
+        );
+
+        let renamed = named_input("a2dp", "AirPods Hands-Free", TransportType::Bluetooth);
+        assert_eq!(
+            resolved_capture_name(&requested, Some(&renamed), None).as_deref(),
+            Some("AirPods Hands-Free")
         );
 
         let builtin = named_input("mic", "MacBook Pro Microphone", TransportType::BuiltIn);
-        assert_eq!(resolved_capture_name(&requested, Some(&builtin)), "AirPods");
-        assert_eq!(resolved_capture_name(&requested, None), "AirPods");
+        assert_eq!(
+            resolved_capture_name(&requested, Some(&builtin), None),
+            None
+        );
+        assert_eq!(
+            resolved_capture_name(&requested, Some(&requested), None),
+            None
+        );
+        assert_eq!(resolved_capture_name(&requested, None, None), None);
+        assert_eq!(
+            resolved_capture_name(
+                &requested,
+                Some(&requested),
+                Some(&[
+                    requested.clone(),
+                    named_input("tsco", "AirPods Hands-Free", TransportType::Bluetooth),
+                ])
+            )
+            .as_deref(),
+            Some("AirPods Hands-Free")
+        );
+    }
+
+    #[test]
+    fn bluetooth_handoff_ignores_the_a2dp_device_just_selected() {
+        let requested = named_input("a2dp", "AirPods", TransportType::Bluetooth);
+        assert!(!bluetooth_handoff_ready(&requested, &requested));
+        assert!(bluetooth_handoff_ready(
+            &requested,
+            &named_input("tsco", "AirPods Hands-Free", TransportType::Bluetooth)
+        ));
+        assert!(!bluetooth_handoff_ready(
+            &requested,
+            &named_input("mic", "MacBook Pro Microphone", TransportType::BuiltIn)
+        ));
+        assert!(!bluetooth_handoff_ready(
+            &requested,
+            &named_input("other", "WH-1000XM5", TransportType::Bluetooth)
+        ));
+    }
+
+    #[test]
+    fn listed_hands_free_endpoint_is_preferred_over_a2dp_default() {
+        let requested = named_input("a2dp", "AirPods", TransportType::Bluetooth);
+        let inputs = vec![
+            requested.clone(),
+            named_input("tsco", "AirPods Hands-Free", TransportType::Bluetooth),
+            named_input("other", "WH-1000XM5 Hands-Free", TransportType::Bluetooth),
+        ];
+        assert_eq!(
+            listed_hands_free_capture(&requested, &inputs).map(|device| device.id.0.as_str()),
+            Some("tsco")
+        );
+        assert_eq!(
+            bluetooth_base_name("AirPods Hands-Free"),
+            bluetooth_base_name("AirPods")
+        );
+        assert_ne!(
+            bluetooth_base_name("AirPods Pro"),
+            bluetooth_base_name("AirPods")
+        );
     }
 
     #[test]

--- a/crates/listener-core/src/actors/source/mod.rs
+++ b/crates/listener-core/src/actors/source/mod.rs
@@ -125,6 +125,15 @@ impl DeviceChangeWatcher {
                     .map_err(|_| mpsc::RecvTimeoutError::Disconnected),
             };
             match event {
+                Ok(DeviceSwitch::DeviceListChanged) => {}
+                Ok(event)
+                    if !device_switch_restarts_source(
+                        &event,
+                        anlg_audio_device::bluetooth_input_owns_system_defaults(),
+                    ) =>
+                {
+                    tracing::info!(?event, "device_switch_ignored_bluetooth_handoff");
+                }
                 Ok(DeviceSwitch::DefaultInputChanged) => {
                     tracing::info!("default_input_changed_restarting_source");
                     actor.stop(Some("device_change".to_string()));
@@ -133,13 +142,19 @@ impl DeviceChangeWatcher {
                     tracing::info!("default_output_changed_restarting_source");
                     actor.stop(Some("device_change".to_string()));
                 }
-                Ok(DeviceSwitch::DeviceListChanged) => {}
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     let Some(routing) = routing.as_mut() else {
                         continue;
                     };
                     let observed = headphone_only_output();
                     if routing.observe(observed) {
+                        if anlg_audio_device::bluetooth_input_owns_system_defaults() {
+                            tracing::info!(
+                                headphone_output = observed,
+                                "output_routing_ignored_bluetooth_handoff"
+                            );
+                            continue;
+                        }
                         tracing::info!(
                             headphone_output = observed,
                             "output_routing_changed_restarting_source"
@@ -155,6 +170,17 @@ impl DeviceChangeWatcher {
 
 fn headphone_only_output() -> bool {
     anlg_audio_device::headphone_only_output().is_some()
+}
+
+// Holding a Bluetooth headset in HFP/SCO sets the system default input and can also move
+// the default output. Those Core Audio events must not bounce the source we just opened.
+fn device_switch_restarts_source(event: &DeviceSwitch, bluetooth_owns_defaults: bool) -> bool {
+    match event {
+        DeviceSwitch::DeviceListChanged => false,
+        DeviceSwitch::DefaultInputChanged | DeviceSwitch::DefaultOutputChanged { .. } => {
+            !bluetooth_owns_defaults
+        }
+    }
 }
 
 // A meeting app can start playing through speakers after capture began, flipping the AEC and
@@ -376,6 +402,9 @@ impl Actor for SourceActor {
         _myself: ActorRef<Self::Msg>,
         st: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        // Drop the watcher before the capture stream so restoring the previous default
+        // input cannot be observed as a device_change restart of this source.
+        st._device_watcher.take();
         if let Some(cancel_token) = st.stream_cancel_token.take() {
             cancel_token.cancel();
         }
@@ -573,6 +602,34 @@ mod tests {
 
         actor.stop(None);
         let _ = handle.await;
+    }
+
+    #[test]
+    fn bluetooth_handoff_device_switches_do_not_restart_the_source() {
+        assert!(device_switch_restarts_source(
+            &DeviceSwitch::DefaultInputChanged,
+            false
+        ));
+        assert!(device_switch_restarts_source(
+            &DeviceSwitch::DefaultOutputChanged {
+                headphone: Some(true)
+            },
+            false
+        ));
+        assert!(!device_switch_restarts_source(
+            &DeviceSwitch::DefaultInputChanged,
+            true
+        ));
+        assert!(!device_switch_restarts_source(
+            &DeviceSwitch::DefaultOutputChanged {
+                headphone: Some(true)
+            },
+            true
+        ));
+        assert!(!device_switch_restarts_source(
+            &DeviceSwitch::DeviceListChanged,
+            false
+        ));
     }
 
     #[test]

--- a/crates/listener-core/src/actors/source/stream.rs
+++ b/crates/listener-core/src/actors/source/stream.rs
@@ -95,9 +95,10 @@ fn resolve_capture_settings(
 // needs a PulseAudio/PipeWire mic capture path.
 const SWAPS_BLUETOOTH_DEFAULT_MIC: bool = cfg!(any(target_os = "macos", target_os = "windows"));
 
-// Opening a Bluetooth headset's mic forces it into HFP: the headset gates the mic to silence
-// between words and the wearer's audio drops to 16 kHz. Only the system default is swapped; an
-// explicit selection is respected.
+// Opening a Bluetooth headset's mic on Windows forces HFP: the headset gates the mic to silence
+// between words and the wearer's audio drops to 16 kHz. On macOS a HAL open does not, so capture
+// later sets the headset as the default input to complete A2DP→HFP/SCO. Only the system default
+// is swapped to wired; an explicit selection is respected.
 fn active_mic_device(explicit: Option<String>, audio: &dyn AudioProvider) -> Option<String> {
     if explicit.is_some() || !SWAPS_BLUETOOTH_DEFAULT_MIC {
         return explicit;


### PR DESCRIPTION
AirPods and other BT headsets stay silent if we only open a HAL input.
Set the device as the system default so Core Audio completes the
A2DP→HFP handoff, then restore the previous default when capture ends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Temporarily changes the system default input on macOS during BT capture; incorrect restore or handoff timing could affect other apps’ mic routing, though scope is limited to explicit/default BT opens and Drop restoration.
> 
> **Overview**
> Fixes **silent Bluetooth headset mics on macOS** by driving Core Audio’s A2DP→HFP/SCO handoff before CPAL opens capture, instead of relying on a HAL open alone.
> 
> **`audio-device`** adds `prepare_bluetooth_input_for_capture` (macOS-only): when the target input is Bluetooth, it temporarily sets that device as the system default input, polls until the live default is a Bluetooth capture endpoint (e.g. “AirPods Hands-Free”), and returns a `BluetoothInputActivation` whose **`Drop` restores the previous default**. Non-macOS platforms no-op. Docs clarify that **wired default replacement** is mainly a **Windows** HFP concern; macOS explicit BT capture uses this new path.
> 
> **`audio-actual`** wires that in at `MicInput` open (explicit device name or system default), prefers the post-handoff device name when ranking CPAL inputs, and keeps the activation alive on `MicStream` for the stream lifetime.
> 
> **`listener-core`** comments are updated to separate Windows default→wired swap from macOS default-input activation at capture time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7339117b9a2773caff3de29378686f67586da180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->