### PR TITLE
Notify team invitees while the desktop is in the background

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -679,6 +679,28 @@ describe("EventListeners notification events", () => {
     expect(openNewMock).not.toHaveBeenCalled();
   });
 
+  test.each(["notification_confirm", "notification_accept"])(
+    "%s opens Team settings for an invitation without creating a session",
+    async (type) => {
+      render(<EventListeners />);
+      await vi.waitFor(() =>
+        expect(notificationListenMock).toHaveBeenCalledTimes(1),
+      );
+      notificationListenMock.mock.calls[0]?.[0]({
+        payload: {
+          type,
+          key: "team-invitation:inv-1",
+          source: null,
+        },
+      });
+      expect(createSessionMock).not.toHaveBeenCalled();
+      expect(openNewMock).toHaveBeenCalledWith({
+        type: "settings",
+        state: { tab: "team" },
+      });
+    },
+  );
+
   test("notification_confirm with session source opens that session", async () => {
     render(<EventListeners />);
 

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -542,6 +542,11 @@ function useNotificationEvents() {
             return;
           }
 
+          if (payload.key?.startsWith("team-invitation:")) {
+            openNewRef.current({ type: "settings", state: { tab: "team" } });
+            return;
+          }
+
           const eventId =
             payload.source?.type === "calendar_event"
               ? payload.source.event_id

--- a/apps/desktop/src/settings/team/invitation-toast.test.tsx
+++ b/apps/desktop/src/settings/team/invitation-toast.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,6 +18,9 @@ const mocks = vi.hoisted(() => ({
   openNew: vi.fn(),
   toast: vi.fn(),
   dismiss: vi.fn(),
+  inactive: vi.fn(),
+  showNotification: vi.fn(),
+  notificationsDisabled: false,
 }));
 
 vi.mock("@lingui/react/macro", () => ({
@@ -30,6 +33,18 @@ vi.mock("@lingui/react/macro", () => ({
         "",
       ),
   }),
+}));
+
+vi.mock("@anlg/plugin-notification", () => ({
+  commands: { showNotification: mocks.showNotification },
+}));
+
+vi.mock("~/shared/window-activity", () => ({
+  isAppWindowInactive: mocks.inactive,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => mocks.notificationsDisabled,
 }));
 
 vi.mock("@anlg/ui/components/ui/toast", () => ({
@@ -60,6 +75,11 @@ const invitation = {
 describe("WorkspaceInvitationToasts", () => {
   beforeEach(() => {
     mocks.invitations.data = undefined;
+    mocks.notificationsDisabled = false;
+    mocks.inactive.mockReset().mockResolvedValue(false);
+    mocks.showNotification
+      .mockReset()
+      .mockResolvedValue({ status: "ok", data: null });
     mocks.openNew.mockClear();
     mocks.toast.mockClear();
     mocks.dismiss.mockClear();
@@ -111,5 +131,60 @@ describe("WorkspaceInvitationToasts", () => {
       state: { tab: "team" },
     });
     expect(mocks.dismiss).toHaveBeenCalledWith("team-invitation:inv-1");
+  });
+  it("notifies once when the app is inactive", async () => {
+    mocks.inactive.mockResolvedValue(true);
+    mocks.invitations.data = [invitation];
+    const view = render(<WorkspaceInvitationToasts />);
+    await waitFor(() =>
+      expect(mocks.showNotification).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "team-invitation:inv-1",
+        title: "You've been invited to join Fastrepl",
+        message: "Invited by owner@example.com",
+        action_label: "View",
+        source: null,
+      }),
+    );
+    mocks.invitations.data = [{ ...invitation }];
+    view.rerender(<WorkspaceInvitationToasts />);
+    expect(mocks.showNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps foreground invitations in the app", async () => {
+    mocks.invitations.data = [invitation];
+    render(<WorkspaceInvitationToasts />);
+    await waitFor(() => expect(mocks.inactive).toHaveBeenCalled());
+    expect(mocks.showNotification).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects disabled notifications while retaining the toast", () => {
+    mocks.notificationsDisabled = true;
+    mocks.invitations.data = [invitation];
+    render(<WorkspaceInvitationToasts />);
+    expect(mocks.showNotification).not.toHaveBeenCalled();
+    expect(mocks.inactive).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels pending notification delivery when an invitation disappears", async () => {
+    let resolveActivity!: (inactive: boolean) => void;
+    mocks.inactive.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveActivity = resolve;
+      }),
+    );
+    mocks.invitations.data = [invitation];
+    const view = render(<WorkspaceInvitationToasts />);
+    mocks.invitations.data = [];
+    view.rerender(<WorkspaceInvitationToasts />);
+    resolveActivity(true);
+    await waitFor(() =>
+      expect(mocks.dismiss).toHaveBeenCalledWith("team-invitation:inv-1"),
+    );
+    expect(mocks.showNotification).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/settings/team/invitation-toast.tsx
+++ b/apps/desktop/src/settings/team/invitation-toast.tsx
@@ -1,50 +1,96 @@
 import { useLingui } from "@lingui/react/macro";
-import { useEffect, useRef } from "react";
 
+import { commands as notificationCommands } from "@anlg/plugin-notification";
 import { sonnerToast } from "@anlg/ui/components/ui/toast";
 
+import type { MyWorkspaceInvitation } from "./client";
 import { useMyWorkspaceInvitations } from "./my-invitations";
 
+import { useConfigValue } from "~/shared/config";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
+import { isAppWindowInactive } from "~/shared/window-activity";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function WorkspaceInvitationToasts() {
-  const { t } = useLingui();
   const invitations = useMyWorkspaceInvitations();
+
+  return invitations.data?.map((invitation) => (
+    <WorkspaceInvitationToast
+      key={invitation.invitationId}
+      invitation={invitation}
+    />
+  ));
+}
+
+function WorkspaceInvitationToast({
+  invitation,
+}: {
+  invitation: MyWorkspaceInvitation;
+}) {
+  const { t } = useLingui();
   const openNew = useTabs((state) => state.openNew);
-  const toastedIds = useRef(new Set<string>());
+  const notificationsDisabled = useConfigValue("notification_disabled");
 
-  useEffect(() => {
-    const current = new Set(
-      (invitations.data ?? []).map((invitation) => invitation.invitationId),
-    );
+  useMountEffect(() => {
+    let cancelled = false;
+    const toastId = `team-invitation:${invitation.invitationId}`;
+    const title = t`You've been invited to join ${invitation.workspaceName}`;
+    const description = invitation.invitedByEmail
+      ? t`Invited by ${invitation.invitedByEmail}`
+      : undefined;
 
-    for (const id of toastedIds.current) {
-      if (!current.has(id)) {
-        sonnerToast.dismiss(`team-invitation:${id}`);
-        toastedIds.current.delete(id);
-      }
-    }
-
-    for (const invitation of invitations.data ?? []) {
-      if (toastedIds.current.has(invitation.invitationId)) continue;
-      toastedIds.current.add(invitation.invitationId);
-      const toastId = `team-invitation:${invitation.invitationId}`;
-      sonnerToast(t`You've been invited to join ${invitation.workspaceName}`, {
-        id: toastId,
-        duration: Infinity,
-        description: invitation.invitedByEmail
-          ? t`Invited by ${invitation.invitedByEmail}`
-          : undefined,
-        action: {
-          label: t`View`,
-          onClick: () => {
-            openNew({ type: "settings", state: { tab: "team" } });
-            sonnerToast.dismiss(toastId);
-          },
+    sonnerToast(title, {
+      id: toastId,
+      duration: Infinity,
+      description,
+      action: {
+        label: t`View`,
+        onClick: () => {
+          openNew({ type: "settings", state: { tab: "team" } });
+          sonnerToast.dismiss(toastId);
         },
+      },
+    });
+
+    const notify = async () => {
+      if (
+        notificationsDisabled ||
+        !(await isAppWindowInactive()) ||
+        cancelled
+      ) {
+        return;
+      }
+      const result = await notificationCommands.showNotification({
+        key: toastId,
+        title,
+        message: description ?? "",
+        timeout: { secs: 15, nanos: 0 },
+        source: null,
+        start_time: null,
+        participants: null,
+        event_details: null,
+        action_label: t`View`,
+        action_variant: null,
+        options: null,
+        footer: null,
+        icon: null,
       });
-    }
-  }, [invitations.data, openNew, t]);
+      if (result.status === "error") {
+        console.error(
+          "[team] failed to show invitation notification",
+          result.error,
+        );
+      }
+    };
+    void notify().catch((error) => {
+      console.error("[team] failed to show invitation notification", error);
+    });
+
+    return () => {
+      cancelled = true;
+      sonnerToast.dismiss(toastId);
+    };
+  });
 
   return null;
 }

--- a/apps/desktop/src/settings/team/my-invitations.ts
+++ b/apps/desktop/src/settings/team/my-invitations.ts
@@ -15,6 +15,7 @@ export function useMyWorkspaceInvitations() {
     enabled: signedIn && !auth.session?.user.is_anonymous,
     queryFn: () => listMyWorkspaceInvitations(requireTeamContext(auth)),
     refetchInterval: 60_000,
+    refetchIntervalInBackground: true,
     refetchOnWindowFocus: true,
   });
 }


### PR DESCRIPTION
Keep invitation polling active in hidden windows and show native notifications when the app is inactive. Open Team settings from notification actions, honor notification preferences, and dismiss invitation toasts when invitations disappear.

Add regression coverage for notification actions, background delivery, disabled notifications, and invitation cleanup.