### PR TITLE
Keep uploaded team logos transparent

### DIFF
--- a/apps/desktop/src/settings/team/index.tsx
+++ b/apps/desktop/src/settings/team/index.tsx
@@ -358,7 +358,7 @@ function WorkspaceTabs({
             aria-pressed={selected}
             onClick={() => onSelect(workspace.workspaceId)}
             className={cn([
-              "flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition-colors",
+              "flex items-center gap-2 rounded-full py-1.5 pr-3 pl-1.5 text-sm transition-colors",
               selected
                 ? "bg-muted text-foreground font-medium"
                 : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",

--- a/apps/desktop/src/settings/team/logo.test.tsx
+++ b/apps/desktop/src/settings/team/logo.test.tsx
@@ -17,8 +17,16 @@ describe("isWorkspaceLogoDataUrl", () => {
     );
   });
 
-  it("rejects non-JPEG and oversized payloads", () => {
-    expect(isWorkspaceLogoDataUrl("data:image/png;base64,AAAA")).toBe(false);
+  it("accepts a bounded PNG data URL", () => {
+    expect(isWorkspaceLogoDataUrl("data:image/png;base64,iVBORw0KGgo=")).toBe(
+      true,
+    );
+  });
+
+  it("rejects unsupported image formats and oversized payloads", () => {
+    expect(isWorkspaceLogoDataUrl("data:image/svg+xml;base64,AAAAAAAA")).toBe(
+      false,
+    );
     expect(isWorkspaceLogoDataUrl("javascript:alert(1)")).toBe(false);
     expect(
       isWorkspaceLogoDataUrl(`data:image/jpeg;base64,${"A".repeat(120_000)}`),
@@ -27,7 +35,7 @@ describe("isWorkspaceLogoDataUrl", () => {
 });
 
 describe("WorkspaceLogoButton", () => {
-  it("crops uploaded logos to a 128 by 128 JPEG", async () => {
+  it("crops uploaded logos to a 128 by 128 PNG without flattening transparency", async () => {
     const context = {
       drawImage: vi.fn(),
       fillRect: vi.fn(),
@@ -35,7 +43,7 @@ describe("WorkspaceLogoButton", () => {
       imageSmoothingQuality: "low",
     };
     const onUpload = vi.fn();
-    const jpeg = "data:image/jpeg;base64,/9j/4AAQ";
+    const png = "data:image/png;base64,iVBORw0KGgo=";
 
     vi.stubGlobal("URL", {
       createObjectURL: vi.fn(() => "blob:logo"),
@@ -61,9 +69,9 @@ describe("WorkspaceLogoButton", () => {
       function (this: HTMLCanvasElement, type, quality) {
         expect(this.width).toBe(128);
         expect(this.height).toBe(128);
-        expect(type).toBe("image/jpeg");
-        expect(quality).toBe(0.85);
-        return jpeg;
+        expect(type).toBe("image/png");
+        expect(quality).toBeUndefined();
+        return png;
       },
     );
 
@@ -90,8 +98,9 @@ describe("WorkspaceLogoButton", () => {
     });
 
     await waitFor(() => {
-      expect(onUpload).toHaveBeenCalledWith(jpeg);
+      expect(onUpload).toHaveBeenCalledWith(png);
     });
+    expect(context.fillRect).not.toHaveBeenCalled();
     expect(context.drawImage).toHaveBeenCalledWith(
       expect.anything(),
       100,

--- a/apps/desktop/src/settings/team/logo.ts
+++ b/apps/desktop/src/settings/team/logo.ts
@@ -2,7 +2,7 @@ export const WORKSPACE_LOGO_RASTER_SIZE = 128;
 export const MAX_WORKSPACE_LOGO_DATA_LENGTH = 120_000;
 
 const WORKSPACE_LOGO_DATA_PATTERN =
-  /^data:image\/jpeg;base64,[A-Za-z0-9+/]+={0,2}$/;
+  /^data:image\/(?:jpeg|png);base64,[A-Za-z0-9+/]+={0,2}$/;
 
 export function isWorkspaceLogoDataUrl(value: string): boolean {
   return (
@@ -25,14 +25,6 @@ export async function compressWorkspaceLogo(file: File): Promise<string> {
     const context = canvas.getContext("2d");
     if (!context) throw new Error("canvas 2d context unavailable");
 
-    // JPEG has no alpha channel; flatten transparency onto white.
-    context.fillStyle = "#ffffff";
-    context.fillRect(
-      0,
-      0,
-      WORKSPACE_LOGO_RASTER_SIZE,
-      WORKSPACE_LOGO_RASTER_SIZE,
-    );
     context.imageSmoothingQuality = "high";
     context.drawImage(
       image,
@@ -45,9 +37,9 @@ export async function compressWorkspaceLogo(file: File): Promise<string> {
       WORKSPACE_LOGO_RASTER_SIZE,
       WORKSPACE_LOGO_RASTER_SIZE,
     );
-    const dataUrl = canvas.toDataURL("image/jpeg", 0.85);
+    const dataUrl = canvas.toDataURL("image/png");
     if (!isWorkspaceLogoDataUrl(dataUrl)) {
-      throw new Error("compressed logo is not a JPEG");
+      throw new Error("compressed logo is invalid or too large");
     }
     return dataUrl;
   } finally {

--- a/supabase/migrations/20260912160000_workspace_logo_transparency.sql
+++ b/supabase/migrations/20260912160000_workspace_logo_transparency.sql
@@ -75,4 +75,3 @@ BEGIN
   SELECT p_workspace_id, v_logo_data;
 END;
 $$;
-

--- a/supabase/migrations/20260912160000_workspace_logo_transparency.sql
+++ b/supabase/migrations/20260912160000_workspace_logo_transparency.sql
@@ -1,0 +1,78 @@
+ALTER TABLE public.workspaces
+DROP CONSTRAINT workspaces_logo_data_check;
+
+ALTER TABLE public.workspaces
+ADD CONSTRAINT workspaces_logo_data_check CHECK (
+  logo_data IS NULL
+  OR (
+    char_length(logo_data) BETWEEN 30 AND 120000
+    AND logo_data ~ '^data:image/(jpeg|png);base64,[A-Za-z0-9+/]+={0,2}$'
+  )
+);
+
+CREATE OR REPLACE FUNCTION private.set_workspace_logo(
+  p_workspace_id uuid,
+  p_logo_data text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  workspace_logo_data text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_actor_role text;
+  v_logo_data text := p_logo_data;
+BEGIN
+  PERFORM private.require_workspace_capability(
+    p_workspace_id,
+    'team.manage_workspace'
+  );
+
+  SELECT membership.role
+  INTO v_actor_role
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND membership.user_id = v_actor_id
+    AND membership.role IN ('owner', 'admin')
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+  FOR UPDATE OF workspace;
+
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'workspace logo operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_logo_data IS NOT NULL THEN
+    v_logo_data := btrim(v_logo_data);
+    IF char_length(v_logo_data) < 30
+      OR char_length(v_logo_data) > 120000
+      OR v_logo_data !~ '^data:image/(jpeg|png);base64,[A-Za-z0-9+/]+={0,2}$'
+    THEN
+      RAISE EXCEPTION 'invalid workspace logo'
+        USING ERRCODE = '22023';
+    END IF;
+  END IF;
+
+  UPDATE public.workspaces
+  SET
+    logo_data = v_logo_data,
+    updated_at = now()
+  WHERE id = p_workspace_id;
+
+  RETURN QUERY
+  SELECT p_workspace_id, v_logo_data;
+END;
+$$;
+

--- a/supabase/tests/045-workspace-logo.sql
+++ b/supabase/tests/045-workspace-logo.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(10);
+select plan(12);
 
 select tests.create_supabase_user('logo_owner', 'logo-owner@example.com');
 select tests.create_supabase_user('logo_member', 'logo-member@example.com');
@@ -68,16 +68,35 @@ select results_eq(
   'The logo is stored on the workspace'
 );
 
+select lives_ok(
+  $$
+    select * from public.set_workspace_logo(
+      (select workspace_id from workspace_logo_test_state where name = 'owner'),
+      'data:image/png;base64,iVBORw0KGgo='
+    )
+  $$,
+  'A workspace manager can set a transparent PNG logo'
+);
+
+select results_eq(
+  $$
+    select logo_data from public.workspaces
+    where id = (select workspace_id from workspace_logo_test_state where name = 'owner')
+  $$,
+  $$values ('data:image/png;base64,iVBORw0KGgo='::text)$$,
+  'The PNG logo is stored unchanged'
+);
+
 select throws_ok(
   $$
     select * from public.set_workspace_logo(
       (select workspace_id from workspace_logo_test_state where name = 'owner'),
-      'data:image/png;base64,AAAA'
+      'data:image/svg+xml;base64,AAAAAAAA'
     )
   $$,
   '22023',
   'invalid workspace logo',
-  'Non-JPEG data URLs are rejected'
+  'Unsupported image data URLs are rejected'
 );
 
 select throws_ok(
@@ -113,7 +132,7 @@ select results_eq(
       select workspace_id from workspace_logo_test_state where name = 'owner'
     )
   $$,
-  $$values ('data:image/jpeg;base64,/9j/4AAQ'::text)$$,
+  $$values ('data:image/png;base64,iVBORw0KGgo='::text)$$,
   'Workspace members can read the logo used by their clients'
 );
 


### PR DESCRIPTION
Rasterize uploaded team logos as 128×128 PNGs so transparent backgrounds survive cropping. Accept bounded PNG data URLs in desktop validation and the workspace logo RPC while retaining JPEG compatibility, and tighten the workspace chip spacing.

Includes upload and database regression coverage.

ANLG-214
