### PR TITLE
Fix Nari coverage in proxy test helpers

### DIFF
--- a/crates/transcribe-proxy/tests/common/mod.rs
+++ b/crates/transcribe-proxy/tests/common/mod.rs
@@ -128,6 +128,7 @@ pub fn env_with_provider(provider: Provider, api_key: String) -> transcribe_prox
         | Provider::Xai
         | Provider::SmallestAI
         | Provider::Meta
+        | Provider::Nari
         | Provider::GoogleGenerativeAi => panic!("{provider} is not configured in the Pro proxy"),
     }
     env


### PR DESCRIPTION
Native workspace CI could not compile transcribe-proxy integration tests after Nari was added. Handle Nari alongside providers unsupported by the Pro proxy test harness. Production routing is unchanged.

Validation: cargo check --locked -p transcribe-proxy --tests, cargo test --locked -p transcribe-proxy --no-run, cargo test --locked -p transcribe-proxy, rustfmt check, 82 release-script tests, and license boundary checks passed. Provider credential E2E tests remain ignored. Workflow security findings are unchanged from ANLG-343 baseline.

ANLG-343