### PR TITLE
fix(linux): let the AppImage use the host's PipeWire libraries

### DIFF
--- a/scripts/repack-linux-appimage.mjs
+++ b/scripts/repack-linux-appimage.mjs
@@ -12,8 +12,17 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// Host Mesa and WebKitGTK must resolve against the host's matching Wayland ABI.
-const waylandLibraryPattern = /^libwayland-.*\.so(?:\..*)?$/;
+// Libraries that must come from the host rather than the Ubuntu build box:
+// Wayland, because host Mesa and WebKitGTK need the matching ABI; PipeWire and
+// its SPA modules, because libpipewire loads plugins from a directory baked in
+// at build time (Ubuntu's multiarch path does not exist on Fedora), so a bundled
+// copy silently fails to capture there. libpulse stays bundled: it only speaks a
+// stable socket protocol to the daemon, and it dlopens its own libpulsecommon.
+const hostLibraryPatterns = [
+  /^libwayland-.*\.so(?:\..*)?$/,
+  /^libpipewire-.*\.so(?:\..*)?$/,
+  /^libspa-.*\.so(?:\..*)?$/,
+];
 const gdkBackendDefault = 'export GDK_BACKEND="${GDK_BACKEND:-x11,wayland}"';
 
 function patchGtkHook(source) {
@@ -44,7 +53,7 @@ async function findSingleBundleEntry(bundleDirectory, suffix, isExpectedType) {
   return path.join(bundleDirectory, matches[0].name);
 }
 
-export async function findBundledWaylandLibraries(directory) {
+export async function findBundledHostLibraries(directory) {
   const matches = [];
 
   async function walk(currentDirectory) {
@@ -53,7 +62,9 @@ export async function findBundledWaylandLibraries(directory) {
       const entryPath = path.join(currentDirectory, entry.name);
       if (entry.isDirectory()) {
         await walk(entryPath);
-      } else if (waylandLibraryPattern.test(entry.name)) {
+      } else if (
+        hostLibraryPatterns.some((pattern) => pattern.test(entry.name))
+      ) {
         matches.push(entryPath);
       }
     }
@@ -112,7 +123,7 @@ export async function repackLinuxAppImage({
     ".AppImage",
     (entry) => entry.isFile(),
   );
-  const waylandLibraries = await findBundledWaylandLibraries(
+  const hostLibraries = await findBundledHostLibraries(
     path.join(appDirectory, "usr"),
   );
   const gtkHook = path.join(
@@ -124,9 +135,9 @@ export async function repackLinuxAppImage({
   const patchedGtkHook = patchGtkHook(originalGtkHook);
   const updatedGtkHook = originalGtkHook !== patchedGtkHook;
 
-  if (waylandLibraries.length === 0 && !updatedGtkHook) {
+  if (hostLibraries.length === 0 && !updatedGtkHook) {
     console.log(
-      `AppImage already uses host Wayland libraries and GTK backends: ${appImage}`,
+      `AppImage already uses host Wayland and PipeWire libraries and GTK backends: ${appImage}`,
     );
     return { appDirectory, appImage, removedLibraries: [], updatedGtkHook };
   }
@@ -144,20 +155,18 @@ export async function repackLinuxAppImage({
   if (updatedGtkHook) {
     await writeFile(gtkHook, patchedGtkHook);
   }
-  await Promise.all(waylandLibraries.map((library) => rm(library)));
+  await Promise.all(hostLibraries.map((library) => rm(library)));
 
-  const remainingLibraries = await findBundledWaylandLibraries(
+  const remainingLibraries = await findBundledHostLibraries(
     path.join(appDirectory, "usr"),
   );
   if (remainingLibraries.length > 0) {
     throw new Error(
-      `Failed to remove bundled Wayland libraries: ${remainingLibraries.join(", ")}`,
+      `Failed to remove bundled host libraries: ${remainingLibraries.join(", ")}`,
     );
   }
 
-  console.log(
-    `Removed bundled Wayland libraries:\n${waylandLibraries.join("\n")}`,
-  );
+  console.log(`Removed bundled host libraries:\n${hostLibraries.join("\n")}`);
 
   await rm(appImage);
   await run(
@@ -191,7 +200,7 @@ export async function repackLinuxAppImage({
   return {
     appDirectory,
     appImage,
-    removedLibraries: waylandLibraries,
+    removedLibraries: hostLibraries,
     updatedGtkHook,
   };
 }

--- a/scripts/repack-linux-appimage.test.mjs
+++ b/scripts/repack-linux-appimage.test.mjs
@@ -18,7 +18,11 @@ import { repackLinuxAppImage } from "./repack-linux-appimage.mjs";
 
 async function createFixture(
   t,
-  { withWaylandLibraries = true, patchedGtkHook = false } = {},
+  {
+    withWaylandLibraries = true,
+    withAudioLibraries = false,
+    patchedGtkHook = false,
+  } = {},
 ) {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "anarlog-appimage-repack-"),
@@ -65,6 +69,17 @@ async function createFixture(
       path.join(nestedLibraryDirectory, "libwayland-cursor.so.0.22.0"),
       "wayland-cursor",
     );
+  }
+  if (withAudioLibraries) {
+    for (const name of [
+      "libpipewire-0.3.so.0",
+      "libpipewire-0.3.so.0.1000.0",
+      "libspa-support.so",
+      "libpulse.so.0",
+      "libpulsecommon-16.1.so",
+    ]) {
+      await writeFile(path.join(libraryDirectory, name), name);
+    }
   }
   await writeFile(appImage, "original-appimage");
   await writeFile(`${appImage}.sig`, "stale-signature");
@@ -140,6 +155,54 @@ test("removes Wayland libraries, repacks, and regenerates the signature", async 
     args: ["-F", "desktop", "tauri", "signer", "sign", fixture.appImage],
     options: undefined,
   });
+});
+
+test("removes bundled PipeWire libraries and SPA modules but keeps PulseAudio", async (t) => {
+  const fixture = await createFixture(t, {
+    withWaylandLibraries: false,
+    withAudioLibraries: true,
+    patchedGtkHook: true,
+  });
+
+  const result = await repackLinuxAppImage({
+    arch: "aarch64",
+    bundleDirectory: fixture.directory,
+    pluginPath: fixture.plugin,
+    run: async (command) => {
+      if (command === fixture.plugin) {
+        await writeFile(fixture.appImage, "repacked-appimage");
+      } else {
+        await writeFile(`${fixture.appImage}.sig`, "fresh-signature");
+      }
+    },
+  });
+
+  assert.deepEqual(
+    result.removedLibraries.map((library) => path.basename(library)),
+    [
+      "libpipewire-0.3.so.0",
+      "libpipewire-0.3.so.0.1000.0",
+      "libspa-support.so",
+    ],
+  );
+  assert.equal(result.updatedGtkHook, false);
+  for (const kept of ["libpulse.so.0", "libpulsecommon-16.1.so"]) {
+    assert.equal(
+      await readFile(
+        path.join(fixture.appDirectory, "usr", "lib", kept),
+        "utf8",
+      ),
+      kept,
+    );
+  }
+  assert.equal(
+    await readFile(
+      path.join(fixture.appDirectory, "usr", "lib", "libgtk-3.so.0"),
+      "utf8",
+    ),
+    "gtk",
+  );
+  assert.equal(await readFile(fixture.appImage, "utf8"), "repacked-appimage");
 });
 
 test("keeps an already-clean AppImage and its signature unchanged", async (t) => {


### PR DESCRIPTION
## Why

A Fedora 44 user (PipeWire 1.6.2) reported the AppImage records nothing, even for the Welcome demo. `--appimage-extract` confirmed the bundle ships Ubuntu's `libpipewire-0.3`. libpipewire loads its SPA plugins from a directory baked in at build time (Ubuntu's multiarch path), which does not exist on Fedora, so the bundled copy silently fails to capture. Like Wayland, this library has to come from the host.

## What

- `scripts/repack-linux-appimage.mjs`: generalise the Wayland strip list into host-library patterns and also remove `libpipewire-*` and `libspa-*` during repack. `libpulse` stays bundled: it only speaks a stable socket protocol to the daemon and dlopens its own `libpulsecommon`, so bundling is safe and keeps the PulseAudio fallback self-contained.
- Test covering PipeWire/SPA removal and PulseAudio retention.

Host `libpipewire-0.3.so.0` becomes a launch requirement for the AppImage, matching what the `.deb` already declares (`libpipewire-0.3-0`). The AppImage is built on Ubuntu 24.04 (glibc 2.39), so every distro able to run it ships PipeWire.

## Verification

- `node --test scripts/repack-linux-appimage.test.mjs` → 8/8
- dprint check on both files

The next Nightly `desktop_cd` Linux lane exercises the real repack.