### PR TITLE
Separate API service roles and drain billing on shutdown

### DIFF
--- a/.github/scripts/deploy_api_drain.py
+++ b/.github/scripts/deploy_api_drain.py
@@ -6,7 +6,7 @@ Fly blue/green cordons old machines and then SIGTERMs them immediately.
 script instead:
 
 1. Builds and pushes a new image
-2. Starts cordoned replacements with the current machine configs and new image
+2. Starts cordoned replacements with the desired runtime config and new image
 3. Adds the replacements to Fly Proxy and waits for routing to propagate
 4. Cordons the previous serving set and waits for routing to propagate
 5. Sends SIGUSR1 so those machines reject new STT and exit once idle
@@ -285,10 +285,115 @@ def stop_config(config_path: str) -> dict[str, str]:
     return result
 
 
+def desired_runtime_config(app: str, config_path: str) -> dict[str, Any]:
+    """Translate the supported API Fly profile; reject unsupported configuration."""
+    with open(config_path, "rb") as config_file:
+        config = tomllib.load(config_file)
+    if config.get("app") != app:
+        raise DeployError("deployment app must match the config app")
+
+    def only(value: dict[str, Any], keys: set[str], section: str) -> None:
+        unknown = value.keys() - keys
+        if unknown:
+            raise DeployError(f"unsupported {section} settings: {sorted(unknown)}")
+
+    only(
+        config,
+        {
+            "app",
+            "primary_region",
+            "kill_signal",
+            "kill_timeout",
+            "swap_size_mb",
+            "restart",
+            "env",
+            "http_service",
+            "vm",
+        },
+        "Fly",
+    )
+    http = config["http_service"]
+    only(
+        http,
+        {
+            "processes",
+            "internal_port",
+            "force_https",
+            "auto_stop_machines",
+            "auto_start_machines",
+            "min_machines_running",
+            "http_options",
+            "concurrency",
+            "checks",
+        },
+        "http_service",
+    )
+    (vm,) = config["vm"]
+    (restart,) = config["restart"]
+    only(vm, {"processes", "memory", "cpu_kind", "cpus"}, "vm")
+    only(restart, {"processes", "policy"}, "restart")
+    for section in (http, vm, restart):
+        if section.get("processes") != ["app"]:
+            raise DeployError("drain deploy supports only the app process group")
+    memory = str(vm["memory"]).lower()
+    if memory.endswith("gb"):
+        memory_mb = int(memory[:-2]) * 1024
+    elif memory.endswith("mb"):
+        memory_mb = int(memory[:-2])
+    else:
+        raise DeployError("vm.memory must use integer mb or gb units")
+    checks = []
+    for check in http["checks"]:
+        only(
+            check,
+            {"grace_period", "interval", "method", "path", "protocol", "timeout"},
+            "health check",
+        )
+        checks.append({"type": "http", **check})
+    if not checks:
+        raise DeployError("at least one HTTP readiness check is required")
+    options = http.get("http_options", {})
+    only(options, {"idle_timeout"}, "http_options")
+    concurrency = http["concurrency"]
+    only(concurrency, {"type", "hard_limit", "soft_limit"}, "concurrency")
+    return {
+        "env": {**config.get("env", {}), "PRIMARY_REGION": config["primary_region"]},
+        "guest": {
+            "memory_mb": memory_mb,
+            "cpu_kind": vm["cpu_kind"],
+            "cpus": vm["cpus"],
+        },
+        "swap_size_mb": config.get("swap_size_mb", 0),
+        "restart": {"policy": restart["policy"]},
+        "services": [
+            {
+                "protocol": "tcp",
+                "internal_port": http["internal_port"],
+                "autostart": http.get("auto_start_machines", False),
+                "autostop": http.get("auto_stop_machines", "off"),
+                "min_machines_running": http.get("min_machines_running", 0),
+                "concurrency": concurrency,
+                "checks": checks,
+                "ports": [
+                    {
+                        "port": 80,
+                        "handlers": ["http"],
+                        "force_https": http.get("force_https", False),
+                        "http_options": options,
+                    },
+                    {"port": 443, "handlers": ["tls", "http"], "http_options": options},
+                ],
+            }
+        ],
+        "checks": {},
+    }
+
+
 def replacement_config(
     machine: dict[str, Any],
     image: str,
     desired_stop_config: dict[str, str],
+    runtime_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     host_status = machine.get("host_status")
     if host_status not in {None, "ok"}:
@@ -307,6 +412,8 @@ def replacement_config(
     replacement["image"] = image
     replacement["restart"] = {"policy": "on-failure"}
     replacement["stop_config"] = desired_stop_config
+    if runtime_config is not None:
+        replacement.update(copy.deepcopy(runtime_config))
     metadata = replacement.get("metadata")
     if not isinstance(metadata, dict):
         metadata = {}
@@ -321,9 +428,12 @@ def create_replacement_machine(
     machine: dict[str, Any],
     image: str,
     desired_stop_config: dict[str, str],
+    runtime_config: dict[str, Any] | None = None,
 ) -> str:
     payload: dict[str, Any] = {
-        "config": replacement_config(machine, image, desired_stop_config),
+        "config": replacement_config(
+            machine, image, desired_stop_config, runtime_config
+        ),
         "skip_service_registration": True,
     }
     if machine.get("region"):
@@ -389,6 +499,17 @@ def validate_serving_set(
         raise DeployError(
             "replacement machines were not safely cordoned: "
             + ", ".join(sorted(unsafe_replacements))
+        )
+
+    unhealthy = [
+        machine_id
+        for machine_id in replacement_ids
+        if not checks_passing(get_machine(app, machine_id))
+    ]
+    if unhealthy:
+        raise DeployError(
+            "replacement machines lost readiness before cutover: "
+            + ", ".join(sorted(unhealthy))
         )
 
 
@@ -536,6 +657,7 @@ def build_and_push_image(app: str, config: str, dockerfile: str, version: str) -
 
 
 def deploy(app: str, config: str, dockerfile: str, version: str) -> None:
+    runtime_config = desired_runtime_config(app, config)
     destroy_drained_machines(app)
     resume_draining_machines(app)
     machines = list_machines(app)
@@ -557,7 +679,9 @@ def deploy(app: str, config: str, dockerfile: str, version: str) -> None:
     try:
         for machine in serving:
             replacement_ids.append(
-                create_replacement_machine(app, machine, image, desired_stop_config)
+                create_replacement_machine(
+                    app, machine, image, desired_stop_config, runtime_config
+                )
             )
         for machine_id in replacement_ids:
             wait_until_healthy(app, machine_id)

--- a/.github/scripts/test_deploy_api_drain.py
+++ b/.github/scripts/test_deploy_api_drain.py
@@ -409,7 +409,7 @@ def test_partial_replacement_failure_destroys_created_machines():
     ]
     destroyed = []
 
-    def create_replacement(_app, machine, _image, _stop_config):
+    def create_replacement(_app, machine, _image, _stop_config, _runtime_config):
         if machine["id"] == "old-b":
             raise DeployError("launch failed")
         return "new-a"
@@ -570,7 +570,106 @@ def test_drain_rejects_unexpected_machine_states():
                 raise AssertionError("expected the unexpected state to fail deployment")
 
 
+def test_desired_runtime_replaces_stale_machine_settings():
+    desired = deploy_api_drain.desired_runtime_config("anarlog-ai", "apps/api/fly.toml")
+    old = {
+        "id": "old",
+        "config": {
+            "env": {"ANARLOG_SERVICE": "sync", "REMOVED_SETTING": "stale"},
+            "guest": {"memory_mb": 256},
+            "checks": {"stale": {"path": "/wrong"}},
+            "services": [{"internal_port": 9999}],
+            "metadata": {"fly_process_group": "app"},
+        },
+    }
+    result = replacement_config(old, "new", {"signal": "SIGTERM"}, desired)
+    assert result["env"] == {
+        "ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED": "true",
+        "PORT": "3001",
+        "PRIMARY_REGION": "sjc",
+    }
+    assert result["guest"] == {"memory_mb": 1024, "cpu_kind": "shared", "cpus": 1}
+    assert result["checks"] == {}
+    (service,) = result["services"]
+    assert service["internal_port"] == 3001
+    assert service["checks"][0]["path"] == "/health"
+    assert service["checks"][0]["type"] == "http"
+    assert service["ports"][1]["http_options"]["idle_timeout"] == 660
+    assert service["autostop"] == "stop"
+    assert result["swap_size_mb"] == 512
+    assert old["config"]["env"]["REMOVED_SETTING"] == "stale"
+    result["env"]["PORT"] = "1234"
+    assert desired["env"]["PORT"] == "3001"
+
+
+def test_invalid_config_fails_before_any_machine_mutation():
+    base = Path("apps/api/fly.toml").read_text()
+    invalid_configs = [
+        base.replace("anarlog-ai", "different-app"),
+        base + "\n[deploy]\nrelease_command = 'unsafe-migration'\n",
+        base.replace(
+            "internal_port = 3001", "internal_port = 3001\nunknown_setting = true"
+        ),
+        base.replace("processes = ['app']", "processes = ['other']"),
+    ]
+    for invalid in invalid_configs:
+        with (
+            NamedTemporaryFile("w") as config,
+            patch.object(deploy_api_drain, "api_request") as api,
+            patch.object(deploy_api_drain, "fly") as fly,
+        ):
+            config.write(invalid)
+            config.flush()
+            try:
+                deploy_api_drain.deploy("anarlog-ai", config.name, "Dockerfile", "test")
+            except DeployError:
+                pass
+            else:
+                raise AssertionError("invalid config was accepted")
+            api.assert_not_called()
+            fly.assert_not_called()
+
+
+def test_standalone_profiles_have_role_checks_and_no_duplicate_cleanup():
+    for role, app, health in [
+        ("ai", "anarlog-inference", "ai"),
+        ("sync", "anarlog-sync", "sync"),
+        ("core", "anarlog-core", "core"),
+        ("billing", "anarlog-billing-api", "billing-api"),
+    ]:
+        config = deploy_api_drain.desired_runtime_config(
+            app, f"apps/api/fly.{role}.toml"
+        )
+        assert config["env"]["ANARLOG_SERVICE"] == role
+        assert config["env"]["ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED"] == "false"
+        (service,) = config["services"]
+        assert service["checks"][0]["path"] == f"/health/ready/{health}"
+        assert service["min_machines_running"] == 2
+        assert service["autostop"] == "off"
+
+
+def test_cutover_preflight_rechecks_candidate_readiness():
+    machines = [{"id": "old", "cordoned": False}, {"id": "new", "cordoned": True}]
+    with (
+        patch.object(deploy_api_drain, "list_machines", return_value=machines),
+        patch.object(deploy_api_drain, "get_machine") as get,
+    ):
+        get.return_value = {"state": "started", "checks": [{"status": "passing"}]}
+        validate_serving_set("anarlog-ai", {"old"}, {"new"})
+        get.return_value = {"state": "started", "checks": [{"status": "critical"}]}
+        try:
+            validate_serving_set("anarlog-ai", {"old"}, {"new"})
+        except DeployError as error:
+            assert "lost readiness" in str(error)
+        else:
+            raise AssertionError("unhealthy candidate was accepted")
+
+
 if __name__ == "__main__":
+    test_cutover_preflight_rechecks_candidate_readiness()
+    test_standalone_profiles_have_role_checks_and_no_duplicate_cleanup()
+    test_desired_runtime_replaces_stale_machine_settings()
+    test_invalid_config_fails_before_any_machine_mutation()
     test_classifies_serving_and_drained_machines()
     test_reads_cordon_from_metadata_when_top_level_flag_is_absent()
     test_checks_passing_requires_every_reported_check()

--- a/.github/workflows/api_ci.yaml
+++ b/.github/workflows/api_ci.yaml
@@ -14,6 +14,7 @@ on:
       - crates/agent-access/**
       - crates/api-auth/**
       - crates/api-cloud/**
+      - crates/api-subscription/**
       - crates/api-sync/**
       - crates/llm-proxy/**
       - crates/mcp/**
@@ -31,6 +32,7 @@ on:
       - crates/agent-access/**
       - crates/api-auth/**
       - crates/api-cloud/**
+      - crates/api-subscription/**
       - crates/api-sync/**
       - crates/llm-proxy/**
       - crates/mcp/**
@@ -55,8 +57,9 @@ jobs:
       - run: cargo test -p mcp
       - run: cargo test -p supabase-auth --features server
       - run: cargo test -p api-sync
+      - run: cargo test --locked -p api-subscription
       - run: cargo test -p transcribe-proxy --lib
-      - run: cargo test -p api drain_status_reports_live_streams_without_failing_health
+      - run: cargo test --locked -p api
       - run: python3 .github/scripts/test_verify_cloudsync_e2ee.py
       - run: python3 .github/scripts/test_deploy_api_drain.py
       - run: |

--- a/.github/workflows/stripe_ci.yaml
+++ b/.github/workflows/stripe_ci.yaml
@@ -1,0 +1,47 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/stripe/**
+      - packages/supabase/**
+      - packages/user-error/**
+      - packages/pricing/**
+      - .github/workflows/stripe_ci.yaml
+      - .github/actions/pnpm_install/**
+      - .github/actions/bun_install/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+  pull_request:
+    paths:
+      - apps/stripe/**
+      - packages/supabase/**
+      - packages/user-error/**
+      - packages/pricing/**
+      - .github/workflows/stripe_ci.yaml
+      - .github/actions/pnpm_install/**
+      - .github/actions/bun_install/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: $/.github/actions/pnpm_install
+      - uses: $/.github/actions/bun_install
+      - run: pnpm -F @anlg/stripe typecheck
+      - run: pnpm -F @anlg/stripe test

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -38,3 +38,21 @@ Role selection does not change Fly routing or provision applications. The
 existing deployment stays on `all` until service-specific configuration,
 readiness, public routing, and deployment/rollback continuity are verified.
 Keep existing URLs working while clients and webhook providers migrate.
+
+
+Separate candidate profiles are `fly.ai.toml` (`anarlog-inference`),
+`fly.sync.toml` (`anarlog-sync`), `fly.core.toml` (`anarlog-core`), and
+`fly.billing.toml` (`anarlog-billing-api`). These names are deployment targets,
+not evidence that the apps exist. The original `anarlog-ai` profile remains
+combined so existing URLs keep working. Candidate profiles disable cleanup;
+transfer cleanup ownership only when the old owner has stopped its worker.
+
+`/health/ready/{service}` verifies the expected runtime role, configuration of
+its primary subsystems, and that it is not draining. The combined role uses
+`api`; Rust billing uses `billing-api`. These checks do not probe external
+providers or prove request continuity. Keep dependency smoke tests and active
+traffic deploy/rollback tests as separate rollout gates.
+
+The drain deploy helper reconciles the supported single-process Fly profile
+into each candidate. Unsupported settings fail before machine mutations;
+extend its translation and tests before introducing additional Fly features.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -11,3 +11,30 @@ infisical export \
 `/anarlog/ai` is the API runtime view. Its Nango entries should reference the
 source secrets in `/anarlog/nango` rather than requiring API jobs to export a
 second secret path.
+
+## Service runtimes
+
+`ANARLOG_SERVICE` selects the routes started by the shared API binary:
+
+| Value | Routes |
+| --- | --- |
+| `all` (default) | Existing combined API, preserving current client URLs |
+| `ai` | Transcription, LLM, research, diarization, and STT callbacks |
+| `sync` | Sync, devices, attachments, sharing, hosted meeting API/MCP |
+| `core` | Nango and integration APIs, account deletion, SCIM |
+| `billing` | Trial/subscription API under the existing `/subscription`, `/rpc`, and `/billing` aliases |
+
+Stripe webhook processing remains in `apps/stripe`; the Rust billing runtime
+is the extracted subscription API, not a replacement for that webhook handler.
+Core retains the existing subscription configuration for account deletion and SCIM.
+
+All roles require Supabase configuration. Only `ai` and `all` require
+`OPENROUTER_API_KEY` and `API_BASE_URL`; the sync runtime requires its shared-note
+email configuration. Optional integration groups are validated only in their
+owning roles. `ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED` is accepted only by `core`
+and `all`. Assign cleanup to one deployment during migration.
+
+Role selection does not change Fly routing or provision applications. The
+existing deployment stays on `all` until service-specific configuration,
+readiness, public routing, and deployment/rollback continuity are verified.
+Keep existing URLs working while clients and webhook providers migrate.

--- a/apps/api/fly.ai.toml
+++ b/apps/api/fly.ai.toml
@@ -1,0 +1,46 @@
+app = 'anarlog-inference'
+primary_region = 'sjc'
+kill_signal = 'SIGTERM'
+# Fly caps this at 300s. Meeting streams can last longer, so api_cd uses
+# cordoned replacement Machines + SIGUSR1 and leaves old Machines up until idle.
+kill_timeout = 300
+swap_size_mb = 512
+
+[[restart]]
+policy = "on-failure"
+processes = ["app"]
+
+[env]
+ANARLOG_SERVICE = "ai"
+ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED = "false"
+PORT = "3001"
+
+[http_service]
+processes = ['app']
+internal_port = 3001
+force_https = true
+auto_stop_machines = 'off'
+auto_start_machines = true
+min_machines_running = 2
+
+[http_service.http_options]
+idle_timeout = 660
+
+[http_service.concurrency]
+type = "connections"
+hard_limit = 200
+soft_limit = 150
+
+[[http_service.checks]]
+grace_period = "20s"
+interval = "15s"
+method = "GET"
+path = "/health/ready/ai"
+protocol = "http"
+timeout = "4s"
+
+[[vm]]
+processes = ['app']
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1

--- a/apps/api/fly.billing.toml
+++ b/apps/api/fly.billing.toml
@@ -1,0 +1,46 @@
+app = 'anarlog-billing-api'
+primary_region = 'sjc'
+kill_signal = 'SIGTERM'
+# Fly caps this at 300s. Meeting streams can last longer, so api_cd uses
+# cordoned replacement Machines + SIGUSR1 and leaves old Machines up until idle.
+kill_timeout = 300
+swap_size_mb = 512
+
+[[restart]]
+policy = "on-failure"
+processes = ["app"]
+
+[env]
+ANARLOG_SERVICE = "billing"
+ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED = "false"
+PORT = "3001"
+
+[http_service]
+processes = ['app']
+internal_port = 3001
+force_https = true
+auto_stop_machines = 'off'
+auto_start_machines = true
+min_machines_running = 2
+
+[http_service.http_options]
+idle_timeout = 660
+
+[http_service.concurrency]
+type = "connections"
+hard_limit = 200
+soft_limit = 150
+
+[[http_service.checks]]
+grace_period = "20s"
+interval = "15s"
+method = "GET"
+path = "/health/ready/billing-api"
+protocol = "http"
+timeout = "4s"
+
+[[vm]]
+processes = ['app']
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1

--- a/apps/api/fly.core.toml
+++ b/apps/api/fly.core.toml
@@ -1,0 +1,46 @@
+app = 'anarlog-core'
+primary_region = 'sjc'
+kill_signal = 'SIGTERM'
+# Fly caps this at 300s. Meeting streams can last longer, so api_cd uses
+# cordoned replacement Machines + SIGUSR1 and leaves old Machines up until idle.
+kill_timeout = 300
+swap_size_mb = 512
+
+[[restart]]
+policy = "on-failure"
+processes = ["app"]
+
+[env]
+ANARLOG_SERVICE = "core"
+ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED = "false"
+PORT = "3001"
+
+[http_service]
+processes = ['app']
+internal_port = 3001
+force_https = true
+auto_stop_machines = 'off'
+auto_start_machines = true
+min_machines_running = 2
+
+[http_service.http_options]
+idle_timeout = 660
+
+[http_service.concurrency]
+type = "connections"
+hard_limit = 200
+soft_limit = 150
+
+[[http_service.checks]]
+grace_period = "20s"
+interval = "15s"
+method = "GET"
+path = "/health/ready/core"
+protocol = "http"
+timeout = "4s"
+
+[[vm]]
+processes = ['app']
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1

--- a/apps/api/fly.sync.toml
+++ b/apps/api/fly.sync.toml
@@ -1,0 +1,46 @@
+app = 'anarlog-sync'
+primary_region = 'sjc'
+kill_signal = 'SIGTERM'
+# Fly caps this at 300s. Meeting streams can last longer, so api_cd uses
+# cordoned replacement Machines + SIGUSR1 and leaves old Machines up until idle.
+kill_timeout = 300
+swap_size_mb = 512
+
+[[restart]]
+policy = "on-failure"
+processes = ["app"]
+
+[env]
+ANARLOG_SERVICE = "sync"
+ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED = "false"
+PORT = "3001"
+
+[http_service]
+processes = ['app']
+internal_port = 3001
+force_https = true
+auto_stop_machines = 'off'
+auto_start_machines = true
+min_machines_running = 2
+
+[http_service.http_options]
+idle_timeout = 660
+
+[http_service.concurrency]
+type = "connections"
+hard_limit = 200
+soft_limit = 150
+
+[[http_service.checks]]
+grace_period = "20s"
+interval = "15s"
+method = "GET"
+path = "/health/ready/sync"
+protocol = "http"
+timeout = "4s"
+
+[[vm]]
+processes = ['app']
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1

--- a/apps/api/src/env.rs
+++ b/apps/api/src/env.rs
@@ -4,6 +4,8 @@ use std::sync::OnceLock;
 use envy::Error as EnvyError;
 use serde::Deserialize;
 
+use crate::service::Service;
+
 fn default_port() -> u16 {
     3001
 }
@@ -44,6 +46,8 @@ struct OptionalLoopsEnv {
 
 #[derive(Deserialize)]
 pub struct Env {
+    #[serde(default)]
+    pub anarlog_service: Service,
     #[serde(default = "default_port")]
     pub port: u16,
     #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
@@ -78,10 +82,14 @@ pub struct Env {
     #[serde(flatten)]
     pub resend: anlg_api_env::ResendEnv,
 
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    openrouter_api_key: Option<String>,
     #[serde(flatten)]
-    pub llm: anlg_llm_proxy::Env,
-    #[serde(flatten)]
-    pub stt: anlg_transcribe_proxy::Env,
+    stt_api_keys: anlg_transcribe_proxy::SttApiKeysEnv,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    api_base_url: Option<String>,
+    #[serde(default, deserialize_with = "anlg_api_env::filter_empty")]
+    callback_secret: Option<String>,
 }
 
 // Raw environment resolved exactly once at startup: every optional integration
@@ -93,6 +101,8 @@ pub struct RuntimeConfig {
     pub subscription: Option<(anlg_api_env::StripeEnv, anlg_api_env::LoopsEnv)>,
     pub pyannote: Option<anlg_api_env::PyannoteEnv>,
     pub research: Option<anlg_api_research::ResearchConfig>,
+    pub llm: Option<anlg_llm_proxy::Env>,
+    pub stt: Option<anlg_transcribe_proxy::Env>,
 }
 
 impl std::ops::Deref for RuntimeConfig {
@@ -104,12 +114,54 @@ impl std::ops::Deref for RuntimeConfig {
 }
 
 impl RuntimeConfig {
-    pub(crate) fn resolve(env: Env) -> Result<Self, String> {
+    pub(crate) fn resolve(mut env: Env) -> Result<Self, String> {
         validate_supabase_env(&env.supabase)?;
-        let nango = resolve_nango(&env.nango)?;
-        let subscription = resolve_subscription(&env.stripe, &env.loops)?;
-        let pyannote = resolve_pyannote(&env.pyannote)?;
-        let research = resolve_research(&env.exa_api_key, &env.jina_api_key)?;
+        let service = env.anarlog_service;
+        let nango = if service.includes(Service::Core) {
+            resolve_nango(&env.nango)?
+        } else {
+            None
+        };
+        let subscription = if service.includes(Service::Core) || service.includes(Service::Billing)
+        {
+            resolve_subscription(&env.stripe, &env.loops)?
+        } else {
+            None
+        };
+        let (llm, stt, pyannote, research) = if service.includes(Service::Ai) {
+            let llm = anlg_llm_proxy::Env {
+                openrouter_api_key: required_integration_value(
+                    &env.openrouter_api_key,
+                    "OPENROUTER_API_KEY",
+                    "AI routes are enabled",
+                )?,
+            };
+            let stt = anlg_transcribe_proxy::Env {
+                stt: std::mem::take(&mut env.stt_api_keys),
+                callback: anlg_transcribe_proxy::CallbackEnv {
+                    api_base_url: required_integration_value(
+                        &env.api_base_url,
+                        "API_BASE_URL",
+                        "AI routes are enabled",
+                    )?,
+                    callback_secret: env.callback_secret.clone(),
+                },
+            };
+            (
+                Some(llm),
+                Some(stt),
+                resolve_pyannote(&env.pyannote)?,
+                resolve_research(&env.exa_api_key, &env.jina_api_key)?,
+            )
+        } else {
+            (None, None, None, None)
+        };
+
+        if env.anarlog_attachment_backup_gc_enabled && !service.includes(Service::Core) {
+            return Err(
+                "ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED is only supported by core or all".to_string(),
+            );
+        }
 
         if !cfg!(debug_assertions)
             && subscription
@@ -131,6 +183,8 @@ impl RuntimeConfig {
             subscription,
             pyannote,
             research,
+            llm,
+            stt,
         })
     }
 }
@@ -308,6 +362,98 @@ fn field_name_to_env_var(field: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn role_config(role: &str, extra: &[(&str, &str)]) -> Result<RuntimeConfig, String> {
+        let mut values = vec![
+            ("ANARLOG_SERVICE", role),
+            ("SUPABASE_URL", "http://127.0.0.1:54321"),
+            ("SUPABASE_ANON_KEY", "anon"),
+            ("SUPABASE_SERVICE_ROLE_KEY", "service"),
+        ];
+        values.extend_from_slice(extra);
+        let raw = envy::from_iter(
+            values
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string())),
+        )
+        .map_err(|error| error.to_string())?;
+        RuntimeConfig::resolve(raw)
+    }
+
+    #[test]
+    fn non_ai_services_start_without_ai_credentials() {
+        for role in ["sync", "core", "billing"] {
+            let config = role_config(role, &[]).unwrap();
+            assert!(config.llm.is_none());
+            assert!(config.stt.is_none());
+        }
+    }
+
+    #[test]
+    fn ai_configuration_remains_required_for_ai_and_combined_runtime() {
+        for role in ["ai", "all"] {
+            assert!(
+                role_config(role, &[])
+                    .err()
+                    .unwrap()
+                    .contains("OPENROUTER_API_KEY")
+            );
+            assert!(
+                role_config(role, &[("OPENROUTER_API_KEY", "key")])
+                    .err()
+                    .unwrap()
+                    .contains("API_BASE_URL")
+            );
+            let config = role_config(
+                role,
+                &[
+                    ("OPENROUTER_API_KEY", "key"),
+                    ("API_BASE_URL", "http://localhost:3001"),
+                ],
+            )
+            .unwrap();
+            assert!(config.llm.is_some());
+            assert!(config.stt.is_some());
+        }
+    }
+
+    #[test]
+    fn unrelated_partial_integrations_do_not_configure_other_services() {
+        let config = role_config(
+            "sync",
+            &[
+                ("NANGO_API_KEY", "partial"),
+                ("STRIPE_SECRET_KEY", "partial"),
+                ("PYANNOTE_API_BASE", "partial"),
+            ],
+        )
+        .unwrap();
+        assert!(config.nango.is_none());
+        assert!(config.subscription.is_none());
+        assert!(config.pyannote.is_none());
+    }
+
+    #[test]
+    fn only_core_can_own_cleanup_in_split_runtimes() {
+        for role in ["ai", "sync", "billing"] {
+            let error = role_config(
+                role,
+                &[
+                    ("ANARLOG_ATTACHMENT_BACKUP_GC_ENABLED", "true"),
+                    ("OPENROUTER_API_KEY", "key"),
+                    ("API_BASE_URL", "http://localhost:3001"),
+                ],
+            )
+            .err()
+            .unwrap();
+            assert!(error.contains("only supported by core or all"));
+        }
+    }
+
+    #[test]
+    fn invalid_service_role_is_rejected() {
+        assert!(role_config("unknown", &[]).is_err());
+    }
 
     #[derive(Deserialize)]
     struct SyncOnlyEnv {

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -109,6 +109,9 @@ async fn app_with_session_gate(
         routes = routes.merge(routes::billing(env, analytics));
     }
     let subsystem_health_state = SubsystemHealthState {
+        service,
+        integrations_configured: env.nango.is_some(),
+        billing_configured: env.subscription.is_some(),
         cloudsync_configured: service.includes(Service::Sync)
             && anlg_api_sync::SyncConfig::from_env(
                 &env.sync,
@@ -130,6 +133,10 @@ async fn app_with_session_gate(
     };
 
     let subsystem_health_routes = Router::new()
+        .route(
+            "/health/ready/{service}",
+            axum::routing::get(service_readiness),
+        )
         .route("/health/sync", axum::routing::get(sync_health))
         .route(
             "/health/transcription",
@@ -420,10 +427,43 @@ fn main() -> std::io::Result<()> {
 
 #[derive(Clone)]
 struct SubsystemHealthState {
+    service: Service,
+    integrations_configured: bool,
+    billing_configured: bool,
     cloudsync_configured: bool,
     transcription_configured: bool,
     llm_configured: bool,
     session_gate: anlg_transcribe_proxy::SessionGate,
+}
+
+async fn service_readiness(
+    axum::extract::Path(expected): axum::extract::Path<String>,
+    axum::extract::State(state): axum::extract::State<SubsystemHealthState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let configured = match state.service {
+        Service::Ai => state.transcription_configured && state.llm_configured,
+        Service::Sync => state.cloudsync_configured,
+        Service::Core => state.integrations_configured && state.billing_configured,
+        Service::Billing => state.billing_configured,
+        Service::All => {
+            state.transcription_configured
+                && state.llm_configured
+                && state.cloudsync_configured
+                && state.integrations_configured
+                && state.billing_configured
+        }
+    };
+    let ready = expected == state.service.name() && configured && !state.session_gate.is_draining();
+    subsystem_health_response(
+        ready,
+        serde_json::json!({
+            "ready": ready,
+            "service": state.service,
+            "version": option_env!("APP_VERSION").unwrap_or("unknown"),
+            "configured": configured,
+            "draining": state.session_gate.is_draining(),
+        }),
+    )
 }
 
 fn subsystem_health_response(

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -3,8 +3,11 @@ mod env;
 mod observability;
 mod openapi;
 mod rate_limit;
+mod routes;
+mod service;
 
 use std::net::SocketAddr;
+#[cfg(test)]
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,7 +15,7 @@ use std::time::SystemTime;
 
 use axum::{
     Json, Router, body::Body, extract::MatchedPath, http::HeaderMap, http::Request,
-    http::StatusCode, middleware,
+    http::StatusCode,
 };
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
 use sentry::protocol::{Context, Value};
@@ -25,8 +28,13 @@ use tower_http::{
     trace::TraceLayer,
 };
 
+#[cfg(test)]
 use auth::AuthState;
 use env::env;
+use service::Service;
+
+#[cfg(test)]
+use routes::build_sync_routes;
 
 use crate::env::Env;
 
@@ -76,88 +84,6 @@ fn request_server_endpoint(request: &Request<Body>, scheme: &str) -> (Option<Str
     (host, port)
 }
 
-fn build_sync_routes(
-    state: Option<anlg_api_sync::AppState>,
-    replica_state: anlg_api_sync::ReplicaState,
-    cloudsync_rate_limit_state: rate_limit::RateLimitState,
-    device_rate_limit_state: rate_limit::RateLimitState,
-    session_share_rate_limit_state: rate_limit::RateLimitState,
-    witness_rate_limit_state: rate_limit::RateLimitState,
-    auth_state: AuthState,
-) -> Router {
-    let replica_routes = anlg_api_sync::replica_router(replica_state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            cloudsync_rate_limit_state.clone(),
-            rate_limit::rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone().with_required_entitlement("hyprnote_pro"),
-            auth::require_auth,
-        ));
-    let device_routes = anlg_api_sync::device_router(replica_state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            device_rate_limit_state,
-            rate_limit::rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone().with_required_entitlement("hyprnote_pro"),
-            auth::require_auth,
-        ));
-    let witness_routes = anlg_api_sync::e2ee_witness_router(replica_state)
-        .route_layer(middleware::from_fn_with_state(
-            witness_rate_limit_state,
-            rate_limit::wait_for_rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone().with_required_entitlement("hyprnote_pro"),
-            auth::require_auth,
-        ));
-    let replica_routes = replica_routes.merge(device_routes).merge(witness_routes);
-
-    let Some(state) = state else {
-        return replica_routes;
-    };
-
-    let cloudsync_routes = anlg_api_sync::cloudsync_router(state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            cloudsync_rate_limit_state,
-            rate_limit::rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone().with_required_entitlement("hyprnote_pro"),
-            auth::require_auth,
-        ));
-    let session_share_routes = anlg_api_sync::session_share_router(state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            session_share_rate_limit_state.clone(),
-            rate_limit::rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone().with_required_entitlement("hyprnote_pro"),
-            auth::require_auth,
-        ));
-    let web_edit_routes = anlg_api_sync::web_edit_router(state)
-        .route_layer(middleware::from_fn_with_state(
-            session_share_rate_limit_state,
-            rate_limit::rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state,
-            auth::require_auth,
-        ));
-
-    replica_routes
-        .merge(cloudsync_routes)
-        .merge(session_share_routes)
-        .merge(web_edit_routes)
-}
-
 #[cfg(test)]
 async fn app_with_env(env: &'static crate::env::RuntimeConfig) -> Router {
     app_with_session_gate(env, anlg_transcribe_proxy::SessionGate::new()).await
@@ -167,321 +93,41 @@ async fn app_with_session_gate(
     env: &'static crate::env::RuntimeConfig,
     session_gate: anlg_transcribe_proxy::SessionGate,
 ) -> Router {
+    let service = env.anarlog_service;
     let analytics = build_analytics_client(env);
-
-    let llm_config =
-        anlg_llm_proxy::LlmProxyConfig::new(&env.llm).with_analytics(analytics.clone());
-    let stt_config = anlg_transcribe_proxy::SttProxyConfig::new(&env.stt, &env.supabase)
-        .with_anarlog_routing(anlg_transcribe_proxy::AnarlogRoutingConfig::default())
-        .with_analytics(analytics.clone());
-
-    let stt_rate_limit = rate_limit::RateLimitState::builder()
-        .pro(
-            governor::Quota::with_period(Duration::from_mins(5))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(20).unwrap()),
-        )
-        .free(
-            governor::Quota::with_period(Duration::from_hours(24))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(3).unwrap()),
-        )
-        .build();
-    let llm_rate_limit = rate_limit::RateLimitState::builder()
-        .pro(
-            governor::Quota::with_period(Duration::from_secs(1))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(30).unwrap()),
-        )
-        .free(
-            governor::Quota::with_period(Duration::from_hours(12))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(5).unwrap()),
-        )
-        .build();
-    let build_sync_rate_limit = || {
-        let quota = || {
-            governor::Quota::with_period(Duration::from_secs(30))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(20).unwrap())
-        };
-        rate_limit::RateLimitState::builder()
-            .pro(quota())
-            .free(quota())
-            .build()
-    };
-    let cloudsync_rate_limit = build_sync_rate_limit();
-    let device_quota = rate_limit::device_management_quota();
-    let device_rate_limit = rate_limit::RateLimitState::builder()
-        .pro(device_quota)
-        .free(device_quota)
-        .build();
-    let session_share_rate_limit = build_sync_rate_limit();
-    let e2ee_witness_rate_limit = rate_limit::RateLimitState::builder()
-        .pro(
-            governor::Quota::with_period(Duration::from_millis(100))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(20).unwrap()),
-        )
-        .free(
-            governor::Quota::with_period(Duration::from_millis(100))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(20).unwrap()),
-        )
-        .build();
-    let shared_notes_rate_limit = rate_limit::IpRateLimitState::new(
-        governor::Quota::with_period(Duration::from_secs(1))
-            .unwrap()
-            .allow_burst(NonZeroU32::new(30).unwrap()),
-    );
-    let cloud_api_rate_limit = rate_limit::RateLimitState::builder()
-        .pro(
-            governor::Quota::with_period(Duration::from_millis(200))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(10).unwrap()),
-        )
-        .free(
-            governor::Quota::with_period(Duration::from_millis(200))
-                .unwrap()
-                .allow_burst(NonZeroU32::new(10).unwrap()),
-        )
-        .build();
-
-    let auth_state = AuthState::new(&env.supabase.supabase_url);
-    let auth_state_paid = auth_state.clone().with_required_entitlements(
-        PAID_ENTITLEMENTS
-            .iter()
-            .map(|entitlement| (*entitlement).to_string())
-            .collect(),
-    );
-    let auth_state_basic = auth_state.clone();
-
-    let nango_config = env.nango.as_ref().map(|nango| {
-        anlg_api_nango::NangoConfig::new(
-            nango,
-            &env.supabase,
-            Some(env.supabase.supabase_service_role_key.clone()),
-        )
-    });
-    let subscription_config = env.subscription.as_ref().map(|(stripe, loops)| {
-        anlg_api_subscription::SubscriptionConfig::new(&env.supabase, stripe, loops)
-            .with_analytics(analytics.clone())
-            .with_durable_cleanup_enabled(env.anarlog_attachment_backup_gc_enabled)
-    });
-    let research_config = env.research.clone();
-    let pyannote_config = env
-        .pyannote
-        .as_ref()
-        .map(anlg_api_pyannote::PyannoteConfig::new);
-    let sync_config = anlg_api_sync::SyncConfig::from_env(
-        &env.sync,
-        &env.supabase.supabase_url,
-        &env.supabase.supabase_anon_key,
-        &env.supabase.supabase_service_role_key,
-    )
-    .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
+    let mut routes = Router::new();
+    if service.includes(Service::Ai) {
+        routes = routes.merge(routes::ai(env, session_gate.clone(), analytics.clone()));
+    }
+    if service.includes(Service::Sync) {
+        routes = routes.merge(routes::sync(env));
+    }
+    if service.includes(Service::Core) {
+        routes = routes.merge(routes::core(env, analytics.clone()));
+    }
+    if service.includes(Service::Billing) {
+        routes = routes.merge(routes::billing(env, analytics));
+    }
     let subsystem_health_state = SubsystemHealthState {
-        cloudsync_configured: sync_config.is_some(),
-        transcription_configured: !stt_config.api_keys.is_empty(),
-        llm_configured: !llm_config.api_key.is_empty(),
+        cloudsync_configured: service.includes(Service::Sync)
+            && anlg_api_sync::SyncConfig::from_env(
+                &env.sync,
+                &env.supabase.supabase_url,
+                &env.supabase.supabase_anon_key,
+                &env.supabase.supabase_service_role_key,
+            )
+            .expect("sync configuration validated")
+            .is_some(),
+        transcription_configured: env
+            .stt
+            .as_ref()
+            .is_some_and(|stt| !anlg_transcribe_proxy::ApiKeys::from(&stt.stt).0.is_empty()),
+        llm_configured: env
+            .llm
+            .as_ref()
+            .is_some_and(|llm| !llm.openrouter_api_key.is_empty()),
         session_gate: session_gate.clone(),
     };
-
-    let shared_notes_config = anlg_api_sync::SharedNotesConfig::new(
-        &env.supabase.supabase_url,
-        &env.supabase.supabase_service_role_key,
-    )
-    .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
-    let (Some(resend_api_key), Some(resend_from_email)) = (
-        env.resend.resend_api_key.as_deref(),
-        env.resend.resend_from_email.as_deref(),
-    ) else {
-        panic!(
-            "Failed to load environment: RESEND_API_KEY and RESEND_FROM_EMAIL are required for shared note email"
-        );
-    };
-    let shared_notes_config = shared_notes_config
-        .with_resend_email(resend_api_key, resend_from_email)
-        .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
-    let cloud_api_state = anlg_api_cloud::AppState::new(
-        anlg_api_cloud::CloudApiConfig::new(
-            &env.supabase.supabase_url,
-            &env.supabase.supabase_service_role_key,
-        )
-        .unwrap_or_else(|error| panic!("Failed to load environment: {error}")),
-    );
-
-    use anlg_api_nango::NangoIntegrationId;
-
-    let nango_webhook_routes = match nango_config.clone() {
-        Some(config) => {
-            let mut forward_handlers = anlg_api_nango::ForwardHandlerRegistry::new();
-            forward_handlers.insert(
-                anlg_api_nango::Linear::ID.to_string(),
-                anlg_api_nango::forward_handler(anlg_linear::webhook::handle),
-            );
-            Router::new().nest(
-                "/nango",
-                anlg_api_nango::webhook_router(config, forward_handlers),
-            )
-        }
-        None => Router::new(),
-    };
-
-    let webhook_routes = Router::new().merge(nango_webhook_routes).nest(
-        "/stt",
-        anlg_transcribe_proxy::callback_router(stt_config.clone()),
-    );
-
-    let paid_routes = if research_config.is_none() && pyannote_config.is_none() {
-        Router::new()
-    } else {
-        let mut routes = Router::new();
-        if let Some(config) = research_config {
-            routes = routes.merge(anlg_api_research::router(config));
-        }
-        if let Some(config) = pyannote_config {
-            routes = routes.nest("/pyannote", anlg_api_pyannote::router(config));
-        }
-        routes
-            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-            .route_layer(middleware::from_fn_with_state(
-                auth_state_paid.clone(),
-                auth::require_auth,
-            ))
-    };
-
-    let replica_state = anlg_api_sync::ReplicaState::new(
-        anlg_api_sync::ReplicaConfig::new(
-            &env.supabase.supabase_url,
-            &env.supabase.supabase_anon_key,
-            &env.supabase.supabase_service_role_key,
-        )
-        .unwrap_or_else(|error| panic!("Failed to load environment: {error}")),
-    );
-    let sync_state = sync_config.map(anlg_api_sync::AppState::new);
-    let sync_routes = build_sync_routes(
-        sync_state,
-        replica_state,
-        cloudsync_rate_limit,
-        device_rate_limit,
-        session_share_rate_limit,
-        e2ee_witness_rate_limit,
-        auth_state.clone(),
-    );
-    let shared_notes_state = anlg_api_sync::SharedNotesState::new(shared_notes_config);
-    let shared_notes_routes = anlg_api_sync::shared_notes_router(shared_notes_state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            shared_notes_rate_limit.clone(),
-            rate_limit::rate_limit_by_ip,
-        ));
-    let authenticated_shared_notes_routes =
-        anlg_api_sync::authenticated_shared_notes_router(shared_notes_state)
-            .route_layer(middleware::from_fn_with_state(
-                shared_notes_rate_limit,
-                rate_limit::rate_limit_by_ip,
-            ))
-            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-            .route_layer(middleware::from_fn_with_state(
-                auth_state.clone(),
-                auth::require_auth,
-            ));
-    let cloud_api_management_routes = anlg_api_cloud::management_router(cloud_api_state.clone())
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state.clone(),
-            auth::require_auth,
-        ));
-    let cloud_api_connector_routes = anlg_api_cloud::connector_router(cloud_api_state.clone())
-        .route_layer(middleware::from_fn_with_state(
-            cloud_api_rate_limit,
-            rate_limit::rate_limit,
-        ))
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            cloud_api_state.clone(),
-            anlg_api_cloud::require_cloud_connector_auth,
-        ));
-    let cloud_api_oauth_routes = anlg_api_cloud::oauth_metadata_router(cloud_api_state);
-
-    let integration_routes = match nango_config.clone() {
-        Some(config) => {
-            let nango_connection_state = anlg_api_nango::NangoConnectionState::from_config(&config);
-            Router::new()
-                .nest("/calendar", anlg_api_calendar::router())
-                .nest("/mail", anlg_api_mail::router())
-                .nest("/messenger", anlg_api_messenger::router())
-                .nest("/notion", anlg_api_notion::router())
-                .nest("/ticket", anlg_api_ticket::router())
-                .nest("/zoom", anlg_api_zoom::router())
-                .merge(anlg_api_meeting_import::router())
-                .nest("/nango", anlg_api_nango::session_router(config))
-                .layer(axum::Extension(nango_connection_state))
-                .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-                .route_layer(middleware::from_fn_with_state(
-                    auth_state_paid,
-                    auth::require_auth,
-                ))
-        }
-        None => Router::new(),
-    };
-
-    let integration_management_routes = match nango_config {
-        Some(config) => Router::new()
-            .nest("/nango", anlg_api_nango::management_router(config))
-            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-            .route_layer(middleware::from_fn_with_state(
-                auth_state_basic.clone(),
-                auth::require_auth,
-            )),
-        None => Router::new(),
-    };
-
-    let stt_routes = Router::new()
-        .merge(anlg_transcribe_proxy::listen_router_with_session_gate(
-            stt_config.clone(),
-            session_gate.clone(),
-        ))
-        .nest(
-            "/stt",
-            anlg_transcribe_proxy::router_with_session_gate(stt_config, session_gate.clone()),
-        )
-        .route_layer(middleware::from_fn_with_state(
-            stt_rate_limit,
-            rate_limit::rate_limit,
-        ));
-
-    let llm_routes = Router::new()
-        .merge(anlg_llm_proxy::chat_completions_router(llm_config.clone()))
-        .nest("/llm", anlg_llm_proxy::router(llm_config))
-        .route_layer(middleware::from_fn_with_state(
-            llm_rate_limit,
-            rate_limit::rate_limit,
-        ));
-
-    let scim_routes = match subscription_config.clone() {
-        Some(config) => anlg_api_subscription::scim_router(config),
-        None => Router::new(),
-    };
-    let subscription_routes = match subscription_config {
-        Some(config) => {
-            let router = anlg_api_subscription::router(config);
-            Router::new()
-                .nest("/subscription", router.clone())
-                .nest("/rpc", router.clone())
-                .nest("/billing", router)
-        }
-        None => Router::new(),
-    };
-    let auth_routes = Router::new()
-        .merge(stt_routes)
-        .merge(llm_routes)
-        .merge(subscription_routes)
-        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
-        .route_layer(middleware::from_fn_with_state(
-            auth_state_basic,
-            auth::require_auth,
-        ));
 
     let subsystem_health_routes = Router::new()
         .route("/health/sync", axum::routing::get(sync_health))
@@ -500,18 +146,7 @@ async fn app_with_session_gate(
         .route("/openapi.json", axum::routing::get(openapi_json))
         .merge(subsystem_health_routes)
         .merge(drain_routes)
-        .merge(webhook_routes)
-        .merge(paid_routes)
-        .merge(shared_notes_routes)
-        .merge(authenticated_shared_notes_routes)
-        .merge(cloud_api_management_routes)
-        .merge(cloud_api_oauth_routes)
-        .merge(cloud_api_connector_routes)
-        .nest("/sync", sync_routes)
-        .merge(integration_routes)
-        .merge(integration_management_routes)
-        .nest("/scim/v2", scim_routes)
-        .merge(auth_routes)
+        .merge(routes)
         .layer(
             CorsLayer::new()
                 .allow_origin(cors::Any)
@@ -704,12 +339,14 @@ fn main() -> std::io::Result<()> {
 
     sentry::configure_scope(|scope| {
         scope.set_tag("service.namespace", "anarlog");
-        scope.set_tag("service.name", "api");
+        scope.set_tag("service.name", env.anarlog_service.name());
     });
 
-    let observability = observability::init("api", &env.observability);
+    let observability = observability::init(env.anarlog_service.name(), &env.observability);
 
-    anlg_transcribe_proxy::ApiKeys::from(&env.stt.stt).log_configured_providers();
+    if let Some(stt) = &env.stt {
+        anlg_transcribe_proxy::ApiKeys::from(&stt.stt).log_configured_providers();
+    }
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/apps/api/src/routes/ai.rs
+++ b/apps/api/src/routes/ai.rs
@@ -1,0 +1,112 @@
+use crate::{PAID_ENTITLEMENTS, rate_limit};
+use crate::{
+    auth::{self, AuthState},
+    env::RuntimeConfig,
+};
+use axum::{Router, middleware};
+use std::{num::NonZeroU32, sync::Arc, time::Duration};
+
+pub(crate) fn router(
+    env: &RuntimeConfig,
+    session_gate: anlg_transcribe_proxy::SessionGate,
+    analytics: Arc<anlg_analytics::AnalyticsClient>,
+) -> Router {
+    let llm_config =
+        anlg_llm_proxy::LlmProxyConfig::new(env.llm.as_ref().expect("AI configuration resolved"))
+            .with_analytics(analytics.clone());
+    let stt_config = anlg_transcribe_proxy::SttProxyConfig::new(
+        env.stt.as_ref().expect("AI configuration resolved"),
+        &env.supabase,
+    )
+    .with_anarlog_routing(anlg_transcribe_proxy::AnarlogRoutingConfig::default())
+    .with_analytics(analytics.clone());
+
+    let stt_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(
+            governor::Quota::with_period(Duration::from_mins(5))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(20).unwrap()),
+        )
+        .free(
+            governor::Quota::with_period(Duration::from_hours(24))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(3).unwrap()),
+        )
+        .build();
+    let llm_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(
+            governor::Quota::with_period(Duration::from_secs(1))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(30).unwrap()),
+        )
+        .free(
+            governor::Quota::with_period(Duration::from_hours(12))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(5).unwrap()),
+        )
+        .build();
+    let auth_state = AuthState::new(&env.supabase.supabase_url);
+    let auth_state_paid = auth_state.clone().with_required_entitlements(
+        PAID_ENTITLEMENTS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+    );
+    let research_config = env.research.clone();
+    let pyannote_config = env
+        .pyannote
+        .as_ref()
+        .map(anlg_api_pyannote::PyannoteConfig::new);
+    let callbacks = Router::new().nest(
+        "/stt",
+        anlg_transcribe_proxy::callback_router(stt_config.clone()),
+    );
+    let paid_routes = if research_config.is_none() && pyannote_config.is_none() {
+        Router::new()
+    } else {
+        let mut routes = Router::new();
+        if let Some(config) = research_config {
+            routes = routes.merge(anlg_api_research::router(config));
+        }
+        if let Some(config) = pyannote_config {
+            routes = routes.nest("/pyannote", anlg_api_pyannote::router(config));
+        }
+        routes
+            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+            .route_layer(middleware::from_fn_with_state(
+                auth_state_paid.clone(),
+                auth::require_auth,
+            ))
+    };
+
+    let stt_routes = Router::new()
+        .merge(anlg_transcribe_proxy::listen_router_with_session_gate(
+            stt_config.clone(),
+            session_gate.clone(),
+        ))
+        .nest(
+            "/stt",
+            anlg_transcribe_proxy::router_with_session_gate(stt_config, session_gate.clone()),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            stt_rate_limit,
+            rate_limit::rate_limit,
+        ));
+
+    let llm_routes = Router::new()
+        .merge(anlg_llm_proxy::chat_completions_router(llm_config.clone()))
+        .nest("/llm", anlg_llm_proxy::router(llm_config))
+        .route_layer(middleware::from_fn_with_state(
+            llm_rate_limit,
+            rate_limit::rate_limit,
+        ));
+
+    let authenticated = stt_routes
+        .merge(llm_routes)
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state,
+            auth::require_auth,
+        ));
+    authenticated.merge(paid_routes).merge(callbacks)
+}

--- a/apps/api/src/routes/billing.rs
+++ b/apps/api/src/routes/billing.rs
@@ -1,0 +1,24 @@
+use super::subscription_aliases;
+use crate::{
+    auth::{self, AuthState},
+    env::RuntimeConfig,
+};
+use axum::{Router, middleware};
+use std::sync::Arc;
+
+pub(crate) fn router(
+    env: &RuntimeConfig,
+    analytics: Arc<anlg_analytics::AnalyticsClient>,
+) -> Router {
+    let Some((stripe, loops)) = env.subscription.as_ref() else {
+        return Router::new();
+    };
+    let config = anlg_api_subscription::SubscriptionConfig::new(&env.supabase, stripe, loops)
+        .with_analytics(analytics);
+    subscription_aliases(anlg_api_subscription::billing_router(config))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            AuthState::new(&env.supabase.supabase_url),
+            auth::require_auth,
+        ))
+}

--- a/apps/api/src/routes/core.rs
+++ b/apps/api/src/routes/core.rs
@@ -1,0 +1,102 @@
+use super::subscription_aliases;
+use crate::PAID_ENTITLEMENTS;
+use crate::{
+    auth::{self, AuthState},
+    env::RuntimeConfig,
+};
+use axum::{Router, middleware};
+use std::sync::Arc;
+
+pub(crate) fn router(
+    env: &RuntimeConfig,
+    analytics: Arc<anlg_analytics::AnalyticsClient>,
+) -> Router {
+    let auth_state = AuthState::new(&env.supabase.supabase_url);
+    let auth_state_paid = auth_state.clone().with_required_entitlements(
+        PAID_ENTITLEMENTS
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+    );
+    let auth_state_basic = auth_state.clone();
+    let nango_config = env.nango.as_ref().map(|nango| {
+        anlg_api_nango::NangoConfig::new(
+            nango,
+            &env.supabase,
+            Some(env.supabase.supabase_service_role_key.clone()),
+        )
+    });
+    let subscription_config = env.subscription.as_ref().map(|(stripe, loops)| {
+        anlg_api_subscription::SubscriptionConfig::new(&env.supabase, stripe, loops)
+            .with_analytics(analytics.clone())
+            .with_durable_cleanup_enabled(env.anarlog_attachment_backup_gc_enabled)
+    });
+    use anlg_api_nango::NangoIntegrationId;
+    let nango_webhook_routes = match nango_config.clone() {
+        Some(config) => {
+            let mut forward_handlers = anlg_api_nango::ForwardHandlerRegistry::new();
+            forward_handlers.insert(
+                anlg_api_nango::Linear::ID.to_string(),
+                anlg_api_nango::forward_handler(anlg_linear::webhook::handle),
+            );
+            Router::new().nest(
+                "/nango",
+                anlg_api_nango::webhook_router(config, forward_handlers),
+            )
+        }
+        None => Router::new(),
+    };
+
+    let integration_routes = match nango_config.clone() {
+        Some(config) => {
+            let nango_connection_state = anlg_api_nango::NangoConnectionState::from_config(&config);
+            Router::new()
+                .nest("/calendar", anlg_api_calendar::router())
+                .nest("/mail", anlg_api_mail::router())
+                .nest("/messenger", anlg_api_messenger::router())
+                .nest("/notion", anlg_api_notion::router())
+                .nest("/ticket", anlg_api_ticket::router())
+                .nest("/zoom", anlg_api_zoom::router())
+                .merge(anlg_api_meeting_import::router())
+                .nest("/nango", anlg_api_nango::session_router(config))
+                .layer(axum::Extension(nango_connection_state))
+                .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+                .route_layer(middleware::from_fn_with_state(
+                    auth_state_paid,
+                    auth::require_auth,
+                ))
+        }
+        None => Router::new(),
+    };
+
+    let integration_management_routes = match nango_config {
+        Some(config) => Router::new()
+            .nest("/nango", anlg_api_nango::management_router(config))
+            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+            .route_layer(middleware::from_fn_with_state(
+                auth_state_basic.clone(),
+                auth::require_auth,
+            )),
+        None => Router::new(),
+    };
+
+    let scim_routes = match subscription_config.clone() {
+        Some(config) => anlg_api_subscription::scim_router(config),
+        None => Router::new(),
+    };
+    let account_routes = match subscription_config {
+        Some(config) => subscription_aliases(anlg_api_subscription::account_router(config))
+            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+            .route_layer(middleware::from_fn_with_state(
+                auth_state,
+                auth::require_auth,
+            )),
+        None => Router::new(),
+    };
+    Router::new()
+        .merge(nango_webhook_routes)
+        .merge(integration_routes)
+        .merge(integration_management_routes)
+        .merge(account_routes)
+        .nest("/scim/v2", scim_routes)
+}

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -1,0 +1,20 @@
+mod ai;
+mod billing;
+mod core;
+mod sync;
+
+use axum::Router;
+
+pub(super) use ai::router as ai;
+pub(super) use billing::router as billing;
+pub(super) use core::router as core;
+#[cfg(test)]
+pub(super) use sync::build_sync_routes;
+pub(super) use sync::router as sync;
+
+fn subscription_aliases(router: Router) -> Router {
+    Router::new()
+        .nest("/subscription", router.clone())
+        .nest("/rpc", router.clone())
+        .nest("/billing", router)
+}

--- a/apps/api/src/routes/sync.rs
+++ b/apps/api/src/routes/sync.rs
@@ -1,0 +1,232 @@
+use crate::rate_limit;
+use crate::{
+    auth::{self, AuthState},
+    env::RuntimeConfig,
+};
+use axum::{Router, middleware};
+use std::{num::NonZeroU32, time::Duration};
+
+pub(crate) fn build_sync_routes(
+    state: Option<anlg_api_sync::AppState>,
+    replica_state: anlg_api_sync::ReplicaState,
+    cloudsync_rate_limit_state: rate_limit::RateLimitState,
+    device_rate_limit_state: rate_limit::RateLimitState,
+    session_share_rate_limit_state: rate_limit::RateLimitState,
+    witness_rate_limit_state: rate_limit::RateLimitState,
+    auth_state: AuthState,
+) -> Router {
+    let replica_routes = anlg_api_sync::replica_router(replica_state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            cloudsync_rate_limit_state.clone(),
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let device_routes = anlg_api_sync::device_router(replica_state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            device_rate_limit_state,
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let witness_routes = anlg_api_sync::e2ee_witness_router(replica_state)
+        .route_layer(middleware::from_fn_with_state(
+            witness_rate_limit_state,
+            rate_limit::wait_for_rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let replica_routes = replica_routes.merge(device_routes).merge(witness_routes);
+
+    let Some(state) = state else {
+        return replica_routes;
+    };
+
+    let cloudsync_routes = anlg_api_sync::cloudsync_router(state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            cloudsync_rate_limit_state,
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let session_share_routes = anlg_api_sync::session_share_router(state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            session_share_rate_limit_state.clone(),
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone().with_required_entitlement("hyprnote_pro"),
+            auth::require_auth,
+        ));
+    let web_edit_routes = anlg_api_sync::web_edit_router(state)
+        .route_layer(middleware::from_fn_with_state(
+            session_share_rate_limit_state,
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state,
+            auth::require_auth,
+        ));
+
+    replica_routes
+        .merge(cloudsync_routes)
+        .merge(session_share_routes)
+        .merge(web_edit_routes)
+}
+
+pub(crate) fn router(env: &RuntimeConfig) -> Router {
+    let build_sync_rate_limit = || {
+        let quota = || {
+            governor::Quota::with_period(Duration::from_secs(30))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(20).unwrap())
+        };
+        rate_limit::RateLimitState::builder()
+            .pro(quota())
+            .free(quota())
+            .build()
+    };
+    let cloudsync_rate_limit = build_sync_rate_limit();
+    let device_quota = rate_limit::device_management_quota();
+    let device_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(device_quota)
+        .free(device_quota)
+        .build();
+    let session_share_rate_limit = build_sync_rate_limit();
+    let e2ee_witness_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(
+            governor::Quota::with_period(Duration::from_millis(100))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(20).unwrap()),
+        )
+        .free(
+            governor::Quota::with_period(Duration::from_millis(100))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(20).unwrap()),
+        )
+        .build();
+    let shared_notes_rate_limit = rate_limit::IpRateLimitState::new(
+        governor::Quota::with_period(Duration::from_secs(1))
+            .unwrap()
+            .allow_burst(NonZeroU32::new(30).unwrap()),
+    );
+    let cloud_api_rate_limit = rate_limit::RateLimitState::builder()
+        .pro(
+            governor::Quota::with_period(Duration::from_millis(200))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(10).unwrap()),
+        )
+        .free(
+            governor::Quota::with_period(Duration::from_millis(200))
+                .unwrap()
+                .allow_burst(NonZeroU32::new(10).unwrap()),
+        )
+        .build();
+
+    let auth_state = AuthState::new(&env.supabase.supabase_url);
+    let sync_config = anlg_api_sync::SyncConfig::from_env(
+        &env.sync,
+        &env.supabase.supabase_url,
+        &env.supabase.supabase_anon_key,
+        &env.supabase.supabase_service_role_key,
+    )
+    .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
+    let shared_notes_config = anlg_api_sync::SharedNotesConfig::new(
+        &env.supabase.supabase_url,
+        &env.supabase.supabase_service_role_key,
+    )
+    .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
+    let (Some(resend_api_key), Some(resend_from_email)) = (
+        env.resend.resend_api_key.as_deref(),
+        env.resend.resend_from_email.as_deref(),
+    ) else {
+        panic!(
+            "Failed to load environment: RESEND_API_KEY and RESEND_FROM_EMAIL are required for shared note email"
+        );
+    };
+    let shared_notes_config = shared_notes_config
+        .with_resend_email(resend_api_key, resend_from_email)
+        .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
+    let cloud_api_state = anlg_api_cloud::AppState::new(
+        anlg_api_cloud::CloudApiConfig::new(
+            &env.supabase.supabase_url,
+            &env.supabase.supabase_service_role_key,
+        )
+        .unwrap_or_else(|error| panic!("Failed to load environment: {error}")),
+    );
+
+    let replica_state = anlg_api_sync::ReplicaState::new(
+        anlg_api_sync::ReplicaConfig::new(
+            &env.supabase.supabase_url,
+            &env.supabase.supabase_anon_key,
+            &env.supabase.supabase_service_role_key,
+        )
+        .unwrap_or_else(|error| panic!("Failed to load environment: {error}")),
+    );
+    let sync_state = sync_config.map(anlg_api_sync::AppState::new);
+    let sync_routes = build_sync_routes(
+        sync_state,
+        replica_state,
+        cloudsync_rate_limit,
+        device_rate_limit,
+        session_share_rate_limit,
+        e2ee_witness_rate_limit,
+        auth_state.clone(),
+    );
+    let shared_notes_state = anlg_api_sync::SharedNotesState::new(shared_notes_config);
+    let shared_notes_routes = anlg_api_sync::shared_notes_router(shared_notes_state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            shared_notes_rate_limit.clone(),
+            rate_limit::rate_limit_by_ip,
+        ));
+    let authenticated_shared_notes_routes =
+        anlg_api_sync::authenticated_shared_notes_router(shared_notes_state)
+            .route_layer(middleware::from_fn_with_state(
+                shared_notes_rate_limit,
+                rate_limit::rate_limit_by_ip,
+            ))
+            .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+            .route_layer(middleware::from_fn_with_state(
+                auth_state.clone(),
+                auth::require_auth,
+            ));
+    let cloud_api_management_routes = anlg_api_cloud::management_router(cloud_api_state.clone())
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            auth_state.clone(),
+            auth::require_auth,
+        ));
+    let cloud_api_connector_routes = anlg_api_cloud::connector_router(cloud_api_state.clone())
+        .route_layer(middleware::from_fn_with_state(
+            cloud_api_rate_limit,
+            rate_limit::rate_limit,
+        ))
+        .route_layer(middleware::from_fn(auth::sentry_and_analytics))
+        .route_layer(middleware::from_fn_with_state(
+            cloud_api_state.clone(),
+            anlg_api_cloud::require_cloud_connector_auth,
+        ));
+    let cloud_api_oauth_routes = anlg_api_cloud::oauth_metadata_router(cloud_api_state);
+
+    Router::new()
+        .nest("/sync", sync_routes)
+        .merge(shared_notes_routes)
+        .merge(authenticated_shared_notes_routes)
+        .merge(cloud_api_management_routes)
+        .merge(cloud_api_connector_routes)
+        .merge(cloud_api_oauth_routes)
+}

--- a/apps/api/src/service.rs
+++ b/apps/api/src/service.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Service {
+    #[default]
+    All,
+    Ai,
+    Sync,
+    Core,
+    Billing,
+}
+
+impl Service {
+    pub fn includes(self, service: Self) -> bool {
+        self == Self::All || self == service
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::All => "api",
+            Self::Ai => "ai",
+            Self::Sync => "sync",
+            Self::Core => "core",
+            Self::Billing => "billing-api",
+        }
+    }
+}

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -14,6 +14,96 @@ use wiremock::{
 use super::*;
 
 const TEST_KEY_ID: &str = "sync-composition-test";
+
+#[tokio::test]
+async fn standalone_services_build_without_other_services_credentials() {
+    for role in ["ai", "sync", "core", "billing"] {
+        let mut values = vec![
+            ("ANARLOG_SERVICE", role),
+            ("SUPABASE_URL", "http://127.0.0.1:54321"),
+            ("SUPABASE_ANON_KEY", "anon"),
+            ("SUPABASE_SERVICE_ROLE_KEY", "service"),
+        ];
+        match role {
+            "ai" => values.extend([
+                ("OPENROUTER_API_KEY", "key"),
+                ("API_BASE_URL", "http://127.0.0.1:3001"),
+            ]),
+            "sync" => values.extend([
+                ("RESEND_API_KEY", "key"),
+                ("RESEND_FROM_EMAIL", "test@example.com"),
+            ]),
+            "core" | "billing" => values.extend([
+                ("STRIPE_SECRET_KEY", "sk_test_role"),
+                ("STRIPE_MONTHLY_PRICE_ID", "price_monthly"),
+                ("STRIPE_YEARLY_PRICE_ID", "price_yearly"),
+                ("LOOPS_KEY", "loops"),
+            ]),
+            _ => unreachable!(),
+        }
+        let raw = envy::from_iter(
+            values
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string())),
+        )
+        .unwrap();
+        let config = crate::env::RuntimeConfig::resolve(raw).unwrap();
+        let app = app_with_env(Box::leak(Box::new(config))).await;
+        assert_eq!(
+            request_status(&app, Method::GET, "/health").await,
+            StatusCode::OK,
+            "{role}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn service_roles_only_expose_owned_routes() {
+    for role in ["all", "ai", "sync", "core", "billing"] {
+        let config = crate::env::RuntimeConfig::resolve(deserialize_api_env([
+            ("ANARLOG_SERVICE", role),
+            ("NANGO_API_KEY", "nango-key"),
+            ("NANGO_WEBHOOK_SIGNING_KEY", "signing-key"),
+            ("STRIPE_SECRET_KEY", "sk_test_role"),
+            ("STRIPE_MONTHLY_PRICE_ID", "price_monthly"),
+            ("STRIPE_YEARLY_PRICE_ID", "price_yearly"),
+            ("LOOPS_KEY", "loops-key"),
+        ]))
+        .unwrap();
+        let app = app_with_env(Box::leak(Box::new(config))).await;
+        for (owner, method, path) in [
+            ("ai", Method::POST, "/llm/chat/completions"),
+            ("ai", Method::GET, "/listen"),
+            ("sync", Method::GET, "/v1/cloud-api/settings"),
+            ("sync", Method::PUT, "/v1/sync-snapshots/session"),
+            ("core", Method::GET, "/nango/connections"),
+            ("core", Method::DELETE, "/subscription/delete-account"),
+            ("core", Method::DELETE, "/rpc/delete-account"),
+            ("core", Method::DELETE, "/billing/delete-account"),
+            ("billing", Method::POST, "/subscription/start-trial"),
+            ("billing", Method::GET, "/rpc/can-start-trial"),
+            ("billing", Method::POST, "/billing/start-trial"),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let expected = if role == "all" || role == owner {
+                StatusCode::UNAUTHORIZED
+            } else {
+                StatusCode::NOT_FOUND
+            };
+            assert_eq!(response.status(), expected, "{role}: {path}");
+        }
+    }
+}
 const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWTFfCGljY6aw3Hrt\n\
 kHmPRiazukxPLb6ilpRAewjW8nihRANCAATDskChT+Altkm9X7MI69T3IUmrQU0L\n\

--- a/apps/api/src/tests.rs
+++ b/apps/api/src/tests.rs
@@ -275,6 +275,9 @@ fn subsystem_health_app(
         .route("/health/transcription", get(transcription_health))
         .route("/health/llm", get(llm_health))
         .with_state(SubsystemHealthState {
+            service: Service::All,
+            integrations_configured: false,
+            billing_configured: false,
             cloudsync_configured,
             transcription_configured,
             llm_configured,
@@ -795,4 +798,57 @@ async fn sync_composition_keeps_devices_and_sharing_available_when_credentials_a
         "shared_note_publication_forbidden"
     );
     server.verify().await;
+}
+
+#[tokio::test]
+async fn readiness_requires_the_expected_role_configuration_and_accepting_state() {
+    for service in [
+        Service::Ai,
+        Service::Sync,
+        Service::Core,
+        Service::Billing,
+        Service::All,
+    ] {
+        let gate = anlg_transcribe_proxy::SessionGate::new();
+        let state = SubsystemHealthState {
+            service,
+            integrations_configured: true,
+            billing_configured: true,
+            cloudsync_configured: true,
+            transcription_configured: true,
+            llm_configured: true,
+            session_gate: gate.clone(),
+        };
+        let router = |state| {
+            Router::new()
+                .route("/health/ready/{service}", get(service_readiness))
+                .with_state(state)
+        };
+        let app = router(state.clone());
+        let path = format!("/health/ready/{}", service.name());
+        assert_eq!(
+            request_status(&app, Method::GET, &path).await,
+            StatusCode::OK
+        );
+        assert_eq!(
+            request_status(&app, Method::GET, "/health/ready/wrong").await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        let mut incomplete = state;
+        match service {
+            Service::Ai | Service::All => incomplete.transcription_configured = false,
+            Service::Sync => incomplete.cloudsync_configured = false,
+            Service::Core => incomplete.integrations_configured = false,
+            Service::Billing => incomplete.billing_configured = false,
+        }
+        assert_eq!(
+            request_status(&router(incomplete), Method::GET, &path).await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        gate.begin_drain();
+        assert_eq!(
+            request_status(&app, Method::GET, &path).await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
 }

--- a/apps/stripe/src/index.ts
+++ b/apps/stripe/src/index.ts
@@ -9,6 +9,7 @@ import { captureOperationalError, sanitizeErrorEvent } from "./error-reporting";
 import type { AppBindings } from "./hono-bindings";
 import { verifyStripeWebhook } from "./middleware";
 import { routes } from "./routes";
+import { drainServer } from "./shutdown";
 import { startWorkspaceSeatWorker } from "./workspace-seat-worker";
 
 Sentry.init({
@@ -57,13 +58,25 @@ app.onError((err, c) => {
 app.notFound((c) => c.text("not_found", 404));
 
 const stopSeatWorker = startWorkspaceSeatWorker();
-for (const signal of ["SIGTERM", "SIGINT"] as const) {
-  process.once(signal, () => {
-    void stopSeatWorker().finally(() => process.exit(0));
-  });
-}
-
-export default {
+const server = Bun.serve({
   port: env.PORT,
   fetch: app.fetch,
-};
+});
+let shuttingDown = false;
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+  process.on(signal, () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    void (async () => {
+      let exitCode = 0;
+      try {
+        await drainServer(server, stopSeatWorker);
+      } catch (error) {
+        exitCode = 1;
+        captureOperationalError(error, { operation: "server_shutdown" });
+      }
+      await Sentry.flush(2000);
+      process.exit(exitCode);
+    })();
+  });
+}

--- a/apps/stripe/src/shutdown.test.ts
+++ b/apps/stripe/src/shutdown.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test";
+
+import { drainServer } from "./shutdown";
+
+test("shutdown lets an accepted webhook finish and waits for the worker", async () => {
+  const accepted = Promise.withResolvers<void>();
+  const finishRequest = Promise.withResolvers<void>();
+  const finishWorker = Promise.withResolvers<void>();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch() {
+      accepted.resolve();
+      await finishRequest.promise;
+      return Response.json({ received: true });
+    },
+  });
+  try {
+    const response = fetch(server.url, { method: "POST" }).then((value) =>
+      value.json(),
+    );
+    await accepted.promise;
+    let stopped = false;
+    const shutdown = drainServer(server, () => finishWorker.promise).then(
+      () => {
+        stopped = true;
+      },
+    );
+    finishRequest.resolve();
+    expect(await response).toEqual({ received: true });
+    expect(stopped).toBe(false);
+    finishWorker.resolve();
+    await shutdown;
+    expect(stopped).toBe(true);
+  } finally {
+    finishRequest.resolve();
+    finishWorker.resolve();
+    await server.stop(true);
+  }
+});
+
+test("a worker shutdown error does not cut off an accepted response", async () => {
+  const accepted = Promise.withResolvers<void>();
+  const finishRequest = Promise.withResolvers<void>();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch() {
+      accepted.resolve();
+      await finishRequest.promise;
+      return new Response("complete");
+    },
+  });
+  try {
+    const response = fetch(server.url).then((value) => value.text());
+    await accepted.promise;
+    const shutdown = drainServer(server, async () => {
+      throw new Error("worker failed");
+    });
+    const result = shutdown.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    finishRequest.resolve();
+    expect(await response).toBe("complete");
+    expect(await result).toBeInstanceOf(AggregateError);
+  } finally {
+    finishRequest.resolve();
+    await server.stop(true);
+  }
+});
+
+test("shutdown preserves a streaming response through its final chunk", async () => {
+  const finishStream = Promise.withResolvers<void>();
+  const encoder = new TextEncoder();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            controller.enqueue(encoder.encode("first "));
+            await finishStream.promise;
+            controller.enqueue(encoder.encode("last"));
+            controller.close();
+          },
+        }),
+      );
+    },
+  });
+  try {
+    const response = await fetch(server.url);
+    const reader = response.body!.getReader();
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+      "first ",
+    );
+    const shutdown = drainServer(server, async () => {});
+    finishStream.resolve();
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("last");
+    expect((await reader.read()).done).toBe(true);
+    await shutdown;
+  } finally {
+    finishStream.resolve();
+    await server.stop(true);
+  }
+});

--- a/apps/stripe/src/shutdown.ts
+++ b/apps/stripe/src/shutdown.ts
@@ -1,0 +1,15 @@
+export async function drainServer(
+  server: Pick<Bun.Server<unknown>, "stop">,
+  stopWorker: () => Promise<void>,
+) {
+  const results = await Promise.allSettled([
+    Promise.resolve().then(() => server.stop()),
+    Promise.resolve().then(stopWorker),
+  ]);
+  const errors = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Billing shutdown failed");
+  }
+}

--- a/crates/api-subscription/src/lib.rs
+++ b/crates/api-subscription/src/lib.rs
@@ -14,4 +14,4 @@ pub use cleanup_worker::CleanupWorker;
 pub use config::{CloudsyncCleanupConfig, SubscriptionConfig};
 pub use env::StripeEnv;
 pub use openapi::openapi;
-pub use routes::{router, scim_router};
+pub use routes::{account_router, billing_router, router, scim_router};

--- a/crates/api-subscription/src/routes/mod.rs
+++ b/crates/api-subscription/src/routes/mod.rs
@@ -16,13 +16,22 @@ pub use account::DeleteAccountResponse;
 pub use rpc::{CanStartTrialReason, CanStartTrialResponse};
 
 pub fn router(config: SubscriptionConfig) -> Router {
+    billing_router(config.clone()).merge(account_router(config))
+}
+
+pub fn billing_router(config: SubscriptionConfig) -> Router {
     let state = AppState::new(config);
 
     Router::new()
         .route("/can-start-trial", get(rpc::can_start_trial))
         .route("/start-trial", post(billing::start_trial))
-        .route("/delete-account", delete(account::delete_account))
         .with_state(state)
+}
+
+pub fn account_router(config: SubscriptionConfig) -> Router {
+    Router::new()
+        .route("/delete-account", delete(account::delete_account))
+        .with_state(AppState::new(config))
 }
 
 pub fn scim_router(config: SubscriptionConfig) -> Router {

--- a/crates/transcribe-proxy/src/lib.rs
+++ b/crates/transcribe-proxy/src/lib.rs
@@ -16,7 +16,7 @@ pub use analytics::{SttAnalyticsReporter, SttEvent};
 pub use anarlog_routing::{AnarlogRouter, AnarlogRoutingConfig, RetryConfig, is_retryable_error};
 pub use anlg_analytics::{AuthenticatedUserId, DeviceFingerprint};
 pub use config::*;
-pub use env::{ApiKeys, Env};
+pub use env::{ApiKeys, CallbackEnv, Env, SttApiKeysEnv};
 pub use error::*;
 pub use openapi::openapi;
 pub use provider_selector::{ProviderSelector, SelectedProvider};


### PR DESCRIPTION
Partition API routes and environment requirements into AI, sync, core, and billing roles while retaining the combined default. Add route-ownership tests and expand API CI coverage.

Make the Stripe service wait for active HTTP requests and the seat worker during shutdown, including worker failure. Add real-connection shutdown tests and a Stripe CI workflow.

Add service-specific Fly profiles and readiness endpoints. Reconcile candidate runtime configuration while cordoned, reject unsupported settings, and recheck readiness before cutover.

ANLG-335
