### PR TITLE
Support content and filename options in Markdown exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17221,6 +17221,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-plugin-db",
  "tauri-specta",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/apps/desktop/src/automations/engine.test.ts
+++ b/apps/desktop/src/automations/engine.test.ts
@@ -159,6 +159,7 @@ describe("runMeetingCompletedAutomations (markdown export)", () => {
     expect(mocks.exportMeetingMarkdown).toHaveBeenCalledWith(
       "session-1",
       "/exports",
+      null,
     );
     expect(recordedRun("automation_markdown_export_last_run")).toMatchObject({
       status: "success",

--- a/apps/desktop/src/automations/engine.ts
+++ b/apps/desktop/src/automations/engine.ts
@@ -370,6 +370,7 @@ async function executeMarkdownExport(
   const result = await localApiCommands.exportMeetingMarkdown(
     sessionId,
     directory,
+    null,
   );
   if (result.status === "error") {
     throw new Error(result.error);

--- a/plugins/local-api/Cargo.toml
+++ b/plugins/local-api/Cargo.toml
@@ -29,6 +29,7 @@ specta = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync", "rt", "time"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/plugins/local-api/js/bindings.gen.ts
+++ b/plugins/local-api/js/bindings.gen.ts
@@ -54,9 +54,9 @@ async dispatchEvent(event: string, meetingId: string) : Promise<Result<number, s
     else return { status: "error", error: e  as any };
 }
 },
-async exportMeetingMarkdown(meetingId: string, directory: string) : Promise<Result<string, string>> {
+async exportMeetingMarkdown(meetingId: string, directory: string, options: MarkdownExportOptions | null) : Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("plugin:local-api|export_meeting_markdown", { meetingId, directory }) };
+    return { status: "ok", data: await TAURI_INVOKE("plugin:local-api|export_meeting_markdown", { meetingId, directory, options }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -92,6 +92,7 @@ async listCloudSnapshotIds() : Promise<Result<string[], string>> {
 
 export type CreatedWebhook = ({ id: string; url: string; events: string[]; active: boolean; created_at: string; last_delivery_at: string | null; last_delivery_status: string }) & { secret: string }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
+export type MarkdownExportOptions = { include_memo: boolean; include_summary: boolean; include_transcript: boolean; include_action_items: boolean; filename: string; include_id_suffix: boolean }
 export type WebhookDelivery = { delivered: boolean; status: string }
 export type WebhookInfo = { id: string; url: string; events: string[]; active: boolean; created_at: string; last_delivery_at: string | null; last_delivery_status: string }
 

--- a/plugins/local-api/src/commands.rs
+++ b/plugins/local-api/src/commands.rs
@@ -310,10 +310,16 @@ pub(crate) fn write_markdown_export_with_options(
     let path = directory.join(&filename);
     let mut markdown = filtered.to_markdown();
     markdown.push('\n');
+    let legacy_prefix = legacy_export_prefix(&export.meeting.id);
+    if options.is_none() {
+        markdown.insert_str(0, &legacy_prefix);
+    }
     let existing = match std::fs::read_to_string(&path) {
         Ok(content) => {
             let marker = format!("- ID: `{}`", export.meeting.id);
             let existing_id = content
+                .strip_prefix(&legacy_prefix)
+                .unwrap_or(&content)
                 .split("\n\n")
                 .nth(1)
                 .and_then(|metadata| metadata.lines().next());
@@ -351,6 +357,27 @@ pub(crate) fn persist_markdown_export(
         .prefix(".anlg-export-")
         .tempfile_in(directory)?;
     write(temporary.as_file_mut())?;
+    if replace_existing {
+        let metadata = std::fs::metadata(path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, fchown};
+            let temporary_metadata = temporary.as_file().metadata()?;
+            if metadata.uid() != temporary_metadata.uid()
+                || metadata.gid() != temporary_metadata.gid()
+            {
+                fchown(
+                    temporary.as_file(),
+                    Some(metadata.uid()),
+                    Some(metadata.gid()),
+                )?;
+            }
+        }
+        // Apply modes after ownership, since changing ownership can clear mode bits.
+        temporary
+            .as_file()
+            .set_permissions(metadata.permissions())?;
+    }
     temporary.as_file_mut().flush()?;
     temporary.as_file().sync_all()?;
     if replace_existing {
@@ -363,9 +390,12 @@ pub(crate) fn persist_markdown_export(
     Ok(())
 }
 
-// A meeting is re-exported when its note is enhanced, and by then the title
-// may have changed (e.g. auto-generated), renaming the export. Best-effort
-// remove the meeting's previous file so only the latest export remains.
+fn legacy_export_prefix(meeting_id: &str) -> String {
+    format!("<!-- anarlog:legacy-markdown-export {meeting_id:?} -->\n\n")
+}
+
+// Only remove files explicitly owned by the legacy exporter. Unmarked files
+// may belong to users or configured actions, even when their ID suffix matches.
 fn remove_stale_exports(directory: &std::path::Path, meeting_id: &str, keep_filename: &str) {
     let id_prefix = meeting_id.chars().take(8).collect::<String>();
     if id_prefix.is_empty() {
@@ -375,12 +405,17 @@ fn remove_stale_exports(directory: &std::path::Path, meeting_id: &str, keep_file
     let Ok(entries) = std::fs::read_dir(directory) else {
         return;
     };
+    let owner = legacy_export_prefix(meeting_id);
     for entry in entries.flatten() {
         let name = entry.file_name();
         let Some(name) = name.to_str() else {
             continue;
         };
-        if name != keep_filename && name.ends_with(&marker) {
+        if name != keep_filename
+            && name.ends_with(&marker)
+            && std::fs::read_to_string(entry.path())
+                .is_ok_and(|content| content.starts_with(&owner))
+        {
             let _ = std::fs::remove_file(entry.path());
         }
     }

--- a/plugins/local-api/src/commands.rs
+++ b/plugins/local-api/src/commands.rs
@@ -3,6 +3,7 @@ use tauri::Manager;
 use crate::{CreatedWebhook, MarkdownExportOptions, WebhookDelivery, WebhookInfo, dispatch};
 
 const MAX_CLOUD_SNAPSHOT_BYTES: usize = 2 * 1024 * 1024;
+static MARKDOWN_EXPORT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn pool<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Result<sqlx::SqlitePool, String> {
     app.try_state::<tauri_plugin_db::ManagedState>()
@@ -272,6 +273,10 @@ pub(crate) fn write_markdown_export_with_options(
 ) -> Result<std::path::PathBuf, String> {
     use std::io::Write;
 
+    // Native dispatch and desktop workflows can export the same meeting concurrently.
+    let _guard = MARKDOWN_EXPORT_LOCK
+        .lock()
+        .map_err(|error| error.to_string())?;
     let defaults = MarkdownExportOptions::default();
     let selected = options.unwrap_or(&defaults);
     if !(selected.include_memo
@@ -305,26 +310,57 @@ pub(crate) fn write_markdown_export_with_options(
     let path = directory.join(&filename);
     let mut markdown = filtered.to_markdown();
     markdown.push('\n');
-    match std::fs::OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(mut file) => file.write_all(markdown.as_bytes()),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let existing = std::fs::read_to_string(&path)
-                .map_err(|error| format!("could not read existing export: {error}"))?;
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(content) => {
             let marker = format!("- ID: `{}`", export.meeting.id);
-            let existing_id = existing.split("\n\n").nth(1).and_then(|metadata| metadata.lines().next());
+            let existing_id = content
+                .split("\n\n")
+                .nth(1)
+                .and_then(|metadata| metadata.lines().next());
             if existing_id != Some(marker.as_str()) {
-                return Err(format!("{filename} already exists for another file; choose a different filename or include the meeting ID suffix"));
+                return Err(format!(
+                    "{filename} already exists for another file; choose a different filename or include the meeting ID suffix"
+                ));
             }
-            std::fs::write(&path, &markdown)
+            true
         }
-        Err(error) => Err(error),
-    }.map_err(|error| format!("could not write markdown export: {error}"))?;
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(format!("could not read existing export: {error}")),
+    };
+    persist_markdown_export(&path, existing, |file| file.write_all(markdown.as_bytes()))
+        .map_err(|error| format!("could not write markdown export: {error}"))?;
     // Configured actions can export different content for the same meeting to
     // the same folder. Only the legacy export owns its old filename cleanup.
     if options.is_none() {
         remove_stale_exports(directory, &export.meeting.id, &filename);
     }
     Ok(path)
+}
+
+pub(crate) fn persist_markdown_export(
+    path: &std::path::Path,
+    replace_existing: bool,
+    write: impl FnOnce(&mut std::fs::File) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let directory = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("export has no parent folder"))?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".anlg-export-")
+        .tempfile_in(directory)?;
+    write(temporary.as_file_mut())?;
+    temporary.as_file_mut().flush()?;
+    temporary.as_file().sync_all()?;
+    if replace_existing {
+        temporary.persist(path).map_err(|error| error.error)?;
+    } else {
+        temporary
+            .persist_noclobber(path)
+            .map_err(|error| error.error)?;
+    }
+    Ok(())
 }
 
 // A meeting is re-exported when its note is enhanced, and by then the title

--- a/plugins/local-api/src/commands.rs
+++ b/plugins/local-api/src/commands.rs
@@ -1,6 +1,6 @@
 use tauri::Manager;
 
-use crate::{CreatedWebhook, WebhookDelivery, WebhookInfo, dispatch};
+use crate::{CreatedWebhook, MarkdownExportOptions, WebhookDelivery, WebhookInfo, dispatch};
 
 const MAX_CLOUD_SNAPSHOT_BYTES: usize = 2 * 1024 * 1024;
 
@@ -170,6 +170,7 @@ pub async fn export_meeting_markdown<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     meeting_id: String,
     directory: String,
+    options: Option<MarkdownExportOptions>,
 ) -> Result<String, String> {
     let directory = directory.trim();
     if directory.is_empty() {
@@ -179,18 +180,69 @@ pub async fn export_meeting_markdown<R: tauri::Runtime>(
     let export = anlg_agent_access::get_meeting_export(&pool, meeting_id)
         .await
         .map_err(|error| error.to_string())?;
-    write_markdown_export(std::path::Path::new(directory), &export)
+    write_markdown_export_with_options(std::path::Path::new(directory), &export, options.as_ref())
         .map(|path| path.to_string_lossy().into_owned())
 }
 
 pub(crate) fn markdown_export_filename(meeting: &anlg_agent_access::Meeting) -> String {
+    configured_markdown_filename(meeting, &MarkdownExportOptions::default())
+}
+
+pub(crate) fn configured_markdown_filename(
+    meeting: &anlg_agent_access::Meeting,
+    options: &MarkdownExportOptions,
+) -> String {
     let title = meeting.title.trim();
     let title = if title.is_empty() {
         "Untitled meeting"
     } else {
         title
     };
-    let sanitized = title
+    let occurred_at = if meeting.started_at.is_empty() {
+        &meeting.created_at
+    } else {
+        &meeting.started_at
+    };
+    let date = occurred_at.get(..10).unwrap_or("");
+    let custom = options.filename.trim();
+    let base = if custom.is_empty() {
+        format!("{date} {title}").trim().to_string()
+    } else {
+        custom.replace("{title}", title).replace("{date}", date)
+    };
+    let base = base.trim();
+    let base = if !custom.is_empty() && base.to_ascii_lowercase().ends_with(".md") {
+        &base[..base.len() - 3]
+    } else {
+        base
+    };
+    let mut sanitized = sanitize_filename_part(base);
+    if sanitized.is_empty() {
+        sanitized = "Untitled meeting".to_string();
+    }
+    let stem = sanitized
+        .split('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || (stem.len() == 4
+            && (stem.starts_with("COM") || stem.starts_with("LPT"))
+            && matches!(stem.as_bytes()[3], b'1'..=b'9'))
+    {
+        sanitized.insert(0, '_');
+    }
+    let suffix = if options.include_id_suffix {
+        let prefix = meeting.id.chars().take(8).collect::<String>();
+        format!(" [{}]", sanitize_filename_part(&prefix))
+    } else {
+        String::new()
+    };
+    format!("{sanitized}{suffix}.md")
+}
+
+fn sanitize_filename_part(value: &str) -> String {
+    let sanitized = value
         .chars()
         .map(|c| match c {
             '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
@@ -198,37 +250,80 @@ pub(crate) fn markdown_export_filename(meeting: &anlg_agent_access::Meeting) -> 
             c => c,
         })
         .collect::<String>();
-    let sanitized = sanitized.trim_matches([' ', '.']);
-    let sanitized = if sanitized.is_empty() {
-        "Untitled meeting"
-    } else {
-        sanitized
-    };
-    let occurred_at = if meeting.started_at.is_empty() {
-        &meeting.created_at
-    } else {
-        &meeting.started_at
-    };
-    let id_prefix = meeting.id.chars().take(8).collect::<String>();
-    match occurred_at.get(..10) {
-        Some(date) => format!("{date} {sanitized} [{id_prefix}].md"),
-        None => format!("{sanitized} [{id_prefix}].md"),
+    // Leave room for the suffix and extension on filesystems with a 255-byte limit.
+    let mut end = sanitized.len().min(180);
+    while !sanitized.is_char_boundary(end) {
+        end -= 1;
     }
+    sanitized[..end].trim_matches([' ', '.']).to_string()
 }
 
 pub(crate) fn write_markdown_export(
     directory: &std::path::Path,
     export: &anlg_agent_access::MeetingExport,
 ) -> Result<std::path::PathBuf, String> {
+    write_markdown_export_with_options(directory, export, None)
+}
+
+pub(crate) fn write_markdown_export_with_options(
+    directory: &std::path::Path,
+    export: &anlg_agent_access::MeetingExport,
+    options: Option<&MarkdownExportOptions>,
+) -> Result<std::path::PathBuf, String> {
+    use std::io::Write;
+
+    let defaults = MarkdownExportOptions::default();
+    let selected = options.unwrap_or(&defaults);
+    if !(selected.include_memo
+        || selected.include_summary
+        || selected.include_transcript
+        || selected.include_action_items)
+    {
+        return Err("choose at least one element to export".to_string());
+    }
+    let mut filtered = export.clone();
+    if !selected.include_memo {
+        filtered.meeting.note = None;
+    }
+    if !selected.include_summary {
+        filtered.meeting.summaries.clear();
+    }
+    if !selected.include_transcript {
+        filtered.transcripts.clear();
+    }
+    if !selected.include_action_items {
+        filtered.meeting.action_items.clear();
+    }
+
     std::fs::create_dir_all(directory)
         .map_err(|error| format!("could not create export directory: {error}"))?;
-    let filename = markdown_export_filename(&export.meeting);
-    remove_stale_exports(directory, &export.meeting.id, &filename);
+    let filename = if options.is_none() {
+        markdown_export_filename(&export.meeting)
+    } else {
+        configured_markdown_filename(&export.meeting, selected)
+    };
     let path = directory.join(&filename);
-    let mut markdown = export.to_markdown();
+    let mut markdown = filtered.to_markdown();
     markdown.push('\n');
-    std::fs::write(&path, markdown)
-        .map_err(|error| format!("could not write markdown export: {error}"))?;
+    match std::fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => file.write_all(markdown.as_bytes()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let existing = std::fs::read_to_string(&path)
+                .map_err(|error| format!("could not read existing export: {error}"))?;
+            let marker = format!("- ID: `{}`", export.meeting.id);
+            let existing_id = existing.split("\n\n").nth(1).and_then(|metadata| metadata.lines().next());
+            if existing_id != Some(marker.as_str()) {
+                return Err(format!("{filename} already exists for another file; choose a different filename or include the meeting ID suffix"));
+            }
+            std::fs::write(&path, &markdown)
+        }
+        Err(error) => Err(error),
+    }.map_err(|error| format!("could not write markdown export: {error}"))?;
+    // Configured actions can export different content for the same meeting to
+    // the same folder. Only the legacy export owns its old filename cleanup.
+    if options.is_none() {
+        remove_stale_exports(directory, &export.meeting.id, &filename);
+    }
     Ok(path)
 }
 

--- a/plugins/local-api/src/commands.rs
+++ b/plugins/local-api/src/commands.rs
@@ -359,21 +359,8 @@ pub(crate) fn persist_markdown_export(
     write(temporary.as_file_mut())?;
     if replace_existing {
         let metadata = std::fs::metadata(path)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::{MetadataExt, fchown};
-            let temporary_metadata = temporary.as_file().metadata()?;
-            if metadata.uid() != temporary_metadata.uid()
-                || metadata.gid() != temporary_metadata.gid()
-            {
-                fchown(
-                    temporary.as_file(),
-                    Some(metadata.uid()),
-                    Some(metadata.gid()),
-                )?;
-            }
-        }
-        // Apply modes after ownership, since changing ownership can clear mode bits.
+        // Atomic replacement keeps the temporary file's ownership. Copying a
+        // foreign owner would require privileges even in a writable shared folder.
         temporary
             .as_file()
             .set_permissions(metadata.permissions())?;

--- a/plugins/local-api/src/lib.rs
+++ b/plugins/local-api/src/lib.rs
@@ -188,6 +188,192 @@ mod test {
     }
 
     #[tokio::test]
+    async fn configured_markdown_export_filters_every_content_combination() {
+        let pool = seeded_pool().await;
+        let mut export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let mut summary = export.meeting.note.clone().unwrap();
+        summary.title = "Summary".to_string();
+        summary.markdown = "Summary-only text".to_string();
+        export.meeting.summaries.push(summary);
+        export
+            .meeting
+            .action_items
+            .push(anlg_agent_access::ActionItem {
+                id: "action-1".to_string(),
+                assignee_human_id: String::new(),
+                status: "open".to_string(),
+                text: "Action-only text".to_string(),
+                due_at: String::new(),
+                completed_at: None,
+            });
+        let directory =
+            std::env::temp_dir().join(format!("anlg-md-options-{}", uuid::Uuid::new_v4()));
+        for bits in 0..16 {
+            let options = MarkdownExportOptions {
+                include_memo: bits & 1 != 0,
+                include_summary: bits & 2 != 0,
+                include_transcript: bits & 4 != 0,
+                include_action_items: bits & 8 != 0,
+                filename: format!("selection-{bits}"),
+                include_id_suffix: false,
+            };
+            let result =
+                commands::write_markdown_export_with_options(&directory, &export, Some(&options));
+            if bits == 0 {
+                assert!(result.unwrap_err().contains("at least one"));
+                assert!(!directory.exists());
+                continue;
+            }
+            let path = result.unwrap();
+            let markdown = std::fs::read_to_string(path).unwrap();
+            assert!(markdown.starts_with("# Planning\n"));
+            assert_eq!(markdown.contains("Launch decision"), options.include_memo);
+            assert_eq!(
+                markdown.contains("Summary-only text"),
+                options.include_summary
+            );
+            assert_eq!(markdown.contains("hello world"), options.include_transcript);
+            assert_eq!(
+                markdown.contains("Action-only text"),
+                options.include_action_items
+            );
+        }
+        assert_eq!(std::fs::read_dir(&directory).unwrap().count(), 15);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn configured_markdown_filenames_are_safe_and_support_patterns() {
+        let pool = seeded_pool().await;
+        let export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        for (name, expected) in [
+            ("Recap.md", "Recap.md"),
+            ("{date} {title} recap", "2026-07-13 Planning recap.md"),
+            ("../outside/report", "_outside_report.md"),
+            ("CON", "_CON.md"),
+            ("...", "Untitled meeting.md"),
+            ("  ", "2026-07-13 Planning.md"),
+            ("recap.MD", "recap.md"),
+            ("a\nb", "a_b.md"),
+        ] {
+            let options = MarkdownExportOptions {
+                filename: name.to_string(),
+                include_id_suffix: false,
+                ..Default::default()
+            };
+            assert_eq!(
+                commands::configured_markdown_filename(&export.meeting, &options),
+                expected
+            );
+        }
+        let options = MarkdownExportOptions {
+            filename: "Recap".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            commands::configured_markdown_filename(&export.meeting, &options),
+            "Recap [meeting-].md"
+        );
+        let options = MarkdownExportOptions {
+            filename: "会".repeat(300),
+            ..Default::default()
+        };
+        let name = commands::configured_markdown_filename(&export.meeting, &options);
+        assert!(name.len() < 255);
+        assert_eq!(std::path::Path::new(&name).components().count(), 1);
+        let defaults: MarkdownExportOptions = serde_json::from_str("{}").unwrap();
+        assert_eq!(defaults, MarkdownExportOptions::default());
+    }
+
+    #[tokio::test]
+    async fn configured_actions_keep_separate_exports_for_the_same_meeting() {
+        let pool = seeded_pool().await;
+        let export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let directory =
+            std::env::temp_dir().join(format!("anlg-md-actions-{}", uuid::Uuid::new_v4()));
+        let memo_options = MarkdownExportOptions {
+            filename: "Memo".to_string(),
+            include_transcript: false,
+            ..Default::default()
+        };
+        let transcript_options = MarkdownExportOptions {
+            filename: "Transcript".to_string(),
+            include_memo: false,
+            ..Default::default()
+        };
+        let memo =
+            commands::write_markdown_export_with_options(&directory, &export, Some(&memo_options))
+                .unwrap();
+        let transcript = commands::write_markdown_export_with_options(
+            &directory,
+            &export,
+            Some(&transcript_options),
+        )
+        .unwrap();
+        assert!(memo.exists());
+        assert!(transcript.exists());
+        assert!(
+            !std::fs::read_to_string(memo)
+                .unwrap()
+                .contains("hello world")
+        );
+        assert!(
+            !std::fs::read_to_string(transcript)
+                .unwrap()
+                .contains("Launch decision")
+        );
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn configured_markdown_export_updates_its_own_file_but_rejects_collisions() {
+        let pool = seeded_pool().await;
+        let mut export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let directory =
+            std::env::temp_dir().join(format!("anlg-md-collision-{}", uuid::Uuid::new_v4()));
+        let options = MarkdownExportOptions {
+            filename: "Recap".to_string(),
+            include_id_suffix: false,
+            ..Default::default()
+        };
+        let path =
+            commands::write_markdown_export_with_options(&directory, &export, Some(&options))
+                .unwrap();
+        export.meeting.note.as_mut().unwrap().markdown = "Updated memo".to_string();
+        assert_eq!(
+            commands::write_markdown_export_with_options(&directory, &export, Some(&options))
+                .unwrap(),
+            path
+        );
+        let updated = std::fs::read_to_string(&path).unwrap();
+        assert!(updated.contains("Updated memo"));
+        export.meeting.id = "another-meeting".to_string();
+        let error =
+            commands::write_markdown_export_with_options(&directory, &export, Some(&options))
+                .unwrap_err();
+        assert!(error.contains("already exists"));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), updated);
+        std::fs::write(&path, "My unrelated notes").unwrap();
+        assert!(
+            commands::write_markdown_export_with_options(&directory, &export, Some(&options))
+                .is_err()
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "My unrelated notes"
+        );
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
     async fn note_enhanced_export_skips_silently_without_configuration() {
         let pool = seeded_pool().await;
 

--- a/plugins/local-api/src/lib.rs
+++ b/plugins/local-api/src/lib.rs
@@ -420,7 +420,7 @@ mod test {
     #[cfg(unix)]
     #[tokio::test]
     async fn markdown_replacement_keeps_existing_permission_bits() {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        use std::os::unix::fs::PermissionsExt;
 
         let pool = seeded_pool().await;
         let export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
@@ -432,13 +432,10 @@ mod test {
             commands::write_markdown_export_with_options(directory.path(), &export, Some(&options))
                 .unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
-        let original = std::fs::metadata(&path).unwrap();
         commands::write_markdown_export_with_options(directory.path(), &export, Some(&options))
             .unwrap();
         let updated = std::fs::metadata(path).unwrap();
         assert_eq!(updated.permissions().mode() & 0o777, 0o640);
-        assert_eq!(updated.uid(), original.uid());
-        assert_eq!(updated.gid(), original.gid());
     }
 
     #[tokio::test]

--- a/plugins/local-api/src/lib.rs
+++ b/plugins/local-api/src/lib.rs
@@ -409,11 +409,90 @@ mod test {
         let path = directory
             .path()
             .join(commands::markdown_export_filename(&export.meeting));
-        assert_eq!(
-            std::fs::read_to_string(path).unwrap(),
-            format!("{}\n", export.to_markdown())
-        );
+        let written = std::fs::read_to_string(path).unwrap();
+        let content = written
+            .strip_prefix("<!-- anarlog:legacy-markdown-export \"meeting-1\" -->\n\n")
+            .unwrap_or(&written);
+        assert_eq!(content, format!("{}\n", export.to_markdown()));
         assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn markdown_replacement_keeps_existing_permission_bits() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let pool = seeded_pool().await;
+        let export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let options = MarkdownExportOptions::default();
+        let path =
+            commands::write_markdown_export_with_options(directory.path(), &export, Some(&options))
+                .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+        let original = std::fs::metadata(&path).unwrap();
+        commands::write_markdown_export_with_options(directory.path(), &export, Some(&options))
+            .unwrap();
+        let updated = std::fs::metadata(path).unwrap();
+        assert_eq!(updated.permissions().mode() & 0o777, 0o640);
+        assert_eq!(updated.uid(), original.uid());
+        assert_eq!(updated.gid(), original.gid());
+    }
+
+    #[tokio::test]
+    async fn legacy_cleanup_keeps_configured_and_unmarked_exports() {
+        let pool = seeded_pool().await;
+        let mut export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let legacy = commands::write_markdown_export(directory.path(), &export).unwrap();
+        let options = MarkdownExportOptions {
+            filename: "Memo".to_string(),
+            ..Default::default()
+        };
+        let configured =
+            commands::write_markdown_export_with_options(directory.path(), &export, Some(&options))
+                .unwrap();
+        let unmarked = directory.path().join("Older export [meeting-].md");
+        std::fs::write(&unmarked, format!("{}\n", export.to_markdown())).unwrap();
+        let mut other = export.clone();
+        other.meeting.id = "meeting-2".to_string();
+        other.meeting.title = "Another meeting".to_string();
+        let same_prefix = commands::write_markdown_export(directory.path(), &other).unwrap();
+
+        export.meeting.title = "Planning updated".to_string();
+        commands::write_markdown_export(directory.path(), &export).unwrap();
+        assert!(!legacy.exists());
+        assert!(configured.exists());
+        assert!(unmarked.exists());
+        assert!(same_prefix.exists());
+    }
+
+    #[tokio::test]
+    async fn configured_export_takes_ownership_of_a_shared_legacy_filename() {
+        let pool = seeded_pool().await;
+        let mut export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let path = commands::write_markdown_export(directory.path(), &export).unwrap();
+        commands::write_markdown_export_with_options(
+            directory.path(),
+            &export,
+            Some(&MarkdownExportOptions::default()),
+        )
+        .unwrap();
+        assert!(
+            !std::fs::read_to_string(&path)
+                .unwrap()
+                .starts_with("<!-- anarlog:legacy-markdown-export")
+        );
+        export.meeting.title = "Planning updated".to_string();
+        commands::write_markdown_export(directory.path(), &export).unwrap();
+        assert!(path.exists());
     }
 
     #[tokio::test]

--- a/plugins/local-api/src/lib.rs
+++ b/plugins/local-api/src/lib.rs
@@ -332,6 +332,91 @@ mod test {
     }
 
     #[tokio::test]
+    async fn failed_markdown_writes_leave_no_partial_export_and_can_be_retried() {
+        use std::io::Write;
+
+        let pool = seeded_pool().await;
+        let export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        let options = MarkdownExportOptions {
+            filename: "Recap".to_string(),
+            include_id_suffix: false,
+            ..Default::default()
+        };
+        for replace_existing in [false, true] {
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("Recap.md");
+            if replace_existing {
+                std::fs::write(&path, format!("{}\n", export.to_markdown())).unwrap();
+            }
+            let before = std::fs::read(&path).ok();
+            let error = commands::persist_markdown_export(&path, replace_existing, |file| {
+                file.write_all(b"# Partial")?;
+                Err(std::io::Error::other("simulated write failure"))
+            })
+            .unwrap_err();
+            assert_eq!(error.to_string(), "simulated write failure");
+            assert_eq!(std::fs::read(&path).ok(), before);
+            assert_eq!(
+                std::fs::read_dir(directory.path()).unwrap().count(),
+                usize::from(replace_existing)
+            );
+            commands::write_markdown_export_with_options(directory.path(), &export, Some(&options))
+                .unwrap();
+            assert!(
+                std::fs::read_to_string(&path)
+                    .unwrap()
+                    .contains("hello world")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn simultaneous_markdown_exports_complete_without_false_collisions() {
+        let pool = seeded_pool().await;
+        let mut export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())
+            .await
+            .unwrap();
+        export.meeting.note.as_mut().unwrap().markdown = "Memo content. ".repeat(20_000);
+        let directory = tempfile::tempdir().unwrap();
+        let barrier = std::sync::Barrier::new(8);
+        let options = MarkdownExportOptions::default();
+        std::thread::scope(|scope| {
+            let handles = (0..8)
+                .map(|index| {
+                    let export = &export;
+                    let directory = directory.path();
+                    let barrier = &barrier;
+                    let options = &options;
+                    scope.spawn(move || {
+                        barrier.wait();
+                        for _ in 0..4 {
+                            commands::write_markdown_export_with_options(
+                                directory,
+                                export,
+                                (index % 2 == 0).then_some(options),
+                            )
+                            .unwrap();
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        });
+        let path = directory
+            .path()
+            .join(commands::markdown_export_filename(&export.meeting));
+        assert_eq!(
+            std::fs::read_to_string(path).unwrap(),
+            format!("{}\n", export.to_markdown())
+        );
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[tokio::test]
     async fn configured_markdown_export_updates_its_own_file_but_rejects_collisions() {
         let pool = seeded_pool().await;
         let mut export = anlg_agent_access::get_meeting_export(&pool, "meeting-1".to_string())

--- a/plugins/local-api/src/types.rs
+++ b/plugins/local-api/src/types.rs
@@ -40,3 +40,27 @@ pub struct WebhookDelivery {
     pub delivered: bool,
     pub status: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(default)]
+pub struct MarkdownExportOptions {
+    pub include_memo: bool,
+    pub include_summary: bool,
+    pub include_transcript: bool,
+    pub include_action_items: bool,
+    pub filename: String,
+    pub include_id_suffix: bool,
+}
+
+impl Default for MarkdownExportOptions {
+    fn default() -> Self {
+        Self {
+            include_memo: true,
+            include_summary: true,
+            include_transcript: true,
+            include_action_items: true,
+            filename: String::new(),
+            include_id_suffix: true,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Problem:** Markdown automation exports need per-action content and filename choices.

**Fix:** The complete implementation, including all changes from this PR and the automation controls, is now in #7555.

**Superseded by #7555.** This backend-only PR is withdrawn to leave one submission for the complete feature. No changes are lost, and #7555 has no dependency on merging this PR.

## Verification

The complete verification results and current review status are documented in #7555.
