### PR TITLE
Support Nari Labs live transcription on desktop and mobile

### DIFF
--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -56,6 +56,7 @@ describe("getDefaultSttModel", () => {
     expect(getDefaultSttModel("openrouter")).toBe("openai/gpt-transcribe");
     expect(getDefaultSttModel("xai")).toBe("xai-stt");
     expect(getDefaultSttModel("smallestai")).toBe("pulse");
+    expect(getDefaultSttModel("nari")).toBe("qwen3-asr-fast:free");
     expect(getDefaultSttModel("meta")).toBe("muse-voice-transcribe-1.0");
     expect(getDefaultSttModel("google_generative_ai")).toBe(
       "gemini-3.5-transcribe-live",

--- a/apps/desktop/src/settings/ai/stt/shared.test.ts
+++ b/apps/desktop/src/settings/ai/stt/shared.test.ts
@@ -39,6 +39,7 @@ describe("STT providers", () => {
       "together",
       "xai",
       "smallestai",
+      "nari",
       "pyannote",
       "cohere",
       "aquavoice",
@@ -237,4 +238,20 @@ describe("STT model deprecation", () => {
     );
     expect(providers.soniox.models).toEqual(["stt-rt-v5"]);
   });
+});
+
+test("Nari exposes the documented Free and Partner transcription models", () => {
+  const provider = PROVIDERS.find(({ id }) => id === "nari")!;
+  expect(provider.disabled).toBe(false);
+  expect(provider.baseUrl).toBe("https://api.narilabs.com");
+  expect(provider.models).toEqual([
+    "qwen3-asr-fast:free",
+    "qwen3-asr:free",
+    "qwen3-asr-fast",
+    "qwen3-asr",
+  ]);
+  expect(displayModelLabel("qwen3-asr-fast:free")).toBe(
+    "Qwen3 ASR Fast (Free)",
+  );
+  expect(displayModelLabel("qwen3-asr")).toBe("Qwen3 ASR (Partner)");
 });

--- a/apps/desktop/src/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/settings/ai/stt/shared.tsx
@@ -73,6 +73,11 @@ const OPENROUTER_MODEL_LABELS: Record<string, string> = {
 };
 
 export const displayModelId = (model: string): string => {
+  if (model === "qwen3-asr-fast:free") return "Qwen3 ASR Fast (Free)";
+  if (model === "qwen3-asr:free") return "Qwen3 ASR (Free)";
+  if (model === "qwen3-asr-fast") return "Qwen3 ASR Fast (Partner)";
+  if (model === "qwen3-asr") return "Qwen3 ASR (Partner)";
+
   if (model === "cloud") {
     return "Pro (Cloud)";
   }
@@ -631,6 +636,28 @@ const _PROVIDERS = [
   },
   {
     disabled: false,
+    id: "nari",
+    displayName: "Nari Labs",
+    badge: null,
+    icon: <Waveform className="h-4 w-4" />,
+    baseUrl: "https://api.narilabs.com",
+    models: [
+      "qwen3-asr-fast:free",
+      "qwen3-asr:free",
+      "qwen3-asr-fast",
+      "qwen3-asr",
+    ],
+    requirements: [{ kind: "requires_config", fields: ["api_key"] }],
+    links: {
+      models: {
+        label: "Models & Pricing",
+        url: "https://docs.narilabs.com/models-and-pricing",
+      },
+      setup: { label: "API Keys", url: "https://app.narilabs.com/keys" },
+    },
+  },
+  {
+    disabled: false,
     id: "smallestai",
     displayName: "Smallest AI",
     badge: null,
@@ -1073,6 +1100,7 @@ const PROVIDER_ORDER = [
   "together",
   "xai",
   "smallestai",
+  "nari",
   "pyannote",
   "cohere",
   "aquavoice",

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -146,6 +146,14 @@ describe("getSttModelTranscriptionMode", () => {
     );
     expect(getSttModelTranscriptionMode("xai", "xai-stt")).toBeUndefined();
     expect(getSttModelTranscriptionMode("smallestai", "pulse")).toBeUndefined();
+    for (const model of [
+      "qwen3-asr:free",
+      "qwen3-asr-fast:free",
+      "qwen3-asr",
+      "qwen3-asr-fast",
+    ]) {
+      expect(getSttModelTranscriptionMode("nari", model)).toBe("live");
+    }
   });
 });
 

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -177,6 +177,8 @@ export function getSttModelTranscriptionMode(
     return "batch";
   }
 
+  if (provider === "nari") return "live";
+
   if (provider === "smallestai" && model === "pulse-pro") {
     return "batch";
   }

--- a/apps/desktop/src/stt/model-selection.ts
+++ b/apps/desktop/src/stt/model-selection.ts
@@ -31,6 +31,7 @@ const DEFAULT_EXTERNAL_STT_MODELS: Record<string, string> = {
   groq: "whisper-large-v3-turbo",
   xai: "xai-stt",
   smallestai: "pulse",
+  nari: "qwen3-asr-fast:free",
   together: "openai/whisper-large-v3",
   speechmatics: "enhanced",
   azure_speech: "fast-transcription",

--- a/apps/mobile/src/data/live-transcription-model.test.mjs
+++ b/apps/mobile/src/data/live-transcription-model.test.mjs
@@ -128,3 +128,20 @@ test("rejects malformed and oversized responses without throwing", () => {
     ],
   );
 });
+
+test("an empty Nari final clears the preview without persisting words", () => {
+  assert.deepEqual(
+    parseHostedTranscriptionMessage(
+      JSON.stringify({
+        type: "Results",
+        is_final: true,
+        start: 0,
+        duration: 1,
+        channel: { alternatives: [{ transcript: "", words: [] }] },
+      }),
+      "transcript",
+      "nari",
+    ),
+    [{ type: "partial", text: "" }],
+  );
+});

--- a/apps/mobile/src/data/live-transcription-model.ts
+++ b/apps/mobile/src/data/live-transcription-model.ts
@@ -201,6 +201,9 @@ function parsePayload(
     start,
     duration,
   });
+  if (provider === "nari" && words.length === 0) {
+    return [{ type: "partial", text: "" }];
+  }
   return words.length === 0
     ? []
     : [{ type: "final", segmentId, text: transcript.trim(), words, hints }];

--- a/apps/mobile/src/settings/provider-model-catalog.ts
+++ b/apps/mobile/src/settings/provider-model-catalog.ts
@@ -62,6 +62,12 @@ const TRANSCRIPTION_MODELS: Record<string, readonly string[]> = {
   ],
   xai: ["xai-stt"],
   smallestai: ["pulse", "pulse-pro"],
+  nari: [
+    "qwen3-asr-fast:free",
+    "qwen3-asr:free",
+    "qwen3-asr-fast",
+    "qwen3-asr",
+  ],
   pyannote: ["parakeet-tdt-0.6b-v3", "faster-whisper-large-v3-turbo"],
   cohere: ["cohere-transcribe-03-2026", "cohere-transcribe-arabic-07-2026"],
   aquavoice: ["avalon-v1.5"],

--- a/apps/mobile/src/settings/providers-model.ts
+++ b/apps/mobile/src/settings/providers-model.ts
@@ -140,6 +140,12 @@ export const TRANSCRIPTION_PROVIDERS = [
     model: "xai-stt",
   },
   {
+    id: "nari",
+    name: "Nari Labs",
+    baseUrl: "https://api.narilabs.com",
+    model: "qwen3-asr-fast:free",
+  },
+  {
     id: "smallestai",
     name: "Smallest AI",
     baseUrl: "https://api.smallest.ai",

--- a/apps/mobile/src/settings/transcription-mode.test.mjs
+++ b/apps/mobile/src/settings/transcription-mode.test.mjs
@@ -54,6 +54,8 @@ test("a saved recording uses the corresponding batch model after live failure", 
     ["mistral", "voxtral-mini-transcribe-realtime-2602", "voxtral-mini-2602"],
     ["custom", "own-model", "own-model"],
     ["dashscope", "qwen3-asr-flash-realtime", null],
+    ["nari", "qwen3-asr-fast:free", null],
+    ["nari", "qwen3-asr", null],
   ])
     assert.equal(batchTranscriptionModel(provider, live), batch);
 });

