### PR TITLE
Prepare 1.4.24 release notes and Team documentation

### DIFF
--- a/docs/models-and-providers.mdx
+++ b/docs/models-and-providers.mdx
@@ -112,6 +112,7 @@ Recent bring-your-own Transcription models in Settings include:
 - **AssemblyAI Universal 3.5 Pro** (`universal-3-5-pro-realtime` during the meeting, `universal-3-5-pro` after recording)
 - **Smallest AI Pulse** (`pulse`) and **Pulse Pro** (`pulse-pro`) for live and after-recording transcription
 - **Meta Muse Voice Transcribe** (`muse-voice-transcribe-1.0`) for live and after-recording transcription with speaker labels
+- **Nari Labs** for live transcription with a Nari API key
 
 Settings may still show older model IDs for compatibility. Prefer the current Gemini 3.5, Universal 3.5, Soniox 5, Smallest AI Pulse, and GPT Transcribe models when you configure a provider yourself.
 

--- a/docs/teams.mdx
+++ b/docs/teams.mdx
@@ -23,6 +23,20 @@ Workspace owners and admins can open **Members** to:
 - Change a member between the Admin and Member roles
 - Remove a member
 
+### Accept an invitation
+
+Sign in with the verified email address that received the invitation, then open **Settings → Teams**. Pending invitations appear under **Invitations**, where you can choose **Accept** or **Decline** without opening the email link. The app checks for invitations every minute and when you return to its window.
+
+An invitation notification opens Teams settings. If an invitation is missing, check that you signed in with the invited email address and ask the inviter to confirm it has not expired or been canceled.
+
+### Membership billing and ownership
+
+You do not need to purchase seats before inviting someone. Pending invitations do not add a billable member. Team billing adjusts when someone joins or leaves, with prorated changes included in the next scheduled invoice. Annual plans keep their annual billing cycle.
+
+Owners can enable automatic joining for coworkers with a verified work email domain. Personal email domains such as Gmail are excluded, and previously removed members are not automatically readmitted.
+
+Ownership transfers require the recipient to accept the request. Until they accept, the current owner keeps ownership.
+
 <Warning>
   Deleting a workspace removes it for everyone in it, and cannot be undone. Only the owner can transfer ownership, so transfer it before leaving if someone else should keep the workspace.
 </Warning>

--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-09-11"
-summary: "Anarlog Nightly returns with shared notes, clearer sync status, Meta Muse, and more reliable recording."
+date: "2026-09-12"
+summary: "Join teams inside Anarlog, manage membership billing, and get more reliable transcription and sync."
 ---
 
 ## Anarlog Nightly is back
@@ -21,12 +21,17 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Hide brief prompts after a meeting ends.
 - Use Bluetooth microphones on macOS reliably by switching to the HFP/SCO profile when the mic opens.
 - Remember names for live one-on-one remote participants across restarts.
+- Apply a speaker name across a meeting without changing unrelated speakers, and preserve assignments through transcript refinement.
+- Connect Nari Labs for live transcription with your own API key.
 
 ## Accounts, sync, and teams
 
 - Choose monthly or yearly billing for your Pro plan in your account.
 - Connect additional sign-in methods from Connected accounts without merging separate accounts.
-- Let team owners automatically admit coworkers with a verified work email domain while respecting seats and previous removals.
+- Accept or decline team invitations in Settings → Teams, even when the invitation email is missing. Get an invitation notification when the app is in the background.
+- Add Team members without purchasing seats first. Billing adjusts when members join or leave, with prorated changes applied to the next scheduled invoice.
+- Let team owners automatically admit coworkers with a verified work email domain while respecting previous removals.
+- See member profiles and roles in a table, and require the recipient to accept an ownership transfer.
 - See why cloud sync is stuck instead of retrying silently, including the failing step when restore or setup cannot continue.
 - Choose **Start fresh on this device** when the notes on a device belong to another Anarlog account. The existing database is kept as a timestamped backup and the signed-in account takes over; nothing from the old notes is uploaded.
 - Switch accounts on a device that never synced without reinstalling.
@@ -34,7 +39,7 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Resolve concurrent edits by when they were made rather than which device published last, merge edits to different paragraphs of the same note, and keep the version that lost so nothing disappears.
 - Sync long transcripts in chunks, so recordings in progress sync incrementally and two devices no longer overwrite each other's transcript.
 - Keep syncing when a newer Anarlog build adds data this version cannot read yet; those records wait for an update instead of stopping sync.
-- Connect **Meta Muse** for transcription and intelligence in Settings → AI.
+- Connect **Meta Muse** for transcription and intelligence in Settings → AI. Thanks [@realtonypark](https://github.com/realtonypark).
 
 ## Meeting controls
 
@@ -43,3 +48,5 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Use more compact email and Slack sharing menus.
 - Confirm destructive actions with a click instead of press-and-hold.
 - Remove the scrollbar from the meeting details popover and simplify typography across the app.
+- Choose where desktop exports are saved in Settings → General.
+- Select transcript text without an overlay obscuring the words.

--- a/packages/changelog/nightly.md
+++ b/packages/changelog/nightly.md
@@ -1,6 +1,6 @@
 ---
-date: "2026-09-09"
-summary: "Nightly is back, with transcription recovery and meeting controls to try before stable."
+date: "2026-09-12"
+summary: "Try in-app team invitations, membership billing, and more reliable transcription and sync."
 ---
 
 ## Anarlog Nightly is back
@@ -14,9 +14,18 @@ Nightly opens the same local notes as your stable Anarlog, while sign-in and set
 - Live transcription recovers when output stalls, with cleaner handoffs between meetings.
 - Canceling post-meeting transcription stops that work, and incomplete post-processing no longer replaces a saved transcript.
 - The folder picker sits beside the note header actions. Meeting details and sharing menus are more compact.
+- Choose a default export folder in Settings → General.
+- Sync tags, folders, daily notes, and transcript chunks, with clearer errors when sync needs attention.
+
+## Teams
+
+- Accept or decline invitations in Settings → Teams without opening the email. Background notifications let you know when an invitation arrives.
+- Invite members without buying seats first. Billing adjusts when members join or leave, with prorated changes on the next scheduled invoice.
+- Review member profiles and permissions in a table. Ownership transfers now require the recipient to accept.
 
 ## Providers
 
 - Connect Meta Muse for transcription and intelligence with your own API key. Thanks [@realtonypark](https://github.com/realtonypark).
+- Connect Nari Labs for live transcription with your own API key.
 
 Please include the Nightly version and your operating system when reporting a problem.


### PR DESCRIPTION
Cover in-app invitations, membership proration, ownership approval, Nari transcription and export preferences; restore Meta Muse contributor credit. Document joining without the invitation email and the annual billing cadence.

Validation: changed-file formatting, changelog typecheck, skill mirror checks, 82 release-script tests, license-boundary checks and Mintlify validation/link checks passed. Offline Zizmor reports existing findings; no workflows changed.

ANLG-343