### PR TITLE
fix(desktop): stop transcript selection overlay stacking on words

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { createRef, type ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { MultiSelectionBar, SelectionMenu } from "./selection-menu";
 import type { TranscriptContextMenuRequest } from "./selection-menu";
@@ -45,30 +45,26 @@ vi.mock("~/shared/hooks/useAutoCloser", () => ({
   useAutoCloser: () => ({ current: null }),
 }));
 
+beforeAll(() => {
+  Object.assign(Range.prototype, {
+    getBoundingClientRect: () => new DOMRect(20, 700, 100, 20),
+    getClientRects(this: Range) {
+      const text = this.toString();
+      return text ? [new DOMRect(20, 700, text.length * 10, 20)] : [];
+    },
+  });
+});
+
 afterEach(() => {
   cleanup();
+  window.getSelection()?.removeAllRanges();
+  document.body.replaceChildren();
   setSessionFabSelectionHost(null);
 });
 
 describe("SelectionMenu", () => {
   it("keeps the speaker picker inside the viewport without a back row", () => {
-    const request = {
-      id: "request-1",
-      range: {
-        getBoundingClientRect: () => new DOMRect(20, 700, 100, 20),
-        getClientRects: () => [],
-        startOffset: 0,
-        endOffset: 4,
-      },
-      selection: {
-        sessionId: "session-1",
-        text: "Test",
-        startMs: 0,
-        groups: [],
-      },
-      x: 20,
-      y: 700,
-    } as unknown as TranscriptContextMenuRequest;
+    const request = createContextRequest();
 
     render(
       <SelectionMenu
@@ -117,6 +113,32 @@ describe("SelectionMenu", () => {
     );
 
     expect(screen.getByRole("button", { name: "Play from here" })).toBeTruthy();
+  });
+
+  it("paints its own highlight only once the native selection is gone", () => {
+    const request = createContextRequest();
+    window.getSelection()?.addRange(request.range);
+
+    render(
+      <SelectionMenu
+        containerRef={createRef()}
+        contextRequest={request}
+        audioExists={false}
+        onContextClose={vi.fn()}
+        onAssignSpeaker={vi.fn()}
+      />,
+    );
+
+    expect(
+      document.querySelectorAll("[data-transcript-selection-overlay]"),
+    ).toHaveLength(0);
+
+    window.getSelection()?.removeAllRanges();
+    fireEvent(document, new Event("selectionchange"));
+
+    expect(
+      document.querySelectorAll("[data-transcript-selection-overlay]"),
+    ).toHaveLength(1);
   });
 });
 
@@ -212,15 +234,16 @@ describe("MultiSelectionBar", () => {
   });
 });
 
-function createContextRequest() {
+function createContextRequest(): TranscriptContextMenuRequest {
+  const container = document.createElement("div");
+  container.textContent = "Test";
+  document.body.append(container);
+  const range = document.createRange();
+  range.selectNodeContents(container);
+
   return {
     id: crypto.randomUUID(),
-    range: {
-      getBoundingClientRect: () => new DOMRect(20, 700, 100, 20),
-      getClientRects: () => [],
-      startOffset: 0,
-      endOffset: 4,
-    },
+    range,
     selection: {
       sessionId: "session-1",
       text: "Test",
@@ -229,5 +252,5 @@ function createContextRequest() {
     },
     x: 20,
     y: 700,
-  } as unknown as TranscriptContextMenuRequest;
+  };
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection-menu.tsx
@@ -26,7 +26,11 @@ import {
 } from "@anlg/ui/components/ui/popover";
 import { cn } from "@anlg/utils";
 
-import { getTranscriptSelectionFromRange } from "./selection";
+import {
+  getTranscriptRangeRects,
+  getTranscriptSelectionFromRange,
+  isRangeCoveredBySelection,
+} from "./selection";
 import type { TranscriptWordSelection } from "./selection";
 import { SpeakerParticipantPicker } from "./speaker-assign";
 
@@ -446,13 +450,15 @@ function SelectionHighlight({
 }) {
   const [rects, setRects] = useState<DOMRect[]>([]);
 
+  // The native selection paints the range while it lasts; the overlay takes
+  // over once focus moves into the menu and the selection is gone.
   const updateRects = useCallback(() => {
-    if (!range) {
-      setRects([]);
+    if (!range || isRangeCoveredBySelection(range, window.getSelection())) {
+      setRects((prev) => (prev.length === 0 ? prev : []));
       return;
     }
 
-    setRects(Array.from(range.getClientRects()));
+    setRects(getTranscriptRangeRects(range));
   }, [range]);
 
   useMountEffect(() => {
@@ -463,10 +469,12 @@ function SelectionHighlight({
     updateRects();
     const container = containerRef.current;
     window.addEventListener("resize", updateRects);
+    document.addEventListener("selectionchange", updateRects);
     container?.addEventListener("scroll", updateRects, { passive: true });
 
     return () => {
       window.removeEventListener("resize", updateRects);
+      document.removeEventListener("selectionchange", updateRects);
       container?.removeEventListener("scroll", updateRects);
     };
   });
@@ -480,6 +488,7 @@ function SelectionHighlight({
       {rects.map((rect, index) => (
         <div
           key={index}
+          data-transcript-selection-overlay
           style={{
             position: "fixed",
             left: rect.left,

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection.test.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection.test.ts
@@ -4,8 +4,10 @@ import {
   canMergeTranscriptEntries,
   getTranscriptContextSelection,
   getTranscriptMergeTarget,
+  getTranscriptRangeRects,
   getTranscriptSelectionFromRange,
   getTranscriptSelectionFromSegment,
+  isRangeCoveredBySelection,
   mergeTranscriptSelections,
 } from "./selection";
 
@@ -279,4 +281,87 @@ function createSection() {
   section.dataset.segmentSpeakerHumanId = "";
   section.dataset.transcriptOffsetMs = "1000";
   return section;
+}
+
+describe("transcript selection overlay", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(Range.prototype, "getClientRects");
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it("collects text rects per line instead of element boxes", () => {
+    const container = document.createElement("div");
+    container.innerHTML =
+      '<span data-line="0"><span>One</span> <span>two</span></span><span data-line="1"><span>three</span></span>';
+    document.body.append(container);
+    const offsets = new Map<Node, number>();
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    let offset = 0;
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      offsets.set(node, offset);
+      offset += node.textContent?.length ?? 0;
+    }
+    Object.assign(Range.prototype, {
+      getClientRects(this: Range) {
+        const text = this.toString();
+        if (!text) {
+          return [];
+        }
+        const line = Number(
+          this.startContainer.parentElement
+            ?.closest("[data-line]")
+            ?.getAttribute("data-line") ?? 0,
+        );
+        const left =
+          ((offsets.get(this.startContainer) ?? 0) + this.startOffset) * 10;
+        return [new DOMRect(left, line * 20, text.length * 10, 20)];
+      },
+    });
+    const textNodes = [...offsets.keys()];
+
+    const range = document.createRange();
+    range.setStart(textNodes[0]!, 0);
+    range.setEnd(textNodes[3]!, 5);
+    expect(getTranscriptRangeRects(range).map(toPlainRect)).toEqual([
+      { left: 0, top: 0, width: 70, height: 20 },
+      { left: 70, top: 20, width: 50, height: 20 },
+    ]);
+
+    range.setStart(textNodes[2]!, 1);
+    range.setEnd(textNodes[3]!, 3);
+    expect(getTranscriptRangeRects(range).map(toPlainRect)).toEqual([
+      { left: 50, top: 0, width: 20, height: 20 },
+      { left: 70, top: 20, width: 30, height: 20 },
+    ]);
+  });
+
+  it("treats the range as covered while the native selection spans it", () => {
+    const container = document.createElement("div");
+    container.textContent = "One two three";
+    document.body.append(container);
+    const text = container.firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 4);
+    range.setEnd(text, 7);
+    const selection = window.getSelection()!;
+
+    expect(isRangeCoveredBySelection(range, selection)).toBe(false);
+
+    const wider = document.createRange();
+    wider.setStart(text, 0);
+    wider.setEnd(text, 13);
+    selection.addRange(wider);
+    expect(isRangeCoveredBySelection(range, selection)).toBe(true);
+
+    const narrower = document.createRange();
+    narrower.setStart(text, 5);
+    narrower.setEnd(text, 7);
+    selection.removeAllRanges();
+    selection.addRange(narrower);
+    expect(isRangeCoveredBySelection(range, selection)).toBe(false);
+  });
+});
+
+function toPlainRect({ left, top, width, height }: DOMRect) {
+  return { left, top, width, height };
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/selection.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/selection.ts
@@ -443,3 +443,84 @@ function rangeIntersectsNode(range: Range, node: Node) {
     return false;
   }
 }
+
+export function isRangeCoveredBySelection(
+  range: Range,
+  selection: Selection | null,
+) {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return false;
+  }
+
+  try {
+    const native = selection.getRangeAt(0);
+    return (
+      native.compareBoundaryPoints(Range.START_TO_START, range) <= 0 &&
+      native.compareBoundaryPoints(Range.END_TO_END, range) >= 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Range.getClientRects() returns the box of every fully selected element plus
+// the boxes of the text inside it, so word spans would be painted twice.
+export function getTranscriptRangeRects(range: Range): DOMRect[] {
+  const rects: DOMRect[] = [];
+  const textRange = document.createRange();
+
+  for (const node of getRangeTextNodes(range)) {
+    textRange.selectNodeContents(node);
+    if (node === range.startContainer) {
+      textRange.setStart(node, range.startOffset);
+    }
+    if (node === range.endContainer) {
+      textRange.setEnd(node, range.endOffset);
+    }
+
+    for (const rect of Array.from(textRange.getClientRects())) {
+      if (rect.width > 0 && rect.height > 0) {
+        appendLineRect(rects, rect);
+      }
+    }
+  }
+
+  return rects;
+}
+
+function getRangeTextNodes(range: Range): Node[] {
+  const root = range.commonAncestorContainer;
+  if (root.nodeType === Node.TEXT_NODE) {
+    return [root];
+  }
+
+  const nodes: Node[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (rangeIntersectsNode(range, node)) {
+      nodes.push(node);
+    }
+  }
+  return nodes;
+}
+
+function appendLineRect(rects: DOMRect[], rect: DOMRect) {
+  const last = rects[rects.length - 1];
+  const continuesLine =
+    last !== undefined &&
+    Math.abs(last.top - rect.top) < 1 &&
+    Math.abs(last.height - rect.height) < 1 &&
+    rect.left >= last.left &&
+    rect.left <= last.right + 1;
+  if (!continuesLine) {
+    rects.push(rect);
+    return;
+  }
+
+  rects[rects.length - 1] = new DOMRect(
+    last.left,
+    last.top,
+    Math.max(last.right, rect.right) - last.left,
+    last.height,
+  );
+}


### PR DESCRIPTION
Dragging across the transcript showed a darker, taller box on every word
because the selection overlay painted every rect from Range.getClientRects,
which includes each fully selected word span plus its text node, on top of
the still-visible native selection.

- Compute overlay rects from text nodes only and merge them per line.
- Keep the overlay hidden while the native selection still covers the
  stored range, so it only takes over once focus moves into the menu.
- Tag overlay divs with data-transcript-selection-overlay and cover both
  behaviors with tests that use real DOM ranges.

ANLG-328