### PR TITLE
Clarify paid Team cloud access

### DIFF
--- a/docs/reference/api-cloud.mdx
+++ b/docs/reference/api-cloud.mdx
@@ -3,7 +3,7 @@ title: "Cloud API and connectors"
 description: "Opt in to hosted REST and remote MCP access for your Anarlog meetings."
 ---
 
-The Cloud API lets remote agents read your Anarlog meetings while the desktop app is closed. It requires Anarlog Pro and stays off until you enable it.
+The Cloud API lets remote agents read your Anarlog meetings while the desktop app is closed. It requires Pro access, either from your personal plan or membership in an active paid Team, and stays off until you enable it.
 
 <Warning>
   Enabling Cloud API & Connectors uploads a separate server-readable copy of
@@ -51,7 +51,7 @@ Errors use this envelope:
 
 Codes: `unauthorized`, `not_found`, `invalid_request`, `internal_error`. The hosted API can also return:
 
-- `403 subscription_required` when the account does not have an active Pro subscription.
+- `403 subscription_required` when the account does not have Pro access through a personal plan or an active paid Team membership.
 - `403 cloud_api_not_enabled` when the account has opted out.
 - `429` with a plain-text `rate limit exceeded` body and `retry-after` header when you exceed the hosted request limit.
 
@@ -198,4 +198,4 @@ Authorization: Bearer anl_...
 
 Turn off **Cloud API & Connectors** under **Settings → Developers**. Anarlog immediately deletes all server-readable meeting snapshots. Your local meetings and end-to-end encrypted cloud sync data are unchanged.
 
-Revoked keys cannot read snapshots. If your Pro subscription ends, existing cloud keys return `subscription_required`.
+Revoked keys cannot read snapshots. If you lose Pro access from both your personal plan and any paid Team memberships, existing cloud keys return `subscription_required`.

--- a/docs/reference/api-cloud.mdx
+++ b/docs/reference/api-cloud.mdx
@@ -90,7 +90,7 @@ https://api.anarlog.so/.well-known/oauth-protected-resource/mcp
 The metadata points the host to Anarlog's existing Supabase authorization server. That server uses dynamic client registration and PKCE with SHA-256. The host sends the MCP `resource` value during authorization and token exchange; Anarlog binds issued OAuth tokens to `https://api.anarlog.so/mcp` and rejects tokens minted for another resource.
 
 <Note>
-  OAuth does not bypass Anarlog's product controls. The account must have an active Pro subscription and **Cloud API & Connectors** must remain enabled. Disabling the feature deletes the uploaded snapshots and makes existing connector tokens unusable for meeting access.
+  OAuth does not bypass Anarlog's product controls. The account must have Pro access through a personal plan or an active paid Team membership, and **Cloud API & Connectors** must remain enabled. Disabling the feature deletes the uploaded snapshots and makes existing connector tokens unusable for meeting access.
 </Note>
 
 ### Claude Code

--- a/packages/changelog/content/1.4.24.md
+++ b/packages/changelog/content/1.4.24.md
@@ -18,6 +18,7 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Re-transcribe stereo recordings even when the available provider only accepts mono audio, and keep both languages when re-transcribing a mixed-language meeting.
 - Pass dictionary hints and speaker diarization through OpenRouter transcription, so custom terms are honored and multi-speaker transcripts no longer collapse into one speaker. Thanks [@ekapratama93](https://github.com/ekapratama93).
 - Use the actual default microphone on Linux instead of silently recording from ALSA's null device. Thanks [@jacopone](https://github.com/jacopone).
+- Use the host's PipeWire libraries in the Linux AppImage to avoid silent recordings on distributions such as Fedora.
 - Hide brief prompts after a meeting ends.
 - Use Bluetooth microphones on macOS reliably by switching to the HFP/SCO profile when the mic opens.
 - Remember names for live one-on-one remote participants across restarts.
@@ -30,6 +31,7 @@ Nightly opens the same local notes as stable. Sign-in and settings stay separate
 - Connect additional sign-in methods from Connected accounts without merging separate accounts.
 - Accept or decline team invitations in Settings → Teams, even when the invitation email is missing. Get an invitation notification when the app is in the background.
 - Add Team members without purchasing seats first. Billing adjusts when members join or leave, with prorated changes applied to the next scheduled invoice.
+- Use Cloud API and Cloud MCP with the Pro access included in your paid Team membership.
 - Let team owners automatically admit coworkers with a verified work email domain while respecting previous removals.
 - See member profiles and roles in a table, and require the recipient to accept an ownership transfer.
 - See why cloud sync is stuck instead of retrying silently, including the failing step when restore or setup cannot continue.


### PR DESCRIPTION
Document paid Team membership as a source of Pro access for Cloud API and Cloud MCP. Complete the 1.4.24 changelog with Team cloud access and the Linux PipeWire fix.

Validation: formatting, changelog typecheck, Mintlify validation and link checks passed.