### PR TITLE
docs(agents): add Linear and record-keeping noteAdd instructions to consult and use Linear as the of record beforestarting work. Explain to Linear (issues, docs, comments and Agentlessons) and create or reuse an ANLG- numbered issue. Instruct contributorsto record decisions, progress, and lessons in that and thelocal ~/.claude/AGENTS.md.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Overview
 
+Linear is the system of record for Anarlog. Before starting work, search Linear (issues, docs, comments, and [Agent lessons](https://linear.app/fastrepl-inc/document/agent-lessons-45018045d01e)) and reuse or create an `ANLG-` issue. Record decisions, progress, and lessons there — follow `~/.claude/AGENTS.md`.
+
 Anarlog is a pnpm and Rust workspace. Read the nearest `AGENTS.md` before changing a component.
 
 - `apps/desktop/`: Tauri 2 with React, TypeScript, Vite, and Tailwind. Zustand owns UI state; TanStack Query/Form own queries, mutations, and forms.


### PR DESCRIPTION
This clarifies where to capture project context and decisions to improvetraceability and reduce duplicated effort across the workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor workflow; no runtime, security, or deployment impact.
> 
> **Overview**
> Adds a **Linear-first workflow** to the root `AGENTS.md` **Overview**: treat Linear as the system of record, search issues/docs/comments and [Agent lessons](https://linear.app/fastrepl-inc/document/agent-lessons-45018045d01e) before starting work, reuse or open an `ANLG-` issue, and log decisions/progress/lessons there (with `~/.claude/AGENTS.md` for local agent guidance).
> 
> No application, CI, or schema changes—only contributor documentation to improve traceability and avoid duplicated context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8eb89fea119adea15af2370a0546f1674c8ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->