### PR TITLE
fix(desktop): show the sidebar spinner in place of the shared-note icon

### DIFF
--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   platform: "macos",
   preloadSession: vi.fn(() => Promise.resolve(null)),
   sessionMode: "inactive",
+  isEnhancing: false,
   stop: vi.fn(),
   getOrCreateSessionForEventId: vi.fn(() => Promise.resolve("session-event")),
   storeTitle: "Live Note",
@@ -82,7 +83,7 @@ vi.mock("@anlg/ui/components/ui/tooltip", () => ({
 }));
 
 vi.mock("~/session/hooks/useEnhancedNotes", () => ({
-  useIsSessionEnhancing: () => false,
+  useIsSessionEnhancing: () => mocks.isEnhancing,
 }));
 
 vi.mock("~/session/queries", () => ({
@@ -203,6 +204,7 @@ describe("TimelineItemComponent", () => {
     cleanup();
     mocks.amplitude = { mic: 0.4, speaker: 0.3 };
     mocks.sessionMode = "inactive";
+    mocks.isEnhancing = false;
     mocks.storeTitle = "Live Note";
     mocks.stop.mockClear();
     mocks.openCurrent.mockClear();
@@ -644,11 +646,42 @@ describe("TimelineItemComponent", () => {
     );
 
     const rowButton = screen.getByText("Finalizing Note").closest("button");
-    const spinnerSlot = screen.getByTestId("spinner").parentElement;
+    const spinner = screen.getByTestId("spinner");
 
-    expect(rowButton?.className).toContain("pr-10");
-    expect(spinnerSlot?.className).toContain("absolute");
-    expect(spinnerSlot?.className).toContain("right-3");
+    expect(rowButton?.className).not.toContain("pr-10");
+    expect(spinner.parentElement?.lastElementChild).toBe(spinner);
+  });
+
+  it("replaces the shared icon with the spinner while a shared note regenerates", () => {
+    mocks.isEnhancing = true;
+    mocks.storeTitle = "Shared plan";
+
+    render(
+      <ManagedSharedSessionIdsContext.Provider
+        value={new Set(["session-shared"])}
+      >
+        <TimelineItemComponent
+          item={{
+            type: "session",
+            id: "session-shared",
+            data: {
+              title: "Shared plan",
+              created_at: "2024-01-15T10:30:00.000Z",
+            },
+          }}
+          precision="time"
+          selected={false}
+          timezone="UTC"
+          multiSelected={false}
+          flatItemKeys={["session-session-shared"]}
+        />
+      </ManagedSharedSessionIdsContext.Provider>,
+    );
+
+    const spinner = screen.getByTestId("spinner");
+
+    expect(screen.queryByLabelText("Shared note")).toBeNull();
+    expect(spinner.parentElement?.lastElementChild).toBe(spinner);
   });
 
   it("marks a locally owned shared note with a people icon", () => {

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -202,7 +202,6 @@ const ItemBase = memo(function ItemBase({
     typeof upcomingProgress === "number"
       ? Math.round(Math.max(0, Math.min(upcomingProgress, 1)) * 100)
       : 0;
-  const showTrailingStatus = showLiveStop || showSpinner;
   const folderLabel = folder ?? "";
   const tagLine = formatSidebarItemTags(tags ?? []);
   const extraRows = Number(Boolean(folderLabel)) + Number(Boolean(tagLine));
@@ -239,7 +238,7 @@ const ItemBase = memo(function ItemBase({
         className={cn([
           "w-full rounded-lg px-3 py-2 text-left",
           showUpcomingGauge && "pl-4",
-          showTrailingStatus && "pr-10",
+          showLiveStop && "pr-10",
           ignored ? "cursor-default" : "cursor-pointer",
           multiSelected && "bg-accent",
           !multiSelected && selected && "bg-accent",
@@ -319,7 +318,13 @@ const ItemBase = memo(function ItemBase({
               />
             )
           ) : null}
-          {isShared ? (
+          {showSpinner ? (
+            <Spinner
+              size={14}
+              aria-hidden
+              className="text-muted-foreground shrink-0"
+            />
+          ) : isShared ? (
             <Users
               aria-label={t`Shared note`}
               className="text-muted-foreground size-3.5 shrink-0"
@@ -338,14 +343,6 @@ const ItemBase = memo(function ItemBase({
             className="bg-destructive absolute bottom-0 left-0 w-full rounded-full transition-[height] duration-300 ease-linear"
             style={{ height: `${upcomingGaugePercent}%` }}
           />
-        </div>
-      ) : null}
-      {showSpinner ? (
-        <div
-          aria-hidden
-          className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center"
-        >
-          <Spinner size={14} />
         </div>
       ) : null}
       {showLiveStop ? (


### PR DESCRIPTION
A regenerating shared note drew the spinner over the people icon because
the spinner was absolutely positioned at the row edge while the shared
icon sat in the row's flex flow, so the two glyphs overlapped and were
misaligned.

Render the spinner in-flow in the row's trailing slot, replacing the
shared icon while the note is enhancing, finalizing, batching, or
opening, and keep the extra right padding only for the live stop button.
Cover the swap in the timeline item tests.

ANLG-329