### PR TITLE
Fix integration failures and verify deployment images

### DIFF
--- a/.github/scripts/deploy_api_drain.py
+++ b/.github/scripts/deploy_api_drain.py
@@ -714,6 +714,8 @@ def adopt_drain_image(app: str, digest: str, candidate: str | None = None) -> No
 
 def build_and_push_image(app: str, config: str, dockerfile: str, version: str) -> str:
     image = image_ref(app, version)
+    source_sha = os.environ.get("GITHUB_SHA")
+    labels = ["--label", f"GH_SHA={source_sha}"] if source_sha else []
     fly(
         "deploy",
         "--app",
@@ -729,6 +731,7 @@ def build_and_push_image(app: str, config: str, dockerfile: str, version: str) -
         image.rsplit(":", 1)[1],
         "--build-arg",
         f"APP_VERSION={version}",
+        *labels,
     )
     return image
 

--- a/.github/scripts/deploy_api_drain.py
+++ b/.github/scripts/deploy_api_drain.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import time
 import tomllib
+import uuid
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -107,7 +108,7 @@ def checks_passing(machine: dict[str, Any]) -> bool:
 
 
 def image_ref(app: str, version: str) -> str:
-    return f"registry.fly.io/{app}:api-{version}"
+    return f"registry.fly.io/{app}:api-{version}-{uuid.uuid4().hex}"
 
 
 def fly(*args: str) -> None:
@@ -725,11 +726,30 @@ def build_and_push_image(app: str, config: str, dockerfile: str, version: str) -
         "--build-only",
         "--push",
         "--image-label",
-        f"api-{version}",
+        image.rsplit(":", 1)[1],
         "--build-arg",
         f"APP_VERSION={version}",
     )
     return image