--- a/apps/mobile/src/settings/transcription-mode.ts
+++ b/apps/mobile/src/settings/transcription-mode.ts
@@ -8,6 +8,7 @@ export function supportsLiveTranscription(provider: string, model: string) {
     case "cloudflare_workers_ai":
     case "cartesia":
     case "dashscope":
+    case "nari":
     case "xai":
     case "meta":
       return true;
@@ -39,7 +40,7 @@ export function supportsLiveTranscription(provider: string, model: string) {
 }
 
 export function batchTranscriptionModel(provider: string, model: string) {
-  if (provider === "dashscope") return null;
+  if (provider === "dashscope" || provider === "nari") return null;
   if (provider === "openai" && model === "gpt-live-transcribe")
     return "gpt-transcribe";
   if (provider === "deepgram" && model.startsWith("flux-"))

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -7,8 +7,9 @@ use ractor::{ActorProcessingErr, ActorRef};
 use owhisper_client::{
     AdapterKind, AnarlogAdapter, ArgmaxAdapter, AssemblyAIAdapter, CartesiaAdapter,
     DashScopeAdapter, DeepgramAdapter, DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter,
-    GladiaAdapter, GoogleGenerativeAiAdapter, MetaAdapter, MistralAdapter, OpenAIAdapter,
-    RealtimeSttAdapter, SmallestAIAdapter, SonioxAdapter, XaiAdapter, anlg_ws_client,
+    GladiaAdapter, GoogleGenerativeAiAdapter, MetaAdapter, MistralAdapter, NariAdapter,
+    OpenAIAdapter, RealtimeSttAdapter, SmallestAIAdapter, SonioxAdapter, XaiAdapter,
+    anlg_ws_client,
 };
 use owhisper_interface::stream::{Extra, StreamResponse};
 use owhisper_interface::{ControlMessage, MixedMessage};
@@ -194,6 +195,7 @@ pub(super) async fn spawn_rx_task(
         Mistral => MistralAdapter,
         Meta => MetaAdapter,
         Xai => XaiAdapter,
+        Nari => NariAdapter,
         SmallestAI => SmallestAIAdapter,
         GoogleGenerativeAi => GoogleGenerativeAiAdapter,
         Anarlog => AnarlogAdapter,

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -119,7 +119,30 @@ impl LiveTranscriptEngine {
         let mut normalized = response.clone();
         self.normalizer.normalize(&mut normalized);
         clamp_response_speaker_indices(&mut normalized, self.max_speaker_index);
-        let transcript_delta: LiveTranscriptDelta = self.processor.process(&normalized)?.into();
+        let delta = match &normalized {
+            StreamResponse::TranscriptResponse {
+                is_final: true,
+                start,
+                duration,
+                channel,
+                channel_index,
+                ..
+            } if matches!(self.normalizer, TranscriptNormalizer::Nari)
+                && *duration > 0.0
+                && channel
+                    .alternatives
+                    .first()
+                    .is_some_and(|alt| alt.transcript.is_empty() && alt.words.is_empty()) =>
+            {
+                self.processor.clear_partials(
+                    channel_index.first().copied().unwrap_or(0),
+                    (*start * 1000.0) as i64,
+                    ((*start + *duration) * 1000.0) as i64,
+                )
+            }
+            _ => self.processor.process(&normalized)?,
+        };
+        let transcript_delta: LiveTranscriptDelta = delta.into();
         let segment_delta = self.rendered_segments.apply_delta(&transcript_delta);
         Some(LiveTranscriptUpdate {
             transcript_delta,

--- a/crates/listener-core/src/live_transcript.rs
+++ b/crates/listener-core/src/live_transcript.rs
@@ -104,7 +104,8 @@ impl LiveTranscriptEngine {
         Self {
             processor: TranscriptProcessor::new()
                 .with_partial_finalization(normalizer.finalize_partials())
-                .with_flush_partial_finalization(normalizer.flush_partials()),
+                .with_flush_partial_finalization(normalizer.flush_partials())
+                .with_final_word_stitching(!matches!(normalizer, TranscriptNormalizer::Nari)),
             normalizer,
             rendered_segments: RenderedSegmentState::new(
                 channel_assignments,

--- a/crates/listener-core/src/live_transcript/normalizer.rs
+++ b/crates/listener-core/src/live_transcript/normalizer.rs
@@ -12,6 +12,7 @@ const SONIQO_INTERNAL_REPEAT_MAX_EXTRA_TOKENS: usize = 3;
 pub(super) enum TranscriptNormalizer {
     Soniqo(SoniqoTranscriptNormalizer),
     AppleSpeech,
+    Nari,
     #[default]
     Passthrough,
 }
@@ -21,6 +22,7 @@ impl TranscriptNormalizer {
         match provider_name {
             "soniqo" => Self::Soniqo(SoniqoTranscriptNormalizer::default()),
             "apple-speech" => Self::AppleSpeech,
+            "nari" => Self::Nari,
             _ => Self::Passthrough,
         }
     }
@@ -28,7 +30,7 @@ impl TranscriptNormalizer {
     pub(super) fn normalize(&mut self, response: &mut StreamResponse) {
         match self {
             Self::Soniqo(normalizer) => normalizer.normalize(response),
-            Self::AppleSpeech | Self::Passthrough => {}
+            Self::AppleSpeech | Self::Nari | Self::Passthrough => {}
         }
     }
 
@@ -37,7 +39,7 @@ impl TranscriptNormalizer {
     }
 
     pub(super) fn flush_partials(&self) -> bool {
-        !matches!(self, Self::AppleSpeech)
+        !matches!(self, Self::AppleSpeech | Self::Nari)
     }
 }
 

--- a/crates/listener-core/src/live_transcript/tests.rs
+++ b/crates/listener-core/src/live_transcript/tests.rs
@@ -764,6 +764,45 @@ fn live_transcript_delta_keeps_speaker_index_on_words() {
 }
 
 #[test]
+fn nari_completed_utterances_finalize_immediately_without_waiting_for_flush() {
+    let mut engine = LiveTranscriptEngine::new("nari", &[], None);
+    for (start, text) in [(0.0, "First answer"), (1.0, "Second answer")] {
+        let preview = transcript_response_at(
+            "provisional",
+            vec![word("provisional", start, start + 1.0)],
+            false,
+            0,
+            start,
+            1.0,
+        );
+        assert!(
+            engine
+                .process(&preview)
+                .unwrap()
+                .transcript_delta
+                .new_words
+                .is_empty()
+        );
+        let completed = transcript_response_at(
+            text,
+            vec![word(text, start, start + 1.0)],
+            true,
+            0,
+            start,
+            1.0,
+        );
+        let update = engine
+            .process(&completed)
+            .expect("completed utterance delta");
+        assert_eq!(update.transcript_delta.new_words.len(), 1);
+        assert_eq!(update.transcript_delta.new_words[0].text.trim(), text);
+        assert!(update.transcript_delta.partials.is_empty());
+        assert!(engine.process(&completed).is_none());
+    }
+    assert!(engine.flush().is_none());
+}
+
+#[test]
 fn nari_empty_final_clears_only_its_preview_and_never_persists_unconfirmed_text() {
     let mut engine = LiveTranscriptEngine::new("nari", &[], None);
     let first = transcript_response_at(

--- a/crates/listener-core/src/live_transcript/tests.rs
+++ b/crates/listener-core/src/live_transcript/tests.rs
@@ -762,3 +762,33 @@ fn live_transcript_delta_keeps_speaker_index_on_words() {
     assert_eq!(converted.partials[0].speaker_index, Some(2));
     assert_eq!(converted.replaced_ids, vec!["replaced"]);
 }
+
+#[test]
+fn nari_empty_final_clears_only_its_preview_and_never_persists_unconfirmed_text() {
+    let mut engine = LiveTranscriptEngine::new("nari", &[], None);
+    let first = transcript_response_at(
+        "discard this",
+        vec![word("discard this", 0.0, 1.0)],
+        false,
+        0,
+        0.0,
+        1.0,
+    );
+    engine.process(&first).unwrap();
+    let second = transcript_response_at(
+        "still pending",
+        vec![word("still pending", 2.0, 3.0)],
+        false,
+        0,
+        2.0,
+        1.0,
+    );
+    engine.process(&second).unwrap();
+    let empty = transcript_response_at("", vec![], true, 0, 0.0, 1.0);
+    let update = engine.process(&empty).unwrap();
+    assert!(update.transcript_delta.new_words.is_empty());
+    assert_eq!(update.transcript_delta.partials.len(), 1);
+    assert_eq!(update.transcript_delta.partials[0].text, "still pending");
+    let flushed = engine.flush();
+    assert!(flushed.is_none_or(|update| update.transcript_delta.new_words.is_empty()));
+}

--- a/crates/listener2-core/src/batch/simple/direct.rs
+++ b/crates/listener2-core/src/batch/simple/direct.rs
@@ -107,7 +107,7 @@ pub(in crate::batch) async fn run_direct_batch_for_adapter_kind(
         Together => TogetherAdapter,
         Xai => XaiAdapter,
         SmallestAI => SmallestAIAdapter,
-    }, unsupported: [DashScope])
+    }, unsupported: [DashScope, Nari])
 }
 
 async fn run_anarlog_batch(

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -145,6 +145,7 @@ pub fn suggest_providers_for_languages_live(languages: &[anlg_language::Language
         AdapterKind::Mistral,
         AdapterKind::Meta,
         AdapterKind::Xai,
+        AdapterKind::Nari,
         AdapterKind::SmallestAI,
         AdapterKind::GoogleGenerativeAi,
     ];

--- a/crates/mobile-bridge/src/live_transcription.rs
+++ b/crates/mobile-bridge/src/live_transcription.rs
@@ -7,8 +7,8 @@ use futures_util::{FutureExt, Stream, StreamExt};
 use owhisper_client::{
     AdapterKind, AssemblyAIAdapter, CartesiaAdapter, DashScopeAdapter, DeepgramAdapter,
     ElevenLabsAdapter, FinalizeHandle, GladiaAdapter, GoogleGenerativeAiAdapter, ListenClient,
-    ListenClientInput, MistralAdapter, OpenAIAdapter, RealtimeSttAdapter, SmallestAIAdapter,
-    SonioxAdapter, XaiAdapter,
+    ListenClientInput, MistralAdapter, NariAdapter, OpenAIAdapter, RealtimeSttAdapter,
+    SmallestAIAdapter, SonioxAdapter, XaiAdapter,
 };
 use owhisper_interface::{ListenParams, MixedMessage, stream::StreamResponse};
 use serde::Deserialize;
@@ -103,6 +103,7 @@ async fn dispatch(
         GoogleGenerativeAi => GoogleGenerativeAiAdapter,
         Mistral => MistralAdapter,
         OpenAI => OpenAIAdapter,
+        Nari => NariAdapter,
         SmallestAI => SmallestAIAdapter,
         Soniox => SonioxAdapter,
         Xai => XaiAdapter,

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -22,6 +22,7 @@ pub mod http;
 mod language;
 pub(crate) mod meta;
 mod mistral;
+pub(crate) mod nari;
 mod openai;
 mod openai_compatible_batch;
 mod openrouter;
@@ -56,6 +57,7 @@ pub use groq::*;
 pub use language::{LanguageQuality, LanguageSupport};
 pub use meta::*;
 pub use mistral::*;
+pub use nari::*;
 pub use openai::*;
 pub use openrouter::*;
 pub use pyannote::*;
@@ -168,6 +170,14 @@ pub trait RealtimeSttAdapter: Clone + Default + Send + Sync + 'static {
     }
 
     fn provider_name(&self) -> &'static str;
+
+    fn initial_response_type(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn required_sample_rate(&self) -> Option<u32> {
+        None
+    }
 
     fn is_supported_languages(
         &self,
@@ -513,6 +523,8 @@ pub enum AdapterKind {
     Together,
     #[strum(serialize = "xai")]
     Xai,
+    #[strum(serialize = "nari")]
+    Nari,
     #[strum(serialize = "smallestai")]
     SmallestAI,
     #[strum(serialize = "anarlog")]
@@ -631,6 +643,7 @@ impl AdapterKind {
             | Self::Mistral
             | Self::Meta
             | Self::Xai
+            | Self::Nari
             | Self::SmallestAI
             | Self::GoogleGenerativeAi
             | Self::Anarlog => true,
@@ -671,6 +684,7 @@ impl AdapterKind {
             | Self::Speechmatics
             | Self::Together => LanguageSupport::NotSupported,
             Self::Xai => XaiAdapter::language_support_live(languages),
+            Self::Nari => NariAdapter::language_support_live(languages, model),
             Self::SmallestAI => SmallestAIAdapter::language_support_live(languages, model),
             Self::GoogleGenerativeAi => GoogleGenerativeAiAdapter::language_support_live(languages),
             Self::Anarlog => AnarlogAdapter::language_support_live(languages, model),
@@ -712,6 +726,7 @@ impl AdapterKind {
             Self::Speechmatics => SpeechmaticsAdapter::language_support_batch(languages),
             Self::Together => TogetherAdapter::language_support_batch(languages),
             Self::Xai => XaiAdapter::language_support_batch(languages),
+            Self::Nari => LanguageSupport::NotSupported,
             Self::SmallestAI => SmallestAIAdapter::language_support_batch(languages, model),
             Self::GoogleGenerativeAi => {
                 GoogleGenerativeAiAdapter::language_support_batch(languages)
@@ -784,6 +799,7 @@ impl From<crate::providers::Provider> for AdapterKind {
             Provider::Speechmatics => Self::Speechmatics,
             Provider::Together => Self::Together,
             Provider::Xai => Self::Xai,
+            Provider::Nari => Self::Nari,
             Provider::SmallestAI => Self::SmallestAI,
         }
     }

--- a/crates/owhisper-client/src/adapter/nari/mod.rs
+++ b/crates/owhisper-client/src/adapter/nari/mod.rs
@@ -1,0 +1,352 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use anlg_ws_client::client::Message;
+use base64::{Engine, engine::general_purpose::STANDARD};
+use owhisper_interface::ListenParams;
+use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse};
+use serde::Deserialize;
+
+use super::{LanguageQuality, LanguageSupport, RealtimeSttAdapter, parsing::WordBuilder};
+use crate::providers::Provider;
+
+pub(crate) const DEFAULT_MODEL: &str = "qwen3-asr-fast:free";
+const MODELS: &[&str] = &[
+    "qwen3-asr-fast:free",
+    "qwen3-asr:free",
+    "qwen3-asr-fast",
+    "qwen3-asr",
+];
+const LANGUAGES: &[&str] = &[
+    "ar", "cs", "da", "de", "el", "en", "es", "fa", "fi", "fil", "fr", "hi", "hu", "id", "it",
+    "ja", "ko", "mk", "ms", "nl", "pl", "pt", "ro", "ru", "sv", "th", "tr", "vi", "yue", "zh",
+];
+const FINALIZE_ID: &str = "anarlog_end_of_input";
+
+#[derive(Clone, Default)]
+pub struct NariAdapter {
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Default)]
+struct State {
+    samples_sent: u64,
+    cursor: f64,
+    order: VecDeque<String>,
+    items: HashMap<String, Item>,
+    completed: VecDeque<String>,
+    end_acknowledged: bool,
+    finalized: bool,
+}
+
+#[derive(Default)]
+struct Item {
+    start: Option<f64>,
+    end: Option<f64>,
+    completed: Option<Event>,
+}
+
+#[derive(Default, Deserialize)]
+struct Event {
+    #[serde(rename = "type")]
+    kind: String,
+    item_id: Option<String>,
+    transcript: Option<String>,
+    language: Option<String>,
+    audio_start_ms: Option<u64>,
+    audio_end_ms: Option<u64>,
+    client_event_id: Option<String>,
+    usage: Option<Usage>,
+    error: Option<ProviderFailure>,
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    input_audio_seconds: f64,
+}
+
+#[derive(Deserialize)]
+struct ProviderFailure {
+    code: String,
+    message: String,
+}
+
+impl NariAdapter {
+    pub fn language_support_live(
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> LanguageSupport {
+        let known_model = model
+            .is_none_or(|model| crate::providers::is_meta_model(model) || MODELS.contains(&model));
+        if known_model
+            && languages.iter().all(|language| {
+                let code = language.iso639().code();
+                LANGUAGES.contains(&code) || code == "tl"
+            })
+        {
+            LanguageSupport::Supported {
+                quality: LanguageQuality::NoData,
+            }
+        } else {
+            LanguageSupport::NotSupported
+        }
+    }
+}
+
+impl RealtimeSttAdapter for NariAdapter {
+    fn fork_session(&self) -> Self {
+        Self::default()
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "nari"
+    }
+
+    fn initial_response_type(&self) -> Option<&'static str> {
+        Some("session.configured")
+    }
+
+    fn required_sample_rate(&self) -> Option<u32> {
+        Some(16_000)
+    }
+
+    fn is_supported_languages(
+        &self,
+        languages: &[anlg_language::Language],
+        model: Option<&str>,
+    ) -> bool {
+        Self::language_support_live(languages, model).is_supported()
+    }
+
+    fn supports_native_multichannel(&self) -> bool {
+        false
+    }
+
+    fn build_ws_url(&self, api_base: &str, _params: &ListenParams, _channels: u8) -> url::Url {
+        let parsed = url::Url::parse(api_base)
+            .unwrap_or_else(|_| Provider::Nari.default_api_base().parse().unwrap());
+        let mut url = super::build_url_with_scheme(
+            &parsed,
+            Provider::Nari.default_ws_host(),
+            Provider::Nari.ws_path(),
+            true,
+        );
+        url.query_pairs_mut().append_pair("intent", "transcription");
+        url
+    }
+
+    fn build_auth_header(&self, api_key: Option<&str>) -> Option<(&'static str, String)> {
+        api_key.and_then(|key| Provider::Nari.build_auth_header(key))
+    }
+
+    fn keep_alive_message(&self) -> Option<Message> {
+        None
+    }
+
+    fn initial_message(
+        &self,
+        _api_key: Option<&str>,
+        params: &ListenParams,
+        _channels: u8,
+    ) -> Option<Message> {
+        let model = params
+            .model
+            .as_deref()
+            .filter(|model| !crate::providers::is_meta_model(model))
+            .unwrap_or(DEFAULT_MODEL);
+        let language = if params.languages.len() == 1 {
+            let code = params.languages[0].iso639().code();
+            Some(if code == "tl" { "fil" } else { code })
+        } else {
+            None
+        };
+        Some(Message::Text(serde_json::json!({
+            "type": "session.configure",
+            "session": {"model": model, "language": language, "prompt": params.keywords.join(", "),
+                "turn_detection": {"type": "server_vad"}}
+        }).to_string().into()))
+    }
+
+    fn audio_to_message(&self, audio: bytes::Bytes) -> Message {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .samples_sent += (audio.len() / 2) as u64;
+        Message::Text(serde_json::json!({"type": "input_audio_buffer.append", "audio": STANDARD.encode(audio)}).to_string().into())
+    }
+
+    fn finalize_message(&self) -> Message {
+        Message::Text(
+            serde_json::json!({"type": "input_audio_buffer.commit", "event_id": FINALIZE_ID})
+                .to_string()
+                .into(),
+        )
+    }
+
+    fn parse_response(&self, raw: &str) -> Vec<StreamResponse> {
+        let Ok(event) = serde_json::from_str::<Event>(raw) else {
+            return vec![];
+        };
+        if event.kind == "error" {
+            return event
+                .error
+                .map(|error| {
+                    vec![StreamResponse::ErrorResponse {
+                        error_code: match error.code.as_str() {
+                            "INVALID_API_KEY" => Some(401),
+                            "INSUFFICIENT_CREDITS" => Some(402),
+                            "UPSTREAM_RATE_LIMITED"
+                            | "FREE_DAILY_LIMIT_EXCEEDED"
+                            | "CONCURRENCY_LIMIT_EXCEEDED" => Some(429),
+                            _ => None,
+                        },
+                        error_message: format!("{}: {}", error.code, error.message),
+                        provider: "nari".into(),
+                    }]
+                })
+                .unwrap_or_default();
+        }
+        if !matches!(
+            event.kind.as_str(),
+            "input_audio_buffer.speech_started"
+                | "input_audio_buffer.speech_stopped"
+                | "input_audio_buffer.committed"
+                | "input_audio_buffer.commit_empty"
+                | "transcript.partial"
+                | "transcript.completed"
+        ) {
+            return vec![];
+        }
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(
+            event.kind.as_str(),
+            "input_audio_buffer.committed" | "input_audio_buffer.commit_empty"
+        ) && event.client_event_id.as_deref() == Some(FINALIZE_ID)
+        {
+            state.end_acknowledged = true;
+        }
+        let mut responses = vec![];
+        if let Some(id) = event.item_id.clone() {
+            if state.completed.contains(&id) {
+                return vec![];
+            }
+            if !state.items.contains_key(&id) {
+                if state.items.len() >= 64 || id.len() > 1024 {
+                    return vec![StreamResponse::ErrorResponse {
+                        error_code: None,
+                        error_message: "Too many pending Nari utterances or invalid item ID".into(),
+                        provider: "nari".into(),
+                    }];
+                }
+                state.order.push_back(id.clone());
+                state.items.insert(id.clone(), Item::default());
+            }
+            let cursor = state.cursor;
+            let sent_end = state.samples_sent as f64 / 16_000.0;
+            let item = state.items.get_mut(&id).unwrap();
+            match event.kind.as_str() {
+                "input_audio_buffer.speech_started" => {
+                    item.start = event.audio_start_ms.map(|ms| ms as f64 / 1000.0)
+                }
+                "input_audio_buffer.speech_stopped" => {
+                    item.end = event.audio_end_ms.map(|ms| ms as f64 / 1000.0)
+                }
+                "transcript.partial" => {
+                    let start = item.start.unwrap_or(cursor);
+                    responses.push(transcript_response(
+                        event.transcript.as_deref().unwrap_or(""),
+                        start,
+                        item.end.unwrap_or(sent_end).max(start),
+                        false,
+                        event.language.clone(),
+                    ));
+                }
+                "transcript.completed" => item.completed = Some(event),
+                _ => {}
+            }
+        }
+        while let Some(id) = state.order.front().cloned() {
+            if state
+                .items
+                .get(&id)
+                .and_then(|item| item.completed.as_ref())
+                .is_none()
+            {
+                break;
+            }
+            let item = state.items.remove(&id).unwrap();
+            state.order.pop_front();
+            let event = item.completed.unwrap();
+            let start = item.start.unwrap_or(state.cursor);
+            let duration = event
+                .usage
+                .map(|usage| usage.input_audio_seconds)
+                .filter(|duration| duration.is_finite() && *duration >= 0.0)
+                .unwrap_or(0.0);
+            let end = item.end.unwrap_or(start + duration).max(start);
+            state.cursor = state.cursor.max(end);
+            responses.push(transcript_response(
+                event.transcript.as_deref().unwrap_or(""),
+                start,
+                end,
+                true,
+                event.language,
+            ));
+            state.completed.push_back(id);
+            if state.completed.len() > 64 {
+                state.completed.pop_front();
+            }
+        }
+        if state.end_acknowledged && state.items.is_empty() && !state.finalized {
+            state.finalized = true;
+            let mut marker = transcript_response("", state.cursor, state.cursor, true, None);
+            if let StreamResponse::TranscriptResponse { from_finalize, .. } = &mut marker {
+                *from_finalize = true;
+            }
+            responses.push(marker);
+        }
+        responses
+    }
+}
+
+fn transcript_response(
+    text: &str,
+    start: f64,
+    end: f64,
+    is_final: bool,
+    language: Option<String>,
+) -> StreamResponse {
+    // Nari exposes utterance timing, not word alignment. Preserve one timed
+    // segment so the transcript store retains the text without invented word times.
+    let words = if text.is_empty() {
+        vec![]
+    } else {
+        vec![
+            WordBuilder::new(text)
+                .start(start)
+                .end(end)
+                .language(language.clone())
+                .build(),
+        ]
+    };
+    StreamResponse::TranscriptResponse {
+        is_final,
+        speech_final: is_final,
+        from_finalize: false,
+        start,
+        duration: end - start,
+        channel: Channel {
+            alternatives: vec![Alternatives {
+                transcript: text.into(),
+                words,
+                confidence: 1.0,
+                languages: language.into_iter().collect(),
+            }],
+        },
+        metadata: Metadata::default(),
+        channel_index: vec![0, 1],
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/owhisper-client/src/adapter/nari/tests.rs
+++ b/crates/owhisper-client/src/adapter/nari/tests.rs
@@ -1,0 +1,171 @@
+use super::*;
+use anlg_language::ISO639;
+
+fn final_event(adapter: &NariAdapter, id: &str, text: &str) -> Vec<StreamResponse> {
+    adapter.parse_response(&serde_json::json!({"type":"transcript.completed", "item_id":id,
+        "transcript":text, "language":"en", "commit_reason":"vad", "usage":{"input_audio_seconds":1.5}}).to_string())
+}
+fn finalized(responses: &[StreamResponse]) -> bool {
+    responses.iter().any(|response| {
+        matches!(
+            response,
+            StreamResponse::TranscriptResponse {
+                from_finalize: true,
+                ..
+            }
+        )
+    })
+}
+fn transcript(response: &StreamResponse) -> &str {
+    match response {
+        StreamResponse::TranscriptResponse { channel, .. } => &channel.alternatives[0].transcript,
+        _ => panic!("not transcript"),
+    }
+}
+
+#[test]
+fn config_uses_documented_models_languages_and_vad() {
+    let adapter = NariAdapter::default();
+    let params = ListenParams {
+        model: Some("qwen3-asr".into()),
+        languages: vec![ISO639::Ko.into()],
+        keywords: vec!["Anarlog".into()],
+        ..Default::default()
+    };
+    let Message::Text(config) = adapter.initial_message(None, &params, 1).unwrap() else {
+        panic!()
+    };
+    let config: serde_json::Value = serde_json::from_str(&config).unwrap();
+    assert_eq!(config["session"]["model"], "qwen3-asr");
+    assert_eq!(config["session"]["language"], "ko");
+    assert_eq!(config["session"]["prompt"], "Anarlog");
+    assert_eq!(config["session"]["turn_detection"]["type"], "server_vad");
+    assert!(
+        NariAdapter::language_support_live(&[ISO639::Ko.into()], Some(DEFAULT_MODEL))
+            .is_supported()
+    );
+    assert!(!NariAdapter::language_support_live(&[ISO639::Sw.into()], None).is_supported());
+    assert!(!NariAdapter::language_support_live(&[], Some("unknown")).is_supported());
+    assert!(
+        !super::super::AdapterKind::Nari
+            .language_support_batch(&[], None)
+            .is_supported()
+    );
+    assert_eq!(
+        adapter
+            .build_ws_url("https://api.narilabs.com", &params, 1)
+            .as_str(),
+        "wss://api.narilabs.com/v1/realtime?intent=transcription"
+    );
+    assert_eq!(
+        Provider::from_url("https://api.narilabs.com"),
+        Some(Provider::Nari)
+    );
+    assert_eq!(Provider::from_url("https://evilnarilabs.com"), None);
+    let Message::Text(audio) = adapter.audio_to_message(bytes::Bytes::from_static(&[0, 1, 2, 3]))
+    else {
+        panic!()
+    };
+    let audio: serde_json::Value = serde_json::from_str(&audio).unwrap();
+    assert_eq!(audio["type"], "input_audio_buffer.append");
+    assert_eq!(audio["audio"], "AAECAw==");
+}
+
+#[test]
+fn partial_revisions_replace_text_and_final_uses_utterance_timing() {
+    let adapter = NariAdapter::default();
+    adapter.parse_response(
+        r#"{"type":"input_audio_buffer.speech_started","item_id":"a","audio_start_ms":2000}"#,
+    );
+    for text in ["I scream", "Ice cream"] {
+        let responses = adapter.parse_response(
+            &serde_json::json!({"type":"transcript.partial","item_id":"a","transcript":text})
+                .to_string(),
+        );
+        assert_eq!(transcript(&responses[0]), text);
+    }
+    adapter.parse_response(
+        r#"{"type":"input_audio_buffer.speech_stopped","item_id":"a","audio_end_ms":3500}"#,
+    );
+    let responses = final_event(&adapter, "a", "Ice cream is delicious.");
+    assert!(!finalized(&responses));
+    match &responses[0] {
+        StreamResponse::TranscriptResponse {
+            start,
+            duration,
+            channel,
+            ..
+        } => {
+            assert_eq!((*start, *duration), (2.0, 1.5));
+            assert_eq!(channel.alternatives[0].words.len(), 1);
+            assert_eq!(channel.alternatives[0].words[0].speaker, None);
+        }
+        _ => panic!(),
+    }
+    assert!(final_event(&adapter, "a", "duplicate").is_empty());
+    assert!(
+        adapter
+            .parse_response(r#"{"type":"transcript.partial","item_id":"a","transcript":"stale"}"#)
+            .is_empty()
+    );
+}
+
+#[test]
+fn empty_final_commit_waits_for_pending_results_in_order() {
+    let adapter = NariAdapter::default();
+    for id in ["a", "b"] {
+        adapter.parse_response(
+            &serde_json::json!({"type":"input_audio_buffer.committed","item_id":id}).to_string(),
+        );
+    }
+    assert!(final_event(&adapter, "b", "second").is_empty());
+    assert!(!finalized(&adapter.parse_response(&serde_json::json!({"type":"input_audio_buffer.commit_empty","client_event_id":FINALIZE_ID}).to_string())));
+    let responses = final_event(&adapter, "a", "first");
+    assert_eq!(responses.len(), 3);
+    assert_eq!(transcript(&responses[0]), "first");
+    assert_eq!(transcript(&responses[1]), "second");
+    assert!(finalized(&responses));
+}
+
+#[test]
+fn stop_ack_does_not_finish_before_its_transcript() {
+    let adapter = NariAdapter::default();
+    let ack = serde_json::json!({"type":"input_audio_buffer.committed","item_id":"a","client_event_id":FINALIZE_ID});
+    assert!(!finalized(&adapter.parse_response(&ack.to_string())));
+    assert!(finalized(&final_event(&adapter, "a", "last words")));
+    let empty = NariAdapter::default();
+    assert!(finalized(&empty.parse_response(&serde_json::json!({"type":"input_audio_buffer.commit_empty","client_event_id":FINALIZE_ID}).to_string())));
+}
+
+#[test]
+fn forked_channels_do_not_share_pending_utterances() {
+    let adapter = NariAdapter::default();
+    adapter.parse_response(r#"{"type":"input_audio_buffer.committed","item_id":"mic"}"#);
+    let speaker = adapter.fork_session();
+    assert_eq!(
+        transcript(&final_event(&speaker, "speaker", "system audio")[0]),
+        "system audio"
+    );
+    assert_eq!(adapter.state.lock().unwrap().items.len(), 1);
+}
+
+#[test]
+fn credit_errors_are_reported_and_pending_state_is_bounded() {
+    let adapter = NariAdapter::default();
+    let errors = adapter.parse_response(
+        r#"{"type":"error","error":{"code":"INSUFFICIENT_CREDITS","message":"Add credits"}}"#,
+    );
+    assert!(
+        matches!(&errors[0],StreamResponse::ErrorResponse {error_code:Some(402),provider,..} if provider=="nari")
+    );
+    for id in 0..64 {
+        adapter.parse_response(
+            &serde_json::json!({"type":"input_audio_buffer.committed","item_id":id.to_string()})
+                .to_string(),
+        );
+    }
+    let errors =
+        adapter.parse_response(r#"{"type":"input_audio_buffer.committed","item_id":"overflow"}"#);
+    assert!(matches!(&errors[0], StreamResponse::ErrorResponse { .. }));
+    assert_eq!(adapter.state.lock().unwrap().items.len(), 64);
+}

--- a/crates/owhisper-client/src/lib.rs
+++ b/crates/owhisper-client/src/lib.rs
@@ -27,11 +27,11 @@ pub use adapter::{
     CallbackSttAdapter, CartesiaAdapter, CohereAdapter, DashScopeAdapter, DeepgramAdapter,
     DeepgramFluxAdapter, ElevenLabsAdapter, FireworksAdapter, GladiaAdapter, GoogleCloudAdapter,
     GoogleGenerativeAiAdapter, GroqAdapter, LanguageQuality, LanguageSupport, MetaAdapter,
-    MistralAdapter, OpenAIAdapter, OpenRouterAdapter, PyannoteAdapter, RealtimeSttAdapter,
-    RevAiAdapter, SiliconFlowAdapter, SmallestAIAdapter, SonioxAdapter, SpeechmaticsAdapter,
-    TogetherAdapter, WhisperCppAdapter, XaiAdapter, ZaiAdapter, append_provider_param,
-    documented_language_codes_batch, documented_language_codes_live, is_anarlog_proxy,
-    is_local_host, normalize_languages,
+    MistralAdapter, NariAdapter, OpenAIAdapter, OpenRouterAdapter, PyannoteAdapter,
+    RealtimeSttAdapter, RevAiAdapter, SiliconFlowAdapter, SmallestAIAdapter, SonioxAdapter,
+    SpeechmaticsAdapter, TogetherAdapter, WhisperCppAdapter, XaiAdapter, ZaiAdapter,
+    append_provider_param, documented_language_codes_batch, documented_language_codes_live,
+    is_anarlog_proxy, is_local_host, normalize_languages,
 };
 pub use adapter::{StreamingBatchEvent, StreamingBatchStream};
 

--- a/crates/owhisper-client/src/live.rs
+++ b/crates/owhisper-client/src/live.rs
@@ -92,6 +92,14 @@ impl<A: RealtimeSttAdapter> ListenClientBuilder<A> {
         params: &ListenParams,
         channels: u8,
     ) -> Result<anlg_ws_client::client::ClientRequestBuilder, crate::Error> {
+        if let Some(rate) = adapter.required_sample_rate()
+            && params.sample_rate != rate
+        {
+            return Err(crate::Error::provider_configuration(
+                adapter.provider_name(),
+                format!("requires {rate} Hz PCM audio"),
+            ));
+        }
         let original_api_base = self.get_api_base();
         let api_base = append_provider_param(original_api_base, adapter.provider_name());
         let url = adapter
@@ -581,6 +589,9 @@ fn websocket_client_with_keep_alive<A: RealtimeSttAdapter>(
     connect_policy: Option<anlg_ws_client::client::WebSocketConnectPolicy>,
 ) -> WebSocketClient {
     let mut client = WebSocketClient::new(request.clone());
+    if let Some(event_type) = adapter.initial_response_type() {
+        client = client.with_initial_response_type(event_type);
+    }
 
     if let Some(connect_policy) = connect_policy {
         client = client.with_connect_policy(connect_policy);

--- a/crates/owhisper-client/src/live/tests.rs
+++ b/crates/owhisper-client/src/live/tests.rs
@@ -289,3 +289,21 @@ async fn test_proxy_assemblyai_dual() {
 
     run_dual_test(client, "proxy-assemblyai").await;
 }
+
+#[tokio::test]
+async fn nari_rejects_audio_at_an_unsupported_sample_rate() {
+    let error = ListenClient::builder()
+        .adapter::<crate::NariAdapter>()
+        .api_base("https://api.narilabs.com")
+        .params(owhisper_interface::ListenParams {
+            sample_rate: 48_000,
+            ..Default::default()
+        })
+        .build_single()
+        .await
+        .err()
+        .expect("Nari only accepts 16 kHz PCM");
+    assert!(
+        matches!(error, crate::Error::ProviderConfiguration {provider,..} if provider == "nari")
+    );
+}

--- a/crates/owhisper-client/src/providers.rs
+++ b/crates/owhisper-client/src/providers.rs
@@ -113,12 +113,14 @@ pub enum Provider {
     Together,
     #[strum(serialize = "xai")]
     Xai,
+    #[strum(serialize = "nari")]
+    Nari,
     #[strum(serialize = "smallestai")]
     SmallestAI,
 }
 
 impl Provider {
-    const ALL: [Provider; 24] = [
+    const ALL: [Provider; 25] = [
         Self::AquaVoice,
         Self::Cartesia,
         Self::Deepgram,
@@ -142,6 +144,7 @@ impl Provider {
         Self::Speechmatics,
         Self::Together,
         Self::Xai,
+        Self::Nari,
         Self::SmallestAI,
     ];
 
@@ -219,6 +222,7 @@ impl Provider {
             | Self::Speechmatics
             | Self::Together
             | Self::Xai
+            | Self::Nari
             | Self::SmallestAI => Auth::Header {
                 name: "Authorization",
                 prefix: Some("Bearer "),
@@ -259,6 +263,7 @@ impl Provider {
             Self::Speechmatics => "eu1.asr.api.speechmatics.com",
             Self::Together => "api.together.xyz",
             Self::Xai => "api.x.ai",
+            Self::Nari => "api.narilabs.com",
             Self::SmallestAI => "api.smallest.ai",
         }
     }
@@ -288,6 +293,7 @@ impl Provider {
             Self::Speechmatics => "eu2.rt.speechmatics.com",
             Self::Together => "api.together.xyz",
             Self::Xai => "api.x.ai",
+            Self::Nari => "api.narilabs.com",
             Self::SmallestAI => "api.smallest.ai",
         }
     }
@@ -309,6 +315,7 @@ impl Provider {
             Self::Pyannote => "/v1/diarize",
             Self::Cohere => "",
             Self::Xai => "/v1/stt",
+            Self::Nari => "/v1/realtime",
             Self::SmallestAI => crate::adapter::smallestai::LIVE_PATH,
             Self::GoogleGenerativeAi => crate::adapter::google_generative_ai::WS_PATH,
             Self::AwsTranscribe
@@ -345,6 +352,7 @@ impl Provider {
             | Self::Speechmatics
             | Self::Together
             | Self::Xai
+            | Self::Nari
             | Self::SmallestAI => None,
         }
     }
@@ -374,6 +382,7 @@ impl Provider {
             Self::Speechmatics => "https://eu1.asr.api.speechmatics.com/v2",
             Self::Together => "https://api.together.xyz/v1",
             Self::Xai => "https://api.x.ai/v1",
+            Self::Nari => "https://api.narilabs.com",
             Self::SmallestAI => "https://api.smallest.ai",
         }
     }
@@ -403,6 +412,7 @@ impl Provider {
             Self::Speechmatics => "speechmatics.com",
             Self::Together => "together.xyz",
             Self::Xai => "x.ai",
+            Self::Nari => "narilabs.com",
             Self::SmallestAI => "smallest.ai",
         }
     }
@@ -456,6 +466,7 @@ impl Provider {
             Self::Speechmatics => "SPEECHMATICS_API_KEY",
             Self::Together => "TOGETHER_API_KEY",
             Self::Xai => "XAI_API_KEY",
+            Self::Nari => "NARI_API_KEY",
             Self::SmallestAI => "SMALLEST_API_KEY",
         }
     }
@@ -485,6 +496,7 @@ impl Provider {
             Self::Speechmatics => "enhanced",
             Self::Together => "openai/whisper-large-v3",
             Self::Xai => "xai-stt",
+            Self::Nari => crate::adapter::nari::DEFAULT_MODEL,
             Self::SmallestAI => crate::adapter::smallestai::DEFAULT_MODEL,
         }
     }
@@ -507,6 +519,7 @@ impl Provider {
             | Self::Speechmatics
             | Self::Together
             | Self::Xai
+            | Self::Nari
             | Self::SmallestAI => 16000,
             _ => 16000,
         }
@@ -537,6 +550,7 @@ impl Provider {
             Self::Speechmatics => "enhanced",
             Self::Together => "openai/whisper-large-v3",
             Self::Xai => "xai-stt",
+            Self::Nari => crate::adapter::nari::DEFAULT_MODEL,
             Self::SmallestAI => crate::adapter::smallestai::DEFAULT_MODEL,
         }
     }
@@ -544,7 +558,7 @@ impl Provider {
     pub fn default_query_params(&self) -> &'static [(&'static str, &'static str)] {
         match self {
             Self::Deepgram => &[("model", "nova-3-general"), ("mip_opt_out", "false")],
-            Self::OpenAI => &[("intent", "transcription")],
+            Self::OpenAI | Self::Nari => &[("intent", "transcription")],
             Self::AquaVoice
             | Self::DashScope
             | Self::Mistral
@@ -587,6 +601,7 @@ impl Provider {
             | Self::RevAi
             | Self::Speechmatics
             | Self::Together
+            | Self::Nari
             | Self::SmallestAI => false,
         }
     }
@@ -606,6 +621,7 @@ impl Provider {
             Self::OpenAI => &[],
             Self::Gladia => &[],
             Self::ElevenLabs => &["commit"],
+            Self::Nari => &["input_audio_buffer.commit"],
             Self::SmallestAI => &["finalize", "close_stream"],
             Self::Meta => &["endStream"],
             Self::DashScope
@@ -653,6 +669,7 @@ impl Provider {
             | Self::Speechmatics
             | Self::Together
             | Self::Xai
+            | Self::Nari
             | Self::SmallestAI => None,
             _ => None,
         }
@@ -697,6 +714,7 @@ impl Provider {
             Self::Pyannote => None,
             Self::Cohere => None,
             Self::Xai => from_adapter(&crate::adapter::XaiAdapter::default(), msg),
+            Self::Nari => from_adapter(&crate::adapter::NariAdapter::default(), msg),
             Self::SmallestAI => from_adapter(&crate::adapter::SmallestAIAdapter, msg),
             Self::GoogleGenerativeAi => {
                 from_adapter(&crate::adapter::GoogleGenerativeAiAdapter, msg)
@@ -736,6 +754,7 @@ impl Provider {
             | Self::Speechmatics
             | Self::Together
             | Self::Xai
+            | Self::Nari
             | Self::SmallestAI => None,
         }
     }

--- a/crates/transcribe-proxy/src/routes/batch/sync.rs
+++ b/crates/transcribe-proxy/src/routes/batch/sync.rs
@@ -330,6 +330,7 @@ pub(super) async fn transcribe_with_provider(
         | Provider::Speechmatics
         | Provider::Together
         | Provider::Xai
+        | Provider::Nari
         | Provider::SmallestAI
         | Provider::Meta
         | Provider::GoogleGenerativeAi => {

--- a/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/anarlog.rs
@@ -71,6 +71,7 @@ fn build_upstream_url_with_adapter(
         | Provider::Speechmatics
         | Provider::Together
         | Provider::Xai
+        | Provider::Nari
         | Provider::SmallestAI
         | Provider::Meta
         | Provider::GoogleGenerativeAi => {
@@ -115,6 +116,7 @@ fn build_initial_message_with_adapter(
         | Provider::Speechmatics
         | Provider::Together
         | Provider::Xai
+        | Provider::Nari
         | Provider::SmallestAI
         | Provider::Meta
         | Provider::GoogleGenerativeAi => {
@@ -162,6 +164,7 @@ fn build_response_transformer(
             | Provider::Speechmatics
             | Provider::Together
             | Provider::Xai
+            | Provider::Nari
             | Provider::SmallestAI
             | Provider::Meta
             | Provider::GoogleGenerativeAi => {

--- a/crates/transcript/src/channel_state.rs
+++ b/crates/transcript/src/channel_state.rs
@@ -22,6 +22,11 @@ impl ChannelState {
         }
     }
 
+    pub(super) fn clear_partials(&mut self, start_ms: i64, end_ms: i64) {
+        self.partials
+            .retain(|word| word.end_ms <= start_ms || word.start_ms >= end_ms);
+    }
+
     /// Process a confirmed final batch.
     ///
     /// When partial finalization is enabled, partials that end before this

--- a/crates/transcript/src/channel_state.rs
+++ b/crates/transcript/src/channel_state.rs
@@ -37,6 +37,7 @@ impl ChannelState {
         words: Vec<RawWord>,
         state: WordState,
         finalize_partials: bool,
+        stitch_final_words: bool,
     ) -> Vec<FinalizedWord> {
         let new_words = dedup(words, self.watermark);
         if new_words.is_empty() {
@@ -60,10 +61,15 @@ impl ChannelState {
         self.watermark = final_end;
 
         let mut to_finalize: Vec<RawWord> = pre_final;
-        let (mut emitted, held) = stitch(self.held.take(), new_words);
-        self.held = held;
-        self.release_oversized_held(&mut emitted);
-        to_finalize.extend(emitted);
+        if stitch_final_words {
+            let (mut emitted, held) = stitch(self.held.take(), new_words);
+            self.held = held;
+            self.release_oversized_held(&mut emitted);
+            to_finalize.extend(emitted);
+        } else {
+            to_finalize.extend(self.held.take());
+            to_finalize.extend(new_words);
+        }
 
         finalize_words(to_finalize, state)
     }

--- a/crates/transcript/src/processor.rs
+++ b/crates/transcript/src/processor.rs
@@ -41,6 +41,7 @@ pub struct TranscriptProcessor {
     next_job_id: u64,
     finalize_partials: bool,
     flush_partials: bool,
+    stitch_final_words: bool,
 }
 
 const MAX_PENDING_CORRECTION_JOBS: usize = 64;
@@ -115,6 +116,7 @@ impl TranscriptProcessor {
             next_job_id: 1,
             finalize_partials: true,
             flush_partials: true,
+            stitch_final_words: true,
         }
     }
 
@@ -129,6 +131,12 @@ impl TranscriptProcessor {
     /// Control whether remaining partials are committed when the session ends.
     pub fn with_flush_partial_finalization(mut self, flush_partials: bool) -> Self {
         self.flush_partials = flush_partials;
+        self
+    }
+
+    /// Disable for complete utterances that cannot receive word-level continuations.
+    pub fn with_final_word_stitching(mut self, stitch_final_words: bool) -> Self {
+        self.stitch_final_words = stitch_final_words;
         self
     }
 
@@ -171,8 +179,12 @@ impl TranscriptProcessor {
                 WordState::Final
             };
 
-            let mut new_words =
-                channel_state.apply_final(raw_words, word_state, self.finalize_partials);
+            let mut new_words = channel_state.apply_final(
+                raw_words,
+                word_state,
+                self.finalize_partials,
+                self.stitch_final_words,
+            );
 
             let mut replaced_ids = vec![];
 
@@ -664,6 +676,7 @@ mod tests {
             }],
             WordState::Final,
             false,
+            true,
         );
 
         let delta = processor.flush();

--- a/crates/transcript/src/processor.rs
+++ b/crates/transcript/src/processor.rs
@@ -132,6 +132,13 @@ impl TranscriptProcessor {
         self
     }
 
+    pub fn clear_partials(&mut self, channel: i32, start_ms: i64, end_ms: i64) -> TranscriptDelta {
+        if let Some(state) = self.channels.get_mut(&channel) {
+            state.clear_partials(start_ms, end_ms);
+        }
+        self.partial_snapshot().into_delta(vec![], vec![])
+    }
+
     pub fn process(&mut self, response: &StreamResponse) -> Option<TranscriptDelta> {
         let parsed = ParsedStreamResponse::from_response(response)?;
         let raw_words = assemble(parsed.words, parsed.transcript, parsed.channel);

--- a/crates/ws-client/Cargo.toml
+++ b/crates/ws-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 bytes = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 thiserror = { workspace = true }
 
 async-stream = { workspace = true }
@@ -22,5 +23,4 @@ tokio-tungstenite = { workspace = true, features = ["native-tls-vendored"] }
 tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 
 [dev-dependencies]
-serde_json.workspace = true
 tokio = { workspace = true, features = ["io-util"] }

--- a/crates/ws-client/src/client.rs
+++ b/crates/ws-client/src/client.rs
@@ -59,6 +59,7 @@ pub struct WebSocketClient {
     keep_alive: Option<KeepAliveConfig>,
     connect_policy: WebSocketConnectPolicy,
     on_retry: Option<WebSocketRetryCallback>,
+    initial_response_type: Option<&'static str>,
 }
 
 impl WebSocketClient {
@@ -68,6 +69,7 @@ impl WebSocketClient {
             keep_alive: None,
             connect_policy: WebSocketConnectPolicy::default(),
             on_retry: None,
+            initial_response_type: None,
         }
     }
 
@@ -77,6 +79,11 @@ impl WebSocketClient {
         message: Message,
     ) -> Self {
         self.keep_alive = Some(KeepAliveConfig { interval, message });
+        self
+    }
+
+    pub fn with_initial_response_type(mut self, event_type: &'static str) -> Self {
+        self.initial_response_type = Some(event_type);
         self
     }
 
@@ -110,6 +117,50 @@ impl WebSocketClient {
         .await?;
 
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
+        let mut initial_message = initial_message;
+        if let Some(expected) = self.initial_response_type {
+            tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                if let Some(message) = initial_message.take() {
+                    ws_sender.send(message).await?;
+                }
+                loop {
+                    match ws_receiver.next().await {
+                        Some(Ok(Message::Text(text))) => {
+                            let event: serde_json::Value =
+                                serde_json::from_str(&text).map_err(|_| {
+                                    crate::Error::ParseError {
+                                        message: "invalid session acknowledgement".into(),
+                                    }
+                                })?;
+                            if event.get("type").and_then(|v| v.as_str()) == Some(expected) {
+                                return Ok::<_, crate::Error>(());
+                            }
+                            return Err(crate::Error::InvalidRequest {
+                                message: format!(
+                                    "session configuration rejected: {}",
+                                    event
+                                        .pointer("/error/code")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("unexpected acknowledgement")
+                                ),
+                            });
+                        }
+                        Some(Ok(Message::Ping(payload))) => {
+                            ws_sender.send(Message::Pong(payload)).await?
+                        }
+                        Some(Ok(Message::Close(_))) | None => {
+                            return Err(crate::Error::InvalidRequest {
+                                message: "connection closed before session acknowledgement".into(),
+                            });
+                        }
+                        Some(Err(error)) => return Err(error.into()),
+                        _ => {}
+                    }
+                }
+            })
+            .await
+            .map_err(crate::Error::Timeout)??;
+        }
 
         let (control_tx, mut control_rx) = tokio::sync::mpsc::unbounded_channel();
         let (error_tx, mut error_rx) = tokio::sync::mpsc::unbounded_channel::<crate::Error>();

--- a/crates/ws-client/tests/client_happy_path.rs
+++ b/crates/ws-client/tests/client_happy_path.rs
@@ -155,3 +155,72 @@ async fn test_input_eof_closes_connection_without_finalize() {
         "connection should close after input EOF without explicit finalize"
     );
 }
+
+#[tokio::test]
+async fn session_acknowledgement_precedes_audio() {
+    let addr = spawn_ws_server(|mut socket| async move {
+        let configure = socket.next().await.unwrap().unwrap();
+        assert_eq!(
+            configure,
+            Message::Text(r#"{"type":"session.configure"}"#.into())
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), socket.next())
+                .await
+                .is_err()
+        );
+        socket
+            .send(Message::Text(r#"{"type":"session.configured"}"#.into()))
+            .await
+            .unwrap();
+        let audio = socket.next().await.unwrap().unwrap();
+        socket.send(audio).await.unwrap();
+    })
+    .await;
+    let client = test_client(addr).with_initial_response_type("session.configured");
+    let (output, _handle) = client
+        .from_audio::<TestIO, _>(
+            Some(Message::Text(r#"{"type":"session.configure"}"#.into())),
+            message_stream("audio"),
+        )
+        .await
+        .unwrap();
+    let received = collect_messages::<TestIO>(output, 1).await;
+    assert_eq!(received[0].text, "audio");
+}
+
+#[tokio::test]
+async fn rejected_session_never_sends_audio() {
+    let (result_tx, result_rx) = oneshot::channel();
+    let addr = spawn_ws_server(|mut socket| async move {
+        socket.next().await.unwrap().unwrap();
+        socket
+            .send(Message::Text(
+                r#"{"type":"error","error":{"code":"INVALID_MODEL","message":"secret payload"}}"#
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        let next = socket.next().await;
+        let no_audio = !matches!(next, Some(Ok(Message::Text(_) | Message::Binary(_))));
+        result_tx.send(no_audio).unwrap();
+    })
+    .await;
+    let client = test_client(addr).with_initial_response_type("session.configured");
+    let error = client
+        .from_audio::<TestIO, _>(
+            Some(Message::Text("configure".into())),
+            message_stream("audio"),
+        )
+        .await
+        .err()
+        .unwrap();
+    assert!(error.to_string().contains("INVALID_MODEL"));
+    assert!(!error.to_string().contains("secret payload"));
+    assert!(
+        tokio::time::timeout(TEST_TIMEOUT, result_rx)
+            .await
+            .unwrap()
+            .unwrap()
+    );
+}

--- a/packages/provider-validation/src/index.test.mjs
+++ b/packages/provider-validation/src/index.test.mjs
@@ -388,3 +388,31 @@ test("never caches a failed verification as accepted", async () => {
   await verifyProviderCredentials(credential, fetcher);
   assert.equal(calls, 2);
 });
+
+test("Nari verifies keys using its non-billable authenticated voice catalog", async () => {
+  const requests = [];
+  await verifyProviderCredentials(
+    {
+      type: "stt",
+      provider: "nari",
+      baseUrl: "https://api.narilabs.com",
+      apiKey: "synthetic-key",
+    },
+    async (url, init) => {
+      requests.push({ url, init });
+      return requests.length === 1
+        ? Response.json({ object: "list", model: "qwen3-tts:free", data: [] })
+        : new Response(null, { status: 401 });
+    },
+  );
+  assert.equal(requests.length, 2);
+  assert.equal(
+    requests[0].url,
+    "https://api.narilabs.com/v1/voices?model=qwen3-tts:free",
+  );
+  assert.equal(requests[0].init.headers.Authorization, "Bearer synthetic-key");
+  assert.equal(
+    requests[1].init.headers.Authorization,
+    "Bearer anarlog-invalid-key-verification",
+  );
+});

--- a/packages/provider-validation/src/index.ts
+++ b/packages/provider-validation/src/index.ts
@@ -229,6 +229,12 @@ function credentialRequest({ provider, baseUrl, apiKey }: ProviderCredential) {
       accept = (value) =>
         Array.isArray(value) || Array.isArray(record(value).data);
       break;
+    case "nari":
+      url = `${origin}/v1/voices?model=qwen3-tts:free`;
+      checkAuthentication = true;
+      accept = (value) =>
+        record(value).object === "list" && Array.isArray(record(value).data);
+      break;
     case "smallestai":
       url = `${base}/waves/v1/voice-cloning`;
       checkAuthentication = true;


### PR DESCRIPTION
Add Nari API-key configuration and four ASR models to desktop and mobile transcription settings. The WebSocket adapter waits for session configuration before sending audio and handles ordered final results, empty results, and stop acknowledgements.

Wire the provider through the shared transcription pipeline and add adapter, audio-gating, transcript, and provider-selection regression coverage.

Completed utterances finalize immediately without the word-stitching delay used by aligned providers. Verified with 225 transcript/listener tests and Clippy; the regression covers preview replacement, duplicate completions, and flush behavior.

ANLG-336