+
+
+def verify_replacement_image(app: str, machine_id: str, expected_image: str) -> None:
+    actual = get_machine(app, machine_id).get("image_ref") or {}
+    digest = actual.get("digest", "")
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise DeployError(f"replacement {machine_id} has no resolved image digest")
+    if "@" in expected_image:
+        matches = digest == expected_image.rsplit("@", 1)[1]
+    else:
+        matches = actual.get("tag") == expected_image.rsplit(":", 1)[1]
+        source_sha = os.environ.get("GITHUB_SHA")
+        if source_sha:
+            matches = (
+                matches and (actual.get("labels") or {}).get("GH_SHA") == source_sha
+            )
+    if not matches:
+        raise DeployError(f"replacement {machine_id} resolved an unexpected image")
+    print(f"verified replacement {machine_id} image {digest}", file=sys.stderr)
 
 
 def deploy(
@@ -805,6 +825,7 @@ def deploy(
             )
         for machine_id in replacement_ids:
             wait_until_healthy(app, machine_id)
+            verify_replacement_image(app, machine_id, image)
         validate_serving_set(app, set(old_ids), set(replacement_ids))
     except Exception:
         destroy_replacements(app, replacement_ids)

--- a/.github/scripts/test_deploy_api_drain.py
+++ b/.github/scripts/test_deploy_api_drain.py
@@ -86,7 +86,16 @@ def test_checks_passing_requires_every_reported_check():
 
 
 def test_image_ref_uses_the_fly_registry_tag():
-    assert image_ref("anarlog-ai", "1.4.14") == "registry.fly.io/anarlog-ai:api-1.4.14"
+    first = image_ref("anarlog-ai", "1.4.14")
+    second = image_ref("anarlog-ai", "1.4.14")
+    assert first.startswith("registry.fly.io/anarlog-ai:api-1.4.14-")
+    assert first != second
+    with patch.object(deploy_api_drain, "fly") as build:
+        image = deploy_api_drain.build_and_push_image(
+            "anarlog-ai", "config", "Dockerfile", "1.4.14"
+        )
+    args = build.call_args.args
+    assert args[args.index("--image-label") + 1] == image.rsplit(":", 1)[1]
 
 
 def test_stop_config_reads_graceful_shutdown_settings():
@@ -759,6 +768,69 @@ def test_cutover_preflight_rechecks_candidate_readiness():
             raise AssertionError("unhealthy candidate was accepted")
 
 
+def test_deploy_rejects_stale_image_before_cutover():
+    old = {"id": "old", "region": "sjc", "cordoned": False, "config": {"image": "old"}}
+    with (
+        patch.object(deploy_api_drain, "destroy_drained_machines"),
+        patch.object(deploy_api_drain, "resume_draining_machines"),
+        patch.object(deploy_api_drain, "list_machines", return_value=[old]),
+        patch.object(
+            deploy_api_drain,
+            "build_and_push_image",
+            return_value="registry.fly.io/anarlog-core:new",
+        ),
+        patch.object(
+            deploy_api_drain,
+            "create_replacement_machine",
+            side_effect=["new-a", "new-b"],
+        ),
+        patch.object(deploy_api_drain, "wait_until_healthy"),
+        patch.object(
+            deploy_api_drain,
+            "get_machine",
+            return_value={
+                "image_ref": {
+                    "tag": "new",
+                    "digest": "sha256:" + "a" * 64,
+                    "labels": {"GH_SHA": "old"},
+                }
+            },
+        ),
+        patch.dict(deploy_api_drain.os.environ, {"GITHUB_SHA": "new"}),
+        patch.object(deploy_api_drain, "destroy_replacements") as cleanup,
+        patch.object(deploy_api_drain, "cut_over") as cutover,
+    ):
+        try:
+            deploy_api_drain.deploy(
+                "anarlog-core", "apps/api/fly.core.toml", "Dockerfile", "test"
+            )
+        except DeployError as error:
+            assert "unexpected image" in str(error)
+        else:
+            raise AssertionError("Stale source image was accepted")
+    cleanup.assert_called_once_with("anarlog-core", ["new-a", "new-b"])
+    cutover.assert_not_called()
+
+
+def test_replacement_digest_is_checked_for_immutable_deploys():
+    digest = "sha256:" + "a" * 64
+    with patch.object(
+        deploy_api_drain, "get_machine", return_value={"image_ref": {"digest": digest}}
+    ):
+        deploy_api_drain.verify_replacement_image(
+            "anarlog-core", "new", "registry.fly.io/anarlog-core@" + digest
+        )
+        for wrong in ["sha256:" + "b" * 64, "invalid"]:
+            try:
+                deploy_api_drain.verify_replacement_image(
+                    "anarlog-core", "new", "registry.fly.io/anarlog-core@" + wrong
+                )
+            except DeployError:
+                pass
+            else:
+                raise AssertionError("Mismatched image digest was accepted")
+
+
 def test_deploy_restores_minimum_primary_region_capacity():
     old = {"id": "old", "region": "nrt", "cordoned": False, "config": {"image": "old"}}
     regions = []
@@ -776,6 +848,7 @@ def test_deploy_restores_minimum_primary_region_capacity():
             deploy_api_drain, "create_replacement_machine", side_effect=create
         ),
         patch.object(deploy_api_drain, "wait_until_healthy"),
+        patch.object(deploy_api_drain, "verify_replacement_image"),
         patch.object(deploy_api_drain, "validate_serving_set"),
         patch.object(deploy_api_drain, "cut_over") as cutover,
         patch.object(deploy_api_drain, "drain_old_machines"),
@@ -917,6 +990,7 @@ def test_override_support_is_verified_before_cleanup():
                 side_effect=["new-a", "new-b"],
             ) as create,
             patch.object(deploy_api_drain, "wait_until_healthy"),
+            patch.object(deploy_api_drain, "verify_replacement_image"),
             patch.object(deploy_api_drain, "validate_serving_set"),
             patch.object(deploy_api_drain, "cut_over"),
             patch.object(deploy_api_drain, "drain_old_machines"),
@@ -1050,6 +1124,8 @@ if __name__ == "__main__":
     test_reads_cordon_from_metadata_when_top_level_flag_is_absent()
     test_checks_passing_requires_every_reported_check()
     test_image_ref_uses_the_fly_registry_tag()
+    test_deploy_rejects_stale_image_before_cutover()
+    test_replacement_digest_is_checked_for_immutable_deploys()
     test_stop_config_reads_graceful_shutdown_settings()
     test_replacement_config_updates_image_without_mutating_source()
     test_replacement_config_rejects_volume_mounts()

--- a/.github/scripts/test_deploy_api_drain.py
+++ b/.github/scripts/test_deploy_api_drain.py
@@ -90,12 +90,16 @@ def test_image_ref_uses_the_fly_registry_tag():
     second = image_ref("anarlog-ai", "1.4.14")
     assert first.startswith("registry.fly.io/anarlog-ai:api-1.4.14-")
     assert first != second
-    with patch.object(deploy_api_drain, "fly") as build:
+    with (
+        patch.object(deploy_api_drain, "fly") as build,
+        patch.dict(deploy_api_drain.os.environ, {"GITHUB_SHA": "test-source"}),
+    ):
         image = deploy_api_drain.build_and_push_image(
             "anarlog-ai", "config", "Dockerfile", "1.4.14"
         )
     args = build.call_args.args
     assert args[args.index("--image-label") + 1] == image.rsplit(":", 1)[1]
+    assert args[args.index("--label") + 1] == "GH_SHA=test-source"
 
 
 def test_stop_config_reads_graceful_shutdown_settings():

--- a/.github/workflows/api_ci.yaml
+++ b/.github/workflows/api_ci.yaml
@@ -17,6 +17,9 @@ on:
       - apps/api/**
       - crates/agent-access/**
       - crates/api-auth/**
+      - crates/api-calendar/**
+      - crates/api-nango/**
+      - crates/api-notion/**
       - crates/api-cloud/**
       - crates/api-subscription/**
       - crates/api-sync/**
@@ -40,6 +43,9 @@ on:
       - apps/api/**
       - crates/agent-access/**
       - crates/api-auth/**
+      - crates/api-calendar/**
+      - crates/api-nango/**
+      - crates/api-notion/**
       - crates/api-cloud/**
       - crates/api-subscription/**
       - crates/api-sync/**
@@ -72,6 +78,7 @@ jobs:
       - run: cargo check -p api
       - run: cargo test -p api-cloud
       - run: cargo test -p api-auth
+      - run: cargo test --locked -p api-calendar -p api-nango -p api-notion
       - run: cargo test -p mcp
       - run: cargo test -p supabase-auth --features server
       - run: cargo test -p api-sync

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "utoipa",
 ]
 

--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -989,6 +989,9 @@
           "401": {
             "description": "Authentication required"
           },
+          "424": {
+            "description": "Notion plan does not include AI meeting notes"
+          },
           "500": {
             "description": "Notion connection unavailable"
           }

--- a/apps/api/src/observability.rs
+++ b/apps/api/src/observability.rs
@@ -13,9 +13,10 @@ use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
 use serde::Deserialize;
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
-use tracing_subscriber::fmt::FmtContext;
+use tracing_subscriber::field::RecordFields;
 use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
 use tracing_subscriber::fmt::time::{FormatTime, SystemTime};
+use tracing_subscriber::fmt::{FmtContext, FormattedFields};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
 
@@ -65,19 +66,54 @@ pub fn init(service_name: &str, env: &Env) -> ObservabilityGuard {
         let tracer = provider.tracer(service_name.to_string());
         tracing_subscriber::registry()
             .with(env_filter)
-            .with(tracing_subscriber::fmt::layer().event_format(SafeEventFormatter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .fmt_fields(SafeSpanFields)
+                    .event_format(SafeEventFormatter),
+            )
             .with(tracing_opentelemetry::layer().with_tracer(tracer))
             .with(sentry::integrations::tracing::layer())
             .init();
     } else {
         tracing_subscriber::registry()
             .with(env_filter)
-            .with(tracing_subscriber::fmt::layer().event_format(SafeEventFormatter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .fmt_fields(SafeSpanFields)
+                    .event_format(SafeEventFormatter),
+            )
             .with(sentry::integrations::tracing::layer())
             .init();
     }
 
     ObservabilityGuard { otel_provider }
+}
+
+struct SafeSpanFields;
+
+impl<'writer> FormatFields<'writer> for SafeSpanFields {
+    fn format_fields<R: RecordFields>(
+        &self,
+        mut writer: Writer<'writer>,
+        fields: R,
+    ) -> std::fmt::Result {
+        let mut visitor = SafeEventVisitor::default();
+        fields.record(&mut visitor);
+        for (key, value) in visitor.safe_fields {
+            if matches!(
+                key.as_str(),
+                "http.route"
+                    | "http.request.method"
+                    | "http.response.status_code"
+                    | "anarlog.error.stage"
+                    | "anarlog.operation"
+                    | "service.peer.name"
+            ) {
+                write!(writer, " {key}={value}")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 struct SafeEventFormatter;
@@ -109,6 +145,9 @@ where
                     "{}:",
                     sanitize_telemetry_name(span.metadata().name(), "span")
                 )?;
+                if let Some(fields) = span.extensions().get::<FormattedFields<SafeSpanFields>>() {
+                    write!(writer, "{} ", fields.fields)?;
+                }
             }
             write!(writer, " ")?;
         }
@@ -671,15 +710,25 @@ mod tests {
     }
 
     #[test]
-    fn stdout_events_keep_safe_span_context_without_span_fields() {
+    fn stdout_events_keep_safe_matched_route_and_drop_private_span_fields() {
         let buffer = LogBuffer::default();
         let subscriber = tracing_subscriber::fmt()
+            .fmt_fields(SafeSpanFields)
             .event_format(SafeEventFormatter)
             .with_writer(buffer.clone())
             .finish();
 
         tracing::subscriber::with_default(subscriber, || {
-            let span = tracing::info_span!("http_request", patient = "Jane Doe");
+            let span = tracing::info_span!(
+                "http_request",
+                http.route = "/calendar/google/list-events",
+                http.request.method = "POST",
+                http.response.status_code = tracing::field::Empty,
+                patient = "Jane Doe",
+                user_id = "private-user",
+                server.address = "private-host",
+            );
+            span.record("http.response.status_code", 500);
             let _entered = span.enter();
             tracing::info!("started processing request");
         });
@@ -688,6 +737,11 @@ mod tests {
             .expect("utf-8 log output");
         assert!(output.contains("http_request:"));
         assert!(!output.contains("Jane Doe"));
+        assert!(!output.contains("private-user"));
+        assert!(!output.contains("private-host"));
+        assert!(output.contains("http.route=/calendar/google/list-events"));
+        assert!(output.contains("http.request.method=POST"));
+        assert!(output.contains("http.response.status_code=500"));
     }
 
     #[test]

--- a/crates/api-nango/src/extractor.rs
+++ b/crates/api-nango/src/extractor.rs
@@ -102,6 +102,10 @@ impl NangoConnectionState {
             .await
             .map_err(|e| NangoConnectionError::Database(e.to_string()))?;
 
+        if response.status() == StatusCode::UNAUTHORIZED {
+            return Err(NangoConnectionError::NotAuthenticated);
+        }
+
         if !response.status().is_success() {
             let status = response.status();
             return Err(NangoConnectionError::Database(format!(
@@ -170,6 +174,10 @@ impl NangoConnectionState {
             .send()
             .await
             .map_err(|e| NangoConnectionError::Database(e.to_string()))?;
+
+        if response.status() == StatusCode::UNAUTHORIZED {
+            return Err(NangoConnectionError::NotAuthenticated);
+        }
 
         if !response.status().is_success() {
             let status = response.status();
@@ -359,6 +367,48 @@ mod tests {
             assert!(!is_provider_auth_failure(&format!(
                 "API error (status 403): {{\"error\":{{\"reason\":\"{reason}\"}}}}"
             )));
+        }
+    }
+
+    #[tokio::test]
+    async fn connection_extractors_preserve_authentication_failures() {
+        for upstream in [401, 503] {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .respond_with(ResponseTemplate::new(upstream))
+                .expect(2)
+                .mount(&server)
+                .await;
+            let config = NangoConfig::for_test(&server.uri(), &server.uri());
+            let state = NangoConnectionState::from_config(&config);
+            let errors = [
+                state
+                    .get_connection_id("test-token", "test-user", "google-calendar")
+                    .await
+                    .err()
+                    .unwrap(),
+                state
+                    .build_http_client(
+                        "test-token",
+                        "test-user",
+                        "google-calendar",
+                        "test-connection",
+                    )
+                    .await
+                    .err()
+                    .unwrap(),
+            ];
+            for error in errors {
+                assert_eq!(
+                    error.into_response().status(),
+                    if upstream == 401 {
+                        StatusCode::UNAUTHORIZED
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                );
+            }
+            server.verify().await;
         }
     }
 

--- a/crates/api-nango/src/extractor.rs
+++ b/crates/api-nango/src/extractor.rs
@@ -275,6 +275,8 @@ pub fn is_provider_auth_failure(message: &str) -> bool {
         || lower.contains("token is expired")
         || lower.contains("lifetime validation failed")
         || lower.contains("invalid_grant")
+        || lower.contains("access_token_scope_insufficient")
+        || lower.contains("insufficientpermissions")
         || lower.contains("could not refresh")
         || lower.contains("refresh access token")
 }
@@ -338,6 +340,26 @@ mod tests {
         assert!(!is_provider_auth_failure(
             "HTTP status client error (403 Forbidden) for url (https://api.nango.dev/proxy/me/calendars/AAMk)"
         ));
+    }
+
+    #[test]
+    fn detects_missing_google_scopes_without_misclassifying_other_forbidden_errors() {
+        assert!(is_provider_auth_failure(
+            r#"API error (status 403): {"error":{"details":[{"reason":"ACCESS_TOKEN_SCOPE_INSUFFICIENT"}],"status":"PERMISSION_DENIED"}}"#
+        ));
+        assert!(is_provider_auth_failure(
+            r#"API error (status 403): {"error":{"errors":[{"reason":"insufficientPermissions"}]}}"#
+        ));
+        for reason in [
+            "rateLimitExceeded",
+            "quotaExceeded",
+            "accessNotConfigured",
+            "forbidden",
+        ] {
+            assert!(!is_provider_auth_failure(&format!(
+                "API error (status 403): {{\"error\":{{\"reason\":\"{reason}\"}}}}"
+            )));
+        }
     }
 
     #[tokio::test]

--- a/crates/api-nango/src/supabase.rs
+++ b/crates/api-nango/src/supabase.rs
@@ -53,13 +53,22 @@ impl SupabaseClient {
         url: &str,
         auth_token: &str,
     ) -> Result<reqwest::Response, crate::error::NangoError> {
-        self.http_client
+        let response = self
+            .http_client
             .get(url)
             .header("Authorization", format!("Bearer {}", auth_token))
             .header("apikey", &self.supabase_anon_key)
             .send()
             .await
-            .map_err(|e| crate::error::NangoError::Internal(e.to_string()))
+            .map_err(|e| crate::error::NangoError::Internal(e.to_string()))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(crate::error::NangoError::Auth(
+                "not authenticated".to_string(),
+            ));
+        }
+
+        Ok(response)
     }
 
     fn service_role_key(&self) -> Result<&str, crate::error::NangoError> {
@@ -315,5 +324,65 @@ impl SupabaseClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{http::StatusCode, response::IntoResponse};
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+    #[tokio::test]
+    async fn connection_queries_preserve_authentication_failures() {
+        for upstream in [401, 503] {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .respond_with(
+                    ResponseTemplate::new(upstream).set_body_string("private upstream details"),
+                )
+                .expect(3)
+                .mount(&server)
+                .await;
+            let client = SupabaseClient::new(server.uri(), "test-anon-key", None);
+            let errors = [
+                client
+                    .list_user_connections("test-token", "test-user")
+                    .await
+                    .err()
+                    .unwrap(),
+                client
+                    .lookup_connection("test-token", "test-user", "google-calendar")
+                    .await
+                    .err()
+                    .unwrap(),
+                client
+                    .verify_connection_ownership(
+                        "test-token",
+                        "test-user",
+                        "test-connection",
+                        "google-calendar",
+                    )
+                    .await
+                    .err()
+                    .unwrap(),
+            ];
+            for error in errors {
+                let response = error.into_response();
+                assert_eq!(
+                    response.status(),
+                    if upstream == 401 {
+                        StatusCode::UNAUTHORIZED
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                );
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                assert!(!String::from_utf8_lossy(&body).contains("private upstream details"));
+            }
+            server.verify().await;
+        }
     }
 }

--- a/crates/api-notion/Cargo.toml
+++ b/crates/api-notion/Cargo.toml
@@ -16,3 +16,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 utoipa = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }

--- a/crates/api-notion/src/error.rs
+++ b/crates/api-notion/src/error.rs
@@ -11,6 +11,9 @@ pub enum NotionError {
     #[error("Invalid request: {0}")]
     BadRequest(String),
 
+    #[error("Notion AI meeting notes are unavailable on this plan")]
+    MeetingNotesUnavailable,
+
     #[error("Notion error: {0}")]
     Notion(String),
 
@@ -26,6 +29,12 @@ impl IntoResponse for NotionError {
     fn into_response(self) -> Response {
         let (status, code, message) = match self {
             Self::BadRequest(message) => (StatusCode::BAD_REQUEST, "bad_request", message),
+            Self::MeetingNotesUnavailable => (
+                StatusCode::FAILED_DEPENDENCY,
+                "notion_meeting_notes_unavailable",
+                "Enable AI meeting notes on your Notion plan to import them, then try again."
+                    .to_string(),
+            ),
             Self::Notion(message) => (StatusCode::INTERNAL_SERVER_ERROR, "notion_error", message),
             Self::Internal(message) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/api-notion/src/import.rs
+++ b/crates/api-notion/src/import.rs
@@ -184,7 +184,7 @@ async fn notion_get(proxy: &OwnedNangoProxy, path: &str) -> Result<Value> {
 
 async fn notion_send(builder: reqwest::RequestBuilder) -> Result<Value> {
     let response = builder
-        .header("Notion-Version", MEETING_NOTES_VERSION)
+        .header("Nango-Proxy-Notion-Version", MEETING_NOTES_VERSION)
         .send()
         .await
         .map_err(|e| NotionError::Notion(e.to_string()))?;
@@ -261,4 +261,78 @@ fn rich_text(value: &Value) -> Option<String> {
         .filter_map(|fragment| fragment["plain_text"].as_str())
         .collect::<String>();
     nonempty(Some(&text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        Json, Router,
+        http::{HeaderMap, StatusCode},
+        routing::{get, post},
+    };
+
+    fn version_is_forwarded(headers: &HeaderMap) -> bool {
+        headers
+            .get("nango-proxy-notion-version")
+            .and_then(|v| v.to_str().ok())
+            == Some("2026-03-11")
+    }
+
+    #[tokio::test]
+    async fn imports_notes_with_the_requested_version_through_nango() {
+        let app = Router::new()
+            .route(
+                "/proxy/v1/blocks/meeting_notes/query",
+                post(|headers: HeaderMap| async move {
+                    if !version_is_forwarded(&headers) {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({"message":"unsupported API version"})),
+                        );
+                    }
+                    (
+                        StatusCode::OK,
+                        Json(json!({"results":[{
+                            "id":"meeting-1", "meeting_notes":{
+                                "title":[{"plain_text":"Fixture meeting"}],
+                                "children":{"summary_block_id":"summary-1"}
+                            }
+                        }]})),
+                    )
+                }),
+            )
+            .route(
+                "/proxy/v1/blocks/summary-1/children",
+                get(|headers: HeaderMap| async move {
+                    if !version_is_forwarded(&headers) {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({"message":"unsupported API version"})),
+                        );
+                    }
+                    (
+                        StatusCode::OK,
+                        Json(json!({"results":[{
+                    "type":"paragraph", "paragraph":{"rich_text":[{"plain_text":"Fixture summary"}]}
+                }], "has_more":false})),
+                    )
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = anlg_nango::NangoClient::builder()
+            .api_key("fixture-key")
+            .api_base(base)
+            .build()
+            .unwrap();
+        let proxy = OwnedNangoProxy::new(&client, "notion".into(), "fixture-connection".into());
+        let result = import_meetings(&proxy, &[]).await;
+        server.abort();
+        let imported = result.unwrap();
+        assert_eq!(imported.files.len(), 1);
+        assert!(imported.files[0].content.contains("Fixture summary"));
+        assert!(imported.warnings.is_empty());
+    }
 }

--- a/crates/api-notion/src/import.rs
+++ b/crates/api-notion/src/import.rs
@@ -197,6 +197,12 @@ async fn notion_send(builder: reqwest::RequestBuilder) -> Result<Value> {
         let message = payload["message"]
             .as_str()
             .unwrap_or("Notion request failed");
+        if status == reqwest::StatusCode::BAD_REQUEST
+            && payload["code"].as_str() == Some("validation_error")
+            && message.contains("requires a plan with AI meeting notes enabled")
+        {
+            return Err(NotionError::MeetingNotesUnavailable);
+        }
         return Err(NotionError::Notion(format!("{status}: {message}")));
     }
     Ok(payload)
@@ -334,5 +340,50 @@ mod tests {
         assert_eq!(imported.files.len(), 1);
         assert!(imported.files[0].content.contains("Fixture summary"));
         assert!(imported.warnings.is_empty());
+    }
+    #[tokio::test]
+    async fn reports_plan_requirements_without_hiding_other_provider_failures() {
+        use axum::response::IntoResponse;
+        for (status, code, message, expected) in [
+            (
+                400,
+                "validation_error",
+                "This endpoint requires a plan with AI meeting notes enabled. Please upgrade your plan to use this feature.",
+                424,
+            ),
+            (400, "validation_error", "Invalid sort property", 500),
+            (503, "service_unavailable", "Notion unavailable", 500),
+        ] {
+            let app = Router::new().fallback(move || async move {
+                (
+                    StatusCode::from_u16(status).unwrap(),
+                    Json(json!({"code":code,"message":message})),
+                )
+            });
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+            let error = notion_send(reqwest::Client::new().post(url))
+                .await
+                .unwrap_err();
+            server.abort();
+            let response = error.into_response();
+            assert_eq!(response.status().as_u16(), expected);
+            let body = axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .unwrap();
+            let body: Value = serde_json::from_slice(&body).unwrap();
+            if expected == 424 {
+                assert_eq!(body["error"]["code"], "notion_meeting_notes_unavailable");
+                assert!(
+                    body["error"]["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("Notion plan")
+                );
+            } else {
+                assert_eq!(body["error"]["message"], "Internal server error");
+            }
+        }
     }
 }

--- a/crates/api-notion/src/routes/notion.rs
+++ b/crates/api-notion/src/routes/notion.rs
@@ -88,7 +88,7 @@ pub async fn search_pages(
             "application/json",
         )
         .map_err(|e| NotionError::Notion(e.to_string()))?
-        .header("Notion-Version", NOTION_VERSION)
+        .header("Nango-Proxy-Notion-Version", NOTION_VERSION)
         .send()
         .await
         .map_err(|e| NotionError::Notion(e.to_string()))?
@@ -159,7 +159,7 @@ pub async fn append_update(
             &json!({ "children": children }),
         )
         .map_err(|e| NotionError::Notion(e.to_string()))?
-        .header("Notion-Version", NOTION_VERSION)
+        .header("Nango-Proxy-Notion-Version", NOTION_VERSION)
         .send()
         .await
         .map_err(|e| NotionError::Notion(e.to_string()))?

--- a/crates/api-notion/src/routes/notion.rs
+++ b/crates/api-notion/src/routes/notion.rs
@@ -199,6 +199,7 @@ pub struct NotionImportMeetingsResponse {
     responses(
         (status = 200, description = "Notion meeting notes fetched for import", body = NotionImportMeetingsResponse),
         (status = 401, description = "Authentication required"),
+        (status = 424, description = "Notion plan does not include AI meeting notes"),
         (status = 500, description = "Notion connection unavailable"),
     ),
     tag = "notion",

--- a/packages/api-client/src/generated/types.gen.ts
+++ b/packages/api-client/src/generated/types.gen.ts
@@ -2868,6 +2868,10 @@ export type NotionImportMeetingsErrors = {
      */
     401: unknown;
     /**
+     * Notion plan does not include AI meeting notes
+     */
+    424: unknown;
+    /**
      * Notion connection unavailable
      */
     500: unknown;


### PR DESCRIPTION
Google Calendar connections missing required scopes repeatedly returned HTTP 500, while Notion meeting imports used Nango’s older default API version and hid plan requirements behind a generic error. Mark insufficient Google permissions as requiring reconnection, forward the intended Notion version through Nango, and return an actionable HTTP 424 when a Notion plan lacks meeting notes.

Preserve HTTP 401 when Supabase rejects user-token connection queries so clients can recover through authentication; upstream outages remain server errors.

Preserve allowlisted request context in privacy-filtered API logs so remaining integration failures can be diagnosed. Add provider transport regressions, generated API types, and integration-crate CI coverage.

The first rollout resolved a reused image tag to the previous build. Give source builds unique tags and verify each replacement’s source revision or immutable digest before cutover; mismatches discard only the cordoned replacements.

Validation: local API workflow checks, integration tests, API client typecheck, license checks, and 82 repository tests pass. Changed workflow security scan has zero findings; the full repository scan retains 360 pre-existing findings. Deployment and continuity Python regressions pass. The immutable-image rollout and live verification are pending.

https://linear.app/fastrepl-inc/issue/ANLG-342
